### PR TITLE
Add u and p gate aliases to match updated qelib1.inc

### DIFF
--- a/pytket/pytket/qasm/qasm.py
+++ b/pytket/pytket/qasm/qasm.py
@@ -17,14 +17,28 @@
 import io
 import os
 from itertools import groupby
-from typing import (Any, Callable, Dict, List, Optional, TextIO, Tuple, Type,
-                    TypeVar, Union)
-
-from pytket import Bit, Circuit, OpType, Qubit
-from pytket.circuit import Op  # type: ignore
-from pytket.circuit import BitRegister, CustomGateDef, QubitRegister, UnitID
-from sympy import pi, sympify  # type: ignore
-
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    List,
+    Optional,
+    TextIO,
+    Tuple,
+    Type,
+    TypeVar,
+    Union,
+)
+from itertools import groupby
+from sympy import sympify, pi  # type: ignore
+from pytket import Circuit, OpType, Qubit, Bit
+from pytket.circuit import (  # type: ignore
+    CustomGateDef,
+    UnitID,
+    BitRegister,
+    QubitRegister,
+    Op,
+)
 NOPARAM_COMMANDS = {
     "CX": OpType.CX,  # built-in gate equivalent to "cx"
     "cx": OpType.CX,

--- a/pytket/pytket/qasm/qasm.py
+++ b/pytket/pytket/qasm/qasm.py
@@ -54,7 +54,7 @@ NOPARAM_COMMANDS = {
 }
 
 PARAM_COMMANDS = {
-    "P": OpType.U1,  # alias. https://github.com/Qiskit/qiskit-terra/pull/4765
+    "p": OpType.U1,  # alias. https://github.com/Qiskit/qiskit-terra/pull/4765
     "u": OpType.U3,  # alias. https://github.com/Qiskit/qiskit-terra/pull/4765
     "U": OpType.U3,  # built-in gate equivalent to "u3"
     "u3": OpType.U3,

--- a/pytket/pytket/qasm/qasm.py
+++ b/pytket/pytket/qasm/qasm.py
@@ -110,7 +110,7 @@ included_gates = {
             "reset",
             "id",
             "barrier",
-            "P",
+            "p",
             "U",
             "u",
             "u3",

--- a/pytket/pytket/qasm/qasm.py
+++ b/pytket/pytket/qasm/qasm.py
@@ -16,28 +16,14 @@
 # TODO: Figure out nice way to make these class methods of Circuit
 import io
 import os
-from typing import (
-    Any,
-    Callable,
-    Dict,
-    List,
-    Optional,
-    TextIO,
-    Tuple,
-    Type,
-    TypeVar,
-    Union,
-)
 from itertools import groupby
-from sympy import sympify, pi  # type: ignore
-from pytket import Circuit, OpType, Qubit, Bit
-from pytket.circuit import (  # type: ignore
-    CustomGateDef,
-    UnitID,
-    BitRegister,
-    QubitRegister,
-    Op,
-)
+from typing import (Any, Callable, Dict, List, Optional, TextIO, Tuple, Type,
+                    TypeVar, Union)
+
+from pytket import Bit, Circuit, OpType, Qubit
+from pytket.circuit import Op  # type: ignore
+from pytket.circuit import BitRegister, CustomGateDef, QubitRegister, UnitID
+from sympy import pi, sympify  # type: ignore
 
 NOPARAM_COMMANDS = {
     "CX": OpType.CX,  # built-in gate equivalent to "cx"
@@ -68,6 +54,8 @@ NOPARAM_COMMANDS = {
 }
 
 PARAM_COMMANDS = {
+    "P": OpType.U1,  # alias. https://github.com/Qiskit/qiskit-terra/pull/4765
+    "u": OpType.U3,  # alias. https://github.com/Qiskit/qiskit-terra/pull/4765
     "U": OpType.U3,  # built-in gate equivalent to "u3"
     "u3": OpType.U3,
     "u2": OpType.U2,
@@ -108,7 +96,9 @@ included_gates = {
             "reset",
             "id",
             "barrier",
+            "P",
             "U",
+            "u",
             "u3",
             "u2",
             "u1",

--- a/pytket/pytket/qasm/qasm.py
+++ b/pytket/pytket/qasm/qasm.py
@@ -16,7 +16,6 @@
 # TODO: Figure out nice way to make these class methods of Circuit
 import io
 import os
-from itertools import groupby
 from typing import (
     Any,
     Callable,
@@ -39,6 +38,7 @@ from pytket.circuit import (  # type: ignore
     QubitRegister,
     Op,
 )
+
 NOPARAM_COMMANDS = {
     "CX": OpType.CX,  # built-in gate equivalent to "cx"
     "cx": OpType.CX,

--- a/pytket/tests/qasm_test.py
+++ b/pytket/tests/qasm_test.py
@@ -334,6 +334,15 @@ def test_builtin_gates() -> None:
     assert "U3(0, 0, 1.75) q[2];" in str(c.get_commands())
 
 
+def test_new_qelib1_aliases() -> None:
+    # Check that aliases added to qelib1 parse into an equivalent instruction.
+    fname = str(curr_file_path / "qasm_test_files/test16.qasm")
+    c = circuit_from_qasm(fname)
+    commands_str = str(c.get_commands())
+    assert "U1(0) q[0]" in commands_str
+    assert "U3(0, 0, 0) q[0]" in commands_str
+
+
 if __name__ == "__main__":
     test_qasm_correct()
     test_qasm_qubit()
@@ -348,3 +357,4 @@ if __name__ == "__main__":
     test_input_error_modes()
     test_output_error_modes()
     test_builtin_gates()
+    test_new_qelib1_aliases()

--- a/pytket/tests/qasm_test_files/test16.qasm
+++ b/pytket/tests/qasm_test_files/test16.qasm
@@ -1,0 +1,5 @@
+OPENQASM 2.0;
+include "qelib1.inc";
+qreg q[1];
+p(0) q[0];
+u(0,0,0) q[0];


### PR DESCRIPTION
Context: https://github.com/Qiskit/qiskit-terra/pull/4765

Before this change the following code would fail
```py
from pytket.qasm import circuit_from_qasm_str
from qiskit import QuantumCircuit

qc = QuantumCircuit(1)
qc.p(0, 0)
qc.u(0, 0, 0, 0)
print(circuit_from_qasm_str(qc.qasm()))
```

With a message like: `pytket.qasm.qasm.QASMParseError: Cannot parse gate of type: p`