### PR TITLE
Fix docs formatting for `AASRouting`.

### DIFF
--- a/pytket/binders/passes.cpp
+++ b/pytket/binders/passes.cpp
@@ -557,16 +557,16 @@ PYBIND11_MODULE(passes, m) {
       ":py:class:`Architecture` is used for the routing. "
       "The direction of the edges is ignored. The placement used "
       "is GraphPlacement. This pass can take a few parameters for the "
-      "routing, described below.\nNB: The circuit needs to have at most as "
+      "routing, described below:"
+      "\n\n- (unsigned) lookahead=1: parameter for the recursive iteration"
+      "\n- (CNotSynthType) cnotsynthtype=CNotSynthType.Rec: CNOT synthesis type"
+      "\n\nNB: The circuit needs to have at most as "
       "many qubits as the architecture has nodes. The resulting circuit will "
       "always have the same number of qubits as the architecture has nodes, "
-      "even if the input circuit had fewer.\n:param arc: The "
-      "architecture used for connectivity information."
-      "\n:param \\**kwargs: Parameters for routing:\n(unsigned) "
-      "lookahead=1: parameter for the recursive iteration\n"
-      "(CNotSynthType) cnotsynthtype=CNotSynthType.Rec: "
-      "type of the CNOT synthesis\n:return: a pass to perform the "
-      "remapping\n",
+      "even if the input circuit had fewer."
+      "\n\n:param arc: target architecture"
+      "\n:param \\**kwargs: parameters for routing (described above)"
+      "\n:return: a pass to perform the remapping",
       py::arg("arc"));
 
   m.def(


### PR DESCRIPTION
Before:
![Screenshot from 2021-11-16 15-57-29](https://user-images.githubusercontent.com/54802828/142020204-945cd845-063a-4ad9-9b9b-667699261ccd.png)
After:
![Screenshot from 2021-11-16 15-56-21](https://user-images.githubusercontent.com/54802828/142020275-a5428885-64d5-435e-9e00-aba4c5e47d05.png)

