### PR TITLE
Add license metadata.

### DIFF
--- a/pytket/setup.py
+++ b/pytket/setup.py
@@ -205,6 +205,7 @@ setup(
     python_requires=">=3.7",
     url="https://cqcl.github.io/pytket",
     description="Python module for interfacing with the CQC tket library of quantum software",
+    license="Apache 2",
     packages=setuptools.find_packages(),
     install_requires=[
         "sympy ~=1.6",


### PR DESCRIPTION
Otherwise `pip show pytket` displays "License: UNKNOWN".