### PR TITLE
Update to pybind11 2.8.1.

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -52,7 +52,6 @@ jobs:
         conan_cmd=/home/runner/.local/bin/conan
         ${conan_cmd} profile new tket --detect
         ${conan_cmd} profile update settings.compiler.libcxx=libstdc++11 tket
-        ${conan_cmd} config set general.revisions_enabled=1
         echo "CONAN_CMD=${conan_cmd}" >> $GITHUB_ENV
     - name: Install ninja and ccache
       run: sudo apt-get install ninja-build ccache
@@ -173,7 +172,6 @@ jobs:
       run: |
         pip install conan
         conan profile new tket --detect --force
-        conan config set general.revisions_enabled=1
         export CC=`which conan`
         echo "CONAN_CMD=${CC}" >> $GITHUB_ENV
     - name: Build symengine
@@ -260,7 +258,6 @@ jobs:
       id: conan
       run: |
         conan profile new tket --detect --force
-        conan config set general.revisions_enabled=1
         export CC=`which conan`
         echo "CONAN_CMD=${CC}" >> $GITHUB_ENV
     - name: Install boost
@@ -339,7 +336,6 @@ jobs:
       run: |
         pip install conan
         conan profile new tket --detect
-        conan config set general.revisions_enabled=1
         $conan_cmd = (gcm conan).Path
         echo "CONAN_CMD=${conan_cmd}" >> $GITHUB_ENV
     - name: Cache tket build

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -68,6 +68,8 @@ jobs:
       run: ${CONAN_CMD} create --profile=tket recipes/tket-tests
     - name: Build and run tket proptests
       run: ${CONAN_CMD} create --profile=tket recipes/tket-proptests
+    - name: Install pybind11
+      run: ${CONAN_CMD} create --profile=tket recipes/pybind11
     - name: Set up Python 3.7
       if: github.event_name == 'push'
       uses: actions/setup-python@v2
@@ -182,6 +184,8 @@ jobs:
       run: conan create --profile=tket recipes/tket-tests
     - name: Build and run tket proptests
       run: conan create --profile=tket recipes/tket-proptests
+    - name: Install pybind11
+      run: conan create --profile=tket recipes/pybind11
     - name: Set up Python 3.7
       if: github.event_name == 'push'
       uses: actions/setup-python@v2
@@ -270,6 +274,8 @@ jobs:
       run: conan create --profile=tket recipes/tket-tests -o boost:without_fiber=True -o boost:without_json=True -o boost:without_nowide=True
     - name: Build and run tket proptests
       run: conan create --profile=tket recipes/tket-proptests -o boost:without_fiber=True -o boost:without_json=True -o boost:without_nowide=True
+    - name: Install pybind11
+      run: conan create --profile=tket recipes/pybind11
     - name: Build pytket (3.8)
       if: github.event_name == 'pull_request' || github.event_name == 'push'
       run: |
@@ -353,6 +359,8 @@ jobs:
       run: conan create --profile=tket recipes/tket-tests
     - name: Build and run tket proptests
       run: conan create --profile=tket recipes/tket-proptests
+    - name: Install pybind11
+      run: conan create --profile=tket recipes/pybind11
     - name: Set up Python 3.7
       if: github.event_name == 'push'
       uses: actions/setup-python@v2

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -275,10 +275,7 @@ jobs:
     - name: Build and run tket proptests
       run: conan create --profile=tket recipes/tket-proptests -o boost:without_fiber=True -o boost:without_json=True -o boost:without_nowide=True
     - name: Install pybind11
-      run: |
-        eval "$(pyenv init -)"
-        pyenv shell tket-3.10
-        conan create --profile=tket recipes/pybind11
+      run: conan create --profile=tket recipes/pybind11
     - name: Build pytket (3.8)
       if: github.event_name == 'pull_request' || github.event_name == 'push'
       run: |

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -275,7 +275,10 @@ jobs:
     - name: Build and run tket proptests
       run: conan create --profile=tket recipes/tket-proptests -o boost:without_fiber=True -o boost:without_json=True -o boost:without_nowide=True
     - name: Install pybind11
-      run: conan create --profile=tket recipes/pybind11
+      run: |
+        eval "$(pyenv init -)"
+        pyenv shell tket-3.10
+        conan create --profile=tket recipes/pybind11
     - name: Build pytket (3.8)
       if: github.event_name == 'pull_request' || github.event_name == 'push'
       run: |

--- a/.github/workflows/linuxbuildwheel
+++ b/.github/workflows/linuxbuildwheel
@@ -26,7 +26,6 @@ export CONAN_CMD=${PYBIN}/conan
 cd /tket
 
 ${CONAN_CMD} profile new tket --detect
-${CONAN_CMD} config set general.revisions_enabled=1
 ${CONAN_CMD} create --profile=tket recipes/symengine
 ${CONAN_CMD} create --profile=tket --test-folder=None recipes/tket
 

--- a/.github/workflows/linuxbuildwheel
+++ b/.github/workflows/linuxbuildwheel
@@ -28,6 +28,7 @@ cd /tket
 ${CONAN_CMD} profile new tket --detect
 ${CONAN_CMD} create --profile=tket recipes/symengine
 ${CONAN_CMD} create --profile=tket --test-folder=None recipes/tket
+${CONAN_CMD} create --profile=tket --test-folder=None recipes/pybind11
 
 cd /tket/pytket
 mkdir wheelhouse

--- a/.github/workflows/pytket_docs.yml
+++ b/.github/workflows/pytket_docs.yml
@@ -61,6 +61,8 @@ jobs:
       run: conan create --profile=tket recipes/symengine
     - name: Build tket
       run: conan create --profile=tket recipes/tket
+    - name: Install pybind11
+      run: conan create --profile=tket recipes/pybind11
     - name: Build pytket
       run: |
         cd pytket

--- a/.github/workflows/pytket_docs.yml
+++ b/.github/workflows/pytket_docs.yml
@@ -57,7 +57,6 @@ jobs:
         pip install conan
         conan profile new tket --detect
         conan profile update settings.compiler.libcxx=libstdc++11 tket
-        conan config set general.revisions_enabled=1
     - name: Build symengine
       run: conan create --profile=tket recipes/symengine
     - name: Build tket

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,19 +98,15 @@ jobs:
       with:
         fetch-depth: '0'
     - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
-    - name: Install pybind11
-      run: |
-        eval "$(pyenv init -)"
-        pyenv shell tket-3.10
-        conan profile new tket --detect --force
-        conan create --profile=tket recipes/pybind11
     - name: Build wheels
       run: |
         eval "$(pyenv init -)"
         pyenv shell tket-3.8
+        conan profile new tket --detect --force
         conan install --profile=tket boost/1.77.0@ --build=missing -o boost:without_fiber=True -o boost:without_json=True -o boost:without_nowide=True
         conan create --profile=tket recipes/symengine -o boost:without_fiber=True -o boost:without_json=True -o boost:without_nowide=True
         conan create --profile=tket recipes/tket -o boost:without_fiber=True -o boost:without_json=True -o boost:without_nowide=True
+        conan create --profile=tket recipes/pybind11
         .github/workflows/build_macos_m1_wheel
         pyenv shell tket-3.9
         .github/workflows/build_macos_m1_wheel

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,15 +98,19 @@ jobs:
       with:
         fetch-depth: '0'
     - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
+    - name: Install pybind11
+      run: |
+        eval "$(pyenv init -)"
+        pyenv shell tket-3.10
+        conan profile new tket --detect --force
+        conan create --profile=tket recipes/pybind11
     - name: Build wheels
       run: |
         eval "$(pyenv init -)"
         pyenv shell tket-3.8
-        conan profile new tket --detect --force
         conan install --profile=tket boost/1.77.0@ --build=missing -o boost:without_fiber=True -o boost:without_json=True -o boost:without_nowide=True
         conan create --profile=tket recipes/symengine -o boost:without_fiber=True -o boost:without_json=True -o boost:without_nowide=True
         conan create --profile=tket recipes/tket -o boost:without_fiber=True -o boost:without_json=True -o boost:without_nowide=True
-        conan create --profile=tket recipes/pybind11
         .github/workflows/build_macos_m1_wheel
         pyenv shell tket-3.9
         .github/workflows/build_macos_m1_wheel

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,6 @@ jobs:
       run: |
         pip install conan
         conan profile new tket --detect --force
-        conan config set general.revisions_enabled=1
         conan create --profile=tket recipes/symengine
         conan create --profile=tket recipes/tket
     - name: Build wheel (3.7)
@@ -102,7 +101,6 @@ jobs:
         eval "$(pyenv init -)"
         pyenv shell tket-3.8
         conan profile new tket --detect --force
-        conan config set general.revisions_enabled=1
         conan install --profile=tket boost/1.77.0@ --build=missing -o boost:without_fiber=True -o boost:without_json=True -o boost:without_nowide=True
         conan create --profile=tket recipes/symengine -o boost:without_fiber=True -o boost:without_json=True -o boost:without_nowide=True
         conan create --profile=tket recipes/tket -o boost:without_fiber=True -o boost:without_json=True -o boost:without_nowide=True
@@ -145,7 +143,6 @@ jobs:
       run: |
         pip install conan
         conan profile new tket --detect
-        conan config set general.revisions_enabled=1
         $conan_cmd = (gcm conan).Path
         echo "CONAN_CMD=${conan_cmd}" >> $GITHUB_ENV
     - name: Cache tket build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,6 +66,8 @@ jobs:
         conan profile new tket --detect --force
         conan create --profile=tket recipes/symengine
         conan create --profile=tket recipes/tket
+    - name: Install pybind11
+      run: conan create --profile=tket recipes/pybind11
     - name: Build wheel (3.7)
       run: .github/workflows/build_macos_wheel
     - name: Set up Python 3.8
@@ -104,6 +106,7 @@ jobs:
         conan install --profile=tket boost/1.77.0@ --build=missing -o boost:without_fiber=True -o boost:without_json=True -o boost:without_nowide=True
         conan create --profile=tket recipes/symengine -o boost:without_fiber=True -o boost:without_json=True -o boost:without_nowide=True
         conan create --profile=tket recipes/tket -o boost:without_fiber=True -o boost:without_json=True -o boost:without_nowide=True
+        conan create --profile=tket recipes/pybind11
         .github/workflows/build_macos_m1_wheel
         pyenv shell tket-3.9
         .github/workflows/build_macos_m1_wheel
@@ -156,6 +159,8 @@ jobs:
     - name: Build tket
       if: steps.cache-tket.outputs.cache-hit != 'true'
       run: conan create --profile=tket recipes/tket
+    - name: Install pybind11
+      run: conan create --profile=tket recipes/pybind11
     - name: Set up Python 3.7
       uses: actions/setup-python@v2
       with:

--- a/README.md
+++ b/README.md
@@ -152,7 +152,13 @@ with:
 conan create --profile=tket recipes/tket-proptests
 ```
 
-Now to build pytket:
+Now to build pytket, first install the `pybind11` headers:
+
+```shell
+conan create --profile=tket recipes/pybind11
+```
+
+Then build the pytket module:
 
 ```shell
 cd pytket

--- a/README.md
+++ b/README.md
@@ -88,15 +88,6 @@ If you wish you can set your profile to Debug mode:
 conan profile update settings.build_type=Debug tket
 ```
 
-#### Enable revisions
-
-In order to pick up the proper revision of the `pybind11` package, it is
-currently necessary to do the following (or equivalent):
-
-```shell
-conan config set general.revisions_enabled=1
-```
-
 #### Test dependencies
 
 A few of the tket tests require a working LaTeX installation, including

--- a/pytket/CMakeLists.txt
+++ b/pytket/CMakeLists.txt
@@ -28,6 +28,9 @@ find_file(CONANBUILDINFO_FILE conanbuildinfo.cmake HINTS ${CMAKE_BINARY_DIR})
 include(${CONANBUILDINFO_FILE})
 conan_basic_setup(NO_OUTPUT_DIRS)
 
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_BINARY_DIR}")
+find_package(pybind11 REQUIRED)
+
 set(Boost_NO_BOOST_CMAKE ON)
 
 if (WIN32)
@@ -37,7 +40,7 @@ else()
 endif()
 
 function(build_module module)
-    pybind11_add_module(${module} NO_EXTRAS ${ARGN})
+    pybind11_add_module(${module} ${ARGN})
     target_include_directories(${module} PRIVATE binders/include)
     target_link_libraries(${module} PRIVATE ${CONAN_LIBS})
 endfunction(build_module)

--- a/pytket/conanfile.txt
+++ b/pytket/conanfile.txt
@@ -1,8 +1,9 @@
 [requires]
 tket/1.0.1
-pybind11/2.6.2#66f97eac059bef5b60bd6898ec4869fd
+pybind11/2.8.1
 nlohmann_json/3.10.4
 pybind11_json/0.2.11
 
 [generators]
 cmake
+cmake_find_package

--- a/recipes/pybind11/conanfile.py
+++ b/recipes/pybind11/conanfile.py
@@ -1,0 +1,95 @@
+# Copyright 2019-2021 Cambridge Quantum Computing
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from conans import ConanFile, tools, CMake
+import os
+
+
+class PyBind11Conan(ConanFile):
+    name = "pybind11"
+    version = "2.8.1"
+    description = "Seamless operability between C++11 and Python"
+    topics = "conan", "pybind11", "python", "binding"
+    homepage = "https://github.com/pybind/pybind11"
+    license = "BSD-3-Clause"
+    exports_sources = "CMakeLists.txt"
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake"
+    no_copy_source = True
+
+    _source_subfolder = "source_subfolder"
+
+    _cmake = None
+
+    def source(self):
+        tools.get(
+            f"https://github.com/pybind/pybind11/archive/refs/tags/v{self.version}.tar.gz"
+        )
+        os.rename("{}-{}".format(self.name, self.version), self._source_subfolder)
+
+    def _configure_cmake(self):
+        if self._cmake:
+            return self._cmake
+        self._cmake = CMake(self)
+        self._cmake.definitions["PYBIND11_INSTALL"] = True
+        self._cmake.definitions["PYBIND11_TEST"] = False
+        self._cmake.definitions[
+            "PYBIND11_CMAKECONFIG_INSTALL_DIR"
+        ] = "lib/cmake/pybind11"
+
+        # Use pybind11's CMakeLists.txt directly. Otherwise,
+        # PYBIND11_MASTER_PROJECT is set to FALSE and the installation does not
+        # generate pybind11Targets.cmake. Without that the generated package
+        # config cannot be used successfully. We want to use the generated
+        # package config as this starting in version 2.6.0 onwards defines the
+        # pybind11::headers target that is required to make full use of all
+        # installed cmake files.
+        self._cmake.configure(
+            source_dir=os.path.join(self.source_folder, self._source_subfolder)
+        )
+        return self._cmake
+
+    def build(self):
+        cmake = self._configure_cmake()
+        cmake.build()
+
+    def package(self):
+        self.copy("LICENSE", src=self._source_subfolder, dst="licenses")
+        cmake = self._configure_cmake()
+        cmake.install()
+        lib_folder = os.path.join(self.package_folder, "lib", "cmake", "pybind11")
+        os.rename(
+            os.path.join(lib_folder, "pybind11Config.cmake"),
+            os.path.join(lib_folder, "pybind11Install.cmake"),
+        )
+        os.unlink(os.path.join(lib_folder, "pybind11ConfigVersion.cmake"))
+
+    def package_id(self):
+        self.info.header_only()
+
+    def package_info(self):
+        self.cpp_info.includedirs.append(
+            os.path.join(self.package_folder, "include", "pybind11")
+        )
+
+        cmake_base_path = os.path.join("lib", "cmake", "pybind11")
+        self.cpp_info.builddirs = [cmake_base_path]
+
+        def get_path(filename):
+            return os.path.join(cmake_base_path, filename)
+
+        self.cpp_info.build_modules = [
+            get_path("FindPythonLibsNew.cmake"),
+            get_path("pybind11Install.cmake"),
+        ]

--- a/recipes/pybind11/conanfile.py
+++ b/recipes/pybind11/conanfile.py
@@ -14,6 +14,7 @@
 
 from conans import ConanFile, tools, CMake
 import os
+import sys
 
 
 class PyBind11Conan(ConanFile):
@@ -56,7 +57,8 @@ class PyBind11Conan(ConanFile):
         # pybind11::headers target that is required to make full use of all
         # installed cmake files.
         self._cmake.configure(
-            source_dir=os.path.join(self.source_folder, self._source_subfolder)
+            source_dir=os.path.join(self.source_folder, self._source_subfolder),
+            defs={"PYTHON_EXECUTABLE": sys.executable},
         )
         return self._cmake
 


### PR DESCRIPTION
Because of an unfortunate [issue](https://github.com/conan-io/conan-center-index/issues/6605) with the pybind11 conan package we have to use a local recipe to install the pybind11 package.

Release workflow tested [here](https://github.com/CQCL/tket/actions/runs/1504692592).