### PR TITLE
Add instructions to link to local `pybind11` recipe.

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,19 @@ The Python tests require a few more packages. These can be installed with:
 pip install -r pytket/tests/requirements.txt
 ```
 
+### Adding local `pybind11`
+
+There is a known [issue](https://github.com/pybind/pybind11/issues/3081) with using `pybind11`
+from the `conan-center` that leads to a Python error when importing `pytket`. To remedy this, 
+`pybind11` must be linked to a local recipe:
+
+```shell
+conan remove -f pybind11/2.8.1
+conan create --profile=tket recipes/pybind11
+```
+
+where the first line is optional, to remove links from potential previous versions.
+
 ### Building symengine
 
 The `symengine` dependency is built from a local conan recipe. Run:

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ pip install -r pytket/tests/requirements.txt
 
 There is a known [issue](https://github.com/conan-io/conan-center-index/issues/6605) with using `pybind11`
 from the `conan-center` that can lead to a Python crash when importing `pytket`. To remedy this, 
-`pybind11` must be linked to a local recipe:
+`pybind11` must be installed from the local recipe:
 
 ```shell
 conan remove -f pybind11/2.8.1

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ pip install -r pytket/tests/requirements.txt
 
 ### Adding local `pybind11`
 
-There is a known [issue](https://github.com/pybind/pybind11/issues/3081) with using `pybind11`
+There is a known [issue](https://github.com/conan-io/conan-center-index/issues/6605) with using `pybind11`
 from the `conan-center` that leads to a Python error when importing `pytket`. To remedy this, 
 `pybind11` must be linked to a local recipe:
 

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ conan remove -f pybind11/2.8.1
 conan create --profile=tket recipes/pybind11
 ```
 
-where the first line is optional, to remove links from potential previous versions.
+where the first line serves to remove any version already installed.
 
 ### Building symengine
 

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ pip install -r pytket/tests/requirements.txt
 ### Adding local `pybind11`
 
 There is a known [issue](https://github.com/conan-io/conan-center-index/issues/6605) with using `pybind11`
-from the `conan-center` that leads to a Python error when importing `pytket`. To remedy this, 
+from the `conan-center` that can lead to a Python crash when importing `pytket`. To remedy this, 
 `pybind11` must be linked to a local recipe:
 
 ```shell

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ from the `conan-center` that can lead to a Python crash when importing `pytket`.
 `pybind11` must be installed from the local recipe:
 
 ```shell
-conan remove -f pybind11/2.8.1
+conan remove -f pybind11/*
 conan create --profile=tket recipes/pybind11
 ```
 


### PR DESCRIPTION
Fixes [TKET-1720](https://cqc.atlassian.net/browse/TKET-1720?atlOrigin=eyJpIjoiMTI4NTI3MTI4ZmU5NDA3OWFiODI0MTFkYzc4ZjI0MzUiLCJwIjoiaiJ9). 

Instructions to add a link to local `pybind11` recipe.