### PR TITLE
[TKET-1598] fix ConnectivityPredicate fails after FullPeepholeOptimise and AASRouting

### DIFF
--- a/tket/src/Predicates/include/Predicates/PassGenerators.hpp
+++ b/tket/src/Predicates/include/Predicates/PassGenerators.hpp
@@ -61,7 +61,7 @@ PassPtr gen_directed_cx_routing_pass(
 /**
  * execute architecture aware synthesis on a given architecture for an allready
  * place circuit, only for circuit which contains Cx+Rz+H gates
- * this pass it not able to handle implicit wire swaps
+ * this pass is not able to handle implicit wire swaps
  * @param arc architecture to route on
  * @param lookahead parameter for the recursion depth in the algorithm, the
  * value should be > 0

--- a/tket/src/Predicates/include/Predicates/PassGenerators.hpp
+++ b/tket/src/Predicates/include/Predicates/PassGenerators.hpp
@@ -61,6 +61,7 @@ PassPtr gen_directed_cx_routing_pass(
 /**
  * execute architecture aware synthesis on a given architecture for an allready
  * place circuit, only for circuit which contains Cx+Rz+H gates
+ * this pass it not able to handle implicit wire swaps
  * @param arc architecture to route on
  * @param lookahead parameter for the recursion depth in the algorithm, the
  * value should be > 0

--- a/tket/src/Transformations/Decomposition.cpp
+++ b/tket/src/Transformations/Decomposition.cpp
@@ -748,15 +748,11 @@ Transform compose_phase_poly_boxes() {
   return Transform([](Circuit &circ) {
     // replace wireswaps with three CX
     while (circ.has_implicit_wireswaps()) {
-      bool foundswap = false;
-
       qubit_map_t perm = circ.implicit_qubit_permutation();
       for (const std::pair<const Qubit, Qubit> &pair : perm) {
         if (pair.first != pair.second) {
-          if (!foundswap) {
-            circ.replace_implicit_wire_swap(pair.first, pair.second);
-            foundswap = true;
-          }
+          circ.replace_implicit_wire_swap(pair.first, pair.second);
+          break;
         }
       }
     }

--- a/tket/src/Transformations/Decomposition.cpp
+++ b/tket/src/Transformations/Decomposition.cpp
@@ -746,6 +746,21 @@ Transform decomp_boxes() {
 
 Transform compose_phase_poly_boxes() {
   return Transform([](Circuit &circ) {
+    // replace wireswaps with three CX
+    while (circ.has_implicit_wireswaps()) {
+      bool foundswap = false;
+
+      qubit_map_t perm = circ.implicit_qubit_permutation();
+      for (const std::pair<const Qubit, Qubit> &pair : perm) {
+        if (pair.first != pair.second) {
+          if (!foundswap) {
+            circ.replace_implicit_wire_swap(pair.first, pair.second);
+            foundswap = true;
+          }
+        }
+      }
+    }
+
     CircToPhasePolyConversion conv = CircToPhasePolyConversion(circ);
     conv.convert();
     circ = conv.get_circuit();

--- a/tket/tests/test_CompilerPass.cpp
+++ b/tket/tests/test_CompilerPass.cpp
@@ -797,7 +797,7 @@ SCENARIO("rebase and decompose PhasePolyBox test") {
     Circuit result = cu.get_circ_ref();
 
     REQUIRE(test_unitary_comparison(result, circ));
-    REQUIRE(!NoWireSwapsPredicate().verify(result));
+    REQUIRE(NoWireSwapsPredicate().verify(result));
   }
   GIVEN("NoWireSwapsPredicate for ComposePhasePolyBoxes II") {
     Circuit circ(5);
@@ -817,7 +817,73 @@ SCENARIO("rebase and decompose PhasePolyBox test") {
     Circuit result = cu.get_circ_ref();
 
     REQUIRE(test_unitary_comparison(result, circ));
-    REQUIRE(!NoWireSwapsPredicate().verify(result));
+    REQUIRE(NoWireSwapsPredicate().verify(result));
+  }
+  GIVEN("NoWireSwapsPredicate for ComposePhasePolyBoxes III") {
+    Circuit circ(5);
+    add_2qb_gates(circ, OpType::CX, {{0, 3}, {1, 4}});
+    circ.add_op<unsigned>(OpType::SWAP, {3, 4});
+    circ.add_op<unsigned>(OpType::CX, {2, 3});
+    circ.add_op<unsigned>(OpType::Z, {3});
+    circ.add_op<unsigned>(OpType::CX, {2, 3});
+    circ.add_op<unsigned>(OpType::SWAP, {0, 1});
+    circ.add_op<unsigned>(OpType::CX, {1, 4});
+    circ.add_op<unsigned>(OpType::Z, {4});
+    circ.add_op<unsigned>(OpType::CX, {1, 4});
+    circ.add_op<unsigned>(OpType::SWAP, {1, 2});
+    circ.add_op<unsigned>(OpType::SWAP, {2, 3});
+    circ.add_op<unsigned>(OpType::CX, {0, 1});
+    circ.add_op<unsigned>(OpType::CX, {1, 2});
+    circ.add_op<unsigned>(OpType::CX, {2, 3});
+
+    REQUIRE(NoWireSwapsPredicate().verify(circ));
+    circ.replace_SWAPs();
+    REQUIRE(!NoWireSwapsPredicate().verify(circ));
+
+    CompilationUnit cu(circ);
+    REQUIRE(ComposePhasePolyBoxes()->apply(cu));
+    Circuit result = cu.get_circ_ref();
+
+    REQUIRE(test_unitary_comparison(result, circ));
+    REQUIRE(NoWireSwapsPredicate().verify(result));
+  }
+  GIVEN("NoWireSwapsPredicate for aas I") {
+    std::vector<Node> nodes = {Node(0), Node(1), Node(2), Node(3), Node(4)};
+    Architecture architecture(
+        {{nodes[0], nodes[1]},
+         {nodes[1], nodes[2]},
+         {nodes[2], nodes[3]},
+         {nodes[3], nodes[4]}});
+
+    Circuit circ(5);
+    add_2qb_gates(circ, OpType::CX, {{0, 3}, {1, 4}});
+    circ.add_op<unsigned>(OpType::SWAP, {3, 4});
+    circ.add_op<unsigned>(OpType::CX, {2, 3});
+    circ.add_op<unsigned>(OpType::Z, {3});
+    circ.add_op<unsigned>(OpType::CX, {2, 3});
+    circ.add_op<unsigned>(OpType::SWAP, {0, 1});
+    circ.add_op<unsigned>(OpType::CX, {1, 4});
+    circ.add_op<unsigned>(OpType::Z, {4});
+    circ.add_op<unsigned>(OpType::CX, {1, 4});
+    circ.add_op<unsigned>(OpType::SWAP, {1, 2});
+    circ.add_op<unsigned>(OpType::SWAP, {2, 3});
+    circ.add_op<unsigned>(OpType::CX, {0, 1});
+    circ.add_op<unsigned>(OpType::CX, {1, 2});
+    circ.add_op<unsigned>(OpType::CX, {2, 3});
+
+    REQUIRE(NoWireSwapsPredicate().verify(circ));
+    circ.replace_SWAPs();
+    REQUIRE(!NoWireSwapsPredicate().verify(circ));
+
+    CompilationUnit cu(circ);
+
+    REQUIRE(gen_full_mapping_pass_phase_poly(
+                architecture, 1, aas::CNotSynthType::Rec)
+                ->apply(cu));
+    Circuit result = cu.get_circ_ref();
+
+    REQUIRE(test_unitary_comparison(result, circ));
+    REQUIRE(NoWireSwapsPredicate().verify(result));
   }
 }
 


### PR DESCRIPTION
This is fixing https://github.com/CQCL/tket/issues/97

The problem has been a wrong handling of the implicit wire swaps in the aas pass