### PR TITLE
Document steps to install pytket natively on M1 Macs.

### DIFF
--- a/pytket/docs/index.rst
+++ b/pytket/docs/index.rst
@@ -15,6 +15,16 @@ To install, run
 
 ``pip install pytket``
 
+.. note::
+    On M1-based Macs running in native (arm64) mode, this command may fail
+    because of an issue installing ``scipy``. To fix this:
+
+    1. Install `brew <https://brew.sh/>`_ (if you haven't already);
+    2. ``brew install openblas``;
+    3. ``pip install -U pip wheel``;
+    4. ``OPENBLAS="$(brew --prefix openblas)" pip install scipy``;
+    5. ``pip install pytket``.
+
 To use ``pytket``, you can simply import the appropriate modules into your python code or in an interactive Python notebook. We can build circuits directly using the ``pytket`` interface by creating a blank circuit and adding gates in the order we want to apply them.
 
 ::


### PR DESCRIPTION
Closes #41 .