### PR TITLE
Use header-only version of spdlog/fmt.

### DIFF
--- a/bubble/src/Routing/Swap_Analysis.cpp
+++ b/bubble/src/Routing/Swap_Analysis.cpp
@@ -202,7 +202,7 @@ std::vector<Swap> Routing::path_to_swaps(const std::vector<Node> &path) {
 // it.
 bool Routing::solve_furthest() {
   bool success = false;
-  std::optional<Node> max_node = std::nullopt;
+  std::optional<Node> max_node;
   unsigned max_dist = 0;
   for (auto [q1, q2] : interaction) {
     unsigned dist = current_arc_.get_distance(q1, q2);

--- a/recipes/tket/conanfile.py
+++ b/recipes/tket/conanfile.py
@@ -61,6 +61,9 @@ class TketConan(ConanFile):
     def configure(self):
         # Disable features that are still under the LGPL.
         self.options["eigen"].MPL2_only = True
+        # Use header-only version of spdlog/fmt to avoid linker warnings.
+        self.options["fmt"].header_only = True
+        self.options["spdlog"].header_only = True
 
     def build(self):
         # Build with boost patches


### PR DESCRIPTION
Closes #43 .

I am in two minds about merging this. It gets rid of the linker warnings, but may make builds slightly slower.