### PR TITLE
[TKET-1603] Version report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ build
 depgraph.png
 dist
 doc
+pytket/pytket/_version.py
 pytket/tests/qasm_test_files/testout.qasm
 pytket/tests/qasm_test_files/testout2.qasm
 pytket/tests/qasm_test_files/testout3.qasm

--- a/pytket/pyproject.toml
+++ b/pytket/pyproject.toml
@@ -4,3 +4,5 @@ build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]
 root = ".."
+write_to = "pytket/pytket/_version.py"
+write_to_template = '__version__ = "{version}"'

--- a/pytket/pytket/__init__.py
+++ b/pytket/pytket/__init__.py
@@ -14,7 +14,7 @@
 
 """Python Interface to CQC tket
 """
-
+import dunamai as _dunamai
 from pytket.circuit import (  # type: ignore
     Circuit,
     OpType,
@@ -26,3 +26,4 @@ import pytket.transform
 import pytket.telemetry
 
 __path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
+__version__ = _dunamai.Version.from_git().base

--- a/pytket/pytket/__init__.py
+++ b/pytket/pytket/__init__.py
@@ -14,7 +14,6 @@
 
 """Python Interface to CQC tket
 """
-import dunamai as _dunamai
 from pytket.circuit import (  # type: ignore
     Circuit,
     OpType,
@@ -25,5 +24,7 @@ import pytket.routing
 import pytket.transform
 import pytket.telemetry
 
+from pytket._version import __version__
+
 __path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
-__version__ = _dunamai.Version.from_git().base
+__version__ = '.'.join(__version__.split('.')[:3])

--- a/pytket/pytket/__init__.py
+++ b/pytket/pytket/__init__.py
@@ -27,4 +27,4 @@ import pytket.telemetry
 from pytket._version import __version__
 
 __path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
-__version__ = '.'.join(__version__.split('.')[:3])
+__version__ = ".".join(__version__.split(".")[:3])

--- a/pytket/pytket/__init__.py
+++ b/pytket/pytket/__init__.py
@@ -27,4 +27,3 @@ import pytket.telemetry
 from pytket._version import __version__
 
 __path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
-__version__ = ".".join(__version__.split(".")[:3])

--- a/pytket/setup.py
+++ b/pytket/setup.py
@@ -209,7 +209,6 @@ setup(
     license="Apache 2",
     packages=setuptools.find_packages(),
     install_requires=[
-        "dunamai ~=1.7.0",
         "sympy ~=1.6",
         "numpy ~=1.19",
         "lark-parser ~=0.7",

--- a/pytket/setup.py
+++ b/pytket/setup.py
@@ -209,6 +209,7 @@ setup(
     license="Apache 2",
     packages=setuptools.find_packages(),
     install_requires=[
+        "dunamai ~=1.7.0",
         "sympy ~=1.6",
         "numpy ~=1.19",
         "lark-parser ~=0.7",


### PR DESCRIPTION
Fixes [TKET-1603](https://cqc.atlassian.net/browse/TKET-1603?atlOrigin=eyJpIjoiNWRiMGU4ZDA0ZGI0NDI1YmJlN2ZiNWM5MjU5ZjM1NzEiLCJwIjoiaiJ9).

This PR addresses the report of the `pytket` version at runtime when query `pytket.__version__`. It uses `dunamai` as a runtime dependency to query `git` source tree.