### PR TITLE
Move "unit bimaps" out of the `Circuit` class and let `Transform` handle them.

### DIFF
--- a/pytket/binders/routing.cpp
+++ b/pytket/binders/routing.cpp
@@ -241,17 +241,23 @@ PYBIND11_MODULE(routing, m) {
                  py::arg("arc"))
             .def("__repr__",
                  [](const Placement &) { return "<tket::Placement>"; })
-            .def("place", &Placement::place,
-                 "Relabels Circuit Qubits to Architecture Nodes and 'unplaced'. For "
-                 "base Placement, all Qubits and labelled 'unplaced'. "
-                 "\n\n:param circuit: The Circuit being relabelled.",
-                 py::arg("circuit"))
+            .def("place",
+              [](const Placement &placement, Circuit &circ) {
+                return placement.place(circ);
+              },
+              "Relabels Circuit Qubits to Architecture Nodes and 'unplaced'. For "
+              "base Placement, all Qubits and labelled 'unplaced'. "
+              "\n\n:param circuit: The Circuit being relabelled.",
+              py::arg("circuit"))
             .def_static(
-                    "place_with_map", &Placement::place_with_map,
-                    "Relabels Circuit Qubits to Architecture Nodes using given map. "
-                    "\n\n:param circuit: The circuit being relabelled\n:param "
-                    "qmap: The map from logical to physical qubits to apply.",
-                    py::arg("circuit"), py::arg("qmap"))
+              "place_with_map",
+              [](Circuit &circ, qubit_mapping_t& qmap) {
+                return Placement::place_with_map(circ, qmap);
+              },
+              "Relabels Circuit Qubits to Architecture Nodes using given map. "
+              "\n\n:param circuit: The circuit being relabelled\n:param "
+              "qmap: The map from logical to physical qubits to apply.",
+              py::arg("circuit"), py::arg("qmap"))
             .def("get_placement_map", &Placement::get_placement_map,
                  "Returns a map from logical to physical qubits that is Architecture "
                  "appropriate for the given Circuit. "

--- a/tket/src/Circuit/basic_circ_manip.cpp
+++ b/tket/src/Circuit/basic_circ_manip.cpp
@@ -50,12 +50,6 @@ void Circuit::remove_blank_wires() {
   for (const UnitID& u : unused_units) {
     boundary.get<TagID>().erase(u);
   }
-  if (unit_bimaps_.initial && unit_bimaps_.final) {
-    for (const UnitID& u : unused_units) {
-      unit_bimaps_.initial->right.erase(u);
-      unit_bimaps_.final->right.erase(u);
-    }
-  }
   remove_vertices(bin, GraphRewiring::No, VertexDeletion::Yes);
 }
 
@@ -315,7 +309,7 @@ void Circuit::remove_edge(const Edge& edge) {
   boost::remove_edge(edge, this->dag);
 }
 
-void Circuit::flatten_registers() {
+unit_map_t Circuit::flatten_registers() {
   unsigned q_index = 0;
   unsigned c_index = 0;
   boundary_t new_map;
@@ -333,8 +327,7 @@ void Circuit::flatten_registers() {
     new_map.insert(new_el);
   }
   boundary = new_map;
-  update_initial_map(qmap);
-  update_final_map(qmap);
+  return qmap;
 }
 
 // this automatically updates the circuit boundaries
@@ -384,21 +377,6 @@ void Circuit::add_qubit(const Qubit& id, bool reject_dups) {
   Vertex out = add_vertex(OpType::Output);
   add_edge({in, 0}, {out, 0}, EdgeType::Quantum);
   boundary.insert({id, in, out});
-
-  unit_bimap_t* ubmap_initial = unit_bimaps_.initial;
-  unit_bimap_t* ubmap_final = unit_bimaps_.final;
-
-  if (ubmap_initial && ubmap_final) {
-    if (ubmap_initial->right.find(id) != ubmap_initial->right.end() ||
-        ubmap_initial->left.find(id) != ubmap_initial->left.end() ||
-        ubmap_final->right.find(id) != ubmap_final->right.end() ||
-        ubmap_final->left.find(id) != ubmap_final->left.end()) {
-      throw CircuitInvalidity(
-          "A unit with ID \"" + id.repr() + "\" already exists");
-    }
-    ubmap_initial->left.insert({id, id});
-    ubmap_final->left.insert({id, id});
-  }
 }
 
 void Circuit::add_bit(const Bit& id, bool reject_dups) {

--- a/tket/src/Circuit/include/Circuit/Circuit.hpp
+++ b/tket/src/Circuit/include/Circuit/Circuit.hpp
@@ -365,7 +365,7 @@ class Circuit {
   /**
    * Construct an empty circuit.
    */
-  Circuit() : unit_bimaps_{nullptr, nullptr}, phase(0) {}
+  Circuit() : phase(0) {}
 
   /**
    * Construct an empty named circuit.
@@ -680,7 +680,12 @@ class Circuit {
   // O(1)
   bool detect_singleq_unitary_op(const Vertex &vert) const;
 
-  void flatten_registers();
+  /**
+   * Convert all quantum and classical bits to use default registers.
+   *
+   * @return mapping from old to new unit IDs
+   */
+  unit_map_t flatten_registers();
 
   //_________________________________________________
 
@@ -945,18 +950,6 @@ class Circuit {
    */
   template <typename UnitA, typename UnitB>
   bool rename_units(const std::map<UnitA, UnitB> &qm);
-
-  /**
-   * When either inputs or outputs are relabelled, this method can be called
-   * to update the parent CompilationUnit's initial/final map (if such a
-   * parent exists).
-   *
-   * @param qm partial relabelling map from current ids to new ids
-   */
-  template <typename UnitA, typename UnitB>
-  void update_initial_map(const std::map<UnitA, UnitB> &qm);
-  template <typename UnitA, typename UnitB>
-  void update_final_map(const std::map<UnitA, UnitB> &qm);
 
   /** Automatically rewire holes when removing vertices from the circuit? */
   enum class GraphRewiring { Yes, No };
@@ -1509,16 +1502,6 @@ class Circuit {
   DAG dag; /** Representation as directed graph */
   boundary_t boundary;
 
-  /**
-   * Pointers to unit maps
-   *
-   * These are used by compilation units.
-   */
-  struct {
-    unit_bimap_t *initial;
-    unit_bimap_t *final;
-  } unit_bimaps_;
-
  private:
   std::optional<std::string>
       name;   /** optional string name descriptor for human identification*/
@@ -1576,61 +1559,7 @@ bool Circuit::rename_units(const std::map<UnitA, UnitB> &qm) {
           "Unit already exists in circuit: " + pair.first.repr());
     TKET_ASSERT(modified);
   }
-  update_initial_map(qm);
-  update_final_map(qm);
   return modified;
-}
-
-template <typename UnitA, typename UnitB>
-void Circuit::update_initial_map(const std::map<UnitA, UnitB> &qm) {
-  // Can only work for Unit classes
-  static_assert(std::is_base_of<UnitID, UnitA>::value);
-  static_assert(std::is_base_of<UnitID, UnitB>::value);
-  // Unit types must be related, so cannot rename e.g. Bits to Qubits
-  static_assert(
-      std::is_base_of<UnitA, UnitB>::value ||
-      std::is_base_of<UnitB, UnitA>::value);
-  unit_bimap_t *ubmap = unit_bimaps_.initial;
-  if (ubmap) {
-    unit_map_t new_initial_map;
-    for (const std::pair<const UnitA, UnitB> &pair : qm) {
-      const auto &it = ubmap->right.find(pair.first);
-      if (it == ubmap->right.end()) {
-        continue;
-      }
-      new_initial_map.insert({it->second, pair.second});
-      ubmap->right.erase(pair.first);
-    }
-    for (const std::pair<const UnitID, UnitID> &pair : new_initial_map) {
-      ubmap->left.insert(pair);
-    }
-  }
-}
-
-template <typename UnitA, typename UnitB>
-void Circuit::update_final_map(const std::map<UnitA, UnitB> &qm) {
-  // Can only work for Unit classes
-  static_assert(std::is_base_of<UnitID, UnitA>::value);
-  static_assert(std::is_base_of<UnitID, UnitB>::value);
-  // Unit types must be related, so cannot rename e.g. Bits to Qubits
-  static_assert(
-      std::is_base_of<UnitA, UnitB>::value ||
-      std::is_base_of<UnitB, UnitA>::value);
-  unit_bimap_t *ubmap = unit_bimaps_.final;
-  if (ubmap) {
-    unit_map_t new_final_map;
-    for (const std::pair<const UnitA, UnitB> &pair : qm) {
-      const auto &it = ubmap->right.find(pair.first);
-      if (it == ubmap->right.end()) {
-        continue;
-      }
-      new_final_map.insert({it->second, pair.second});
-      ubmap->right.erase(pair.first);
-    }
-    for (const std::pair<const UnitID, UnitID> &pair : new_final_map) {
-      ubmap->left.insert(pair);
-    }
-  }
 }
 
 template <>

--- a/tket/src/Predicates/CompilationUnit.cpp
+++ b/tket/src/Predicates/CompilationUnit.cpp
@@ -13,6 +13,10 @@
 // limitations under the License.
 
 #include "CompilationUnit.hpp"
+
+#include <memory>
+
+#include "Utils/UnitID.hpp"
 namespace tket {
 
 CompilationUnit::CompilationUnit(const Circuit& circ) : circ_(circ) {
@@ -91,13 +95,11 @@ void CompilationUnit::initialize_cache() const {
 }
 
 void CompilationUnit::initialize_maps() {
-  if (!initial_map_.empty())
-    throw std::logic_error("Initial map must be empty to be initialized");
-  if (!final_map_.empty())
-    throw std::logic_error("Final map must be empty to be initialized");
+  if (maps) throw std::logic_error("Maps already initialized");
+  maps = std::make_shared<unit_bimaps_t>();
   for (const UnitID& u : circ_.all_units()) {
-    initial_map_.insert({u, u});
-    final_map_.insert({u, u});
+    maps->initial.insert({u, u});
+    maps->final.insert({u, u});
   }
 }
 

--- a/tket/src/Predicates/CompilerPass.cpp
+++ b/tket/src/Predicates/CompilerPass.cpp
@@ -14,12 +14,15 @@
 
 #include "CompilerPass.hpp"
 
+#include <memory>
+
 #include "PassGenerators.hpp"
 #include "PassLibrary.hpp"
 #include "Transformations/ContextualReduction.hpp"
 #include "Transformations/PauliOptimisation.hpp"
 #include "Utils/Json.hpp"
 #include "Utils/TketLog.hpp"
+#include "Utils/UnitID.hpp"
 
 namespace tket {
 
@@ -194,9 +197,7 @@ bool StandardPass::apply(
         unsatisfied_precon.value()
             ->to_string());  // just raise warning in super-unsafe mode
   // Allow trans_ to update the initial and final map
-  c_unit.circ_.unit_bimaps_ = {&c_unit.initial_map_, &c_unit.final_map_};
-  bool changed = trans_.apply(c_unit.circ_);
-  c_unit.circ_.unit_bimaps_ = {nullptr, nullptr};
+  bool changed = trans_.apply_fn(c_unit.circ_, c_unit.maps);
   update_cache(c_unit, safe_mode);
   after_apply(c_unit, this->get_config());
   return changed;

--- a/tket/src/Predicates/PassGenerators.cpp
+++ b/tket/src/Predicates/PassGenerators.cpp
@@ -141,7 +141,7 @@ PassPtr gen_rename_qubits_pass(const std::map<Qubit, Qubit>& qm) {
 }
 
 PassPtr gen_placement_pass(const PlacementPtr& placement_ptr) {
-  Transform::Transformation trans = [=](Circuit& circ) {
+  Transform::SimpleTransformation trans = [=](Circuit& circ) {
     // Fall back to line placement if graph placement fails
     bool changed;
     try {
@@ -202,7 +202,7 @@ PassPtr gen_cx_mapping_pass(
 }
 
 PassPtr gen_routing_pass(const Architecture& arc, const RoutingConfig& config) {
-  Transform::Transformation trans =
+  Transform::SimpleTransformation trans =
       [=](Circuit& circ) {  // this doesn't work if capture by ref for some
                             // reason....
         Routing route(circ, arc);
@@ -245,7 +245,7 @@ PassPtr gen_routing_pass(const Architecture& arc, const RoutingConfig& config) {
 }
 
 PassPtr gen_placement_pass_phase_poly(const Architecture& arc) {
-  Transform::Transformation trans = [=](Circuit& circ) {
+  Transform::SimpleTransformation trans = [=](Circuit& circ) {
     if (arc.n_nodes() < circ.n_qubits()) {
       throw CircuitInvalidity(
           "Circuit has more qubits than the architecture has nodes.");
@@ -287,7 +287,7 @@ PassPtr gen_placement_pass_phase_poly(const Architecture& arc) {
 PassPtr aas_routing_pass(
     const Architecture& arc, const unsigned lookahead,
     const aas::CNotSynthType cnotsynthtype) {
-  Transform::Transformation trans = [=](Circuit& circ) {
+  Transform::SimpleTransformation trans = [=](Circuit& circ) {
     // check input:
     if (lookahead == 0) {
       throw std::logic_error("lookahead must be > 0");

--- a/tket/src/Predicates/PassLibrary.cpp
+++ b/tket/src/Predicates/PassLibrary.cpp
@@ -368,11 +368,13 @@ const PassPtr &DecomposeBridges() {
 
 const PassPtr &FlattenRegisters() {
   static const PassPtr pp([]() {
-    Transform t = Transform([](Circuit &circ) {
-      if (circ.is_simple()) return false;
-      circ.flatten_registers();
-      return true;
-    });
+    Transform t =
+        Transform([](Circuit &circ, std::shared_ptr<unit_bimaps_t> maps) {
+          if (circ.is_simple()) return false;
+          unit_map_t qmap = circ.flatten_registers();
+          update_maps(maps, qmap, qmap);
+          return true;
+        });
     PredicatePtrMap s_ps;
     PredicatePtr simple = std::make_shared<DefaultRegisterPredicate>();
     PredicatePtrMap spec_postcons{CompilationUnit::make_type_pair(simple)};

--- a/tket/src/Predicates/include/Predicates/CompilationUnit.hpp
+++ b/tket/src/Predicates/include/Predicates/CompilationUnit.hpp
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <memory>
+
 #include "Predicates.hpp"
 
 namespace tket {
@@ -42,8 +44,8 @@ class CompilationUnit {
   /* getters to inspect the data members */
   const Circuit& get_circ_ref() const { return circ_; }
   const PredicateCache& get_cache_ref() const { return cache_; }
-  const unit_bimap_t& get_initial_map_ref() const { return initial_map_; }
-  const unit_bimap_t& get_final_map_ref() const { return final_map_; }
+  const unit_bimap_t& get_initial_map_ref() const { return maps->initial; }
+  const unit_bimap_t& get_final_map_ref() const { return maps->final; }
   std::string to_string() const;
 
   friend class Circuit;
@@ -62,12 +64,8 @@ class CompilationUnit {
                      // satisfy by the end of your Compiler Passes
   mutable PredicateCache cache_;  // updated continuously
 
-  /** Map from original logical qubits to corresponding current qubits wtr
-   * inputs */
-  unit_bimap_t initial_map_;
-  /** Map from original logical qubits to corresponding current qubits wtr
-   * outputs */
-  unit_bimap_t final_map_;
+  // Maps from original logical qubits to corresponding current qubits
+  std::shared_ptr<unit_bimaps_t> maps;
 };
 
 }  // namespace tket

--- a/tket/src/Routing/Placement.cpp
+++ b/tket/src/Routing/Placement.cpp
@@ -127,15 +127,20 @@ void fill_partial_mapping(
 }
 
 // Default placement methods
-bool Placement::place(Circuit &circ_) const {
+bool Placement::place(
+    Circuit &circ_, std::shared_ptr<unit_bimaps_t> maps) const {
   qubit_mapping_t map_ = get_placement_map(circ_);
-  return place_with_map(circ_, map_);
+  return place_with_map(circ_, map_, maps);
 }
 
-bool Placement::place_with_map(Circuit &circ_, qubit_mapping_t &map_) {
+bool Placement::place_with_map(
+    Circuit &circ_, qubit_mapping_t &map_,
+    std::shared_ptr<unit_bimaps_t> maps) {
   qubit_vector_t circ_qbs = circ_.all_qubits();
   fill_partial_mapping(circ_qbs, map_);
-  return circ_.rename_units(map_);
+  bool changed = circ_.rename_units(map_);
+  changed |= update_maps(maps, map_, map_);
+  return changed;
 }
 
 qubit_mapping_t Placement::get_placement_map(const Circuit &circ_) const {

--- a/tket/src/Routing/Routing.cpp
+++ b/tket/src/Routing/Routing.cpp
@@ -50,7 +50,6 @@ bool Routing::circuit_modified() const {
 /* Class Constructor */
 Routing::Routing(const Circuit& _circ, const Architecture& _arc)
     : circ_(_circ), slice_frontier_(circ_), original_arc_(_arc) {
-  circ_.unit_bimaps_ = _circ.unit_bimaps_;
   original_boundary = circ_.boundary;
 
   current_arc_ = original_arc_;
@@ -177,12 +176,13 @@ qubit_mapping_t get_qmap_from_circuit(Architecture& arc, Circuit& circ) {
   return qubit_map;
 }
 
-std::pair<Circuit, bool> Routing::solve(const RoutingConfig& config) {
+std::pair<Circuit, bool> Routing::solve(
+    const RoutingConfig& config, std::shared_ptr<unit_bimaps_t> maps) {
   config_ = config;
   qubit_mapping_t qubit_map = get_qmap_from_circuit(current_arc_, circ_);
   slice_frontier_.init();
   if (slice_frontier_.slice->empty()) {
-    organise_registers_and_maps();
+    organise_registers_and_maps(maps);
   } else {
     // Some nodes are permanently unused due to difference in architecture nodes
     // and number of used wires in circuit To account for this, place highest
@@ -199,14 +199,14 @@ std::pair<Circuit, bool> Routing::solve(const RoutingConfig& config) {
     }
     remove_unmapped_nodes(current_arc_, init_map, circ_);
     final_map = remap(init_map);
-    organise_registers_and_maps();
+    organise_registers_and_maps(maps);
   }
   bool modified = circuit_modified();
   return {circ_, modified};
 }
 
 // Tidying up of qregisters and initial and final maps after SWAP adding.
-void Routing::organise_registers_and_maps() {
+void Routing::organise_registers_and_maps(std::shared_ptr<unit_bimaps_t> maps) {
   // Given all the new empty wires with no home, if a qubit isnt in the initial
   // map, find it an unassigned node and shove it there.
   auto all_nodes = original_arc_.get_all_nodes_vec();
@@ -248,8 +248,8 @@ void Routing::organise_registers_and_maps() {
   }
 
   circ_.boundary = new_boundary;
-  circ_.update_initial_map(reorder_map);
-  circ_.update_final_map(bimap_to_map(final_map.left));
+
+  update_maps(maps, reorder_map, bimap_to_map(final_map.left));
 }
 
 // Remap completes the routing algorithm

--- a/tket/src/Routing/include/Routing/Placement.hpp
+++ b/tket/src/Routing/include/Routing/Placement.hpp
@@ -17,6 +17,7 @@
 #include <algorithm>
 #include <iostream>
 #include <map>
+#include <memory>
 #include <stdexcept>
 #include <string>
 #include <utility>
@@ -218,16 +219,19 @@ class Placement {
   /**
    * Modify qubits in place.
    *
-   * @return true iff circuit is modified
+   * @return true iff circuit or maps are modified
    */
-  bool place(Circuit& circ_) const;
+  bool place(
+      Circuit& circ_, std::shared_ptr<unit_bimaps_t> maps = nullptr) const;
 
   /**
    * Relabel circuit qubits to device nodes according to given map.
    *
-   * @return true iff circuit was modified
+   * @return true iff circuit or maps were modified
    */
-  static bool place_with_map(Circuit& circ_, qubit_mapping_t& map_);
+  static bool place_with_map(
+      Circuit& circ, qubit_mapping_t& map_,
+      std::shared_ptr<unit_bimaps_t> maps = nullptr);
 
   virtual qubit_mapping_t get_placement_map(const Circuit& circ_) const;
 

--- a/tket/src/Routing/include/Routing/Routing.hpp
+++ b/tket/src/Routing/include/Routing/Routing.hpp
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <map>
+#include <memory>
 #include <string>
 #include <utility>
 #include <vector>
@@ -214,9 +215,12 @@ class Routing {
   // specified.
 
   // solve with default mapping and provided config
-  std::pair<Circuit, bool> solve(const RoutingConfig &_config = {});
+  std::pair<Circuit, bool> solve(
+      const RoutingConfig &_config = {},
+      std::shared_ptr<unit_bimaps_t> maps = nullptr);
   qubit_bimap_t remap(const qubit_bimap_t &init);
-  void organise_registers_and_maps();
+  void organise_registers_and_maps(
+      std::shared_ptr<unit_bimaps_t> maps = nullptr);
 
   // TODO:: Make relevant and useful again
   qubit_mapping_t return_final_map() const;

--- a/tket/src/Utils/include/Utils/UnitID.hpp
+++ b/tket/src/Utils/include/Utils/UnitID.hpp
@@ -21,6 +21,7 @@
 
 #include <boost/functional/hash.hpp>
 #include <map>
+#include <memory>
 #include <optional>
 #include <regex>
 #include <set>
@@ -248,8 +249,14 @@ class Node : public Qubit {
 
 JSON_DECL(Node)
 
-/** A correspondence between two sets of node IDs */
+/** A correspondence between two sets of unit IDs */
 typedef boost::bimap<UnitID, UnitID> unit_bimap_t;
+
+/** A pair of ("initial" and "final") correspondences between unit IDs */
+typedef struct {
+  unit_bimap_t initial;
+  unit_bimap_t final;
+} unit_bimaps_t;
 
 typedef std::vector<UnitID> unit_vector_t;
 typedef std::map<UnitID, UnitID> unit_map_t;
@@ -267,5 +274,57 @@ typedef std::vector<Node> node_vector_t;
 
 /** A register of locations sharing the same name */
 typedef std::map<unsigned, UnitID> register_t;
+
+template <typename UnitA, typename UnitB>
+static bool update_map(unit_bimap_t &m, const std::map<UnitA, UnitB> &um) {
+  unit_map_t new_m;
+  bool changed = false;
+  for (const std::pair<const UnitA, UnitB> &pair : um) {
+    const auto &it = m.right.find(pair.first);
+    if (it == m.right.end()) {
+      continue;
+    }
+    new_m.insert({it->second, pair.second});
+    changed |= (m.right.erase(pair.first) > 0);
+  }
+  for (const std::pair<const UnitID, UnitID> &pair : new_m) {
+    changed |= m.left.insert(pair).second;
+  }
+  return changed;
+}
+
+/**
+ * Update a pair of "initial" and "final" correspondences.
+ *
+ * If \p maps is null then the function does nothing and returns false.
+ *
+ * @param[in,out] maps maps to be updated
+ * @param[in] um_initial new correspondences added to initial map
+ * @param[in] um_final new correspondences added to final map
+ *
+ * @tparam UnitA first unit type
+ * @tparam UnitB second unit type
+ *
+ * @return whether any changes were made to the maps
+ */
+template <typename UnitA, typename UnitB>
+bool update_maps(
+    std::shared_ptr<unit_bimaps_t> maps,
+    const std::map<UnitA, UnitB> &um_initial,
+    const std::map<UnitA, UnitB> &um_final) {
+  if (!maps) return false;
+  // Can only work for Unit classes
+  static_assert(std::is_base_of<UnitID, UnitA>::value);
+  static_assert(std::is_base_of<UnitID, UnitB>::value);
+  // Unit types must be related, so cannot rename e.g. Bits to Qubits
+  static_assert(
+      std::is_base_of<UnitA, UnitB>::value ||
+      std::is_base_of<UnitB, UnitA>::value);
+
+  bool changed = false;
+  changed |= update_map(maps->initial, um_initial);
+  changed |= update_map(maps->final, um_final);
+  return changed;
+}
 
 }  // namespace tket

--- a/tket/tests/test_CompilerPass.cpp
+++ b/tket/tests/test_CompilerPass.cpp
@@ -102,13 +102,7 @@ SCENARIO("Test that qubits added via add_qubit are tracked.") {
     circ.add_qubit(weird_qb2);
     circ.add_bit(weird_cb);
 
-    unit_bimap_t* ubmap_initial_missing = circ.unit_bimaps_.initial;
-    REQUIRE(!ubmap_initial_missing);
-
     CompilationUnit cu(circ);
-    // At initialisation, circuit bimaps are set to nullptr
-    unit_bimap_t* ubmap_initial = circ.unit_bimaps_.initial;
-    REQUIRE(!ubmap_initial);
 
     // circuit bimaps property wont be changed, nor will compilation unit
     circ.add_qubit(weird_qb3);
@@ -118,11 +112,16 @@ SCENARIO("Test that qubits added via add_qubit are tracked.") {
     REQUIRE(it == cu_initial.left.end());
 
     // Instead add transform for running it
-    Transform t = Transform([](Circuit& circ) {
-      Qubit weird_qb4("weird_qb", 9);
-      circ.add_qubit(weird_qb4);
-      return true;
-    });
+    Transform t =
+        Transform([](Circuit& circ, std::shared_ptr<unit_bimaps_t> maps) {
+          Qubit weird_qb4("weird_qb", 9);
+          circ.add_qubit(weird_qb4);
+          if (maps) {
+            maps->initial.left.insert({weird_qb4, weird_qb4});
+            maps->final.left.insert({weird_qb4, weird_qb4});
+          }
+          return true;
+        });
 
     // convert to pass
     PredicatePtrMap s_ps;


### PR DESCRIPTION
Closes #137 .