### PR TITLE
[bugfix] Removed `is_simple` condition in `remove_blank_wires`

### DIFF
--- a/tket/src/Circuit/basic_circ_manip.cpp
+++ b/tket/src/Circuit/basic_circ_manip.cpp
@@ -32,7 +32,6 @@ namespace tket {
 // this method removes them and removes the vertices
 // from boundaries
 void Circuit::remove_blank_wires() {
-  if (!is_simple()) throw SimpleOnly();
   VertexList bin;
   unit_vector_t unused_units;
   const Op_ptr noop = get_op_ptr(OpType::noop);


### PR DESCRIPTION
I've looked through the relevant code, ran tests and double checked everything. Still don't see a reason to have this check here. So I'm removing it as you suggested @sjdilkes