### PR TITLE
[TKET-1669] Setting deadlines to None to avoid timeouts.

### DIFF
--- a/pytket/tests/backend_test.py
+++ b/pytket/tests/backend_test.py
@@ -14,7 +14,7 @@
 
 from collections import Counter
 
-from hypothesis import given, strategies
+from hypothesis import given, settings, strategies
 import json
 import pytest  # type: ignore
 from typing import Any, List
@@ -399,6 +399,7 @@ def test_empty_result(n_shots, n_bits) -> None:
     status=strategies.sampled_from(StatusEnum),
     message=strategies.text(),
 )
+@settings(deadline=None)
 def test_status_serialization(status: StatusEnum, message: str) -> None:
     c_stat = CircuitStatus(status, message)
     assert CircuitStatus.from_dict(c_stat.to_dict()) == c_stat

--- a/pytket/tests/classical_test.py
+++ b/pytket/tests/classical_test.py
@@ -365,7 +365,7 @@ def reg_const_predicates(
 
 
 @given(condition=strategies.one_of(bit_const_predicates(), reg_const_predicates()))
-@settings(print_blob=True)
+@settings(print_blob=True, deadline=None)
 def test_const_predicate(condition: ConstPredicate) -> None:
     assert isinstance(condition, ConstPredicate)
     # test serialization round trip here


### PR DESCRIPTION
Fixes [TKET-1669](https://cqc.atlassian.net/browse/TKET-1669?atlOrigin=eyJpIjoiMjkwNWFlMmZiOTExNGE1MTk5MjMzOTE0YjFhNzM4YjMiLCJwIjoiaiJ9).

This PR addresses CI timeouts that cause hypothesis test failures. Following the recommendation, I added a deadline to `None` in the `@settings` to disable the 200 ms timeout as documented [here](https://hypothesis.readthedocs.io/en/latest/settings.html).