### PR TITLE
Build Linux wheels using `manylinux2014_x86_64:2021-08-01-bce1ff9`.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
     - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
     - name: Set up container
       run: |
-        docker create --name linux_build -i -v /:/host quay.io/pypa/manylinux2014_x86_64:latest /bin/bash
+        docker create --name linux_build -i -v /:/host quay.io/pypa/manylinux2014_x86_64:2021-08-01-bce1ff9 /bin/bash
         docker cp . linux_build:/tket/
     - name: Run build
       run: |


### PR DESCRIPTION
This is the last "good" tag. The following commit broke our wheels:
https://github.com/pypa/manylinux/commit/1f0eec43eed0de2b7a8aa783d13b1c15840481c7

Fixes https://github.com/CQCL/pytket/issues/106.

This is not a long-term solution, but allows us to make a working release again.