### PR TITLE
[TKET-1670] Expose free symbols

### DIFF
--- a/pytket/binders/circuit/main.cpp
+++ b/pytket/binders/circuit/main.cpp
@@ -31,6 +31,15 @@
 
 namespace py = pybind11;
 
+// A type that should be raised as an exception in Python
+class OpException : public std::exception {
+public:
+    explicit OpException(const char * m) : message{m} {}
+    const char * what() const noexcept override {return message.c_str();}
+private:
+    std::string message = "";
+};
+
 namespace tket {
 
 void init_unitid(py::module &m);

--- a/pytket/binders/circuit/main.cpp
+++ b/pytket/binders/circuit/main.cpp
@@ -74,7 +74,7 @@ PYBIND11_MODULE(circuit, m) {
           py::arg("latex") = false)
       .def("__eq__", &Op::operator==)
       .def("__repr__", [](const Op &op) { return op.get_name(); })
-      .def("free_symbols", [](const Op &op) { return op->free_symbols(); })
+      .def("free_symbols", [](const Op &op) { return op.free_symbols(); })
       .def(
           "get_unitary",
           [](const Op *op) {

--- a/pytket/binders/circuit/main.cpp
+++ b/pytket/binders/circuit/main.cpp
@@ -74,9 +74,7 @@ PYBIND11_MODULE(circuit, m) {
           py::arg("latex") = false)
       .def("__eq__", &Op::operator==)
       .def("__repr__", [](const Op &op) { return op.get_name(); })
-      .def(
-          "free_symbols",
-          [](const Op *op) { return op->free_symbols(); })
+      .def("free_symbols", [](const Op *op) { return op->free_symbols(); })
       .def(
           "get_unitary",
           [](const Op *op) {

--- a/pytket/binders/circuit/main.cpp
+++ b/pytket/binders/circuit/main.cpp
@@ -31,7 +31,6 @@
 
 namespace py = pybind11;
 
-
 namespace tket {
 
 void init_unitid(py::module &m);
@@ -82,7 +81,8 @@ PYBIND11_MODULE(circuit, m) {
             try {
               symbols = op->free_symbols();
             } catch (const std::runtime_error &e) {
-              throw std::runtime_error("Free symbols are not defined for that Op.");
+              throw std::runtime_error(
+                  "Free symbols are not defined for that Op.");
             }
             return symbols;
           })

--- a/pytket/binders/circuit/main.cpp
+++ b/pytket/binders/circuit/main.cpp
@@ -33,11 +33,12 @@ namespace py = pybind11;
 
 // A type that should be raised as an exception in Python
 class OpException : public std::exception {
-public:
-    explicit OpException(const char * m) : message{m} {}
-    const char * what() const noexcept override {return message.c_str();}
-private:
-    std::string message = "";
+ public:
+  explicit OpException(const char *m) : message{m} {}
+  const char *what() const noexcept override { return message.c_str(); }
+
+ private:
+  std::string message = "";
 };
 
 namespace tket {
@@ -51,12 +52,12 @@ PYBIND11_MODULE(circuit, m) {
   init_unitid(m);
   static py::exception<OpException> ex(m, "OpException");
   py::register_exception_translator([](std::exception_ptr p) {
-      try {
-          if (p) std::rethrow_exception(p);
-      } catch (const OpException &e) {
-          // Set OpException as the active python error
-          ex(e.what());
-      }
+    try {
+      if (p) std::rethrow_exception(p);
+    } catch (const OpException &e) {
+      // Set OpException as the active python error
+      ex(e.what());
+    }
   });
   py::class_<Op, std::shared_ptr<Op>>(
       m, "Op", "Encapsulates operation information")
@@ -95,15 +96,14 @@ PYBIND11_MODULE(circuit, m) {
       .def(
           "free_symbols",
           [](const Op *op) {
-              SymSet symbols;
-              const auto &gate = static_cast<const Gate &>(*op);
-              try {
-                  symbols = gate.free_symbols();
-              }
-              catch (const std::runtime_error& e) {
-                  throw OpException("Free symbols are not defined for that Op.");
-              }
-              return symbols;
+            SymSet symbols;
+            const auto &gate = static_cast<const Gate &>(*op);
+            try {
+              symbols = gate.free_symbols();
+            } catch (const std::runtime_error &e) {
+              throw OpException("Free symbols are not defined for that Op.");
+            }
+            return symbols;
           })
       .def(
           "get_unitary",

--- a/pytket/binders/circuit/main.cpp
+++ b/pytket/binders/circuit/main.cpp
@@ -74,7 +74,7 @@ PYBIND11_MODULE(circuit, m) {
           py::arg("latex") = false)
       .def("__eq__", &Op::operator==)
       .def("__repr__", [](const Op &op) { return op.get_name(); })
-      .def("free_symbols", [](const Op *op) { return op->free_symbols(); })
+      .def("free_symbols", [](const Op &op) { return op->free_symbols(); })
       .def(
           "get_unitary",
           [](const Op *op) {

--- a/pytket/binders/circuit/main.cpp
+++ b/pytket/binders/circuit/main.cpp
@@ -80,8 +80,9 @@ PYBIND11_MODULE(circuit, m) {
           [](const Op *op) {
             SymSet symbols;
             try {
-              symbols = gate.free_symbols();
+              symbols = op->free_symbols();
             } catch (const std::runtime_error &e) {
+              throw std::runtime_error("Free symbols are not defined for that Op.");
             }
             return symbols;
           })

--- a/pytket/binders/circuit/main.cpp
+++ b/pytket/binders/circuit/main.cpp
@@ -93,6 +93,19 @@ PYBIND11_MODULE(circuit, m) {
       .def("__eq__", &Op::operator==)
       .def("__repr__", [](const Op &op) { return op.get_name(); })
       .def(
+          "free_symbols",
+          [](const Op *op) {
+              SymSet symbols;
+              const auto &gate = static_cast<const Gate &>(*op);
+              try {
+                  symbols = gate.free_symbols();
+              }
+              catch (const std::runtime_error& e) {
+                  throw OpException("Free symbols are not defined for that Op.");
+              }
+              return symbols;
+          })
+      .def(
           "get_unitary",
           [](const Op *op) {
             const auto &gate = static_cast<const Gate &>(*op);

--- a/pytket/binders/circuit/main.cpp
+++ b/pytket/binders/circuit/main.cpp
@@ -49,6 +49,15 @@ void init_boxes(py::module &m);
 
 PYBIND11_MODULE(circuit, m) {
   init_unitid(m);
+  static py::exception<OpException> ex(m, "OpException");
+  py::register_exception_translator([](std::exception_ptr p) {
+      try {
+          if (p) std::rethrow_exception(p);
+      } catch (const OpException &e) {
+          // Set OpException as the active python error
+          ex(e.what());
+      }
+  });
   py::class_<Op, std::shared_ptr<Op>>(
       m, "Op", "Encapsulates operation information")
       .def_static(

--- a/pytket/binders/circuit/main.cpp
+++ b/pytket/binders/circuit/main.cpp
@@ -76,16 +76,7 @@ PYBIND11_MODULE(circuit, m) {
       .def("__repr__", [](const Op &op) { return op.get_name(); })
       .def(
           "free_symbols",
-          [](const Op *op) {
-            SymSet symbols;
-            try {
-              symbols = op->free_symbols();
-            } catch (const std::runtime_error &e) {
-              throw std::runtime_error(
-                  "Free symbols are not defined for that Op.");
-            }
-            return symbols;
-          })
+          [](const Op *op) { return op->free_symbols(); })
       .def(
           "get_unitary",
           [](const Op *op) {

--- a/pytket/tests/circuit_test.py
+++ b/pytket/tests/circuit_test.py
@@ -59,6 +59,17 @@ with open(curr_file_path.parent.parent / "schemas/circuit_v1.json", "r") as f:
     schema = json.load(f)
 
 
+def test_op_free_symbols() -> None:
+    c = Circuit(2)
+    c.add_barrier([0, 1])
+    op = c.get_commands()[0].op
+    assert op.free_symbols() == set()
+    alpha = Symbol("alpha")
+    c.Rx(alpha, 0)
+    op = c.get_commands()[1].op
+    assert op.free_symbols() == {alpha}
+
+
 def test_circuit_transpose() -> None:
     c = Circuit(2)
     u = np.asarray([[0, 1, 0, 0], [0, 0, 0, 1], [0, 0, 1, 0], [1, 0, 0, 0]])


### PR DESCRIPTION
Fixes [TKET-1670](https://cqc.atlassian.net/browse/TKET-1670?atlOrigin=eyJpIjoiM2ViZTZjNWQ4MmY3NGQwYThjMTQ4MThkNTAwMzM3NWYiLCJwIjoiaiJ9).

This PR addresses exposing the `free_symbols` method from the underlying gate at the op level in Python. 
It also adds an `pybind11` custom exception to be thrown in Python if the method is not defined for that gate. 

However, local checks return an empty set in that case. 