### PR TITLE
Use spdlog library

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -182,7 +182,7 @@ jobs:
     - name: Build symengine
       run: conan create --profile=tket recipes/symengine
     - name: Build tket
-      run: conan create --profile=tket recipes/tket
+      run: conan create --profile=tket recipes/tket --build=spdlog --build=tket
     - name: Build and run tket tests
       run: conan create --profile=tket recipes/tket-tests
     - name: Build and run tket proptests
@@ -274,7 +274,7 @@ jobs:
     - name: Build symengine
       run: conan create --profile=tket recipes/symengine
     - name: Build tket
-      run: conan create --profile=tket recipes/tket
+      run: conan create --profile=tket recipes/tket --build=spdlog --build=tket
     - name: Build and run tket tests
       run: conan create --profile=tket recipes/tket-tests
     - name: Build and run tket proptests

--- a/.github/workflows/linuxbuildwheel
+++ b/.github/workflows/linuxbuildwheel
@@ -28,7 +28,7 @@ cd /tket
 ${CONAN_CMD} profile new tket --detect
 ${CONAN_CMD} profile update options.tket:shared=True tket
 ${CONAN_CMD} create --profile=tket recipes/symengine
-${CONAN_CMD} create --profile=tket --test-folder=None recipes/tket
+${CONAN_CMD} create --profile=tket --test-folder=None -o tket:spdlog_ho=True recipes/tket
 ${CONAN_CMD} create --profile=tket --test-folder=None recipes/pybind11
 
 cd /tket/pytket

--- a/.github/workflows/linuxbuildwheel
+++ b/.github/workflows/linuxbuildwheel
@@ -28,6 +28,8 @@ cd /tket
 ${CONAN_CMD} profile new tket --detect
 ${CONAN_CMD} profile update options.tket:shared=True tket
 ${CONAN_CMD} create --profile=tket recipes/symengine
+# Use header-only version of spdlog:
+# https://github.com/conan-io/conan-docker-tools/issues/303#issuecomment-922492130
 ${CONAN_CMD} create --profile=tket --test-folder=None -o tket:spdlog_ho=True recipes/tket
 ${CONAN_CMD} create --profile=tket --test-folder=None recipes/pybind11
 

--- a/README.md
+++ b/README.md
@@ -149,13 +149,6 @@ conan create --profile=tket recipes/tket
 
 to build the tket library.
 
-Note: by default, `tket` uses the header-only version of `spdlog`. This avoids
-an
-[issue](https://github.com/conan-io/conan-docker-tools/issues/303#issuecomment-922492130)
-with an undefined symbol when run in some Linux virtual environments, but makes
-builds slower. For faster local builds you can supply the option
-`-o tket:spdlog_ho=False` to the above `conan create` command.
-
 To build and run the tket tests:
 
 ```shell

--- a/pytket/CMakeLists.txt
+++ b/pytket/CMakeLists.txt
@@ -38,6 +38,9 @@ else()
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Werror")
 endif()
 
+list(APPEND TKET_EXTRA_LIBS
+    ${CONAN_LIBS_FMT} ${CONAN_LIBS_SPDLOG} ${CONAN_LIBS_SYMENGINE})
+
 pybind11_add_module(circuit
     binders/circuit/main.cpp
     binders/circuit/unitid.cpp
@@ -56,8 +59,7 @@ target_link_libraries(circuit PRIVATE
     tket-Routing
     tket-Simulation
     tket-Utils)
-target_link_libraries(circuit PRIVATE
-    ${CONAN_LIBS_FMT} ${CONAN_LIBS_SPDLOG} ${CONAN_LIBS_SYMENGINE})
+target_link_libraries(circuit PRIVATE ${TKET_EXTRA_LIBS})
 if (WIN32)
     # For boost::uuid:
     target_link_libraries(circuit PRIVATE bcrypt)
@@ -75,8 +77,7 @@ target_link_libraries(routing PRIVATE
     tket-OpType
     tket-Routing
     tket-Utils)
-target_link_libraries(routing PRIVATE
-    ${CONAN_LIBS_FMT} ${CONAN_LIBS_SPDLOG} ${CONAN_LIBS_SYMENGINE})
+target_link_libraries(routing PRIVATE ${TKET_EXTRA_LIBS})
 if (WIN32)
     # For boost::uuid:
     target_link_libraries(routing PRIVATE bcrypt)
@@ -97,8 +98,7 @@ target_link_libraries(transform PRIVATE
     tket-PauliGraph
     tket-Transformations
     tket-Utils)
-target_link_libraries(transform PRIVATE
-    ${CONAN_LIBS_FMT} ${CONAN_LIBS_SPDLOG} ${CONAN_LIBS_SYMENGINE})
+target_link_libraries(transform PRIVATE ${TKET_EXTRA_LIBS})
 if (WIN32)
     # For boost::uuid:
     target_link_libraries(transform PRIVATE bcrypt)
@@ -122,8 +122,7 @@ target_link_libraries(predicates PRIVATE
     tket-Routing
     tket-Transformations
     tket-Utils)
-target_link_libraries(predicates PRIVATE
-    ${CONAN_LIBS_FMT} ${CONAN_LIBS_SPDLOG} ${CONAN_LIBS_SYMENGINE})
+target_link_libraries(predicates PRIVATE ${TKET_EXTRA_LIBS})
 if (WIN32)
     # For boost::uuid:
     target_link_libraries(predicates PRIVATE bcrypt)
@@ -147,8 +146,7 @@ target_link_libraries(passes PRIVATE
     tket-Routing
     tket-Transformations
     tket-Utils)
-target_link_libraries(passes PRIVATE
-    ${CONAN_LIBS_FMT} ${CONAN_LIBS_SPDLOG} ${CONAN_LIBS_SYMENGINE})
+target_link_libraries(passes PRIVATE ${TKET_EXTRA_LIBS})
 if (WIN32)
     # For boost::uuid:
     target_link_libraries(passes PRIVATE bcrypt)
@@ -163,8 +161,7 @@ target_link_libraries(program PRIVATE
     tket-OpType
     tket-Program
     tket-Utils)
-target_link_libraries(program PRIVATE
-    ${CONAN_LIBS_FMT} ${CONAN_LIBS_SPDLOG} ${CONAN_LIBS_SYMENGINE})
+target_link_libraries(program PRIVATE ${TKET_EXTRA_LIBS})
 if (WIN32)
     # For boost::uuid:
     target_link_libraries(program PRIVATE bcrypt)
@@ -183,8 +180,7 @@ target_link_libraries(partition PRIVATE
     tket-OpType
     tket-PauliGraph
     tket-Utils)
-target_link_libraries(partition PRIVATE
-    ${CONAN_LIBS_FMT} ${CONAN_LIBS_SPDLOG} ${CONAN_LIBS_SYMENGINE})
+target_link_libraries(partition PRIVATE ${TKET_EXTRA_LIBS})
 if (WIN32)
     # For boost::uuid:
     target_link_libraries(partition PRIVATE bcrypt)
@@ -194,22 +190,19 @@ pybind11_add_module(pauli binders/pauli.cpp)
 target_include_directories(pauli PRIVATE binders/include)
 target_link_libraries(pauli PRIVATE
     tket-Utils)
-target_link_libraries(pauli PRIVATE
-    ${CONAN_LIBS_FMT} ${CONAN_LIBS_SPDLOG} ${CONAN_LIBS_SYMENGINE})
+target_link_libraries(pauli PRIVATE ${TKET_EXTRA_LIBS})
 
 pybind11_add_module(logging binders/logging.cpp)
 target_include_directories(logging PRIVATE binders/include)
 target_link_libraries(logging PRIVATE
     tket-Utils)
-target_link_libraries(logging PRIVATE
-    ${CONAN_LIBS_FMT} ${CONAN_LIBS_SPDLOG} ${CONAN_LIBS_SYMENGINE})
+target_link_libraries(logging PRIVATE ${TKET_EXTRA_LIBS})
 
 pybind11_add_module(utils_serialization binders/utils_serialization.cpp)
 target_include_directories(utils_serialization PRIVATE binders/include)
 target_link_libraries(utils_serialization PRIVATE
     tket-Utils)
-target_link_libraries(utils_serialization PRIVATE
-    ${CONAN_LIBS_FMT} ${CONAN_LIBS_SPDLOG} ${CONAN_LIBS_SYMENGINE})
+target_link_libraries(utils_serialization PRIVATE ${TKET_EXTRA_LIBS})
 
 pybind11_add_module(tailoring binders/tailoring.cpp)
 target_include_directories(tailoring PRIVATE binders/include)
@@ -226,8 +219,7 @@ target_link_libraries(tailoring PRIVATE
     tket-OpType
     tket-PauliGraph
     tket-Utils)
-target_link_libraries(tailoring PRIVATE
-    ${CONAN_LIBS_FMT} ${CONAN_LIBS_SPDLOG} ${CONAN_LIBS_SYMENGINE})
+target_link_libraries(tailoring PRIVATE ${TKET_EXTRA_LIBS})
 if (WIN32)
     # For boost::uuid:
     target_link_libraries(tailoring PRIVATE bcrypt)
@@ -245,8 +237,7 @@ target_link_libraries(tableau PRIVATE
     tket-OpType
     tket-PauliGraph
     tket-Utils)
-target_link_libraries(tableau PRIVATE
-    ${CONAN_LIBS_FMT} ${CONAN_LIBS_SPDLOG} ${CONAN_LIBS_SYMENGINE})
+target_link_libraries(tableau PRIVATE ${TKET_EXTRA_LIBS})
 if (WIN32)
     # For boost::uuid:
     target_link_libraries(tableau PRIVATE bcrypt)
@@ -259,5 +250,4 @@ target_include_directories(zx PRIVATE binders/include)
 target_link_libraries(zx PRIVATE
     tket-Utils
     tket-ZX)
-target_link_libraries(zx PRIVATE
-    ${CONAN_LIBS_FMT} ${CONAN_LIBS_SPDLOG} ${CONAN_LIBS_SYMENGINE})
+target_link_libraries(zx PRIVATE ${TKET_EXTRA_LIBS})

--- a/pytket/CMakeLists.txt
+++ b/pytket/CMakeLists.txt
@@ -56,7 +56,8 @@ target_link_libraries(circuit PRIVATE
     tket-Routing
     tket-Simulation
     tket-Utils)
-target_link_libraries(circuit PRIVATE ${CONAN_LIBS_SYMENGINE})
+target_link_libraries(circuit PRIVATE
+    ${CONAN_LIBS_FMT} ${CONAN_LIBS_SPDLOG} ${CONAN_LIBS_SYMENGINE})
 if (WIN32)
     # For boost::uuid:
     target_link_libraries(circuit PRIVATE bcrypt)
@@ -74,7 +75,8 @@ target_link_libraries(routing PRIVATE
     tket-OpType
     tket-Routing
     tket-Utils)
-target_link_libraries(routing PRIVATE ${CONAN_LIBS_SYMENGINE})
+target_link_libraries(routing PRIVATE
+    ${CONAN_LIBS_FMT} ${CONAN_LIBS_SPDLOG} ${CONAN_LIBS_SYMENGINE})
 if (WIN32)
     # For boost::uuid:
     target_link_libraries(routing PRIVATE bcrypt)
@@ -95,7 +97,8 @@ target_link_libraries(transform PRIVATE
     tket-PauliGraph
     tket-Transformations
     tket-Utils)
-target_link_libraries(transform PRIVATE ${CONAN_LIBS_SYMENGINE})
+target_link_libraries(transform PRIVATE
+    ${CONAN_LIBS_FMT} ${CONAN_LIBS_SPDLOG} ${CONAN_LIBS_SYMENGINE})
 if (WIN32)
     # For boost::uuid:
     target_link_libraries(transform PRIVATE bcrypt)
@@ -119,7 +122,8 @@ target_link_libraries(predicates PRIVATE
     tket-Routing
     tket-Transformations
     tket-Utils)
-target_link_libraries(predicates PRIVATE ${CONAN_LIBS_SYMENGINE})
+target_link_libraries(predicates PRIVATE
+    ${CONAN_LIBS_FMT} ${CONAN_LIBS_SPDLOG} ${CONAN_LIBS_SYMENGINE})
 if (WIN32)
     # For boost::uuid:
     target_link_libraries(predicates PRIVATE bcrypt)
@@ -143,7 +147,8 @@ target_link_libraries(passes PRIVATE
     tket-Routing
     tket-Transformations
     tket-Utils)
-target_link_libraries(passes PRIVATE ${CONAN_LIBS_SYMENGINE})
+target_link_libraries(passes PRIVATE
+    ${CONAN_LIBS_FMT} ${CONAN_LIBS_SPDLOG} ${CONAN_LIBS_SYMENGINE})
 if (WIN32)
     # For boost::uuid:
     target_link_libraries(passes PRIVATE bcrypt)
@@ -158,7 +163,8 @@ target_link_libraries(program PRIVATE
     tket-OpType
     tket-Program
     tket-Utils)
-target_link_libraries(program PRIVATE ${CONAN_LIBS_SYMENGINE})
+target_link_libraries(program PRIVATE
+    ${CONAN_LIBS_FMT} ${CONAN_LIBS_SPDLOG} ${CONAN_LIBS_SYMENGINE})
 if (WIN32)
     # For boost::uuid:
     target_link_libraries(program PRIVATE bcrypt)
@@ -177,7 +183,8 @@ target_link_libraries(partition PRIVATE
     tket-OpType
     tket-PauliGraph
     tket-Utils)
-target_link_libraries(partition PRIVATE ${CONAN_LIBS_SYMENGINE})
+target_link_libraries(partition PRIVATE
+    ${CONAN_LIBS_FMT} ${CONAN_LIBS_SPDLOG} ${CONAN_LIBS_SYMENGINE})
 if (WIN32)
     # For boost::uuid:
     target_link_libraries(partition PRIVATE bcrypt)
@@ -187,19 +194,22 @@ pybind11_add_module(pauli binders/pauli.cpp)
 target_include_directories(pauli PRIVATE binders/include)
 target_link_libraries(pauli PRIVATE
     tket-Utils)
-target_link_libraries(pauli PRIVATE ${CONAN_LIBS_SYMENGINE})
+target_link_libraries(pauli PRIVATE
+    ${CONAN_LIBS_FMT} ${CONAN_LIBS_SPDLOG} ${CONAN_LIBS_SYMENGINE})
 
 pybind11_add_module(logging binders/logging.cpp)
 target_include_directories(logging PRIVATE binders/include)
 target_link_libraries(logging PRIVATE
     tket-Utils)
-target_link_libraries(logging PRIVATE ${CONAN_LIBS_SYMENGINE})
+target_link_libraries(logging PRIVATE
+    ${CONAN_LIBS_FMT} ${CONAN_LIBS_SPDLOG} ${CONAN_LIBS_SYMENGINE})
 
 pybind11_add_module(utils_serialization binders/utils_serialization.cpp)
 target_include_directories(utils_serialization PRIVATE binders/include)
 target_link_libraries(utils_serialization PRIVATE
     tket-Utils)
-target_link_libraries(utils_serialization PRIVATE ${CONAN_LIBS_SYMENGINE})
+target_link_libraries(utils_serialization PRIVATE
+    ${CONAN_LIBS_FMT} ${CONAN_LIBS_SPDLOG} ${CONAN_LIBS_SYMENGINE})
 
 pybind11_add_module(tailoring binders/tailoring.cpp)
 target_include_directories(tailoring PRIVATE binders/include)
@@ -216,7 +226,8 @@ target_link_libraries(tailoring PRIVATE
     tket-OpType
     tket-PauliGraph
     tket-Utils)
-target_link_libraries(tailoring PRIVATE ${CONAN_LIBS_SYMENGINE})
+target_link_libraries(tailoring PRIVATE
+    ${CONAN_LIBS_FMT} ${CONAN_LIBS_SPDLOG} ${CONAN_LIBS_SYMENGINE})
 if (WIN32)
     # For boost::uuid:
     target_link_libraries(tailoring PRIVATE bcrypt)
@@ -234,7 +245,8 @@ target_link_libraries(tableau PRIVATE
     tket-OpType
     tket-PauliGraph
     tket-Utils)
-target_link_libraries(tableau PRIVATE ${CONAN_LIBS_SYMENGINE})
+target_link_libraries(tableau PRIVATE
+    ${CONAN_LIBS_FMT} ${CONAN_LIBS_SPDLOG} ${CONAN_LIBS_SYMENGINE})
 if (WIN32)
     # For boost::uuid:
     target_link_libraries(tableau PRIVATE bcrypt)
@@ -247,4 +259,5 @@ target_include_directories(zx PRIVATE binders/include)
 target_link_libraries(zx PRIVATE
     tket-Utils
     tket-ZX)
-target_link_libraries(zx PRIVATE ${CONAN_LIBS_SYMENGINE})
+target_link_libraries(zx PRIVATE
+    ${CONAN_LIBS_FMT} ${CONAN_LIBS_SPDLOG} ${CONAN_LIBS_SYMENGINE})

--- a/recipes/tket/conanfile.py
+++ b/recipes/tket/conanfile.py
@@ -32,7 +32,7 @@ class TketConan(ConanFile):
         "profile_coverage": [True, False],
         "spdlog_ho": [True, False],
     }
-    default_options = {"shared": False, "profile_coverage": False, "spdlog_ho": True}
+    default_options = {"shared": False, "profile_coverage": False, "spdlog_ho": False}
     generators = "cmake"
     # Putting "patches" in both "exports_sources" and "exports" means that this works
     # in either the CI workflow (`conan create`) or the development workflow

--- a/recipes/tket/test_package/CMakeLists.txt
+++ b/recipes/tket/test_package/CMakeLists.txt
@@ -39,4 +39,5 @@ target_link_libraries(test PRIVATE
     tket-Transformations
     tket-Utils)
 
-target_link_libraries(test PRIVATE ${CONAN_LIBS_SYMENGINE})
+target_link_libraries(test PRIVATE
+    ${CONAN_LIBS_FMT} ${CONAN_LIBS_SPDLOG} ${CONAN_LIBS_SYMENGINE})

--- a/tket/proptests/CMakeLists.txt
+++ b/tket/proptests/CMakeLists.txt
@@ -54,4 +54,5 @@ target_link_libraries(proptest PRIVATE
     tket-Transformations
     tket-Utils)
 
-target_link_libraries(proptest PRIVATE ${CONAN_LIBS_SYMENGINE})
+target_link_libraries(proptest PRIVATE
+    ${CONAN_LIBS_FMT} ${CONAN_LIBS_SPDLOG} ${CONAN_LIBS_SYMENGINE})

--- a/tket/src/Utils/CMakeLists.txt
+++ b/tket/src/Utils/CMakeLists.txt
@@ -42,4 +42,6 @@ target_include_directories(tket-${COMP}
     ${TKET_${COMP}_INCLUDE_DIR}
     ${TKET_${COMP}_INCLUDE_DIR}/${COMP})
 
+target_link_libraries(tket-${COMP} PUBLIC
+    ${CONAN_LIBS_FMT} ${CONAN_LIBS_SPDLOG})
 target_link_libraries(tket-${COMP} PRIVATE ${CONAN_LIBS_SYMENGINE})

--- a/tket/tests/CMakeLists.txt
+++ b/tket/tests/CMakeLists.txt
@@ -65,4 +65,5 @@ target_link_libraries(test_tket PRIVATE
     tket-Utils
     tket-ZX)
 
-target_link_libraries(test_tket PRIVATE ${CONAN_LIBS_SYMENGINE})
+target_link_libraries(test_tket PRIVATE
+    ${CONAN_LIBS_FMT} ${CONAN_LIBS_SPDLOG} ${CONAN_LIBS_SYMENGINE})


### PR DESCRIPTION
Go back to using the library version of spdlog/fmt, except when building Linux wheels.
This mostly reverts #44 . It should make builds a bit faster, and _may_ solve #178 (we'll see).