### PR TITLE
Run lint check on pull request rather than push.

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,6 @@
 name: Lint python projects
 
-on: [push]
+on: [pull_request]
 
 jobs:
   lint:


### PR DESCRIPTION
1. To avoid unnecessary checks when pushing to private branches.
2. So that it is triggered when we get external PRs from forks.