### PR TITLE
Don't publish docs for prereleases.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -418,7 +418,7 @@ jobs:
     name: Publish docs
     needs: build_docs
     concurrency: gh_pages
-    if: github.event_name == 'release'
+    if: github.event_name == 'release' && github.event.release.prerelease != true
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Closes #114 .

This is difficult to properly test without doing a pre-release, but it seems to be a pattern used in other projects; the YAML [passed](https://github.com/CQCL/tket/actions/runs/1471152587) the syntax check; and I will do a pre-release afterwards to check.