### PR TITLE
Use `pyproject.toml` (PEP 517, 518) instead of deprecated `setup_requires`.

### DIFF
--- a/pytket/pyproject.toml
+++ b/pytket/pyproject.toml
@@ -1,3 +1,6 @@
 [build-system]
-requires = ["setuptools", "wheel", "setuptools_scm", "conan"]
+requires = ["setuptools>=45", "wheel", "setuptools_scm>=6.2", "conan"]
 build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]
+root = ".."

--- a/pytket/pyproject.toml
+++ b/pytket/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "wheel", "setuptools_scm", "conan"]
+build-backend = "setuptools.build_meta"

--- a/pytket/setup.py
+++ b/pytket/setup.py
@@ -249,5 +249,4 @@ setup(
         # with access to less git history.
         "git_describe_command": "git describe --dirty --tags --long --match *[0-9]* --abbrev=14",
     },
-    setup_requires=["setuptools_scm"],
 )

--- a/pytket/setup.py
+++ b/pytket/setup.py
@@ -241,12 +241,4 @@ setup(
     include_package_data=True,
     package_data={"pytket": ["py.typed"]},
     zip_safe=False,
-    use_scm_version={
-        "root": "..",
-        "relative_to": __file__,
-        # Force git describe to abbreviate hashes to 14 characters.
-        # This makes the version numbers more likely to be consistent when building wheels
-        # with access to less git history.
-        "git_describe_command": "git describe --dirty --tags --long --match *[0-9]* --abbrev=14",
-    },
 )


### PR DESCRIPTION
Add `tool.setuptools_scm` section and simplify.

Release workflow tested here: https://github.com/CQCL/tket/actions/runs/1244904528