### PR TITLE
Fix digraph name in dependency script.

### DIFF
--- a/tket/tket_deps
+++ b/tket/tket_deps
@@ -57,7 +57,7 @@ def generate_graph():
                                         if comp1 + "/" in fline:
                                             deps[comp].add(comp1)
     with open("depgraph.dot", "w") as f:
-        f.write("digraph C++ tket {\n")
+        f.write("digraph tket {\n")
         for comp, depcomps in deps.items():
             for depcomp in depcomps:
                 f.write("    %s -> %s;\n" % (comp, depcomp))


### PR DESCRIPTION
Otherwise fails with `Error: depgraph.dot: syntax error in line 1 near '+'`.