### PR TITLE
Install `setuptools_scm` before building wheels.

### DIFF
--- a/.github/workflows/build_macos_m1_wheel
+++ b/.github/workflows/build_macos_m1_wheel
@@ -19,5 +19,6 @@ set -evu
 pip install conan delocate wheel
 cd $GITHUB_WORKSPACE/pytket
 export PYVER=`python -c 'import sys; print(".".join(map(str, sys.version_info[:3])))'`
+python -m pip install -U pip setuptools_scm
 python setup.py bdist_wheel -d "$GITHUB_WORKSPACE/tmp/tmpwheel_${PYVER}"
 delocate-wheel -v -w "$GITHUB_WORKSPACE/wheelhouse/${PYVER}/" "$GITHUB_WORKSPACE/tmp/tmpwheel_${PYVER}/pytket-"*".whl"

--- a/.github/workflows/build_macos_wheel
+++ b/.github/workflows/build_macos_wheel
@@ -19,5 +19,6 @@ set -evu
 pip install conan delocate wheel
 cd $GITHUB_WORKSPACE/pytket
 export PYVER=`python -c 'import sys; print(".".join(map(str, sys.version_info[:3])))'`
+python -m pip install -U pip setuptools_scm
 python setup.py bdist_wheel -d "$GITHUB_WORKSPACE/tmp/tmpwheel_${PYVER}" --plat-name=macosx_10_14_x86_64
 delocate-wheel -v -w "$GITHUB_WORKSPACE/wheelhouse/${PYVER}/" "$GITHUB_WORKSPACE/tmp/tmpwheel_${PYVER}/pytket-"*".whl"

--- a/.github/workflows/linuxbuildwheel
+++ b/.github/workflows/linuxbuildwheel
@@ -38,6 +38,7 @@ do
     cd /tket/pytket
     export PYEX=/opt/python/${pyX}/bin/python
     export PYVER=`${PYEX} -c 'import sys; print(".".join(map(str, sys.version_info[:3])))'`
+    ${PYEX} -m pip install -U pip setuptools_scm
     ${PYEX} setup.py bdist_wheel -d "tmpwheel_${PYVER}"
     auditwheel repair "tmpwheel_${PYVER}/pytket-"*".whl" -w "audited/${PYVER}/"
 done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -152,6 +152,7 @@ jobs:
       run: |
         pip install wheel
         cd pytket
+        python -m pip install -U pip setuptools_scm
         python setup.py bdist_wheel -d "${{ github.workspace }}/wheelhouse/3.7"
     - uses: actions/upload-artifact@v2
       with:
@@ -165,6 +166,7 @@ jobs:
       run: |
         pip install wheel
         cd pytket
+        python -m pip install -U pip setuptools_scm
         python setup.py bdist_wheel -d "${{ github.workspace }}/wheelhouse/3.8"
     - uses: actions/upload-artifact@v2
       with:
@@ -178,6 +180,7 @@ jobs:
       run: |
         pip install wheel
         cd pytket
+        python -m pip install -U pip setuptools_scm
         python setup.py bdist_wheel -d "${{ github.workspace }}/wheelhouse/3.9"
     - uses: actions/upload-artifact@v2
       with:


### PR DESCRIPTION
This is necessary even when we use a `pyproject.toml` file, as explained here: https://github.com/pypa/setuptools_scm/issues/386.