### PR TITLE
Use `#pragma once` throughout.

### DIFF
--- a/pytket/binders/include/UnitRegister.hpp
+++ b/pytket/binders/include/UnitRegister.hpp
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _TKET_UnitRegister_H_
-#define _TKET_UnitRegister_H_
+#pragma once
 
 #include "Utils/UnitID.hpp"
 
@@ -62,4 +61,3 @@ class UnitRegister {
 typedef UnitRegister<Bit> BitRegister;
 typedef UnitRegister<Qubit> QubitRegister;
 }  // namespace tket
-#endif  //_TKET_UnitRegister_H_

--- a/pytket/binders/include/binder_json.hpp
+++ b/pytket/binders/include/binder_json.hpp
@@ -25,4 +25,3 @@
 #if defined(__clang__)
 #pragma GCC diagnostic pop
 #endif
-

--- a/pytket/binders/include/binder_json.hpp
+++ b/pytket/binders/include/binder_json.hpp
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _TKET_BINDER_JSON_H_
-#define _TKET_BINDER_JSON_H_
+#pragma once
 
 #if defined(__clang__)
 #pragma GCC diagnostic push
@@ -27,4 +26,3 @@
 #pragma GCC diagnostic pop
 #endif
 
-#endif

--- a/pytket/binders/include/binder_utils.hpp
+++ b/pytket/binders/include/binder_utils.hpp
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _TKET_BINDER_UTILS_H_
-#define _TKET_BINDER_UTILS_H_
+#pragma once
 
 /** Narrow No-Break Space (U+202F, UTF-8 encoding) */
 #define NNBSP "\xE2\x80\xAF"
@@ -21,4 +20,3 @@
 /** Pluralize a reference to a class object in a docstring */
 #define CLSOBJS(a) ":py:class:`" #a "`" NNBSP "s"
 
-#endif

--- a/pytket/binders/include/binder_utils.hpp
+++ b/pytket/binders/include/binder_utils.hpp
@@ -19,4 +19,3 @@
 
 /** Pluralize a reference to a class object in a docstring */
 #define CLSOBJS(a) ":py:class:`" #a "`" NNBSP "s"
-

--- a/pytket/binders/include/typecast.hpp
+++ b/pytket/binders/include/typecast.hpp
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _TKET__typecast_H_
-#define _TKET__typecast_H_
+#pragma once
 
 #include <pybind11/detail/typeid.h>
 #include <pybind11/functional.h>
@@ -328,4 +327,3 @@ struct type_caster<SymEngine::RCP<const SymEngine::Symbol>> {
 }  // namespace detail
 }  // namespace pybind11
 
-#endif

--- a/pytket/binders/include/typecast.hpp
+++ b/pytket/binders/include/typecast.hpp
@@ -326,4 +326,3 @@ struct type_caster<SymEngine::RCP<const SymEngine::Symbol>> {
 };
 }  // namespace detail
 }  // namespace pybind11
-

--- a/pytket/binders/include/unit_downcast.hpp
+++ b/pytket/binders/include/unit_downcast.hpp
@@ -38,4 +38,3 @@ struct polymorphic_type_hook<tket::UnitID> {
   }
 };
 }  // namespace pybind11
-

--- a/pytket/binders/include/unit_downcast.hpp
+++ b/pytket/binders/include/unit_downcast.hpp
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _TKET__unit_downcast_H_
-#define _TKET__unit_downcast_H_
+#pragma once
 #include <pybind11/pybind11.h>
 
 #include "Utils/UnitID.hpp"
@@ -40,4 +39,3 @@ struct polymorphic_type_hook<tket::UnitID> {
 };
 }  // namespace pybind11
 
-#endif  //_TKET__unit_downcast_H_

--- a/tket/proptests/ComparisonFunctions.hpp
+++ b/tket/proptests/ComparisonFunctions.hpp
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _TKET_PROPTESTS_ComparisonFunctions_H_
-#define _TKET_PROPTESTS_ComparisonFunctions_H_
+#pragma once
 
 #include "Utils/MatrixAnalysis.hpp"
 
@@ -48,4 +47,3 @@ bool compare_statevectors_or_unitaries(
 }  // namespace tket_sim
 }  // namespace tket
 
-#endif

--- a/tket/proptests/ComparisonFunctions.hpp
+++ b/tket/proptests/ComparisonFunctions.hpp
@@ -46,4 +46,3 @@ bool compare_statevectors_or_unitaries(
 
 }  // namespace tket_sim
 }  // namespace tket
-

--- a/tket/src/ArchAwareSynth/Path.hpp
+++ b/tket/src/ArchAwareSynth/Path.hpp
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _TKET_Path_H_
-#define _TKET_Path_H_
+#pragma once
 #include "Architecture/Architecture.hpp"
 #include "Routing/Placement.hpp"
 #include "Utils/MatrixAnalysis.hpp"
@@ -142,4 +141,3 @@ std::ostream &operator<<(std::ostream &out, const PathHandler &path);
 
 }  // namespace aas
 }  // namespace tket
-#endif  //_TKET_Path_H_

--- a/tket/src/ArchAwareSynth/SteinerForest.hpp
+++ b/tket/src/ArchAwareSynth/SteinerForest.hpp
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _TKET_SteinerForest_H_
-#define _TKET_SteinerForest_H_
+#pragma once
 #include "Circuit/Circuit.hpp"
 #include "Converters/PhasePoly.hpp"
 #include "Graphs/UIDConnectivity.hpp"
@@ -173,4 +172,3 @@ Circuit phase_poly_synthesis(
 
 }  // namespace aas
 }  // namespace tket
-#endif  //_TKET_SteinerForest_H_

--- a/tket/src/ArchAwareSynth/SteinerTree.hpp
+++ b/tket/src/ArchAwareSynth/SteinerTree.hpp
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _TKET_SteinerTree_H_
-#define _TKET_SteinerTree_H_
+#pragma once
 #include "Converters/Gauss.hpp"
 #include "Path.hpp"
 #include "Utils/Exceptions.hpp"
@@ -227,4 +226,3 @@ Circuit aas_CNOT_synth_SWAP(DiagMatrix &CNOT_matrix, const PathHandler &paths);
 
 }  // namespace aas
 }  // namespace tket
-#endif  //_TKET_SteinerTree_H_

--- a/tket/src/Architecture/Architecture.hpp
+++ b/tket/src/Architecture/Architecture.hpp
@@ -168,4 +168,3 @@ int tri_lexicographical_comparison(
     const dist_vec &dist1, const dist_vec &dist2);
 
 }  // namespace tket
-

--- a/tket/src/Architecture/Architecture.hpp
+++ b/tket/src/Architecture/Architecture.hpp
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _TKET_Architecture_H_
-#define _TKET_Architecture_H_
+#pragma once
 
 #include <iostream>
 #include <numeric>
@@ -170,4 +169,3 @@ int tri_lexicographical_comparison(
 
 }  // namespace tket
 
-#endif

--- a/tket/src/Characterisation/Cycles.hpp
+++ b/tket/src/Characterisation/Cycles.hpp
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _TKET_Cycles_H_
-#define _TKET_Cycles_H_
+#pragma once
 
 #include "Circuit/Circuit.hpp"
 
@@ -145,4 +144,3 @@ class CycleFinder {
   void order_keys(unsigned& new_key, std::set<unsigned>& old_keys) const;
 };
 }  // namespace tket
-#endif

--- a/tket/src/Characterisation/DeviceCharacterisation.hpp
+++ b/tket/src/Characterisation/DeviceCharacterisation.hpp
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _TKET_DeviceCharacterisation_H_
-#define _TKET_DeviceCharacterisation_H_
+#pragma once
 
 #include <map>
 #include <nlohmann/json.hpp>
@@ -101,4 +100,3 @@ class DeviceCharacterisation {
 JSON_DECL(DeviceCharacterisation)
 
 }  // namespace tket
-#endif

--- a/tket/src/Characterisation/FrameRandomisation.hpp
+++ b/tket/src/Characterisation/FrameRandomisation.hpp
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _TKET_FrameRandomisation_H_
-#define _TKET_FrameRandomisation_H_
+#pragma once
 
 #include "Characterisation/Cycles.hpp"
 #include "Circuit/Circuit.hpp"
@@ -162,4 +161,3 @@ class FrameRandomisationTester {
 };
 
 }  // namespace tket
-#endif

--- a/tket/src/Circuit/AssertionSynthesis.hpp
+++ b/tket/src/Circuit/AssertionSynthesis.hpp
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _TKET_AssertionSynthesis_H_
-#define _TKET_AssertionSynthesis_H_
+#pragma once
 
 #include "Circuit.hpp"
 #include "Utils/EigenConfig.hpp"
@@ -46,4 +45,3 @@ std::tuple<Circuit, std::vector<bool>> stabiliser_assertion_synthesis(
     const PauliStabiliserList &paulis);
 }  // namespace tket
 
-#endif

--- a/tket/src/Circuit/AssertionSynthesis.hpp
+++ b/tket/src/Circuit/AssertionSynthesis.hpp
@@ -44,4 +44,3 @@ std::tuple<Circuit, std::vector<bool>> projector_assertion_synthesis(
 std::tuple<Circuit, std::vector<bool>> stabiliser_assertion_synthesis(
     const PauliStabiliserList &paulis);
 }  // namespace tket
-

--- a/tket/src/Circuit/Boxes.hpp
+++ b/tket/src/Circuit/Boxes.hpp
@@ -703,4 +703,3 @@ class StabiliserAssertionBox : public Box {
 };
 
 }  // namespace tket
-

--- a/tket/src/Circuit/Boxes.hpp
+++ b/tket/src/Circuit/Boxes.hpp
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _TKET_Boxes_H_
-#define _TKET_Boxes_H_
+#pragma once
 
 #include <boost/uuid/uuid.hpp>
 #include <boost/uuid/uuid_generators.hpp>
@@ -705,4 +704,3 @@ class StabiliserAssertionBox : public Box {
 
 }  // namespace tket
 
-#endif  // BOXES_H_

--- a/tket/src/Circuit/CircPool.hpp
+++ b/tket/src/Circuit/CircPool.hpp
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _TKET_CircPool_H_
-#define _TKET_CircPool_H_
+#pragma once
 
 #include "Circuit.hpp"
 #include "Utils/Expression.hpp"
@@ -224,4 +223,3 @@ Circuit NPhasedX_using_CX(unsigned int number_of_qubits, Expr alpha, Expr beta);
 
 }  // namespace tket
 
-#endif  // _TKET_CircPool_H_

--- a/tket/src/Circuit/CircPool.hpp
+++ b/tket/src/Circuit/CircPool.hpp
@@ -222,4 +222,3 @@ Circuit NPhasedX_using_CX(unsigned int number_of_qubits, Expr alpha, Expr beta);
 }  // namespace CircPool
 
 }  // namespace tket
-

--- a/tket/src/Circuit/CircUtils.hpp
+++ b/tket/src/Circuit/CircUtils.hpp
@@ -152,4 +152,3 @@ Circuit pauli_gadget(
 Circuit with_controls(const Circuit& c, unsigned n_controls = 1);
 
 }  // namespace tket
-

--- a/tket/src/Circuit/CircUtils.hpp
+++ b/tket/src/Circuit/CircUtils.hpp
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _TKET_CircUtils_H_
-#define _TKET_CircUtils_H_
+#pragma once
 
 #include "Circuit.hpp"
 #include "DAGDefs.hpp"
@@ -154,4 +153,3 @@ Circuit with_controls(const Circuit& c, unsigned n_controls = 1);
 
 }  // namespace tket
 
-#endif

--- a/tket/src/Circuit/Circuit.hpp
+++ b/tket/src/Circuit/Circuit.hpp
@@ -1674,4 +1674,3 @@ Vertex Circuit::add_op(
 }
 
 }  // namespace tket
-

--- a/tket/src/Circuit/Circuit.hpp
+++ b/tket/src/Circuit/Circuit.hpp
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _TKET_Circuit_H_
-#define _TKET_Circuit_H_
+#pragma once
 
 // NOTE: FOR ALL COMMENTS ON SCALING 'alpha' IS THE MAXIMUM ARITY OF VERTICES IN
 // THE GRAPH CIRCUITS ARE TYPICALLY SPARSE UNLESS THEY CONTAIN LARGE PHASE
@@ -1676,4 +1675,3 @@ Vertex Circuit::add_op(
 
 }  // namespace tket
 
-#endif  // CIRCUIT_H_

--- a/tket/src/Circuit/ClassicalExpBox.hpp
+++ b/tket/src/Circuit/ClassicalExpBox.hpp
@@ -130,4 +130,3 @@ class ClassicalExpBox : public Box {
 };
 
 }  // namespace tket
-

--- a/tket/src/Circuit/ClassicalExpBox.hpp
+++ b/tket/src/Circuit/ClassicalExpBox.hpp
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _TKET_ClassicalExpBox_H_
-#define _TKET_ClassicalExpBox_H_
+#pragma once
 
 /**
  * @file
@@ -132,4 +131,3 @@ class ClassicalExpBox : public Box {
 
 }  // namespace tket
 
-#endif

--- a/tket/src/Circuit/Command.hpp
+++ b/tket/src/Circuit/Command.hpp
@@ -93,4 +93,3 @@ class Command {
 JSON_DECL(Command)
 
 }  // namespace tket
-

--- a/tket/src/Circuit/Command.hpp
+++ b/tket/src/Circuit/Command.hpp
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _TKET_Command_H_
-#define _TKET_Command_H_
+#pragma once
 
 #include <optional>
 #include <sstream>
@@ -95,4 +94,3 @@ JSON_DECL(Command)
 
 }  // namespace tket
 
-#endif  // _TKET_Command_H_

--- a/tket/src/Circuit/DAGDefs.hpp
+++ b/tket/src/Circuit/DAGDefs.hpp
@@ -92,4 +92,3 @@ typedef std::list<Edge> EdgeList;
 typedef std::pair<Vertex, port_t> VertPort;
 
 }  // namespace tket
-

--- a/tket/src/Circuit/DAGDefs.hpp
+++ b/tket/src/Circuit/DAGDefs.hpp
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _TKET_Circuit_DAGDefs_H_
-#define _TKET_Circuit_DAGDefs_H_
+#pragma once
 
 #include <list>
 #include <optional>
@@ -94,4 +93,3 @@ typedef std::pair<Vertex, port_t> VertPort;
 
 }  // namespace tket
 
-#endif

--- a/tket/src/Circuit/DAGProperties.hpp
+++ b/tket/src/Circuit/DAGProperties.hpp
@@ -60,4 +60,3 @@ namespace tket {
 bool is_valid(const DAG &G);
 
 }  // namespace tket
-

--- a/tket/src/Circuit/DAGProperties.hpp
+++ b/tket/src/Circuit/DAGProperties.hpp
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _TKET_DAGProperties_H_
-#define _TKET_DAGProperties_H_
+#pragma once
 
 #include "DAGDefs.hpp"
 
@@ -62,4 +61,3 @@ bool is_valid(const DAG &G);
 
 }  // namespace tket
 
-#endif

--- a/tket/src/Circuit/ThreeQubitConversion.hpp
+++ b/tket/src/Circuit/ThreeQubitConversion.hpp
@@ -44,4 +44,3 @@ Circuit three_qubit_synthesis(const Eigen::MatrixXcd &U);
 Eigen::MatrixXcd get_3q_unitary(const Circuit &c);
 
 }  // namespace tket
-

--- a/tket/src/Circuit/ThreeQubitConversion.hpp
+++ b/tket/src/Circuit/ThreeQubitConversion.hpp
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _TKET_ThreeQubitConversion_H_
-#define _TKET_ThreeQubitConversion_H_
+#pragma once
 
 #include "Circuit.hpp"
 #include "Utils/EigenConfig.hpp"
@@ -46,4 +45,3 @@ Eigen::MatrixXcd get_3q_unitary(const Circuit &c);
 
 }  // namespace tket
 
-#endif

--- a/tket/src/Clifford/CliffTableau.hpp
+++ b/tket/src/Clifford/CliffTableau.hpp
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _TKET_CliffTableau_H_
-#define _TKET_CliffTableau_H_
+#pragma once
 
 #include "OpType/OpType.hpp"
 #include "Utils/BiMapHeaders.hpp"
@@ -208,4 +207,3 @@ std::ostream &operator<<(std::ostream &os, CliffTableau const &tab);
 
 }  // namespace tket
 
-#endif  // CLIFFTABLEAU_H_

--- a/tket/src/Clifford/CliffTableau.hpp
+++ b/tket/src/Clifford/CliffTableau.hpp
@@ -206,4 +206,3 @@ class CliffTableau {
 std::ostream &operator<<(std::ostream &os, CliffTableau const &tab);
 
 }  // namespace tket
-

--- a/tket/src/Converters/Converters.hpp
+++ b/tket/src/Converters/Converters.hpp
@@ -63,4 +63,3 @@ Circuit pauli_graph_to_circuit_sets(
     const PauliGraph &pg, CXConfigType cx_config = CXConfigType::Snake);
 
 }  // namespace tket
-

--- a/tket/src/Converters/Converters.hpp
+++ b/tket/src/Converters/Converters.hpp
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _TKET_Converters_H_
-#define _TKET_Converters_H_
+#pragma once
 
 #include "Circuit/Circuit.hpp"
 #include "Clifford/CliffTableau.hpp"
@@ -65,4 +64,3 @@ Circuit pauli_graph_to_circuit_sets(
 
 }  // namespace tket
 
-#endif

--- a/tket/src/Converters/Gauss.hpp
+++ b/tket/src/Converters/Gauss.hpp
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _TKET_Gauss_H_
-#define _TKET_Gauss_H_
+#pragma once
 #include "Circuit/Circuit.hpp"
 #include "Converters.hpp"
 
@@ -47,4 +46,3 @@ class DiagMatrix {
 
 }  // namespace tket
 
-#endif  //_TKET_Gauss_H_

--- a/tket/src/Converters/Gauss.hpp
+++ b/tket/src/Converters/Gauss.hpp
@@ -45,4 +45,3 @@ class DiagMatrix {
 };
 
 }  // namespace tket
-

--- a/tket/src/Converters/PauliGadget.hpp
+++ b/tket/src/Converters/PauliGadget.hpp
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _TKET_PauliGadget_H_
-#define _TKET_PauliGadget_H_
+#pragma once
 
 #include "Circuit/Circuit.hpp"
 #include "Utils/PauliStrings.hpp"
@@ -55,4 +54,3 @@ void append_pauli_gadget_pair(
 
 }  // namespace tket
 
-#endif  // _PAULI_GADGET_H_

--- a/tket/src/Converters/PauliGadget.hpp
+++ b/tket/src/Converters/PauliGadget.hpp
@@ -53,4 +53,3 @@ void append_pauli_gadget_pair(
     CXConfigType cx_config = CXConfigType::Snake);
 
 }  // namespace tket
-

--- a/tket/src/Converters/PhasePoly.hpp
+++ b/tket/src/Converters/PhasePoly.hpp
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _TKET_PhasePoly_H_
-#define _TKET_PhasePoly_H_
+#pragma once
 #include "Circuit/Boxes.hpp"
 #include "Circuit/CircUtils.hpp"
 #include "Circuit/Circuit.hpp"
@@ -137,4 +136,3 @@ class CircToPhasePolyConversion {
 };
 
 }  // namespace tket
-#endif  // PhasePoly_H_

--- a/tket/src/Diagonalisation/DiagUtils.hpp
+++ b/tket/src/Diagonalisation/DiagUtils.hpp
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _TKET_DiagUtils_H_
-#define _TKET_DiagUtils_H_
+#pragma once
 
 #include "PauliGraph/PauliGraph.hpp"
 
@@ -40,4 +39,3 @@ void insert_into_gadget_map(
 
 }  // namespace tket
 
-#endif  // _TKET_DiagUtils_H_

--- a/tket/src/Diagonalisation/DiagUtils.hpp
+++ b/tket/src/Diagonalisation/DiagUtils.hpp
@@ -38,4 +38,3 @@ void insert_into_gadget_map(
     QubitOperator &gadget_map, const std::pair<QubitPauliTensor, Expr> &pgp);
 
 }  // namespace tket
-

--- a/tket/src/Diagonalisation/Diagonalisation.hpp
+++ b/tket/src/Diagonalisation/Diagonalisation.hpp
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _TKET_Diagonalisation_H_
-#define _TKET_Diagonalisation_H_
+#pragma once
 
 #include "Circuit/Boxes.hpp"
 #include "Circuit/Circuit.hpp"
@@ -73,4 +72,3 @@ bool conjugate_with_xxphase3(
 
 }  // namespace tket
 
-#endif  // _TKET_Diagonalisation_H_

--- a/tket/src/Diagonalisation/Diagonalisation.hpp
+++ b/tket/src/Diagonalisation/Diagonalisation.hpp
@@ -71,4 +71,3 @@ bool conjugate_with_xxphase3(
     Circuit &cliff_circ);
 
 }  // namespace tket
-

--- a/tket/src/Diagonalisation/PauliPartition.hpp
+++ b/tket/src/Diagonalisation/PauliPartition.hpp
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _TKET_PauliPartition_H_
-#define _TKET_PauliPartition_H_
+#pragma once
 
 #include "DiagUtils.hpp"
 
@@ -106,4 +105,3 @@ std::list<std::list<QubitPauliString>> term_sequence(
 
 }  // namespace tket
 
-#endif  // _TKET_PauliPartition_H_

--- a/tket/src/Diagonalisation/PauliPartition.hpp
+++ b/tket/src/Diagonalisation/PauliPartition.hpp
@@ -104,4 +104,3 @@ std::list<std::list<QubitPauliString>> term_sequence(
     GraphColourMethod method = GraphColourMethod::Lazy);
 
 }  // namespace tket
-

--- a/tket/src/Gate/Gate.hpp
+++ b/tket/src/Gate/Gate.hpp
@@ -82,4 +82,3 @@ class Gate : public Op {
 };
 
 }  // namespace tket
-

--- a/tket/src/Gate/Gate.hpp
+++ b/tket/src/Gate/Gate.hpp
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _TKET_Ops_Gate_H_
-#define _TKET_Ops_Gate_H_
+#pragma once
 
 #include "Ops/Op.hpp"
 #include "Utils/Json.hpp"
@@ -84,4 +83,3 @@ class Gate : public Op {
 
 }  // namespace tket
 
-#endif

--- a/tket/src/Gate/GatePtr.hpp
+++ b/tket/src/Gate/GatePtr.hpp
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _TKET_Gate_GatePtr_H_
-#define _TKET_Gate_GatePtr_H_
+#pragma once
 
 #include <memory>
 
@@ -33,4 +32,3 @@ Gate_ptr as_gate_ptr(Op_ptr op);
 
 }  // namespace tket
 
-#endif

--- a/tket/src/Gate/GatePtr.hpp
+++ b/tket/src/Gate/GatePtr.hpp
@@ -31,4 +31,3 @@ typedef std::shared_ptr<const Gate> Gate_ptr;
 Gate_ptr as_gate_ptr(Op_ptr op);
 
 }  // namespace tket
-

--- a/tket/src/Gate/GateUnitaryMatrix.hpp
+++ b/tket/src/Gate/GateUnitaryMatrix.hpp
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _CQC_TKET_SIMULATION_GateUnitaryMatrix_HPP_
-#define _CQC_TKET_SIMULATION_GateUnitaryMatrix_HPP_
+#pragma once
 
 #include "OpType/OpType.hpp"
 #include "Utils/MatrixAnalysis.hpp"
@@ -54,4 +53,3 @@ struct GateUnitaryMatrix {
 };
 
 }  // namespace tket
-#endif

--- a/tket/src/Gate/GateUnitaryMatrixError.hpp
+++ b/tket/src/Gate/GateUnitaryMatrixError.hpp
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _CQC_TKET_SIMULATION_GateUnitaryMatrixError_HPP_
-#define _CQC_TKET_SIMULATION_GateUnitaryMatrixError_HPP_
+#pragma once
 
 #include <stdexcept>
 #include <string>
@@ -42,4 +41,3 @@ struct GateUnitaryMatrixError : public std::runtime_error {
 };
 
 }  // namespace tket
-#endif

--- a/tket/src/Gate/GateUnitaryMatrixImplementations.hpp
+++ b/tket/src/Gate/GateUnitaryMatrixImplementations.hpp
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _CQC_TKET_SIMULATION_GateUnitaryMatrixImplementations_HPP_
-#define _CQC_TKET_SIMULATION_GateUnitaryMatrixImplementations_HPP_
+#pragma once
 
 #include "Utils/MatrixAnalysis.hpp"
 
@@ -140,4 +139,3 @@ struct GateUnitaryMatrixImplementations {
 
 }  // namespace internal
 }  // namespace tket
-#endif

--- a/tket/src/Gate/GateUnitaryMatrixUtils.hpp
+++ b/tket/src/Gate/GateUnitaryMatrixUtils.hpp
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _CQC_TKET_SIMULATION_GateUnitaryMatrixUtils_HPP_
-#define _CQC_TKET_SIMULATION_GateUnitaryMatrixUtils_HPP_
+#pragma once
 
 #include <string>
 
@@ -67,4 +66,3 @@ struct GateUnitaryMatrixUtils {
 
 }  // namespace internal
 }  // namespace tket
-#endif

--- a/tket/src/Gate/GateUnitaryMatrixVariableQubits.hpp
+++ b/tket/src/Gate/GateUnitaryMatrixVariableQubits.hpp
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _CQC_TKET_SIMULATION_GateUnitaryMatrixVariableQubits_HPP_
-#define _CQC_TKET_SIMULATION_GateUnitaryMatrixVariableQubits_HPP_
+#pragma once
 
 #include "OpType/OpType.hpp"
 #include "Utils/MatrixAnalysis.hpp"
@@ -48,4 +47,3 @@ class GateUnitaryMatrixVariableQubits {
 
 }  // namespace internal
 }  // namespace tket
-#endif

--- a/tket/src/Gate/GateUnitarySparseMatrix.hpp
+++ b/tket/src/Gate/GateUnitarySparseMatrix.hpp
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _CQC_TKET_SIMULATION_GateUnitarySparseMatrix_HPP_
-#define _CQC_TKET_SIMULATION_GateUnitarySparseMatrix_HPP_
+#pragma once
 
 #include "Utils/MatrixAnalysis.hpp"
 
@@ -45,4 +44,3 @@ struct GateUnitarySparseMatrix {
 
 }  // namespace internal
 }  // namespace tket
-#endif

--- a/tket/src/Gate/OpPtrFunctions.hpp
+++ b/tket/src/Gate/OpPtrFunctions.hpp
@@ -43,4 +43,3 @@ Op_ptr get_op_ptr(
     unsigned n_qubits = 0);
 
 }  // namespace tket
-

--- a/tket/src/Gate/OpPtrFunctions.hpp
+++ b/tket/src/Gate/OpPtrFunctions.hpp
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _TKET_Ops_OpPtrFunctions_H_
-#define _TKET_Ops_OpPtrFunctions_H_
+#pragma once
 
 #include "OpType/OpType.hpp"
 #include "Ops/OpPtr.hpp"
@@ -45,4 +44,3 @@ Op_ptr get_op_ptr(
 
 }  // namespace tket
 
-#endif

--- a/tket/src/Gate/Rotation.hpp
+++ b/tket/src/Gate/Rotation.hpp
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _TKET_Rotation_H_
-#define _TKET_Rotation_H_
+#pragma once
 
 #include "OpType/OpType.hpp"
 #include "Utils/Expression.hpp"
@@ -113,4 +112,3 @@ Eigen::Matrix2cd get_matrix_from_tk1_angles(std::vector<Expr> params);
 
 }  // namespace tket
 
-#endif

--- a/tket/src/Gate/Rotation.hpp
+++ b/tket/src/Gate/Rotation.hpp
@@ -111,4 +111,3 @@ std::vector<double> tk1_angles_from_unitary(const Eigen::Matrix2cd& U);
 Eigen::Matrix2cd get_matrix_from_tk1_angles(std::vector<Expr> params);
 
 }  // namespace tket
-

--- a/tket/src/Gate/SymTable.hpp
+++ b/tket/src/Gate/SymTable.hpp
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _TKET_Ops_SymTable_H_
-#define _TKET_Ops_SymTable_H_
+#pragma once
 
 #include "Utils/Expression.hpp"
 
@@ -47,4 +46,3 @@ struct SymTable {
 
 }  // namespace tket
 
-#endif

--- a/tket/src/Gate/SymTable.hpp
+++ b/tket/src/Gate/SymTable.hpp
@@ -45,4 +45,3 @@ struct SymTable {
 };
 
 }  // namespace tket
-

--- a/tket/src/Graphs/AdjacencyData.hpp
+++ b/tket/src/Graphs/AdjacencyData.hpp
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _TKET_GRAPHS_AdjacencyData_H_
-#define _TKET_GRAPHS_AdjacencyData_H_
+#pragma once
 
 #include <map>
 #include <memory>
@@ -133,4 +132,3 @@ class AdjacencyData {
 
 }  // namespace graphs
 }  // namespace tket
-#endif

--- a/tket/src/Graphs/ArticulationPoints.hpp
+++ b/tket/src/Graphs/ArticulationPoints.hpp
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _TKET_ArticulationPoints_H
-#define _TKET_ArticulationPoints_H
+#pragma once
 
 #include <boost/graph/biconnected_components.hpp>
 #include <set>
@@ -90,4 +89,3 @@ extern template std::set<Node> get_subgraph_aps(
 
 }  // namespace tket::graphs
 
-#endif

--- a/tket/src/Graphs/ArticulationPoints.hpp
+++ b/tket/src/Graphs/ArticulationPoints.hpp
@@ -88,4 +88,3 @@ extern template std::set<Node> get_subgraph_aps(
     const UndirectedConnGraph<Node>& subgraph);
 
 }  // namespace tket::graphs
-

--- a/tket/src/Graphs/ArticulationPoints_impl.hpp
+++ b/tket/src/Graphs/ArticulationPoints_impl.hpp
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _TKET_ArticulationPoints_impl_H
-#define _TKET_ArticulationPoints_impl_H
+#pragma once
 
 #include <boost/graph/adjacency_list.hpp>
 #include <boost/pending/property.hpp>
@@ -140,4 +139,3 @@ class BicomponentGraphTester {
 
 }  // namespace tket::graphs
 
-#endif

--- a/tket/src/Graphs/ArticulationPoints_impl.hpp
+++ b/tket/src/Graphs/ArticulationPoints_impl.hpp
@@ -138,4 +138,3 @@ class BicomponentGraphTester {
 }  // namespace detail
 
 }  // namespace tket::graphs
-

--- a/tket/src/Graphs/BruteForceColouring.hpp
+++ b/tket/src/Graphs/BruteForceColouring.hpp
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _TKET_GRAPHS_BruteForceColouring_H_
-#define _TKET_GRAPHS_BruteForceColouring_H_
+#pragma once
 
 #include <cstddef>
 #include <map>
@@ -62,4 +61,3 @@ class BruteForceColouring {
 
 }  // namespace graphs
 }  // namespace tket
-#endif

--- a/tket/src/Graphs/ColouringPriority.hpp
+++ b/tket/src/Graphs/ColouringPriority.hpp
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _TKET_GRAPHS_ColouringPriority_H_
-#define _TKET_GRAPHS_ColouringPriority_H_
+#pragma once
 
 #include <cstddef>
 #include <set>
@@ -123,4 +122,3 @@ class ColouringPriority {
 
 }  // namespace graphs
 }  // namespace tket
-#endif

--- a/tket/src/Graphs/GraphColouring.hpp
+++ b/tket/src/Graphs/GraphColouring.hpp
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _TKET_GRAPHS_GraphColouring_H_
-#define _TKET_GRAPHS_GraphColouring_H_
+#pragma once
 
 #include <cstddef>
 #include <string>
@@ -71,4 +70,3 @@ struct GraphColouringRoutines {
 
 }  // namespace graphs
 }  // namespace tket
-#endif

--- a/tket/src/Graphs/GraphRoutines.hpp
+++ b/tket/src/Graphs/GraphRoutines.hpp
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _TKET_GRAPHS_GraphRoutines_H_
-#define _TKET_GRAPHS_GraphRoutines_H_
+#pragma once
 
 #include <cstddef>
 #include <map>
@@ -43,4 +42,3 @@ struct GraphRoutines {
 
 }  // namespace graphs
 }  // namespace tket
-#endif

--- a/tket/src/Graphs/LargeCliquesResult.hpp
+++ b/tket/src/Graphs/LargeCliquesResult.hpp
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _TKET_GRAPHS_LargeCliquesResult_H_
-#define _TKET_GRAPHS_LargeCliquesResult_H_
+#pragma once
 
 #include <cstddef>
 #include <set>
@@ -60,4 +59,3 @@ struct LargeCliquesResult {
 
 }  // namespace graphs
 }  // namespace tket
-#endif

--- a/tket/src/Graphs/TreeSearch.hpp
+++ b/tket/src/Graphs/TreeSearch.hpp
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _TKET_TreeSearch_H
-#define _TKET_TreeSearch_H
+#pragma once
 
 #include <utility>
 #include <vector>
@@ -116,4 +115,3 @@ std::vector<utils::vertex<Graph>> longest_simple_path(
 
 }  // namespace tket::graphs
 
-#endif

--- a/tket/src/Graphs/TreeSearch.hpp
+++ b/tket/src/Graphs/TreeSearch.hpp
@@ -114,4 +114,3 @@ std::vector<utils::vertex<Graph>> longest_simple_path(
 }
 
 }  // namespace tket::graphs
-

--- a/tket/src/Graphs/TreeSearch_impl.hpp
+++ b/tket/src/Graphs/TreeSearch_impl.hpp
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _TKET_TreeSearch_impl_H
-#define _TKET_TreeSearch_impl_H
+#pragma once
 
 #include <boost/graph/breadth_first_search.hpp>
 #include <boost/graph/depth_first_search.hpp>
@@ -284,4 +283,3 @@ class DFS : public detail::TreeSearch<Args...> {
 
 }  // namespace tket::graphs
 
-#endif

--- a/tket/src/Graphs/TreeSearch_impl.hpp
+++ b/tket/src/Graphs/TreeSearch_impl.hpp
@@ -282,4 +282,3 @@ class DFS : public detail::TreeSearch<Args...> {
 };
 
 }  // namespace tket::graphs
-

--- a/tket/src/Graphs/UIDConnectivity.hpp
+++ b/tket/src/Graphs/UIDConnectivity.hpp
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _TKET_UIDConnectivity_H
-#define _TKET_UIDConnectivity_H
+#pragma once
 
 #include <algorithm>
 #include <boost/range/adaptor/transformed.hpp>
@@ -336,4 +335,3 @@ extern template class UIDConnectivity<Qubit>;
 
 }  // namespace tket::graphs
 
-#endif

--- a/tket/src/Graphs/UIDConnectivity.hpp
+++ b/tket/src/Graphs/UIDConnectivity.hpp
@@ -334,4 +334,3 @@ extern template class UIDConnectivity<Node>;
 extern template class UIDConnectivity<Qubit>;
 
 }  // namespace tket::graphs
-

--- a/tket/src/Graphs/Utils.hpp
+++ b/tket/src/Graphs/Utils.hpp
@@ -235,4 +235,3 @@ std::set<vertex<Graph>> min_degree_nodes(const Graph& g) {
 
 }  // namespace utils
 }  // namespace tket::graphs
-

--- a/tket/src/Graphs/Utils.hpp
+++ b/tket/src/Graphs/Utils.hpp
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _TKET_GraphUtils_H_
-#define _TKET_GraphUtils_H_
+#pragma once
 
 #include <algorithm>
 #include <boost/graph/copy.hpp>
@@ -237,4 +236,3 @@ std::set<vertex<Graph>> min_degree_nodes(const Graph& g) {
 }  // namespace utils
 }  // namespace tket::graphs
 
-#endif

--- a/tket/src/Graphs/Utils_impl.hpp
+++ b/tket/src/Graphs/Utils_impl.hpp
@@ -477,4 +477,3 @@ class graph_utils_impl_with_map
 
 }  // namespace detail
 }  // namespace tket::graphs::utils
-

--- a/tket/src/Graphs/Utils_impl.hpp
+++ b/tket/src/Graphs/Utils_impl.hpp
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _TKET_GraphUtils_impl_H_
-#define _TKET_GraphUtils_impl_H_
+#pragma once
 
 #include <algorithm>
 #include <boost/iterator/transform_iterator.hpp>
@@ -479,4 +478,3 @@ class graph_utils_impl_with_map
 }  // namespace detail
 }  // namespace tket::graphs::utils
 
-#endif

--- a/tket/src/MeasurementSetup/MeasurementReduction.hpp
+++ b/tket/src/MeasurementSetup/MeasurementReduction.hpp
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _TKET_MeasurementReduction_H_
-#define _TKET_MeasurementReduction_H_
+#pragma once
 
 #include "Diagonalisation/Diagonalisation.hpp"
 #include "Diagonalisation/PauliPartition.hpp"
@@ -36,4 +35,3 @@ MeasurementSetup measurement_reduction(
 
 }  // namespace tket
 
-#endif  // _TKET_MeasurementReduction_H_

--- a/tket/src/MeasurementSetup/MeasurementReduction.hpp
+++ b/tket/src/MeasurementSetup/MeasurementReduction.hpp
@@ -34,4 +34,3 @@ MeasurementSetup measurement_reduction(
     CXConfigType cx_config = CXConfigType::Snake);
 
 }  // namespace tket
-

--- a/tket/src/MeasurementSetup/MeasurementSetup.hpp
+++ b/tket/src/MeasurementSetup/MeasurementSetup.hpp
@@ -92,4 +92,3 @@ class MeasurementSetup {
 };
 
 }  // namespace tket
-

--- a/tket/src/MeasurementSetup/MeasurementSetup.hpp
+++ b/tket/src/MeasurementSetup/MeasurementSetup.hpp
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _TKET_MeasurementSetup_H_
-#define _TKET_MeasurementSetup_H_
+#pragma once
 
 #include "Circuit/Circuit.hpp"
 #include "Utils/PauliStrings.hpp"
@@ -94,4 +93,3 @@ class MeasurementSetup {
 
 }  // namespace tket
 
-#endif

--- a/tket/src/OpType/EdgeType.hpp
+++ b/tket/src/OpType/EdgeType.hpp
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _TKET_Ops_EdgeType_H_
-#define _TKET_Ops_EdgeType_H_
+#pragma once
 
 #include <vector>
 
@@ -57,4 +56,3 @@ typedef std::vector<EdgeType> op_signature_t;
 
 }  // namespace tket
 
-#endif

--- a/tket/src/OpType/EdgeType.hpp
+++ b/tket/src/OpType/EdgeType.hpp
@@ -55,4 +55,3 @@ NLOHMANN_JSON_SERIALIZE_ENUM(
 typedef std::vector<EdgeType> op_signature_t;
 
 }  // namespace tket
-

--- a/tket/src/OpType/OpDesc.hpp
+++ b/tket/src/OpType/OpDesc.hpp
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _TKET_Ops_OpDesc_H_
-#define _TKET_Ops_OpDesc_H_
+#pragma once
 
 #include <optional>
 #include <string>
@@ -124,4 +123,3 @@ class OpDesc {
 
 }  // namespace tket
 
-#endif

--- a/tket/src/OpType/OpDesc.hpp
+++ b/tket/src/OpType/OpDesc.hpp
@@ -122,4 +122,3 @@ class OpDesc {
 };
 
 }  // namespace tket
-

--- a/tket/src/OpType/OpType.hpp
+++ b/tket/src/OpType/OpType.hpp
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _TKET_OpType_OpType_H_
-#define _TKET_OpType_OpType_H_
+#pragma once
 
 #include "Utils/Json.hpp"
 
@@ -605,4 +604,3 @@ JSON_DECL(OpType)
 
 }  // namespace tket
 
-#endif  // _TKET_OpType_OpType_H_

--- a/tket/src/OpType/OpType.hpp
+++ b/tket/src/OpType/OpType.hpp
@@ -603,4 +603,3 @@ enum class OpType {
 JSON_DECL(OpType)
 
 }  // namespace tket
-

--- a/tket/src/OpType/OpTypeFunctions.hpp
+++ b/tket/src/OpType/OpTypeFunctions.hpp
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _TKET_Ops_OpTypeFunctions_H_
-#define _TKET_Ops_OpTypeFunctions_H_
+#pragma once
 
 #include <unordered_set>
 #include <vector>
@@ -93,4 +92,3 @@ bool find_in_set(const OpType &val, const OpTypeSet &set);
 
 }  // namespace tket
 
-#endif

--- a/tket/src/OpType/OpTypeFunctions.hpp
+++ b/tket/src/OpType/OpTypeFunctions.hpp
@@ -91,4 +91,3 @@ bool is_classical_type(OpType optype);
 bool find_in_set(const OpType &val, const OpTypeSet &set);
 
 }  // namespace tket
-

--- a/tket/src/OpType/OpTypeInfo.hpp
+++ b/tket/src/OpType/OpTypeInfo.hpp
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _TKET_Ops_OpTypeInfo_H_
-#define _TKET_Ops_OpTypeInfo_H_
+#pragma once
 
 #include <map>
 #include <optional>
@@ -51,4 +50,3 @@ const std::map<OpType, OpTypeInfo> &optypeinfo();
 
 }  // namespace tket
 
-#endif

--- a/tket/src/OpType/OpTypeInfo.hpp
+++ b/tket/src/OpType/OpTypeInfo.hpp
@@ -49,4 +49,3 @@ struct OpTypeInfo {
 const std::map<OpType, OpTypeInfo> &optypeinfo();
 
 }  // namespace tket
-

--- a/tket/src/Ops/ClassicalOps.hpp
+++ b/tket/src/Ops/ClassicalOps.hpp
@@ -361,4 +361,3 @@ std::shared_ptr<ExplicitModifierOp> OrWithOp();
 std::shared_ptr<ExplicitModifierOp> XorWithOp();
 
 }  // namespace tket
-

--- a/tket/src/Ops/ClassicalOps.hpp
+++ b/tket/src/Ops/ClassicalOps.hpp
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _TKET_ClassicalOps_H_
-#define _TKET_ClassicalOps_H_
+#pragma once
 
 /**
  * @file
@@ -363,4 +362,3 @@ std::shared_ptr<ExplicitModifierOp> XorWithOp();
 
 }  // namespace tket
 
-#endif  // _TKET_Classical_H_

--- a/tket/src/Ops/Conditional.hpp
+++ b/tket/src/Ops/Conditional.hpp
@@ -80,4 +80,3 @@ class Conditional : public Op {
 };
 
 }  // namespace tket
-

--- a/tket/src/Ops/Conditional.hpp
+++ b/tket/src/Ops/Conditional.hpp
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _TKET_Ops_Conditional_H_
-#define _TKET_Ops_Conditional_H_
+#pragma once
 
 #include "Op.hpp"
 #include "Utils/Json.hpp"
@@ -82,4 +81,3 @@ class Conditional : public Op {
 
 }  // namespace tket
 
-#endif

--- a/tket/src/Ops/FlowOp.hpp
+++ b/tket/src/Ops/FlowOp.hpp
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _TKET_Ops_FlowOp_H_
-#define _TKET_Ops_FlowOp_H_
+#pragma once
 
 #include "Op.hpp"
 
@@ -50,4 +49,3 @@ class FlowOp : public Op {
 
 }  // namespace tket
 
-#endif

--- a/tket/src/Ops/FlowOp.hpp
+++ b/tket/src/Ops/FlowOp.hpp
@@ -48,4 +48,3 @@ class FlowOp : public Op {
 };
 
 }  // namespace tket
-

--- a/tket/src/Ops/MetaOp.hpp
+++ b/tket/src/Ops/MetaOp.hpp
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _TKET_Ops_MetaOp_H_
-#define _TKET_Ops_MetaOp_H_
+#pragma once
 
 #include "Op.hpp"
 #include "Utils/Json.hpp"
@@ -54,4 +53,3 @@ class MetaOp : public Op {
 
 }  // namespace tket
 
-#endif

--- a/tket/src/Ops/MetaOp.hpp
+++ b/tket/src/Ops/MetaOp.hpp
@@ -52,4 +52,3 @@ class MetaOp : public Op {
 };
 
 }  // namespace tket
-

--- a/tket/src/Ops/Op.hpp
+++ b/tket/src/Ops/Op.hpp
@@ -178,4 +178,3 @@ class Op : public std::enable_shared_from_this<Op> {
 std::ostream &operator<<(std::ostream &os, Op const &operation);
 
 }  // namespace tket
-

--- a/tket/src/Ops/Op.hpp
+++ b/tket/src/Ops/Op.hpp
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _TKET_Ops_Op_H_
-#define _TKET_Ops_Op_H_
+#pragma once
 
 /**
  * @file
@@ -180,4 +179,3 @@ std::ostream &operator<<(std::ostream &os, Op const &operation);
 
 }  // namespace tket
 
-#endif  // OPS_H_

--- a/tket/src/Ops/OpJsonFactory.hpp
+++ b/tket/src/Ops/OpJsonFactory.hpp
@@ -53,4 +53,3 @@ class OpJsonFactory {
 };
 
 }  // namespace tket
-

--- a/tket/src/Ops/OpJsonFactory.hpp
+++ b/tket/src/Ops/OpJsonFactory.hpp
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _TKET_Ops_OpJsonFactory_H_
-#define _TKET_Ops_OpJsonFactory_H_
+#pragma once
 
 #include "OpType/OpType.hpp"
 #include "Ops/OpPtr.hpp"
@@ -55,4 +54,3 @@ class OpJsonFactory {
 
 }  // namespace tket
 
-#endif  //_TKET_Ops_OpJsonFactory_H_

--- a/tket/src/Ops/OpPtr.hpp
+++ b/tket/src/Ops/OpPtr.hpp
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _TKET_Ops_OpPtr_H_
-#define _TKET_Ops_OpPtr_H_
+#pragma once
 
 #include <memory>
 
@@ -28,4 +27,3 @@ JSON_DECL(Op_ptr)
 
 }  // namespace tket
 
-#endif

--- a/tket/src/Ops/OpPtr.hpp
+++ b/tket/src/Ops/OpPtr.hpp
@@ -26,4 +26,3 @@ typedef std::shared_ptr<const Op> Op_ptr;
 JSON_DECL(Op_ptr)
 
 }  // namespace tket
-

--- a/tket/src/PauliGraph/ConjugatePauliFunctions.hpp
+++ b/tket/src/PauliGraph/ConjugatePauliFunctions.hpp
@@ -43,4 +43,3 @@ void conjugate_PauliTensor(
     const Qubit &qb2);
 
 }  // namespace tket
-

--- a/tket/src/PauliGraph/ConjugatePauliFunctions.hpp
+++ b/tket/src/PauliGraph/ConjugatePauliFunctions.hpp
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _TKET_PauliGraph_ConjugatePauliFunctions_H_
-#define _TKET_PauliGraph_ConjugatePauliFunctions_H_
+#pragma once
 
 #include "OpType/OpType.hpp"
 #include "Utils/PauliStrings.hpp"
@@ -45,4 +44,3 @@ void conjugate_PauliTensor(
 
 }  // namespace tket
 
-#endif

--- a/tket/src/PauliGraph/PauliGraph.hpp
+++ b/tket/src/PauliGraph/PauliGraph.hpp
@@ -156,4 +156,3 @@ class PauliGraph {
 };
 
 }  // namespace tket
-

--- a/tket/src/PauliGraph/PauliGraph.hpp
+++ b/tket/src/PauliGraph/PauliGraph.hpp
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _TKET_PauliGraph_H_
-#define _TKET_PauliGraph_H_
+#pragma once
 
 #include <fstream>
 
@@ -158,4 +157,3 @@ class PauliGraph {
 
 }  // namespace tket
 
-#endif  // PAULIGRAPH_H_

--- a/tket/src/Predicates/CompilationUnit.hpp
+++ b/tket/src/Predicates/CompilationUnit.hpp
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _TKET_CompilationUnit_H_
-#define _TKET_CompilationUnit_H_
+#pragma once
 
 #include "Predicates.hpp"
 
@@ -72,4 +71,3 @@ class CompilationUnit {
 };
 
 }  // namespace tket
-#endif  // COMPILATIONUNIT_H_

--- a/tket/src/Predicates/CompilerPass.hpp
+++ b/tket/src/Predicates/CompilerPass.hpp
@@ -267,4 +267,3 @@ class RepeatUntilSatisfiedPass : public BasePass {
 // TODO: Repeat with a metric, repeat until a Predicate is satisfied...
 
 }  // namespace tket
-

--- a/tket/src/Predicates/CompilerPass.hpp
+++ b/tket/src/Predicates/CompilerPass.hpp
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _TKET_CompilerPass_H_
-#define _TKET_CompilerPass_H_
+#pragma once
 
 #include "CompilationUnit.hpp"
 #include "Predicates.hpp"
@@ -269,4 +268,3 @@ class RepeatUntilSatisfiedPass : public BasePass {
 
 }  // namespace tket
 
-#endif  // PROGRAMTRANSFORM_H_

--- a/tket/src/Predicates/PassGenerators.hpp
+++ b/tket/src/Predicates/PassGenerators.hpp
@@ -188,4 +188,3 @@ PassPtr gen_contextual_pass(
 PassPtr PauliSquash(PauliSynthStrat strat, CXConfigType cx_config);
 
 }  // namespace tket
-

--- a/tket/src/Predicates/PassGenerators.hpp
+++ b/tket/src/Predicates/PassGenerators.hpp
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _TKET_PassGenerators_H_
-#define _TKET_PassGenerators_H_
+#pragma once
 
 #include "ArchAwareSynth/SteinerForest.hpp"
 #include "CompilerPass.hpp"
@@ -190,4 +189,3 @@ PassPtr PauliSquash(PauliSynthStrat strat, CXConfigType cx_config);
 
 }  // namespace tket
 
-#endif  // PASSGENERATORS_H_

--- a/tket/src/Predicates/PassLibrary.hpp
+++ b/tket/src/Predicates/PassLibrary.hpp
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _TKET_PassLibrary_H_
-#define _TKET_PassLibrary_H_
+#pragma once
 
 #include "CompilerPass.hpp"
 
@@ -79,4 +78,3 @@ const PassPtr &SimplifyMeasured();
 
 }  // namespace tket
 
-#endif  // PASSLIBRARY_H_

--- a/tket/src/Predicates/PassLibrary.hpp
+++ b/tket/src/Predicates/PassLibrary.hpp
@@ -77,4 +77,3 @@ const PassPtr &RemoveDiscarded();
 const PassPtr &SimplifyMeasured();
 
 }  // namespace tket
-

--- a/tket/src/Predicates/Predicates.hpp
+++ b/tket/src/Predicates/Predicates.hpp
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _TKET_Predicates_H_
-#define _TKET_Predicates_H_
+#pragma once
 #include <typeindex>
 
 #include "Routing/Routing.hpp"
@@ -257,4 +256,3 @@ class GlobalPhasedXPredicate : public Predicate {
 
 }  // namespace tket
 
-#endif  // PREDICATES_H_

--- a/tket/src/Predicates/Predicates.hpp
+++ b/tket/src/Predicates/Predicates.hpp
@@ -255,4 +255,3 @@ class GlobalPhasedXPredicate : public Predicate {
 };
 
 }  // namespace tket
-

--- a/tket/src/Program/Program.hpp
+++ b/tket/src/Program/Program.hpp
@@ -280,4 +280,3 @@ class Program {
 };
 
 }  // namespace tket
-

--- a/tket/src/Program/Program.hpp
+++ b/tket/src/Program/Program.hpp
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _TKET_Program_H_
-#define _TKET_Program_H_
+#pragma once
 
 #include "Circuit/Circuit.hpp"
 
@@ -282,4 +281,3 @@ class Program {
 
 }  // namespace tket
 
-#endif  // Program_H_

--- a/tket/src/Routing/Placement.hpp
+++ b/tket/src/Routing/Placement.hpp
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _TKET_Placement_H_
-#define _TKET_Placement_H_
+#pragma once
 
 #include <algorithm>
 #include <iostream>
@@ -360,4 +359,3 @@ class NoiseAwarePlacement : public Placement {
 };
 
 }  // namespace tket
-#endif  // PLACEMENT_H_

--- a/tket/src/Routing/Routing.hpp
+++ b/tket/src/Routing/Routing.hpp
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _TKET_Routing_H_
-#define _TKET_Routing_H_
+#pragma once
 
 #include <map>
 #include <string>
@@ -366,4 +365,3 @@ class RoutingTester {
 
 }  // namespace tket
 
-#endif

--- a/tket/src/Routing/Routing.hpp
+++ b/tket/src/Routing/Routing.hpp
@@ -364,4 +364,3 @@ class RoutingTester {
 };
 
 }  // namespace tket
-

--- a/tket/src/Routing/Verification.hpp
+++ b/tket/src/Routing/Verification.hpp
@@ -32,4 +32,3 @@ bool respects_connectivity_constraints(
     bool bridge_allowed = false);
 
 }  // namespace tket
-

--- a/tket/src/Routing/Verification.hpp
+++ b/tket/src/Routing/Verification.hpp
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _TKET_Verification_H_
-#define _TKET_Verification_H_
+#pragma once
 
 #include "Architecture/Architecture.hpp"
 #include "Circuit/Circuit.hpp"
@@ -34,4 +33,3 @@ bool respects_connectivity_constraints(
 
 }  // namespace tket
 
-#endif  //_TKET_Verification_H_

--- a/tket/src/Simulation/BitOperations.hpp
+++ b/tket/src/Simulation/BitOperations.hpp
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _TKET_Simulation_BitOperations_H_
-#define _TKET_Simulation_BitOperations_H_
+#pragma once
 
 #include <cstdint>
 #include <utility>
@@ -53,4 +52,3 @@ SimUInt get_expanded_bits(const ExpansionData& expansion_data, SimUInt bits);
 }  // namespace internal
 }  // namespace tket_sim
 }  // namespace tket
-#endif

--- a/tket/src/Simulation/CircuitSimulator.hpp
+++ b/tket/src/Simulation/CircuitSimulator.hpp
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _TKET_Simulation_CircuitSimulator_H_
-#define _TKET_Simulation_CircuitSimulator_H_
+#pragma once
 
 #include "Utils/MatrixAnalysis.hpp"
 
@@ -76,4 +75,3 @@ void apply_unitary(
 
 }  // namespace tket_sim
 }  // namespace tket
-#endif

--- a/tket/src/Simulation/DecomposeCircuit.hpp
+++ b/tket/src/Simulation/DecomposeCircuit.hpp
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _TKET_Simulation_DecomposeCircuit_H_
-#define _TKET_Simulation_DecomposeCircuit_H_
+#pragma once
 
 #include "Utils/MatrixAnalysis.hpp"
 
@@ -34,4 +33,3 @@ void decompose_circuit(
 }  // namespace internal
 }  // namespace tket_sim
 }  // namespace tket
-#endif

--- a/tket/src/Simulation/GateNode.hpp
+++ b/tket/src/Simulation/GateNode.hpp
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _TKET_Simulation_GateNode_H_
-#define _TKET_Simulation_GateNode_H_
+#pragma once
 
 #include "Utils/MatrixAnalysis.hpp"
 
@@ -42,4 +41,3 @@ struct GateNode {
 }  // namespace internal
 }  // namespace tket_sim
 }  // namespace tket
-#endif

--- a/tket/src/Simulation/GateNodesBuffer.hpp
+++ b/tket/src/Simulation/GateNodesBuffer.hpp
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _TKET_Simulation_GateNodesBuffer_H_
-#define _TKET_Simulation_GateNodesBuffer_H_
+#pragma once
 
 #include <memory>
 
@@ -92,4 +91,3 @@ class GateNodesBuffer {
 }  // namespace internal
 }  // namespace tket_sim
 }  // namespace tket
-#endif

--- a/tket/src/Simulation/PauliExpBoxUnitaryCalculator.hpp
+++ b/tket/src/Simulation/PauliExpBoxUnitaryCalculator.hpp
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _TKET_Simulation_PauliExpBoxUnitaryCalculator_H_
-#define _TKET_Simulation_PauliExpBoxUnitaryCalculator_H_
+#pragma once
 
 #include "Utils/MatrixAnalysis.hpp"
 
@@ -30,4 +29,3 @@ std::vector<TripletCd> get_triplets(const PauliExpBox& box);
 }  // namespace internal
 }  // namespace tket_sim
 }  // namespace tket
-#endif

--- a/tket/src/Transformations/CliffordReductionPass.hpp
+++ b/tket/src/Transformations/CliffordReductionPass.hpp
@@ -207,4 +207,3 @@ class CliffordReductionPassTester {
 };
 
 }  // namespace tket
-

--- a/tket/src/Transformations/CliffordReductionPass.hpp
+++ b/tket/src/Transformations/CliffordReductionPass.hpp
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _TKET_CliffordReductionPass_H_
-#define _TKET_CliffordReductionPass_H_
+#pragma once
 
 #include "Transform.hpp"
 
@@ -209,4 +208,3 @@ class CliffordReductionPassTester {
 
 }  // namespace tket
 
-#endif

--- a/tket/src/Transformations/ContextualReduction.hpp
+++ b/tket/src/Transformations/ContextualReduction.hpp
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _TKET_ContextualReduction_H_
-#define _TKET_ContextualReduction_H_
+#pragma once
 
 #include "Circuit/Circuit.hpp"
 #include "Utils/UnitID.hpp"
@@ -39,4 +38,3 @@ std::pair<Circuit, Circuit> separate_classical(const Circuit &circ);
 
 }  // namespace tket
 
-#endif  // _TKET_ContextualReduction_H_

--- a/tket/src/Transformations/ContextualReduction.hpp
+++ b/tket/src/Transformations/ContextualReduction.hpp
@@ -37,4 +37,3 @@ namespace tket {
 std::pair<Circuit, Circuit> separate_classical(const Circuit &circ);
 
 }  // namespace tket
-

--- a/tket/src/Transformations/Replacement.hpp
+++ b/tket/src/Transformations/Replacement.hpp
@@ -41,4 +41,3 @@ Circuit CX_circ_from_multiq(const Op_ptr op);
 Circuit CX_ZX_circ_from_op(const Op_ptr op);
 
 }  // namespace tket
-

--- a/tket/src/Transformations/Replacement.hpp
+++ b/tket/src/Transformations/Replacement.hpp
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _TKET_Replacement_H_
-#define _TKET_Replacement_H_
+#pragma once
 
 #include "Circuit/Circuit.hpp"
 
@@ -43,4 +42,3 @@ Circuit CX_ZX_circ_from_op(const Op_ptr op);
 
 }  // namespace tket
 
-#endif

--- a/tket/src/Transformations/Transform.hpp
+++ b/tket/src/Transformations/Transform.hpp
@@ -591,4 +591,3 @@ inline const Transform Transform::id = Transform([](const Circuit&) {
 });  // returns `false` as it does not change the Circuit in any way
 
 }  // namespace tket
-

--- a/tket/src/Transformations/Transform.hpp
+++ b/tket/src/Transformations/Transform.hpp
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _TKET_Transform_H_
-#define _TKET_Transform_H_
+#pragma once
 
 #include <functional>
 #include <map>
@@ -593,4 +592,3 @@ inline const Transform Transform::id = Transform([](const Circuit&) {
 
 }  // namespace tket
 
-#endif

--- a/tket/src/Utils/Assert.hpp
+++ b/tket/src/Utils/Assert.hpp
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _TKET_Assert_H_
-#define _TKET_Assert_H_
+#pragma once
 
 #include <cstdlib>
 #include <sstream>
@@ -34,4 +33,3 @@
     }                                                                      \
   } while (0)
 
-#endif  // _TKET_Assert_H_

--- a/tket/src/Utils/Assert.hpp
+++ b/tket/src/Utils/Assert.hpp
@@ -32,4 +32,3 @@
       std::abort();                                                        \
     }                                                                      \
   } while (0)
-

--- a/tket/src/Utils/BiMapHeaders.hpp
+++ b/tket/src/Utils/BiMapHeaders.hpp
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _TKET_BI_MAP_H_
-#define _TKET_BI_MAP_H_
+#pragma once
 
 #if defined(_MSC_VER)
 #pragma warning(push)
@@ -26,4 +25,3 @@
 #pragma warning(pop)
 #endif
 
-#endif

--- a/tket/src/Utils/BiMapHeaders.hpp
+++ b/tket/src/Utils/BiMapHeaders.hpp
@@ -24,4 +24,3 @@
 #if defined(_MSC_VER)
 #pragma warning(pop)
 #endif
-

--- a/tket/src/Utils/Constants.hpp
+++ b/tket/src/Utils/Constants.hpp
@@ -67,4 +67,3 @@ enum class BasisOrder {
 };
 
 }  // namespace tket
-

--- a/tket/src/Utils/Constants.hpp
+++ b/tket/src/Utils/Constants.hpp
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _TKET_Constants_H_
-#define _TKET_Constants_H_
+#pragma once
 
 /**
  * @file
@@ -69,4 +68,3 @@ enum class BasisOrder {
 
 }  // namespace tket
 
-#endif  // CONSTANTS_H_

--- a/tket/src/Utils/CosSinDecomposition.hpp
+++ b/tket/src/Utils/CosSinDecomposition.hpp
@@ -44,4 +44,3 @@ typedef std::tuple<
 csd_t CS_decomp(const Eigen::MatrixXcd &u);
 
 }  // namespace tket
-

--- a/tket/src/Utils/CosSinDecomposition.hpp
+++ b/tket/src/Utils/CosSinDecomposition.hpp
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _TKET_CosSinDecomposition_H_
-#define _TKET_CosSinDecomposition_H_
+#pragma once
 
 #include "EigenConfig.hpp"
 
@@ -46,4 +45,3 @@ csd_t CS_decomp(const Eigen::MatrixXcd &u);
 
 }  // namespace tket
 
-#endif

--- a/tket/src/Utils/EigenConfig.hpp
+++ b/tket/src/Utils/EigenConfig.hpp
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _TKET_EigenConfig_H_
-#define _TKET_EigenConfig_H_
+#pragma once
 
 /**
  * @file
@@ -66,4 +65,3 @@ void from_json(const nlohmann::json& j, Matrix<_Scalar, _Rows, _Cols>& matrix) {
 
 }  // namespace Eigen
 
-#endif  // _EIGEN_CONFIG_H_

--- a/tket/src/Utils/EigenConfig.hpp
+++ b/tket/src/Utils/EigenConfig.hpp
@@ -64,4 +64,3 @@ void from_json(const nlohmann::json& j, Matrix<_Scalar, _Rows, _Cols>& matrix) {
 }
 
 }  // namespace Eigen
-

--- a/tket/src/Utils/Exceptions.hpp
+++ b/tket/src/Utils/Exceptions.hpp
@@ -42,4 +42,3 @@ class NotUnitary : public std::logic_error {
 };
 
 }  // namespace tket
-

--- a/tket/src/Utils/Exceptions.hpp
+++ b/tket/src/Utils/Exceptions.hpp
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _TKET_Exceptions_H_
-#define _TKET_Exceptions_H_
+#pragma once
 
 #include <exception>
 #include <stdexcept>
@@ -44,4 +43,3 @@ class NotUnitary : public std::logic_error {
 
 }  // namespace tket
 
-#endif  // _TKET_Exceptions_H_

--- a/tket/src/Utils/Expression.hpp
+++ b/tket/src/Utils/Expression.hpp
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _TKET_Expression_H_
-#define _TKET_Expression_H_
+#pragma once
 
 /**
  * @file
@@ -200,4 +199,3 @@ std::optional<unsigned> equiv_Clifford(
 
 }  // namespace tket
 
-#endif  // EXPR_H_

--- a/tket/src/Utils/Expression.hpp
+++ b/tket/src/Utils/Expression.hpp
@@ -198,4 +198,3 @@ std::optional<unsigned> equiv_Clifford(
     const Expr& e, unsigned n = 2, double tol = EPS);
 
 }  // namespace tket
-

--- a/tket/src/Utils/GraphHeaders.hpp
+++ b/tket/src/Utils/GraphHeaders.hpp
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _TKET_UTILS_GRAPH_H_
-#define _TKET_UTILS_GRAPH_H_
+#pragma once
 
 #if !defined(_MSC_VER)
 #pragma GCC diagnostic push
@@ -45,4 +44,3 @@
 #pragma GCC diagnostic pop
 #endif
 
-#endif

--- a/tket/src/Utils/GraphHeaders.hpp
+++ b/tket/src/Utils/GraphHeaders.hpp
@@ -43,4 +43,3 @@
 #if !defined(_MSC_VER)
 #pragma GCC diagnostic pop
 #endif
-

--- a/tket/src/Utils/HelperFunctions.hpp
+++ b/tket/src/Utils/HelperFunctions.hpp
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _TKET_HelperFunctions_H_
-#define _TKET_HelperFunctions_H_
+#pragma once
 
 #include <boost/range/adaptor/transformed.hpp>
 #include <cstdint>
@@ -84,4 +83,3 @@ uint32_t reverse_bits(uint32_t v, unsigned w);
 
 }  // namespace tket
 
-#endif  //_TKET_HelperFunctions_H_

--- a/tket/src/Utils/HelperFunctions.hpp
+++ b/tket/src/Utils/HelperFunctions.hpp
@@ -82,4 +82,3 @@ bimap_to_map(MapT& bm) {
 uint32_t reverse_bits(uint32_t v, unsigned w);
 
 }  // namespace tket
-

--- a/tket/src/Utils/Json.hpp
+++ b/tket/src/Utils/Json.hpp
@@ -51,4 +51,3 @@ void from_json(const nlohmann::json& j, std::complex<T>& p) {
 }
 
 }  // namespace std
-

--- a/tket/src/Utils/Json.hpp
+++ b/tket/src/Utils/Json.hpp
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _TKET_UTILS_JSON_H_
-#define _TKET_UTILS_JSON_H_
+#pragma once
 
 #include <complex>
 #include <exception>
@@ -53,4 +52,3 @@ void from_json(const nlohmann::json& j, std::complex<T>& p) {
 
 }  // namespace std
 
-#endif

--- a/tket/src/Utils/MatrixAnalysis.hpp
+++ b/tket/src/Utils/MatrixAnalysis.hpp
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _TKET_MatrixAnalysis_H_
-#define _TKET_MatrixAnalysis_H_
+#pragma once
 
 #include <vector>
 
@@ -152,4 +151,3 @@ std::vector<TripletCd> get_triplets(
 
 }  // namespace tket
 
-#endif

--- a/tket/src/Utils/MatrixAnalysis.hpp
+++ b/tket/src/Utils/MatrixAnalysis.hpp
@@ -150,4 +150,3 @@ std::vector<TripletCd> get_triplets(
     const Eigen::MatrixXcd &matr, double abs_epsilon = EPS);
 
 }  // namespace tket
-

--- a/tket/src/Utils/PauliStrings.hpp
+++ b/tket/src/Utils/PauliStrings.hpp
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _TKET_PauliStrings_H_
-#define _TKET_PauliStrings_H_
+#pragma once
 
 #include <map>
 #include <set>
@@ -525,4 +524,3 @@ QubitPauliTensor operator*(Complex a, const QubitPauliTensor &qpt);
 
 }  // namespace tket
 
-#endif

--- a/tket/src/Utils/PauliStrings.hpp
+++ b/tket/src/Utils/PauliStrings.hpp
@@ -523,4 +523,3 @@ class QubitPauliTensor {
 QubitPauliTensor operator*(Complex a, const QubitPauliTensor &qpt);
 
 }  // namespace tket
-

--- a/tket/src/Utils/SequencedContainers.hpp
+++ b/tket/src/Utils/SequencedContainers.hpp
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _TKET_SequencedContainers_H_
-#define _TKET_SequencedContainers_H_
+#pragma once
 
 #include <boost/multi_index/mem_fun.hpp>
 #include <boost/multi_index/member.hpp>
@@ -45,4 +44,3 @@ using sequence_set_t = boost::multi_index::multi_index_container<
 
 }  // namespace tket
 
-#endif

--- a/tket/src/Utils/SequencedContainers.hpp
+++ b/tket/src/Utils/SequencedContainers.hpp
@@ -43,4 +43,3 @@ using sequence_set_t = boost::multi_index::multi_index_container<
         boost::multi_index::sequenced<boost::multi_index::tag<TagSeq>>>>;
 
 }  // namespace tket
-

--- a/tket/src/Utils/Symbols.hpp
+++ b/tket/src/Utils/Symbols.hpp
@@ -32,4 +32,3 @@
 #if !defined(_MSC_VER)
 #pragma GCC diagnostic pop
 #endif
-

--- a/tket/src/Utils/Symbols.hpp
+++ b/tket/src/Utils/Symbols.hpp
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _TKET_UTILS_SYMBOLS_H_
-#define _TKET_UTILS_SYMBOLS_H_
+#pragma once
 
 #if !defined(_MSC_VER)
 #pragma GCC diagnostic push
@@ -34,4 +33,3 @@
 #pragma GCC diagnostic pop
 #endif
 
-#endif

--- a/tket/src/Utils/TketLog.hpp
+++ b/tket/src/Utils/TketLog.hpp
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _TKET_TketLog_H_
-#define _TKET_TketLog_H_
+#pragma once
 
 /**
  * @file
@@ -34,4 +33,3 @@ LogPtr_t &tket_log();
 
 }  // namespace tket
 
-#endif

--- a/tket/src/Utils/TketLog.hpp
+++ b/tket/src/Utils/TketLog.hpp
@@ -32,4 +32,3 @@ typedef std::shared_ptr<spdlog::logger> LogPtr_t;
 LogPtr_t &tket_log();
 
 }  // namespace tket
-

--- a/tket/src/Utils/UnitID.hpp
+++ b/tket/src/Utils/UnitID.hpp
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _TKET_UnitID_H_
-#define _TKET_UnitID_H_
+#pragma once
 
 /**
  * @file
@@ -271,4 +270,3 @@ typedef std::map<unsigned, UnitID> register_t;
 
 }  // namespace tket
 
-#endif

--- a/tket/src/Utils/UnitID.hpp
+++ b/tket/src/Utils/UnitID.hpp
@@ -269,4 +269,3 @@ typedef std::vector<Node> node_vector_t;
 typedef std::map<unsigned, UnitID> register_t;
 
 }  // namespace tket
-

--- a/tket/tests/CircuitsForTesting.hpp
+++ b/tket/tests/CircuitsForTesting.hpp
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _TKET_TESTS_CircuitsForTesting_hpp_
-#define _TKET_TESTS_CircuitsForTesting_hpp_
+#pragma once
 
 #include "Circuit/Circuit.hpp"
 
@@ -51,4 +50,3 @@ struct CircuitsForTesting {
 };
 
 }  // namespace tket
-#endif

--- a/tket/tests/Gate/GatesData.hpp
+++ b/tket/tests/Gate/GatesData.hpp
@@ -41,4 +41,3 @@ struct GatesData {
 
 }  // namespace internal
 }  // namespace tket
-

--- a/tket/tests/Gate/GatesData.hpp
+++ b/tket/tests/Gate/GatesData.hpp
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _TKET_TESTS_Gate_GatesData_H_
-#define _TKET_TESTS_Gate_GatesData_H_
+#pragma once
 
 #include <map>
 #include <vector>
@@ -43,4 +42,3 @@ struct GatesData {
 }  // namespace internal
 }  // namespace tket
 
-#endif

--- a/tket/tests/Graphs/EdgeSequence.hpp
+++ b/tket/tests/Graphs/EdgeSequence.hpp
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _TKET_TESTS_GRAPHS_EdgeSequence_H_
-#define _TKET_TESTS_GRAPHS_EdgeSequence_H_
+#pragma once
 
 #include <cstddef>
 #include <utility>
@@ -67,4 +66,3 @@ struct EdgeSequence {
 }  // namespace tests
 }  // namespace graphs
 }  // namespace tket
-#endif

--- a/tket/tests/Graphs/EdgeSequenceColouringParameters.hpp
+++ b/tket/tests/Graphs/EdgeSequenceColouringParameters.hpp
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _TKET_TESTS_GRAPHS_EdgeSequenceColouringParameters_H_
-#define _TKET_TESTS_GRAPHS_EdgeSequenceColouringParameters_H_
+#pragma once
 
 #include <cstddef>
 #include <limits>
@@ -81,4 +80,3 @@ struct EdgeSequenceColouringParameters {
 }  // namespace tests
 }  // namespace graphs
 }  // namespace tket
-#endif

--- a/tket/tests/Graphs/GraphTestingRoutines.hpp
+++ b/tket/tests/Graphs/GraphTestingRoutines.hpp
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _TKET_TESTS_GRAPHS_GraphTestingRoutines_H_
-#define _TKET_TESTS_GRAPHS_GraphTestingRoutines_H_
+#pragma once
 
 #include <cstddef>
 #include <utility>
@@ -69,4 +68,3 @@ struct GraphTestingRoutines {
 }  // namespace tests
 }  // namespace graphs
 }  // namespace tket
-#endif

--- a/tket/tests/Graphs/RNG.hpp
+++ b/tket/tests/Graphs/RNG.hpp
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _TKET_TESTS_GRAPHS_RNG_H_
-#define _TKET_TESTS_GRAPHS_RNG_H_
+#pragma once
 
 #include <algorithm>
 #include <random>
@@ -162,4 +161,3 @@ class RNG {
 }  // namespace tests
 }  // namespace graphs
 }  // namespace tket
-#endif

--- a/tket/tests/Graphs/RandomGraphGeneration.hpp
+++ b/tket/tests/Graphs/RandomGraphGeneration.hpp
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _TKET_TESTS_GRAPHS_RandomGraphGeneration_H_
-#define _TKET_TESTS_GRAPHS_RandomGraphGeneration_H_
+#pragma once
 
 #include <limits>
 
@@ -183,4 +182,3 @@ struct CompleteGraph : public RandomGraphParameters {
 }  // namespace tests
 }  // namespace graphs
 }  // namespace tket
-#endif

--- a/tket/tests/Graphs/RandomPlanarGraphs.hpp
+++ b/tket/tests/Graphs/RandomPlanarGraphs.hpp
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _TKET_TESTS_GRAPHS_RandomPlanarGraphs_H_
-#define _TKET_TESTS_GRAPHS_RandomPlanarGraphs_H_
+#pragma once
 
 #include <cstddef>
 #include <map>
@@ -91,4 +90,3 @@ class RandomPlanarGraphs {
 }  // namespace tests
 }  // namespace graphs
 }  // namespace tket
-#endif

--- a/tket/tests/Simulation/ComparisonFunctions.hpp
+++ b/tket/tests/Simulation/ComparisonFunctions.hpp
@@ -46,4 +46,3 @@ bool compare_statevectors_or_unitaries(
 
 }  // namespace tket_sim
 }  // namespace tket
-

--- a/tket/tests/Simulation/ComparisonFunctions.hpp
+++ b/tket/tests/Simulation/ComparisonFunctions.hpp
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _TKET_TESTS_Simulation_ComparisonFunctions_H_
-#define _TKET_TESTS_Simulation_ComparisonFunctions_H_
+#pragma once
 
 #include "Utils/MatrixAnalysis.hpp"
 
@@ -48,4 +47,3 @@ bool compare_statevectors_or_unitaries(
 }  // namespace tket_sim
 }  // namespace tket
 
-#endif

--- a/tket/tests/testutil.hpp
+++ b/tket/tests/testutil.hpp
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _TESTUTIL_H_
-#define _TESTUTIL_H_
+#pragma once
 
 /**
  * @file
@@ -125,4 +124,3 @@ Eigen::MatrixXcd random_unitary(unsigned n, int seed);
 
 }  // namespace tket
 
-#endif /* _TESTUTIL_H_ */

--- a/tket/tests/testutil.hpp
+++ b/tket/tests/testutil.hpp
@@ -123,4 +123,3 @@ bool matrices_are_equal(const Matr1& mat1, const Matr2& mat2) {
 Eigen::MatrixXcd random_unitary(unsigned n, int seed);
 
 }  // namespace tket
-


### PR DESCRIPTION
Despite being non-standard this works fine with all the compilers we care about, and it is easier to read and write.

For the record, this is the script I used to make the change:
```python
import subprocess

all_hdrs = [
    f
    for f in (
        subprocess.run(["git", "ls-files"], stdout=subprocess.PIPE)
        .stdout.decode("utf-8")
        .split("\n")
    )
    if f.endswith(".hpp")
]

for hdr in all_hdrs:
    with open(hdr, "r") as f:
        lines = f.readlines()
        n_lines = len(lines)
        try:
            n0 = next(n for n in range(n_lines) if lines[n].startswith("#ifndef"))
            assert lines[n0 + 1].startswith("#define")
            assert lines[-1].startswith("#endif")
            lines[n0] = "#pragma once\n"
            del lines[n0 + 1]
            del lines[-1]
        except StopIteration:
            assert "#pragma once\n" in lines
            continue
    with open(hdr, "w") as f:
        f.writelines(lines)
```