### PR TITLE
Add pytket.tableau to API docs

### DIFF
--- a/pytket/docs/index.rst
+++ b/pytket/docs/index.rst
@@ -166,6 +166,7 @@ Our telemetry data policy can be viewed in the `Telemetry Data Policy`_ page.
     qasm.rst
     quipper.rst
     routing.rst
+    tableau.rst
     transform.rst
     tailoring.rst
     zx.rst

--- a/pytket/docs/tableau.rst
+++ b/pytket/docs/tableau.rst
@@ -1,0 +1,6 @@
+pytket.tableau
+=========
+
+.. automodule:: pytket._tket.tableau
+    :members:
+    :special-members: __init__

--- a/pytket/docs/tableau.rst
+++ b/pytket/docs/tableau.rst
@@ -1,5 +1,5 @@
 pytket.tableau
-=========
+==============
 
 .. automodule:: pytket._tket.tableau
     :members:


### PR DESCRIPTION
Forgot to update the docs with #151 . My bad