### PR TITLE
Explicit linking of library dependencies

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -371,7 +371,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: C:\Users\runneradmin\.conan\data\tket
-        key: ${{ runner.os }}-tket-tket-${{ steps.hash_tket_source.outputs.tket_hash }}-13
+        key: ${{ runner.os }}-tket-tket-${{ steps.hash_tket_source.outputs.tket_hash }}-14
     - name: Build symengine
       run: conan create --profile=tket recipes/symengine
     - name: Build tket

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -270,15 +270,15 @@ jobs:
         export CC=`which conan`
         echo "CONAN_CMD=${CC}" >> $GITHUB_ENV
     - name: Install boost
-      run: conan install --profile=tket boost/1.78.0@ --build=missing -o boost:without_fiber=True -o boost:without_json=True -o boost:without_nowide=True
+      run: conan install --profile=tket boost/1.78.0@ --build=missing
     - name: Build symengine
-      run: conan create --profile=tket recipes/symengine -o boost:without_fiber=True -o boost:without_json=True -o boost:without_nowide=True
+      run: conan create --profile=tket recipes/symengine
     - name: Build tket
-      run: conan create --profile=tket recipes/tket -o boost:without_fiber=True -o boost:without_json=True -o boost:without_nowide=True
+      run: conan create --profile=tket recipes/tket
     - name: Build and run tket tests
-      run: conan create --profile=tket recipes/tket-tests -o boost:without_fiber=True -o boost:without_json=True -o boost:without_nowide=True
+      run: conan create --profile=tket recipes/tket-tests
     - name: Build and run tket proptests
-      run: conan create --profile=tket recipes/tket-proptests -o boost:without_fiber=True -o boost:without_json=True -o boost:without_nowide=True
+      run: conan create --profile=tket recipes/tket-proptests
     - name: Install pybind11
       run: conan create --profile=tket recipes/pybind11
     - name: Build pytket (3.8)

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -178,7 +178,7 @@ jobs:
         export CC=`which conan`
         echo "CONAN_CMD=${CC}" >> $GITHUB_ENV
     - name: Install boost
-      run: conan install --profile=tket boost/1.77.0@ --build=missing
+      run: conan install --profile=tket boost/1.78.0@ --build=missing
     - name: Build symengine
       run: conan create --profile=tket recipes/symengine
     - name: Build tket
@@ -270,7 +270,7 @@ jobs:
         export CC=`which conan`
         echo "CONAN_CMD=${CC}" >> $GITHUB_ENV
     - name: Install boost
-      run: conan install --profile=tket boost/1.77.0@ --build=missing -o boost:without_fiber=True -o boost:without_json=True -o boost:without_nowide=True
+      run: conan install --profile=tket boost/1.78.0@ --build=missing -o boost:without_fiber=True -o boost:without_json=True -o boost:without_nowide=True
     - name: Build symengine
       run: conan create --profile=tket recipes/symengine -o boost:without_fiber=True -o boost:without_json=True -o boost:without_nowide=True
     - name: Build tket

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -335,7 +335,6 @@ jobs:
     runs-on: windows-2019
     env:
       PYTKET_SKIP_REGISTRATION: "true"
-      CMAKE_BUILD_PARALLEL_LEVEL: "2"
     steps:
     - uses: actions/checkout@v2
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -165,7 +165,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: C:\Users\runneradmin\.conan\data\tket
-        key: ${{ runner.os }}-tket-tket-${{ steps.hash_tket_source.outputs.tket_hash }}-7
+        key: ${{ runner.os }}-tket-tket-${{ steps.hash_tket_source.outputs.tket_hash }}-8
     - name: Build symengine
       run: conan create --profile=tket recipes/symengine
     - name: Build tket

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,9 +112,9 @@ jobs:
         pyenv shell tket-3.8
         conan profile new tket --detect --force
         conan profile update options.tket:shared=True tket
-        conan install --profile=tket boost/1.78.0@ --build=missing -o boost:without_fiber=True -o boost:without_json=True -o boost:without_nowide=True
-        conan create --profile=tket recipes/symengine -o boost:without_fiber=True -o boost:without_json=True -o boost:without_nowide=True
-        conan create --profile=tket recipes/tket -o boost:without_fiber=True -o boost:without_json=True -o boost:without_nowide=True
+        conan install --profile=tket boost/1.78.0@ --build=missing
+        conan create --profile=tket recipes/symengine
+        conan create --profile=tket recipes/tket
         conan create --profile=tket recipes/pybind11
         .github/workflows/build_macos_m1_wheel
         pyenv shell tket-3.9

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,7 +65,7 @@ jobs:
         pip install conan
         conan profile new tket --detect --force
         conan profile update options.tket:shared=True tket
-        conan install --profile=tket boost/1.77.0@ --build=missing
+        conan install --profile=tket boost/1.78.0@ --build=missing
         conan create --profile=tket recipes/symengine
         conan create --profile=tket recipes/tket
     - name: Install pybind11
@@ -112,7 +112,7 @@ jobs:
         pyenv shell tket-3.8
         conan profile new tket --detect --force
         conan profile update options.tket:shared=True tket
-        conan install --profile=tket boost/1.77.0@ --build=missing -o boost:without_fiber=True -o boost:without_json=True -o boost:without_nowide=True
+        conan install --profile=tket boost/1.78.0@ --build=missing -o boost:without_fiber=True -o boost:without_json=True -o boost:without_nowide=True
         conan create --profile=tket recipes/symengine -o boost:without_fiber=True -o boost:without_json=True -o boost:without_nowide=True
         conan create --profile=tket recipes/tket -o boost:without_fiber=True -o boost:without_json=True -o boost:without_nowide=True
         conan create --profile=tket recipes/pybind11

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,8 +129,6 @@ jobs:
   build_Windows_wheels:
     name: Build Windows wheels
     runs-on: windows-2019
-    env:
-      CMAKE_BUILD_PARALLEL_LEVEL: "2"
     steps:
     - uses: actions/checkout@v2
       with:

--- a/pytket/CMakeLists.txt
+++ b/pytket/CMakeLists.txt
@@ -38,13 +38,7 @@ else()
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Werror")
 endif()
 
-function(build_module module)
-    pybind11_add_module(${module} ${ARGN})
-    target_include_directories(${module} PRIVATE binders/include)
-    target_link_libraries(${module} PRIVATE ${CONAN_LIBS})
-endfunction(build_module)
-
-build_module(circuit
+pybind11_add_module(circuit
     binders/circuit/main.cpp
     binders/circuit/unitid.cpp
     binders/circuit/boxes.cpp
@@ -52,17 +46,74 @@ build_module(circuit
     binders/circuit/Circuit/main.cpp
     binders/circuit/Circuit/add_op.cpp
     binders/circuit/Circuit/add_classical_op.cpp)
-build_module(routing binders/routing.cpp)
-build_module(transform binders/transform.cpp)
-build_module(predicates binders/predicates.cpp)
-build_module(passes binders/passes.cpp)
-build_module(program binders/program.cpp)
-build_module(partition binders/partition.cpp)
-build_module(pauli binders/pauli.cpp)
-build_module(logging binders/logging.cpp)
-build_module(utils_serialization binders/utils_serialization.cpp)
-build_module(tailoring binders/tailoring.cpp)
-build_module(tableau binders/tableau.cpp)
-build_module(zx
+target_include_directories(circuit PRIVATE binders/include)
+target_link_libraries(circuit PRIVATE
+    symengine
+    tket-Converters
+    tket-Routing
+    tket-Simulation)
+
+pybind11_add_module(routing binders/routing.cpp)
+target_include_directories(routing PRIVATE binders/include)
+target_link_libraries(routing PRIVATE tket-Routing)
+
+pybind11_add_module(transform binders/transform.cpp)
+target_include_directories(transform PRIVATE binders/include)
+target_link_libraries(transform PRIVATE
+    symengine
+    tket-Transformations)
+
+pybind11_add_module(predicates binders/predicates.cpp)
+target_include_directories(predicates PRIVATE binders/include)
+target_link_libraries(predicates PRIVATE
+    symengine
+    tket-Predicates)
+
+pybind11_add_module(passes binders/passes.cpp)
+target_include_directories(passes PRIVATE binders/include)
+target_link_libraries(passes PRIVATE
+    symengine
+    tket-Predicates)
+
+pybind11_add_module(program binders/program.cpp)
+target_include_directories(program PRIVATE binders/include)
+target_link_libraries(program PRIVATE
+    symengine
+    tket-Program)
+
+pybind11_add_module(partition binders/partition.cpp)
+target_include_directories(partition PRIVATE binders/include)
+target_link_libraries(partition PRIVATE
+    symengine
+    tket-MeasurementSetup)
+
+pybind11_add_module(pauli binders/pauli.cpp)
+target_include_directories(pauli PRIVATE binders/include)
+target_link_libraries(pauli PRIVATE tket-Utils)
+
+pybind11_add_module(logging binders/logging.cpp)
+target_include_directories(logging PRIVATE binders/include)
+target_link_libraries(logging PRIVATE tket-Utils)
+
+pybind11_add_module(utils_serialization binders/utils_serialization.cpp)
+target_include_directories(utils_serialization PRIVATE binders/include)
+target_link_libraries(utils_serialization PRIVATE tket-Utils)
+
+pybind11_add_module(tailoring binders/tailoring.cpp)
+target_include_directories(tailoring PRIVATE binders/include)
+target_link_libraries(tailoring PRIVATE
+    symengine
+    tket-Characterisation
+    tket-Converters)
+
+pybind11_add_module(tableau binders/tableau.cpp)
+target_include_directories(tableau PRIVATE binders/include)
+target_link_libraries(tableau PRIVATE tket-Converters)
+
+pybind11_add_module(zx
     binders/zx/diagram.cpp
     binders/zx/rewrite.cpp)
+target_include_directories(zx PRIVATE binders/include)
+target_link_libraries(zx PRIVATE
+    symengine
+    tket-ZX)

--- a/pytket/CMakeLists.txt
+++ b/pytket/CMakeLists.txt
@@ -49,66 +49,196 @@ pybind11_add_module(circuit
 target_include_directories(circuit PRIVATE binders/include)
 target_link_libraries(circuit PRIVATE
     symengine
+    tket-Circuit
     tket-Converters
+    tket-Gate
+    tket-Ops
+    tket-OpType
     tket-Routing
-    tket-Simulation)
+    tket-Simulation
+    tket-Utils)
+if (WIN32)
+    # For boost::uuid:
+    target_link_libraries(circuit PRIVATE bcrypt)
+endif()
 
 pybind11_add_module(routing binders/routing.cpp)
 target_include_directories(routing PRIVATE binders/include)
-target_link_libraries(routing PRIVATE tket-Routing)
+target_link_libraries(routing PRIVATE
+    symengine
+    tket-Architecture
+    tket-Characterisation
+    tket-Circuit
+    tket-Gate
+    tket-Graphs
+    tket-Ops
+    tket-OpType
+    tket-Routing
+    tket-Utils)
+if (WIN32)
+    # For boost::uuid:
+    target_link_libraries(routing PRIVATE bcrypt)
+endif()
 
 pybind11_add_module(transform binders/transform.cpp)
 target_include_directories(transform PRIVATE binders/include)
 target_link_libraries(transform PRIVATE
     symengine
-    tket-Transformations)
+    tket-Architecture
+    tket-Characterisation
+    tket-Circuit
+    tket-Clifford
+    tket-Converters
+    tket-Gate
+    tket-Graphs
+    tket-Ops
+    tket-OpType
+    tket-PauliGraph
+    tket-Transformations
+    tket-Utils)
+if (WIN32)
+    # For boost::uuid:
+    target_link_libraries(transform PRIVATE bcrypt)
+endif()
 
 pybind11_add_module(predicates binders/predicates.cpp)
 target_include_directories(predicates PRIVATE binders/include)
 target_link_libraries(predicates PRIVATE
     symengine
-    tket-Predicates)
+    tket-ArchAwareSynth
+    tket-Architecture
+    tket-Characterisation
+    tket-Circuit
+    tket-Clifford
+    tket-Converters
+    tket-Gate
+    tket-Graphs
+    tket-Ops
+    tket-OpType
+    tket-PauliGraph
+    tket-Predicates
+    tket-Routing
+    tket-Transformations
+    tket-Utils)
+if (WIN32)
+    # For boost::uuid:
+    target_link_libraries(predicates PRIVATE bcrypt)
+endif()
 
 pybind11_add_module(passes binders/passes.cpp)
 target_include_directories(passes PRIVATE binders/include)
 target_link_libraries(passes PRIVATE
     symengine
-    tket-Predicates)
+    tket-ArchAwareSynth
+    tket-Architecture
+    tket-Characterisation
+    tket-Circuit
+    tket-Clifford
+    tket-Converters
+    tket-Gate
+    tket-Graphs
+    tket-Ops
+    tket-OpType
+    tket-PauliGraph
+    tket-Predicates
+    tket-Routing
+    tket-Transformations
+    tket-Utils)
+if (WIN32)
+    # For boost::uuid:
+    target_link_libraries(passes PRIVATE bcrypt)
+endif()
 
 pybind11_add_module(program binders/program.cpp)
 target_include_directories(program PRIVATE binders/include)
 target_link_libraries(program PRIVATE
     symengine
-    tket-Program)
+    tket-Circuit
+    tket-Gate
+    tket-Ops
+    tket-OpType
+    tket-Program
+    tket-Utils)
+if (WIN32)
+    # For boost::uuid:
+    target_link_libraries(program PRIVATE bcrypt)
+endif()
 
 pybind11_add_module(partition binders/partition.cpp)
 target_include_directories(partition PRIVATE binders/include)
 target_link_libraries(partition PRIVATE
     symengine
-    tket-MeasurementSetup)
+    tket-Circuit
+    tket-Clifford
+    tket-Converters
+    tket-Diagonalisation
+    tket-Gate
+    tket-MeasurementSetup
+    tket-Ops
+    tket-OpType
+    tket-PauliGraph
+    tket-Utils)
+if (WIN32)
+    # For boost::uuid:
+    target_link_libraries(partition PRIVATE bcrypt)
+endif()
 
 pybind11_add_module(pauli binders/pauli.cpp)
 target_include_directories(pauli PRIVATE binders/include)
-target_link_libraries(pauli PRIVATE tket-Utils)
+target_link_libraries(pauli PRIVATE
+    symengine
+    tket-Utils)
 
 pybind11_add_module(logging binders/logging.cpp)
 target_include_directories(logging PRIVATE binders/include)
-target_link_libraries(logging PRIVATE tket-Utils)
+target_link_libraries(logging PRIVATE
+    symengine
+    tket-Utils)
 
 pybind11_add_module(utils_serialization binders/utils_serialization.cpp)
 target_include_directories(utils_serialization PRIVATE binders/include)
-target_link_libraries(utils_serialization PRIVATE tket-Utils)
+target_link_libraries(utils_serialization PRIVATE
+    symengine
+    tket-Utils)
 
 pybind11_add_module(tailoring binders/tailoring.cpp)
 target_include_directories(tailoring PRIVATE binders/include)
 target_link_libraries(tailoring PRIVATE
     symengine
+    tket-Architecture
     tket-Characterisation
-    tket-Converters)
+    tket-Circuit
+    tket-Clifford
+    tket-Converters
+    tket-Diagonalisation
+    tket-Gate
+    tket-Graphs
+    tket-Ops
+    tket-OpType
+    tket-PauliGraph
+    tket-Utils)
+if (WIN32)
+    # For boost::uuid:
+    target_link_libraries(tailoring PRIVATE bcrypt)
+endif()
 
 pybind11_add_module(tableau binders/tableau.cpp)
 target_include_directories(tableau PRIVATE binders/include)
-target_link_libraries(tableau PRIVATE tket-Converters)
+target_link_libraries(tableau PRIVATE
+    symengine
+    tket-Circuit
+    tket-Clifford
+    tket-Converters
+    tket-Diagonalisation
+    tket-Gate
+    tket-Ops
+    tket-OpType
+    tket-PauliGraph
+    tket-Utils)
+if (WIN32)
+    # For boost::uuid:
+    target_link_libraries(tableau PRIVATE bcrypt)
+endif()
 
 pybind11_add_module(zx
     binders/zx/diagram.cpp
@@ -116,4 +246,5 @@ pybind11_add_module(zx
 target_include_directories(zx PRIVATE binders/include)
 target_link_libraries(zx PRIVATE
     symengine
+    tket-Utils
     tket-ZX)

--- a/pytket/CMakeLists.txt
+++ b/pytket/CMakeLists.txt
@@ -48,7 +48,6 @@ pybind11_add_module(circuit
     binders/circuit/Circuit/add_classical_op.cpp)
 target_include_directories(circuit PRIVATE binders/include)
 target_link_libraries(circuit PRIVATE
-    symengine
     tket-Circuit
     tket-Converters
     tket-Gate
@@ -57,6 +56,7 @@ target_link_libraries(circuit PRIVATE
     tket-Routing
     tket-Simulation
     tket-Utils)
+target_link_libraries(circuit PRIVATE ${CONAN_LIBS_SYMENGINE})
 if (WIN32)
     # For boost::uuid:
     target_link_libraries(circuit PRIVATE bcrypt)
@@ -65,7 +65,6 @@ endif()
 pybind11_add_module(routing binders/routing.cpp)
 target_include_directories(routing PRIVATE binders/include)
 target_link_libraries(routing PRIVATE
-    symengine
     tket-Architecture
     tket-Characterisation
     tket-Circuit
@@ -75,6 +74,7 @@ target_link_libraries(routing PRIVATE
     tket-OpType
     tket-Routing
     tket-Utils)
+target_link_libraries(routing PRIVATE ${CONAN_LIBS_SYMENGINE})
 if (WIN32)
     # For boost::uuid:
     target_link_libraries(routing PRIVATE bcrypt)
@@ -83,7 +83,6 @@ endif()
 pybind11_add_module(transform binders/transform.cpp)
 target_include_directories(transform PRIVATE binders/include)
 target_link_libraries(transform PRIVATE
-    symengine
     tket-Architecture
     tket-Characterisation
     tket-Circuit
@@ -96,6 +95,7 @@ target_link_libraries(transform PRIVATE
     tket-PauliGraph
     tket-Transformations
     tket-Utils)
+target_link_libraries(transform PRIVATE ${CONAN_LIBS_SYMENGINE})
 if (WIN32)
     # For boost::uuid:
     target_link_libraries(transform PRIVATE bcrypt)
@@ -104,7 +104,6 @@ endif()
 pybind11_add_module(predicates binders/predicates.cpp)
 target_include_directories(predicates PRIVATE binders/include)
 target_link_libraries(predicates PRIVATE
-    symengine
     tket-ArchAwareSynth
     tket-Architecture
     tket-Characterisation
@@ -120,6 +119,7 @@ target_link_libraries(predicates PRIVATE
     tket-Routing
     tket-Transformations
     tket-Utils)
+target_link_libraries(predicates PRIVATE ${CONAN_LIBS_SYMENGINE})
 if (WIN32)
     # For boost::uuid:
     target_link_libraries(predicates PRIVATE bcrypt)
@@ -128,7 +128,6 @@ endif()
 pybind11_add_module(passes binders/passes.cpp)
 target_include_directories(passes PRIVATE binders/include)
 target_link_libraries(passes PRIVATE
-    symengine
     tket-ArchAwareSynth
     tket-Architecture
     tket-Characterisation
@@ -144,6 +143,7 @@ target_link_libraries(passes PRIVATE
     tket-Routing
     tket-Transformations
     tket-Utils)
+target_link_libraries(passes PRIVATE ${CONAN_LIBS_SYMENGINE})
 if (WIN32)
     # For boost::uuid:
     target_link_libraries(passes PRIVATE bcrypt)
@@ -152,13 +152,13 @@ endif()
 pybind11_add_module(program binders/program.cpp)
 target_include_directories(program PRIVATE binders/include)
 target_link_libraries(program PRIVATE
-    symengine
     tket-Circuit
     tket-Gate
     tket-Ops
     tket-OpType
     tket-Program
     tket-Utils)
+target_link_libraries(program PRIVATE ${CONAN_LIBS_SYMENGINE})
 if (WIN32)
     # For boost::uuid:
     target_link_libraries(program PRIVATE bcrypt)
@@ -167,7 +167,6 @@ endif()
 pybind11_add_module(partition binders/partition.cpp)
 target_include_directories(partition PRIVATE binders/include)
 target_link_libraries(partition PRIVATE
-    symengine
     tket-Circuit
     tket-Clifford
     tket-Converters
@@ -178,6 +177,7 @@ target_link_libraries(partition PRIVATE
     tket-OpType
     tket-PauliGraph
     tket-Utils)
+target_link_libraries(partition PRIVATE ${CONAN_LIBS_SYMENGINE})
 if (WIN32)
     # For boost::uuid:
     target_link_libraries(partition PRIVATE bcrypt)
@@ -186,25 +186,24 @@ endif()
 pybind11_add_module(pauli binders/pauli.cpp)
 target_include_directories(pauli PRIVATE binders/include)
 target_link_libraries(pauli PRIVATE
-    symengine
     tket-Utils)
+target_link_libraries(pauli PRIVATE ${CONAN_LIBS_SYMENGINE})
 
 pybind11_add_module(logging binders/logging.cpp)
 target_include_directories(logging PRIVATE binders/include)
 target_link_libraries(logging PRIVATE
-    symengine
     tket-Utils)
+target_link_libraries(logging PRIVATE ${CONAN_LIBS_SYMENGINE})
 
 pybind11_add_module(utils_serialization binders/utils_serialization.cpp)
 target_include_directories(utils_serialization PRIVATE binders/include)
 target_link_libraries(utils_serialization PRIVATE
-    symengine
     tket-Utils)
+target_link_libraries(utils_serialization PRIVATE ${CONAN_LIBS_SYMENGINE})
 
 pybind11_add_module(tailoring binders/tailoring.cpp)
 target_include_directories(tailoring PRIVATE binders/include)
 target_link_libraries(tailoring PRIVATE
-    symengine
     tket-Architecture
     tket-Characterisation
     tket-Circuit
@@ -217,6 +216,7 @@ target_link_libraries(tailoring PRIVATE
     tket-OpType
     tket-PauliGraph
     tket-Utils)
+target_link_libraries(tailoring PRIVATE ${CONAN_LIBS_SYMENGINE})
 if (WIN32)
     # For boost::uuid:
     target_link_libraries(tailoring PRIVATE bcrypt)
@@ -225,7 +225,6 @@ endif()
 pybind11_add_module(tableau binders/tableau.cpp)
 target_include_directories(tableau PRIVATE binders/include)
 target_link_libraries(tableau PRIVATE
-    symengine
     tket-Circuit
     tket-Clifford
     tket-Converters
@@ -235,6 +234,7 @@ target_link_libraries(tableau PRIVATE
     tket-OpType
     tket-PauliGraph
     tket-Utils)
+target_link_libraries(tableau PRIVATE ${CONAN_LIBS_SYMENGINE})
 if (WIN32)
     # For boost::uuid:
     target_link_libraries(tableau PRIVATE bcrypt)
@@ -245,6 +245,6 @@ pybind11_add_module(zx
     binders/zx/rewrite.cpp)
 target_include_directories(zx PRIVATE binders/include)
 target_link_libraries(zx PRIVATE
-    symengine
     tket-Utils
     tket-ZX)
+target_link_libraries(zx PRIVATE ${CONAN_LIBS_SYMENGINE})

--- a/recipes/symengine/conanfile.py
+++ b/recipes/symengine/conanfile.py
@@ -44,7 +44,7 @@ class SymengineConan(ConanFile):
 
     def requirements(self):
         if self.options.integer_class == "boostmp":
-            self.requires("boost/1.77.0")
+            self.requires("boost/1.78.0")
         else:
             self.requires("gmp/6.2.1")
 

--- a/recipes/tket/conanfile.py
+++ b/recipes/tket/conanfile.py
@@ -100,15 +100,14 @@ class TketConan(ConanFile):
         boost_include_path = self.deps_cpp_info["boost"].include_paths[0]
         curdir = os.path.dirname(os.path.realpath(__file__))
         patches = {
-            # TKET-1407
-            # If and when the boost package is fixed we will remove this.
+            # Patch pending merge of https://github.com/boostorg/graph/pull/269
+            # and new boost release.
             os.path.join(
                 boost_include_path, "boost", "graph", "detail", "adjacency_list.hpp"
             ): os.path.join(curdir, "patches", "adjacency_list.diff"),
-            # TKET-1376
-            # This will be submitted as a PR to boost. If it is accepted we will remove
-            # the patch here. If not, we should consider switching to another library
-            # for subgraph matching, or writing our own code.
+            # Patch pending merge of https://github.com/boostorg/graph/pull/280
+            # and new boost release. (Note that PR implements a different solution so
+            # code will need updating as well.)
             os.path.join(
                 boost_include_path, "boost", "graph", "vf2_sub_graph_iso.hpp"
             ): os.path.join(curdir, "patches", "vf2_sub_graph_iso.diff"),

--- a/recipes/tket/conanfile.py
+++ b/recipes/tket/conanfile.py
@@ -40,7 +40,7 @@ class TketConan(ConanFile):
     exports_sources = ["../../tket/src/*", "!*/build/*", "patches/*"]
     exports = ["patches/*"]
     requires = (
-        "boost/1.77.0",
+        "boost/1.78.0",
         "symengine/0.8.1.1",
         "eigen/3.4.0",
         "spdlog/1.9.2",

--- a/recipes/tket/patches/vf2_sub_graph_iso.diff
+++ b/recipes/tket/patches/vf2_sub_graph_iso.diff
@@ -4,9 +4,9 @@
  #include <utility>
  
  #include <boost/assert.hpp>
-+#include <boost/chrono.hpp>
-+#include <boost/chrono/duration.hpp>
-+#include <boost/chrono/system_clocks.hpp>
++
++#include <chrono>
++
  #include <boost/concept/assert.hpp>
  #include <boost/concept_check.hpp>
  #include <boost/graph/graph_utility.hpp>
@@ -34,11 +34,11 @@
          bool found_match = false;
 -
 +        bool have_timeout = timeout_ms > 0;
-+        const boost::chrono::steady_clock::time_point end_time =
-+            boost::chrono::steady_clock::now()
-+            + boost::chrono::milliseconds(timeout_ms);
++        const std::chrono::steady_clock::time_point end_time =
++            std::chrono::steady_clock::now()
++            + std::chrono::milliseconds(timeout_ms);
      recur:
-+        if (have_timeout && boost::chrono::steady_clock::now() >= end_time)
++        if (have_timeout && std::chrono::steady_clock::now() >= end_time)
 +            return found_match;
 +
          if (s.success())

--- a/recipes/tket/test_package/CMakeLists.txt
+++ b/recipes/tket/test_package/CMakeLists.txt
@@ -31,4 +31,11 @@ ENDIF()
 include_directories(${CONAN_INCLUDE_DIRS_TKET})
 
 add_executable(test test.cpp)
-target_link_libraries(test ${CONAN_LIBS})
+
+target_link_libraries(test
+    symengine
+    tket-Circuit
+    tket-Gate
+    tket-OpType
+    tket-Transformations
+    tket-Utils)

--- a/recipes/tket/test_package/CMakeLists.txt
+++ b/recipes/tket/test_package/CMakeLists.txt
@@ -32,10 +32,11 @@ include_directories(${CONAN_INCLUDE_DIRS_TKET})
 
 add_executable(test test.cpp)
 
-target_link_libraries(test
-    symengine
+target_link_libraries(test PRIVATE
     tket-Circuit
     tket-Gate
     tket-OpType
     tket-Transformations
     tket-Utils)
+
+target_link_libraries(test PRIVATE ${CONAN_LIBS_SYMENGINE})

--- a/tket/proptests/CMakeLists.txt
+++ b/tket/proptests/CMakeLists.txt
@@ -41,4 +41,16 @@ add_executable(proptest
     proptest.cpp
 )
 
-target_link_libraries(proptest ${CONAN_LIBS})
+target_link_libraries(proptest
+    rapidcheck
+    symengine
+    tket-Architecture
+    tket-Circuit
+    tket-Gate
+    tket-Ops
+    tket-OpType
+    tket-Predicates
+    tket-Routing
+    tket-Simulation
+    tket-Transformations
+    tket-Utils)

--- a/tket/proptests/CMakeLists.txt
+++ b/tket/proptests/CMakeLists.txt
@@ -41,9 +41,8 @@ add_executable(proptest
     proptest.cpp
 )
 
-target_link_libraries(proptest
+target_link_libraries(proptest PRIVATE
     rapidcheck
-    symengine
     tket-Architecture
     tket-Circuit
     tket-Gate
@@ -54,3 +53,5 @@ target_link_libraries(proptest
     tket-Simulation
     tket-Transformations
     tket-Utils)
+
+target_link_libraries(proptest PRIVATE ${CONAN_LIBS_SYMENGINE})

--- a/tket/src/ArchAwareSynth/CMakeLists.txt
+++ b/tket/src/ArchAwareSynth/CMakeLists.txt
@@ -50,4 +50,4 @@ target_include_directories(tket-${COMP}
     ${TKET_${COMP}_INCLUDE_DIR}
     ${TKET_${COMP}_INCLUDE_DIR}/${COMP})
 
-target_link_libraries(tket-${COMP} PRIVATE ${CONAN_LIBS})
+target_link_libraries(tket-${COMP} PRIVATE boost_chrono)

--- a/tket/src/ArchAwareSynth/CMakeLists.txt
+++ b/tket/src/ArchAwareSynth/CMakeLists.txt
@@ -50,4 +50,8 @@ target_include_directories(tket-${COMP}
     ${TKET_${COMP}_INCLUDE_DIR}
     ${TKET_${COMP}_INCLUDE_DIR}/${COMP})
 
-target_link_libraries(tket-${COMP} PRIVATE boost_chrono)
+if (WIN32)
+    target_link_libraries(tket-${COMP} PRIVATE libboost_chrono)
+else()
+    target_link_libraries(tket-${COMP} PRIVATE boost_chrono)
+endif()

--- a/tket/src/ArchAwareSynth/CMakeLists.txt
+++ b/tket/src/ArchAwareSynth/CMakeLists.txt
@@ -51,9 +51,3 @@ target_include_directories(tket-${COMP}
     ${TKET_${COMP}_INCLUDE_DIR}/${COMP})
 
 target_link_libraries(tket-${COMP} PRIVATE symengine)
-
-if (WIN32)
-    target_link_libraries(tket-${COMP} PRIVATE libboost_chrono)
-else()
-    target_link_libraries(tket-${COMP} PRIVATE boost_chrono)
-endif()

--- a/tket/src/ArchAwareSynth/CMakeLists.txt
+++ b/tket/src/ArchAwareSynth/CMakeLists.txt
@@ -50,6 +50,8 @@ target_include_directories(tket-${COMP}
     ${TKET_${COMP}_INCLUDE_DIR}
     ${TKET_${COMP}_INCLUDE_DIR}/${COMP})
 
+target_link_libraries(tket-${COMP} PRIVATE symengine)
+
 if (WIN32)
     target_link_libraries(tket-${COMP} PRIVATE libboost_chrono)
 else()

--- a/tket/src/ArchAwareSynth/CMakeLists.txt
+++ b/tket/src/ArchAwareSynth/CMakeLists.txt
@@ -50,4 +50,4 @@ target_include_directories(tket-${COMP}
     ${TKET_${COMP}_INCLUDE_DIR}
     ${TKET_${COMP}_INCLUDE_DIR}/${COMP})
 
-target_link_libraries(tket-${COMP} PRIVATE symengine)
+target_link_libraries(tket-${COMP} PRIVATE ${CONAN_LIBS_SYMENGINE})

--- a/tket/src/Architecture/CMakeLists.txt
+++ b/tket/src/Architecture/CMakeLists.txt
@@ -38,5 +38,3 @@ target_include_directories(tket-${COMP}
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${TKET_${COMP}_INCLUDE_DIR}
     ${TKET_${COMP}_INCLUDE_DIR}/${COMP})
-
-target_link_libraries(tket-${COMP} PRIVATE ${CONAN_LIBS})

--- a/tket/src/Characterisation/CMakeLists.txt
+++ b/tket/src/Characterisation/CMakeLists.txt
@@ -45,5 +45,3 @@ target_include_directories(tket-${COMP}
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${TKET_${COMP}_INCLUDE_DIR}
     ${TKET_${COMP}_INCLUDE_DIR}/${COMP})
-
-target_link_libraries(tket-${COMP} PRIVATE ${CONAN_LIBS})

--- a/tket/src/Circuit/CMakeLists.txt
+++ b/tket/src/Circuit/CMakeLists.txt
@@ -55,7 +55,7 @@ target_include_directories(tket-${COMP}
     ${TKET_${COMP}_INCLUDE_DIR}
     ${TKET_${COMP}_INCLUDE_DIR}/${COMP})
 
-target_link_libraries(tket-${COMP} PRIVATE symengine)
+target_link_libraries(tket-${COMP} PRIVATE ${CONAN_LIBS_SYMENGINE})
 
 if (WIN32)
     # For boost::uuid:

--- a/tket/src/Circuit/CMakeLists.txt
+++ b/tket/src/Circuit/CMakeLists.txt
@@ -54,3 +54,10 @@ target_include_directories(tket-${COMP}
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${TKET_${COMP}_INCLUDE_DIR}
     ${TKET_${COMP}_INCLUDE_DIR}/${COMP})
+
+target_link_libraries(tket-${COMP} PRIVATE symengine)
+
+if (WIN32)
+    # For boost::uuid:
+    target_link_libraries(tket-${COMP} PRIVATE bcrypt)
+endif()

--- a/tket/src/Circuit/CMakeLists.txt
+++ b/tket/src/Circuit/CMakeLists.txt
@@ -54,5 +54,3 @@ target_include_directories(tket-${COMP}
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${TKET_${COMP}_INCLUDE_DIR}
     ${TKET_${COMP}_INCLUDE_DIR}/${COMP})
-
-target_link_libraries(tket-${COMP} PRIVATE ${CONAN_LIBS})

--- a/tket/src/Clifford/CMakeLists.txt
+++ b/tket/src/Clifford/CMakeLists.txt
@@ -39,5 +39,3 @@ target_include_directories(tket-${COMP}
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${TKET_${COMP}_INCLUDE_DIR}
     ${TKET_${COMP}_INCLUDE_DIR}/${COMP})
-
-target_link_libraries(tket-${COMP} PRIVATE ${CONAN_LIBS})

--- a/tket/src/Converters/CMakeLists.txt
+++ b/tket/src/Converters/CMakeLists.txt
@@ -50,7 +50,7 @@ target_include_directories(tket-${COMP}
     ${TKET_${COMP}_INCLUDE_DIR}
     ${TKET_${COMP}_INCLUDE_DIR}/${COMP})
 
-target_link_libraries(tket-${COMP} PRIVATE symengine)
+target_link_libraries(tket-${COMP} PRIVATE ${CONAN_LIBS_SYMENGINE})
 
 if (WIN32)
     # For boost::uuid:

--- a/tket/src/Converters/CMakeLists.txt
+++ b/tket/src/Converters/CMakeLists.txt
@@ -49,5 +49,3 @@ target_include_directories(tket-${COMP}
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${TKET_${COMP}_INCLUDE_DIR}
     ${TKET_${COMP}_INCLUDE_DIR}/${COMP})
-
-target_link_libraries(tket-${COMP} PRIVATE ${CONAN_LIBS})

--- a/tket/src/Converters/CMakeLists.txt
+++ b/tket/src/Converters/CMakeLists.txt
@@ -49,3 +49,10 @@ target_include_directories(tket-${COMP}
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${TKET_${COMP}_INCLUDE_DIR}
     ${TKET_${COMP}_INCLUDE_DIR}/${COMP})
+
+target_link_libraries(tket-${COMP} PRIVATE symengine)
+
+if (WIN32)
+    # For boost::uuid:
+    target_link_libraries(tket-${COMP} PRIVATE bcrypt)
+endif()

--- a/tket/src/Diagonalisation/CMakeLists.txt
+++ b/tket/src/Diagonalisation/CMakeLists.txt
@@ -45,5 +45,3 @@ target_include_directories(tket-${COMP}
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${TKET_${COMP}_INCLUDE_DIR}
     ${TKET_${COMP}_INCLUDE_DIR}/${COMP})
-
-target_link_libraries(tket-${COMP} PRIVATE ${CONAN_LIBS})

--- a/tket/src/Diagonalisation/CMakeLists.txt
+++ b/tket/src/Diagonalisation/CMakeLists.txt
@@ -45,3 +45,5 @@ target_include_directories(tket-${COMP}
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${TKET_${COMP}_INCLUDE_DIR}
     ${TKET_${COMP}_INCLUDE_DIR}/${COMP})
+
+target_link_libraries(tket-${COMP} PRIVATE symengine)

--- a/tket/src/Diagonalisation/CMakeLists.txt
+++ b/tket/src/Diagonalisation/CMakeLists.txt
@@ -46,4 +46,4 @@ target_include_directories(tket-${COMP}
     ${TKET_${COMP}_INCLUDE_DIR}
     ${TKET_${COMP}_INCLUDE_DIR}/${COMP})
 
-target_link_libraries(tket-${COMP} PRIVATE symengine)
+target_link_libraries(tket-${COMP} PRIVATE ${CONAN_LIBS_SYMENGINE})

--- a/tket/src/Gate/CMakeLists.txt
+++ b/tket/src/Gate/CMakeLists.txt
@@ -51,4 +51,4 @@ target_include_directories(tket-${COMP}
     ${TKET_${COMP}_INCLUDE_DIR}
     ${TKET_${COMP}_INCLUDE_DIR}/${COMP})
 
-target_link_libraries(tket-${COMP} PRIVATE symengine)
+target_link_libraries(tket-${COMP} PRIVATE ${CONAN_LIBS_SYMENGINE})

--- a/tket/src/Gate/CMakeLists.txt
+++ b/tket/src/Gate/CMakeLists.txt
@@ -50,5 +50,3 @@ target_include_directories(tket-${COMP}
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${TKET_${COMP}_INCLUDE_DIR}
     ${TKET_${COMP}_INCLUDE_DIR}/${COMP})
-
-target_link_libraries(tket-${COMP} PRIVATE ${CONAN_LIBS})

--- a/tket/src/Gate/CMakeLists.txt
+++ b/tket/src/Gate/CMakeLists.txt
@@ -50,3 +50,5 @@ target_include_directories(tket-${COMP}
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${TKET_${COMP}_INCLUDE_DIR}
     ${TKET_${COMP}_INCLUDE_DIR}/${COMP})
+
+target_link_libraries(tket-${COMP} PRIVATE symengine)

--- a/tket/src/Graphs/CMakeLists.txt
+++ b/tket/src/Graphs/CMakeLists.txt
@@ -42,5 +42,3 @@ target_include_directories(tket-${COMP}
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${TKET_${COMP}_INCLUDE_DIR}
     ${TKET_${COMP}_INCLUDE_DIR}/${COMP})
-
-target_link_libraries(tket-${COMP} PRIVATE ${CONAN_LIBS})

--- a/tket/src/MeasurementSetup/CMakeLists.txt
+++ b/tket/src/MeasurementSetup/CMakeLists.txt
@@ -45,5 +45,3 @@ target_include_directories(tket-${COMP}
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${TKET_${COMP}_INCLUDE_DIR}
     ${TKET_${COMP}_INCLUDE_DIR}/${COMP})
-
-target_link_libraries(tket-${COMP} PRIVATE ${CONAN_LIBS})

--- a/tket/src/MeasurementSetup/CMakeLists.txt
+++ b/tket/src/MeasurementSetup/CMakeLists.txt
@@ -45,3 +45,5 @@ target_include_directories(tket-${COMP}
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${TKET_${COMP}_INCLUDE_DIR}
     ${TKET_${COMP}_INCLUDE_DIR}/${COMP})
+
+target_link_libraries(tket-${COMP} PRIVATE symengine)

--- a/tket/src/MeasurementSetup/CMakeLists.txt
+++ b/tket/src/MeasurementSetup/CMakeLists.txt
@@ -46,4 +46,4 @@ target_include_directories(tket-${COMP}
     ${TKET_${COMP}_INCLUDE_DIR}
     ${TKET_${COMP}_INCLUDE_DIR}/${COMP})
 
-target_link_libraries(tket-${COMP} PRIVATE symengine)
+target_link_libraries(tket-${COMP} PRIVATE ${CONAN_LIBS_SYMENGINE})

--- a/tket/src/OpType/CMakeLists.txt
+++ b/tket/src/OpType/CMakeLists.txt
@@ -39,5 +39,3 @@ target_include_directories(tket-${COMP}
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${TKET_${COMP}_INCLUDE_DIR}
     ${TKET_${COMP}_INCLUDE_DIR}/${COMP})
-
-target_link_libraries(tket-${COMP} PRIVATE ${CONAN_LIBS})

--- a/tket/src/Ops/CMakeLists.txt
+++ b/tket/src/Ops/CMakeLists.txt
@@ -41,5 +41,3 @@ target_include_directories(tket-${COMP}
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${TKET_${COMP}_INCLUDE_DIR}
     ${TKET_${COMP}_INCLUDE_DIR}/${COMP})
-
-target_link_libraries(tket-${COMP} PRIVATE ${CONAN_LIBS})

--- a/tket/src/PauliGraph/CMakeLists.txt
+++ b/tket/src/PauliGraph/CMakeLists.txt
@@ -41,5 +41,3 @@ target_include_directories(tket-${COMP}
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${TKET_${COMP}_INCLUDE_DIR}
     ${TKET_${COMP}_INCLUDE_DIR}/${COMP})
-
-target_link_libraries(tket-${COMP} PRIVATE ${CONAN_LIBS})

--- a/tket/src/PauliGraph/CMakeLists.txt
+++ b/tket/src/PauliGraph/CMakeLists.txt
@@ -41,3 +41,5 @@ target_include_directories(tket-${COMP}
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${TKET_${COMP}_INCLUDE_DIR}
     ${TKET_${COMP}_INCLUDE_DIR}/${COMP})
+
+target_link_libraries(tket-${COMP} PRIVATE symengine)

--- a/tket/src/PauliGraph/CMakeLists.txt
+++ b/tket/src/PauliGraph/CMakeLists.txt
@@ -42,4 +42,4 @@ target_include_directories(tket-${COMP}
     ${TKET_${COMP}_INCLUDE_DIR}
     ${TKET_${COMP}_INCLUDE_DIR}/${COMP})
 
-target_link_libraries(tket-${COMP} PRIVATE symengine)
+target_link_libraries(tket-${COMP} PRIVATE ${CONAN_LIBS_SYMENGINE})

--- a/tket/src/Predicates/CMakeLists.txt
+++ b/tket/src/Predicates/CMakeLists.txt
@@ -53,5 +53,3 @@ target_include_directories(tket-${COMP}
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${TKET_${COMP}_INCLUDE_DIR}
     ${TKET_${COMP}_INCLUDE_DIR}/${COMP})
-
-target_link_libraries(tket-${COMP} PRIVATE ${CONAN_LIBS})

--- a/tket/src/Predicates/CMakeLists.txt
+++ b/tket/src/Predicates/CMakeLists.txt
@@ -48,6 +48,8 @@ foreach(DEP ${DEPS_${COMP}})
         tket-${COMP} PRIVATE tket-${DEP})
 endforeach()
 
+target_link_libraries(tket-${COMP} PRIVATE symengine)
+
 target_include_directories(tket-${COMP}
     PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}

--- a/tket/src/Predicates/CMakeLists.txt
+++ b/tket/src/Predicates/CMakeLists.txt
@@ -48,10 +48,10 @@ foreach(DEP ${DEPS_${COMP}})
         tket-${COMP} PRIVATE tket-${DEP})
 endforeach()
 
-target_link_libraries(tket-${COMP} PRIVATE symengine)
-
 target_include_directories(tket-${COMP}
     PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${TKET_${COMP}_INCLUDE_DIR}
     ${TKET_${COMP}_INCLUDE_DIR}/${COMP})
+
+target_link_libraries(tket-${COMP} PRIVATE ${CONAN_LIBS_SYMENGINE})

--- a/tket/src/Program/CMakeLists.txt
+++ b/tket/src/Program/CMakeLists.txt
@@ -44,3 +44,5 @@ target_include_directories(tket-${COMP}
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${TKET_${COMP}_INCLUDE_DIR}
     ${TKET_${COMP}_INCLUDE_DIR}/${COMP})
+
+target_link_libraries(tket-${COMP} PRIVATE symengine)

--- a/tket/src/Program/CMakeLists.txt
+++ b/tket/src/Program/CMakeLists.txt
@@ -45,4 +45,4 @@ target_include_directories(tket-${COMP}
     ${TKET_${COMP}_INCLUDE_DIR}
     ${TKET_${COMP}_INCLUDE_DIR}/${COMP})
 
-target_link_libraries(tket-${COMP} PRIVATE symengine)
+target_link_libraries(tket-${COMP} PRIVATE ${CONAN_LIBS_SYMENGINE})

--- a/tket/src/Program/CMakeLists.txt
+++ b/tket/src/Program/CMakeLists.txt
@@ -44,5 +44,3 @@ target_include_directories(tket-${COMP}
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${TKET_${COMP}_INCLUDE_DIR}
     ${TKET_${COMP}_INCLUDE_DIR}/${COMP})
-
-target_link_libraries(tket-${COMP} PRIVATE ${CONAN_LIBS})

--- a/tket/src/Routing/CMakeLists.txt
+++ b/tket/src/Routing/CMakeLists.txt
@@ -51,9 +51,3 @@ target_include_directories(tket-${COMP}
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${TKET_${COMP}_INCLUDE_DIR}
     ${TKET_${COMP}_INCLUDE_DIR}/${COMP})
-
-if (WIN32)
-    target_link_libraries(tket-${COMP} PRIVATE libboost_chrono)
-else()
-    target_link_libraries(tket-${COMP} PRIVATE boost_chrono)
-endif()

--- a/tket/src/Routing/CMakeLists.txt
+++ b/tket/src/Routing/CMakeLists.txt
@@ -52,4 +52,4 @@ target_include_directories(tket-${COMP}
     ${TKET_${COMP}_INCLUDE_DIR}
     ${TKET_${COMP}_INCLUDE_DIR}/${COMP})
 
-target_link_libraries(tket-${COMP} PRIVATE ${CONAN_LIBS})
+target_link_libraries(tket-${COMP} PRIVATE boost_chrono)

--- a/tket/src/Routing/CMakeLists.txt
+++ b/tket/src/Routing/CMakeLists.txt
@@ -52,4 +52,8 @@ target_include_directories(tket-${COMP}
     ${TKET_${COMP}_INCLUDE_DIR}
     ${TKET_${COMP}_INCLUDE_DIR}/${COMP})
 
-target_link_libraries(tket-${COMP} PRIVATE boost_chrono)
+if (WIN32)
+    target_link_libraries(tket-${COMP} PRIVATE libboost_chrono)
+else()
+    target_link_libraries(tket-${COMP} PRIVATE boost_chrono)
+endif()

--- a/tket/src/Simulation/CMakeLists.txt
+++ b/tket/src/Simulation/CMakeLists.txt
@@ -45,5 +45,3 @@ target_include_directories(tket-${COMP}
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${TKET_${COMP}_INCLUDE_DIR}
     ${TKET_${COMP}_INCLUDE_DIR}/${COMP})
-
-target_link_libraries(tket-${COMP} PRIVATE ${CONAN_LIBS})

--- a/tket/src/Transformations/CMakeLists.txt
+++ b/tket/src/Transformations/CMakeLists.txt
@@ -60,4 +60,4 @@ target_include_directories(tket-${COMP}
     ${TKET_${COMP}_INCLUDE_DIR}
     ${TKET_${COMP}_INCLUDE_DIR}/${COMP})
 
-target_link_libraries(tket-${COMP} PRIVATE symengine)
+target_link_libraries(tket-${COMP} PRIVATE ${CONAN_LIBS_SYMENGINE})

--- a/tket/src/Transformations/CMakeLists.txt
+++ b/tket/src/Transformations/CMakeLists.txt
@@ -59,3 +59,5 @@ target_include_directories(tket-${COMP}
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${TKET_${COMP}_INCLUDE_DIR}
     ${TKET_${COMP}_INCLUDE_DIR}/${COMP})
+
+target_link_libraries(tket-${COMP} PRIVATE symengine)

--- a/tket/src/Transformations/CMakeLists.txt
+++ b/tket/src/Transformations/CMakeLists.txt
@@ -59,5 +59,3 @@ target_include_directories(tket-${COMP}
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${TKET_${COMP}_INCLUDE_DIR}
     ${TKET_${COMP}_INCLUDE_DIR}/${COMP})
-
-target_link_libraries(tket-${COMP} PRIVATE ${CONAN_LIBS})

--- a/tket/src/Utils/CMakeLists.txt
+++ b/tket/src/Utils/CMakeLists.txt
@@ -41,5 +41,3 @@ target_include_directories(tket-${COMP}
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${TKET_${COMP}_INCLUDE_DIR}
     ${TKET_${COMP}_INCLUDE_DIR}/${COMP})
-
-target_link_libraries(tket-${COMP} PRIVATE ${CONAN_LIBS})

--- a/tket/src/Utils/CMakeLists.txt
+++ b/tket/src/Utils/CMakeLists.txt
@@ -18,7 +18,7 @@ if (NOT ${COMP} STREQUAL "Utils")
     message(FATAL_ERROR "Unexpected component name.")
 endif()
 
-add_library(tket-Utils
+add_library(tket-{COMP}
     TketLog.cpp
     UnitID.cpp
     HelperFunctions.cpp

--- a/tket/src/Utils/CMakeLists.txt
+++ b/tket/src/Utils/CMakeLists.txt
@@ -41,3 +41,5 @@ target_include_directories(tket-${COMP}
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${TKET_${COMP}_INCLUDE_DIR}
     ${TKET_${COMP}_INCLUDE_DIR}/${COMP})
+
+target_link_libraries(tket-${COMP} PRIVATE symengine)

--- a/tket/src/Utils/CMakeLists.txt
+++ b/tket/src/Utils/CMakeLists.txt
@@ -18,7 +18,7 @@ if (NOT ${COMP} STREQUAL "Utils")
     message(FATAL_ERROR "Unexpected component name.")
 endif()
 
-add_library(tket-{COMP}
+add_library(tket-${COMP}
     TketLog.cpp
     UnitID.cpp
     HelperFunctions.cpp

--- a/tket/src/Utils/CMakeLists.txt
+++ b/tket/src/Utils/CMakeLists.txt
@@ -42,4 +42,4 @@ target_include_directories(tket-${COMP}
     ${TKET_${COMP}_INCLUDE_DIR}
     ${TKET_${COMP}_INCLUDE_DIR}/${COMP})
 
-target_link_libraries(tket-${COMP} PRIVATE symengine)
+target_link_libraries(tket-${COMP} PRIVATE ${CONAN_LIBS_SYMENGINE})

--- a/tket/src/ZX/CMakeLists.txt
+++ b/tket/src/ZX/CMakeLists.txt
@@ -45,5 +45,3 @@ target_include_directories(tket-${COMP}
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${TKET_${COMP}_INCLUDE_DIR}
     ${TKET_${COMP}_INCLUDE_DIR}/${COMP})
-
-target_link_libraries(tket-${COMP} PRIVATE ${CONAN_LIBS})

--- a/tket/src/ZX/CMakeLists.txt
+++ b/tket/src/ZX/CMakeLists.txt
@@ -45,3 +45,5 @@ target_include_directories(tket-${COMP}
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${TKET_${COMP}_INCLUDE_DIR}
     ${TKET_${COMP}_INCLUDE_DIR}/${COMP})
+
+target_link_libraries(tket-${COMP} PRIVATE symengine)

--- a/tket/src/ZX/CMakeLists.txt
+++ b/tket/src/ZX/CMakeLists.txt
@@ -46,4 +46,4 @@ target_include_directories(tket-${COMP}
     ${TKET_${COMP}_INCLUDE_DIR}
     ${TKET_${COMP}_INCLUDE_DIR}/${COMP})
 
-target_link_libraries(tket-${COMP} PRIVATE symengine)
+target_link_libraries(tket-${COMP} PRIVATE ${CONAN_LIBS_SYMENGINE})

--- a/tket/tests/CMakeLists.txt
+++ b/tket/tests/CMakeLists.txt
@@ -43,8 +43,7 @@ include(tkettestsfiles.cmake)
 
 add_executable(test_tket ${TEST_SOURCES})
 
-target_link_libraries(test_tket
-    symengine
+target_link_libraries(test_tket PRIVATE
     tket-ArchAwareSynth
     tket-Architecture
     tket-Characterisation
@@ -65,3 +64,5 @@ target_link_libraries(test_tket
     tket-Transformations
     tket-Utils
     tket-ZX)
+
+target_link_libraries(test_tket PRIVATE ${CONAN_LIBS_SYMENGINE})

--- a/tket/tests/CMakeLists.txt
+++ b/tket/tests/CMakeLists.txt
@@ -42,4 +42,26 @@ set(TKET_TESTS_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 include(tkettestsfiles.cmake)
 
 add_executable(test_tket ${TEST_SOURCES})
-target_link_libraries(test_tket ${CONAN_LIBS})
+
+target_link_libraries(test_tket
+    symengine
+    tket-ArchAwareSynth
+    tket-Architecture
+    tket-Characterisation
+    tket-Circuit
+    tket-Clifford
+    tket-Converters
+    tket-Diagonalisation
+    tket-Gate
+    tket-Graphs
+    tket-MeasurementSetup
+    tket-Ops
+    tket-OpType
+    tket-PauliGraph
+    tket-Predicates
+    tket-Program
+    tket-Routing
+    tket-Simulation
+    tket-Transformations
+    tket-Utils
+    tket-ZX)


### PR DESCRIPTION
A few changes are rolled together here:
* Update to boost 1.78.0.
* Install boost with all-default options on M1. (Previous build issues seem to have been fixed.)
* Specify target link libraries explicitly, rather than using `CONAN_LIBS` which includes many unnecessary libraries.
* Remove restriction on build parallelism on Windows.
* Eliminate the dependency on `boost::chrono` by modifying our boost patch to use `std::chrono`. (The original version used `boost::chrono` because it was intended as a patch to boost, which needs to build without `std::chrono`, but that PR has since been dropped and replaced by another one without this dependency.)