### PR TITLE
Build symengine locally

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -347,7 +347,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: C:\Users\runneradmin\.conan\data\tket
-        key: ${{ runner.os }}-tket-tket-${{ steps.hash_tket_source.outputs.tket_hash }}-11
+        key: ${{ runner.os }}-tket-tket-${{ steps.hash_tket_source.outputs.tket_hash }}-13
     - name: Build symengine
       run: conan create --profile=tket recipes/symengine
     - name: Build tket

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -56,8 +56,10 @@ jobs:
         echo "CONAN_CMD=${conan_cmd}" >> $GITHUB_ENV
     - name: Install ninja and ccache
       run: sudo apt-get install ninja-build ccache
+    - name: Build symengine
+      run: ${CONAN_CMD} create --profile=tket recipes/symengine
     - name: Build tket
-      run: ${CONAN_CMD} create --profile=tket --build=missing recipes/tket
+      run: ${CONAN_CMD} create --profile=tket recipes/tket
     - name: Install runtime test requirements
       run: |
         sudo apt-get install texlive texlive-latex-extra latexmk
@@ -174,12 +176,14 @@ jobs:
         conan config set general.revisions_enabled=1
         export CC=`which conan`
         echo "CONAN_CMD=${CC}" >> $GITHUB_ENV
+    - name: Build symengine
+      run: conan create --profile=tket recipes/symengine
     - name: Build tket
-      run: conan create --profile=tket --build=missing recipes/tket
+      run: conan create --profile=tket recipes/tket
     - name: Build and run tket tests
       run: conan create --profile=tket recipes/tket-tests
     - name: Build and run tket proptests
-      run: conan create --profile=tket --build=missing recipes/tket-proptests
+      run: conan create --profile=tket recipes/tket-proptests
     - name: Set up Python 3.7
       if: github.event_name == 'push'
       uses: actions/setup-python@v2
@@ -261,12 +265,14 @@ jobs:
         echo "CONAN_CMD=${CC}" >> $GITHUB_ENV
     - name: Install boost
       run: conan install --profile=tket boost/1.77.0@ --build=missing -o boost:without_fiber=True -o boost:without_json=True -o boost:without_nowide=True
+    - name: Build symengine
+      run: conan create --profile=tket recipes/symengine -o boost:without_fiber=True -o boost:without_json=True -o boost:without_nowide=True
     - name: Build tket
-      run: conan create --profile=tket recipes/tket --build=missing -o boost:without_fiber=True -o boost:without_json=True -o boost:without_nowide=True
+      run: conan create --profile=tket recipes/tket -o boost:without_fiber=True -o boost:without_json=True -o boost:without_nowide=True
     - name: Build and run tket tests
       run: conan create --profile=tket recipes/tket-tests -o boost:without_fiber=True -o boost:without_json=True -o boost:without_nowide=True
     - name: Build and run tket proptests
-      run: conan create --profile=tket recipes/tket-proptests --build=missing -o boost:without_fiber=True -o boost:without_json=True -o boost:without_nowide=True
+      run: conan create --profile=tket recipes/tket-proptests -o boost:without_fiber=True -o boost:without_json=True -o boost:without_nowide=True
     - name: Build pytket (3.8)
       if: github.event_name == 'pull_request' || github.event_name == 'push'
       run: |
@@ -342,6 +348,8 @@ jobs:
       with:
         path: C:\Users\runneradmin\.conan\data\tket
         key: ${{ runner.os }}-tket-tket-${{ steps.hash_tket_source.outputs.tket_hash }}-11
+    - name: Build symengine
+      run: conan create --profile=tket recipes/symengine
     - name: Build tket
       if: steps.cache-tket.outputs.cache-hit != 'true'
       run: conan create --profile=tket recipes/tket

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -62,6 +62,9 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install ninja-build ccache
+    - name: Build symengine
+      run:
+        ${CONAN_CMD} create --profile=tket recipes/symengine
     - name: Build tket
       run: |
         ${CONAN_CMD} install recipes/tket --install-folder=build/tket --profile=tket -o tket:profile_coverage=True

--- a/.github/workflows/linuxbuildwheel
+++ b/.github/workflows/linuxbuildwheel
@@ -27,6 +27,7 @@ cd /tket
 
 ${CONAN_CMD} profile new tket --detect
 ${CONAN_CMD} config set general.revisions_enabled=1
+${CONAN_CMD} create --profile=tket recipes/symengine
 ${CONAN_CMD} create --profile=tket --test-folder=None recipes/tket
 
 cd /tket/pytket

--- a/.github/workflows/pytket_docs.yml
+++ b/.github/workflows/pytket_docs.yml
@@ -58,6 +58,8 @@ jobs:
         conan profile new tket --detect
         conan profile update settings.compiler.libcxx=libstdc++11 tket
         conan config set general.revisions_enabled=1
+    - name: Build symengine
+      run: conan create --profile=tket recipes/symengine
     - name: Build tket
       run: conan create --profile=tket recipes/tket
     - name: Build pytket

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,7 +65,8 @@ jobs:
         pip install conan
         conan profile new tket --detect --force
         conan config set general.revisions_enabled=1
-        conan create --profile=tket --build=missing recipes/tket
+        conan create --profile=tket recipes/symengine
+        conan create --profile=tket recipes/tket
     - name: Build wheel (3.7)
       run: .github/workflows/build_macos_wheel
     - name: Set up Python 3.8
@@ -103,7 +104,8 @@ jobs:
         conan profile new tket --detect --force
         conan config set general.revisions_enabled=1
         conan install --profile=tket boost/1.77.0@ --build=missing -o boost:without_fiber=True -o boost:without_json=True -o boost:without_nowide=True
-        conan create --profile=tket recipes/tket --build=missing -o boost:without_fiber=True -o boost:without_json=True -o boost:without_nowide=True
+        conan create --profile=tket recipes/symengine -o boost:without_fiber=True -o boost:without_json=True -o boost:without_nowide=True
+        conan create --profile=tket recipes/tket -o boost:without_fiber=True -o boost:without_json=True -o boost:without_nowide=True
         .github/workflows/build_macos_m1_wheel
         pyenv shell tket-3.9
         .github/workflows/build_macos_m1_wheel
@@ -152,10 +154,11 @@ jobs:
       with:
         path: C:\Users\runneradmin\.conan\data\tket
         key: ${{ runner.os }}-tket-tket-${{ steps.hash_tket_source.outputs.tket_hash }}-5
+    - name: Build symengine
+      run: conan create --profile=tket recipes/symengine
     - name: Build tket
       if: steps.cache-tket.outputs.cache-hit != 'true'
-      run: |
-        conan create --profile=tket recipes/tket
+      run: conan create --profile=tket recipes/tket
     - name: Set up Python 3.7
       uses: actions/setup-python@v2
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -153,7 +153,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: C:\Users\runneradmin\.conan\data\tket
-        key: ${{ runner.os }}-tket-tket-${{ steps.hash_tket_source.outputs.tket_hash }}-5
+        key: ${{ runner.os }}-tket-tket-${{ steps.hash_tket_source.outputs.tket_hash }}-7
     - name: Build symengine
       run: conan create --profile=tket recipes/symengine
     - name: Build tket

--- a/README.md
+++ b/README.md
@@ -115,6 +115,17 @@ The Python tests require a few more packages. These can be installed with:
 ```shell
 pip install -r pytket/tests/requirements.txt
 ```
+
+### Building symengine
+
+The `symengine` dependency is built from a local conan recipe. Run:
+
+```shell
+conan create --profile=tket recipes/symengine
+```
+
+to build it.
+
 ### Building tket
 
 #### Method 1

--- a/recipes/symengine/conanfile.py
+++ b/recipes/symengine/conanfile.py
@@ -1,0 +1,104 @@
+# Copyright 2019-2021 Cambridge Quantum Computing
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from conans import ConanFile, CMake, tools
+import os
+
+required_conan_version = ">=1.33.0"
+
+
+class SymengineConan(ConanFile):
+    name = "symengine"
+    version = "0.8.1.1"
+    description = "A fast symbolic manipulation library, written in C++"
+    license = "MIT"
+    topics = ("symbolic", "algebra")
+    homepage = "https://symengine.org/"
+    exports_sources = ["CMakeLists.txt"]
+    generators = "cmake"
+    settings = "os", "compiler", "build_type", "arch"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+        "integer_class": ["boostmp", "gmp"],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+        "integer_class": "boostmp",
+    }
+    short_paths = True
+
+    _cmake = None
+
+    def requirements(self):
+        if self.options.integer_class == "boostmp":
+            self.requires("boost/1.77.0")
+        else:
+            self.requires("gmp/6.2.1")
+
+    def source(self):
+        git = tools.Git()
+        git.clone(
+            "https://github.com/symengine/symengine",
+            branch="2eb109a0e554b62683662cc5559fccf2ea0c0348",
+            shallow=True,
+        )
+
+    def _configure_cmake(self):
+        if self._cmake is None:
+            self._cmake = CMake(self)
+            self._cmake.definitions["BUILD_TESTS"] = False
+            self._cmake.definitions["BUILD_BENCHMARKS"] = False
+            self._cmake.definitions["INTEGER_CLASS"] = self.options.integer_class
+            self._cmake.definitions["MSVC_USE_MT"] = False
+            self._cmake.configure()
+        return self._cmake
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def configure(self):
+        if self.options.shared:
+            del self.options.fPIC
+
+    def build(self):
+        tools.replace_in_file(
+            os.path.join(self.source_folder, "CMakeLists.txt"),
+            "project(symengine)",
+            """project(symengine)
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup()""",
+        )
+        cmake = self._configure_cmake()
+        cmake.build()
+
+    def package(self):
+        self.copy("LICENSE", dst="licenses", src=self.source_folder)
+        cmake = self._configure_cmake()
+        cmake.install()
+        cmake.patch_config_paths()
+        # [CMAKE-MODULES-CONFIG-FILES (KB-H016)]
+        tools.remove_files_by_mask(self.package_folder, "*.cmake")
+        # [DEFAULT PACKAGE LAYOUT (KB-H013)]
+        tools.rmdir(os.path.join(self.package_folder, "CMake"))
+
+    def package_info(self):
+        self.cpp_info.libs = ["symengine"]
+        if any("teuchos" in v for v in tools.collect_libs(self)):
+            self.cpp_info.libs.append("teuchos")
+        self.cpp_info.names["cmake_find_package"] = "symengine"
+        # FIXME: symengine exports a non-namespaced `symengine` target.
+        self.cpp_info.names["cmake_find_package_multi"] = "symengine"

--- a/recipes/tket/conanfile.py
+++ b/recipes/tket/conanfile.py
@@ -41,7 +41,7 @@ class TketConan(ConanFile):
     exports = ["patches/*"]
     requires = (
         "boost/1.77.0",
-        "symengine/0.8.1",
+        "symengine/0.8.1.1",
         "eigen/3.4.0",
         "spdlog/1.9.2",
         "nlohmann_json/3.10.4",


### PR DESCRIPTION
This is in order to pick up the fixes from https://github.com/symengine/symengine/pull/1849, which unblock a few other things.

The conanfile is based on the one we used to have in the CQCL-DEV/tket repo, but with some improvements (like the addition of options) from the one in the conan-center, and a more recent boost version (same as tket requires). I am not sure why we can't just use the one in the conan-center but it gave me some obscure boost linkage errors when built locally.

We should be able to revert this after the next release of symengine is uploaded to conan-center.