### PR TITLE
Ensure that the standard fields of `BackendInfo` are JSON-serializable

### DIFF
--- a/pytket/binders/circuit/main.cpp
+++ b/pytket/binders/circuit/main.cpp
@@ -26,10 +26,12 @@
 #include "Ops/Op.hpp"
 #include "Utils/Constants.hpp"
 #include "Utils/Symbols.hpp"
+#include "binder_json.hpp"
 #include "binder_utils.hpp"
 #include "typecast.hpp"
 
 namespace py = pybind11;
+using json = nlohmann::json;
 
 namespace tket {
 
@@ -443,7 +445,10 @@ PYBIND11_MODULE(circuit, m) {
           "A classical operation applied to multiple bits simultaneously")
       .value(
           "ClassicalExpBox", OpType::ClassicalExpBox,
-          "A box for holding compound classical operations on Bits.");
+          "A box for holding compound classical operations on Bits.")
+      .def_static(
+          "from_name", [](const json &j) { return j.get<OpType>(); },
+          "Construct from name");
   py::enum_<BasisOrder>(
       m, "BasisOrder",
       "Enum for readout basis and ordering.\n"

--- a/pytket/pytket/backends/backendinfo.py
+++ b/pytket/pytket/backends/backendinfo.py
@@ -13,11 +13,101 @@
 # limitations under the License.
 
 """ BackendInfo class: additional information on Backends """
+
+from ast import literal_eval
 from dataclasses import dataclass, field, asdict
 from typing import Any, Dict, List, Optional, Set, cast, Tuple, Union
 
 from pytket.routing import Architecture, FullyConnected  # type: ignore
 from pytket.circuit import Node, OpType  # type: ignore
+
+
+def serialize_all_node_gate_errors(d):
+    if d is None:
+        return None
+    return {
+        str(n.to_list()): {ot.value: err for ot, err in errs.items()}
+        for n, errs in d.items()
+    }
+
+
+def deserialize_all_node_gate_errors(d):
+    if d is None:
+        return None
+    return {
+        Node.from_list(literal_eval(n)): {
+            OpType(int(ot)): err for ot, err in errs.items()
+        }
+        for n, errs in d.items()
+    }
+
+
+def serialize_all_edge_gate_errors(d):
+    if d is None:
+        return None
+    return {
+        str((n0.to_list(), n1.to_list())): {ot.value: err for ot, err in errs.items()}
+        for (n0, n1), errs in d.items()
+    }
+
+
+def deserialize_all_edge_gate_errors(d):
+    if d is None:
+        return None
+    return {
+        tuple(map(Node.from_list, literal_eval(n))): {
+            OpType(int(ot)): err for ot, err in errs.items()
+        }
+        for n, errs in d.items()
+    }
+
+
+def serialize_all_readout_errors(d):
+    if d is None:
+        return None
+    return {str(n.to_list()): errs for n, errs in d.items()}
+
+
+def deserialize_all_readout_errors(d):
+    if d is None:
+        return None
+    return {Node.from_list(literal_eval(n)): errs for n, errs in d.items()}
+
+
+def serialize_averaged_node_gate_errors(d):
+    if d is None:
+        return None
+    return {str(n.to_list()): err for n, err in d.items()}
+
+
+def deserialize_averaged_node_gate_errors(d):
+    if d is None:
+        return None
+    return {Node.from_list(literal_eval(n)): err for n, err in d.items()}
+
+
+def serialize_averaged_edge_gate_errors(d):
+    if d is None:
+        return None
+    return {str((n0.to_list(), n1.to_list())): err for (n0, n1), err in d.items()}
+
+
+def deserialize_averaged_edge_gate_errors(d):
+    if d is None:
+        return None
+    return {tuple(map(Node.from_list, literal_eval(n))): err for n, err in d.items()}
+
+
+def serialize_averaged_readout_errors(d):
+    if d is None:
+        return None
+    return {str(n.to_list()): err for n, err in d.items()}
+
+
+def deserialize_averaged_readout_errors(d):
+    if d is None:
+        return None
+    return {Node.from_list(literal_eval(n)): err for n, err in d.items()}
 
 
 @dataclass
@@ -131,6 +221,24 @@ class BackendInfo:
         self_dict = asdict(self)
         self_dict["architecture"] = self_dict["architecture"].to_dict()
         self_dict["gate_set"] = [op.value for op in self_dict["gate_set"]]
+        self_dict["all_node_gate_errors"] = serialize_all_node_gate_errors(
+            self_dict["all_node_gate_errors"]
+        )
+        self_dict["all_edge_gate_errors"] = serialize_all_edge_gate_errors(
+            self_dict["all_edge_gate_errors"]
+        )
+        self_dict["all_readout_errors"] = serialize_all_readout_errors(
+            self_dict["all_readout_errors"]
+        )
+        self_dict["averaged_node_gate_errors"] = serialize_averaged_node_gate_errors(
+            self_dict["averaged_node_gate_errors"]
+        )
+        self_dict["averaged_edge_gate_errors"] = serialize_averaged_edge_gate_errors(
+            self_dict["averaged_edge_gate_errors"]
+        )
+        self_dict["averaged_readout_errors"] = serialize_averaged_readout_errors(
+            self_dict["averaged_readout_errors"]
+        )
         return self_dict
 
     @classmethod
@@ -149,6 +257,24 @@ class BackendInfo:
         else:
             args["architecture"] = FullyConnected.from_dict(args["architecture"])
         args["gate_set"] = {OpType(op) for op in args["gate_set"]}
+        args["all_node_gate_errors"] = deserialize_all_node_gate_errors(
+            args["all_node_gate_errors"]
+        )
+        args["all_edge_gate_errors"] = deserialize_all_edge_gate_errors(
+            args["all_edge_gate_errors"]
+        )
+        args["all_readout_errors"] = deserialize_all_readout_errors(
+            args["all_readout_errors"]
+        )
+        args["averaged_node_gate_errors"] = deserialize_averaged_node_gate_errors(
+            args["averaged_node_gate_errors"]
+        )
+        args["averaged_edge_gate_errors"] = deserialize_averaged_edge_gate_errors(
+            args["averaged_edge_gate_errors"]
+        )
+        args["averaged_readout_errors"] = deserialize_averaged_readout_errors(
+            args["averaged_readout_errors"]
+        )
         return cls(**args)
 
 

--- a/pytket/pytket/backends/backendinfo.py
+++ b/pytket/pytket/backends/backendinfo.py
@@ -23,17 +23,17 @@ from pytket.circuit import Node, OpType  # type: ignore
 
 def _serialize_all_node_gate_errors(
     d: Optional[Dict[Node, Dict[OpType, float]]]
-) -> Optional[List[Tuple[List, Dict[str, float]]]]:
+) -> Optional[List[List]]:
     if d is None:
         return None
     return [
-        (n.to_list(), {ot.name: err for ot, err in errs.items()})
+        [n.to_list(), {ot.name: err for ot, err in errs.items()}]
         for n, errs in d.items()
     ]
 
 
 def _deserialize_all_node_gate_errors(
-    l: Optional[List[Tuple[List, Dict[str, float]]]]
+    l: Optional[List[List]],
 ) -> Optional[Dict[Node, Dict[OpType, float]]]:
     if l is None:
         return None
@@ -45,17 +45,17 @@ def _deserialize_all_node_gate_errors(
 
 def _serialize_all_edge_gate_errors(
     d: Optional[Dict[Tuple[Node, Node], Dict[OpType, float]]]
-) -> Optional[List[Tuple[Tuple[List, List], Dict[str, float]]]]:
+) -> Optional[List]:
     if d is None:
         return None
     return [
-        ((n0.to_list(), n1.to_list()), {ot.name: err for ot, err in errs.items()})
+        [[n0.to_list(), n1.to_list()], {ot.name: err for ot, err in errs.items()}]
         for (n0, n1), errs in d.items()
     ]
 
 
 def _deserialize_all_edge_gate_errors(
-    l: Optional[List[Tuple[Tuple[List, List], Dict[str, float]]]],
+    l: Optional[List],
 ) -> Optional[Dict[Tuple, Dict[OpType, float]]]:
     if l is None:
         return None
@@ -69,14 +69,14 @@ def _deserialize_all_edge_gate_errors(
 
 def _serialize_all_readout_errors(
     d: Optional[Dict[Node, List[List[float]]]]
-) -> Optional[List[Tuple[List, List[List[float]]]]]:
+) -> Optional[List[List]]:
     if d is None:
         return None
-    return [(n.to_list(), errs) for n, errs in d.items()]
+    return [[n.to_list(), errs] for n, errs in d.items()]
 
 
 def _deserialize_all_readout_errors(
-    l: Optional[List[Tuple[List, List[List[float]]]]]
+    l: Optional[List[List]],
 ) -> Optional[Dict[Node, List[List[float]]]]:
     if l is None:
         return None
@@ -85,14 +85,14 @@ def _deserialize_all_readout_errors(
 
 def _serialize_averaged_node_gate_errors(
     d: Optional[Dict[Node, float]]
-) -> Optional[List[Tuple[List, float]]]:
+) -> Optional[List[List]]:
     if d is None:
         return None
-    return [(n.to_list(), err) for n, err in d.items()]
+    return [[n.to_list(), err] for n, err in d.items()]
 
 
 def _deserialize_averaged_node_gate_errors(
-    l: Optional[List[Tuple[List, float]]]
+    l: Optional[List[List]],
 ) -> Optional[Dict[Node, float]]:
     if l is None:
         return None
@@ -101,14 +101,14 @@ def _deserialize_averaged_node_gate_errors(
 
 def _serialize_averaged_edge_gate_errors(
     d: Optional[Dict[Tuple[Node, Node], float]]
-) -> Optional[List[Tuple[Tuple[List, List], float]]]:
+) -> Optional[List[List]]:
     if d is None:
         return None
-    return [((n0.to_list(), n1.to_list()), err) for (n0, n1), err in d.items()]
+    return [[[n0.to_list(), n1.to_list()], err] for (n0, n1), err in d.items()]
 
 
 def _deserialize_averaged_edge_gate_errors(
-    l: Optional[List[Tuple[Tuple[List, List], float]]]
+    l: Optional[List[List]],
 ) -> Optional[Dict[Tuple, float]]:
     if l is None:
         return None
@@ -117,14 +117,14 @@ def _deserialize_averaged_edge_gate_errors(
 
 def _serialize_averaged_readout_errors(
     d: Optional[Dict[Node, float]]
-) -> Optional[List[Tuple[List, float]]]:
+) -> Optional[List[List]]:
     if d is None:
         return None
-    return [(n.to_list(), err) for n, err in d.items()]
+    return [[n.to_list(), err] for n, err in d.items()]
 
 
 def _deserialize_averaged_readout_errors(
-    l: Optional[List[Tuple[List, float]]]
+    l: Optional[List[List]],
 ) -> Optional[Dict[Node, float]]:
     if l is None:
         return None

--- a/pytket/pytket/backends/backendinfo.py
+++ b/pytket/pytket/backends/backendinfo.py
@@ -14,7 +14,6 @@
 
 """ BackendInfo class: additional information on Backends """
 
-from ast import literal_eval
 from dataclasses import dataclass, field, asdict
 from typing import Any, Dict, List, Optional, Set, cast, Tuple, Union
 
@@ -24,114 +23,112 @@ from pytket.circuit import Node, OpType  # type: ignore
 
 def _serialize_all_node_gate_errors(
     d: Optional[Dict[Node, Dict[OpType, float]]]
-) -> Optional[Dict[str, Dict[int, float]]]:
+) -> Optional[List[Tuple[List, Dict[int, float]]]]:
     if d is None:
         return None
-    return {
-        str(n.to_list()): {ot.value: err for ot, err in errs.items()}
+    return [
+        (n.to_list(), {ot.value: err for ot, err in errs.items()})
         for n, errs in d.items()
-    }
+    ]
 
 
 def _deserialize_all_node_gate_errors(
-    d: Optional[Dict[str, Dict[int, float]]]
+    l: Optional[List[Tuple[List, Dict[int, float]]]]
 ) -> Optional[Dict[Node, Dict[OpType, float]]]:
-    if d is None:
+    if l is None:
         return None
     return {
-        Node.from_list(literal_eval(n)): {
-            OpType(int(ot)): err for ot, err in errs.items()
-        }
-        for n, errs in d.items()
+        Node.from_list(n): {OpType(int(ot)): err for ot, err in errs.items()}
+        for n, errs in l
     }
 
 
 def _serialize_all_edge_gate_errors(
     d: Optional[Dict[Tuple[Node, Node], Dict[OpType, float]]]
-) -> Optional[Dict[str, Dict[int, float]]]:
+) -> Optional[List[Tuple[Tuple[List, List], Dict[int, float]]]]:
     if d is None:
         return None
-    return {
-        str((n0.to_list(), n1.to_list())): {ot.value: err for ot, err in errs.items()}
+    return [
+        ((n0.to_list(), n1.to_list()), {ot.value: err for ot, err in errs.items()})
         for (n0, n1), errs in d.items()
-    }
+    ]
 
 
 def _deserialize_all_edge_gate_errors(
-    d: Optional[Dict[str, Dict[int, float]]],
+    l: Optional[List[Tuple[Tuple[List, List], Dict[int, float]]]],
 ) -> Optional[Dict[Tuple, Dict[OpType, float]]]:
-    if d is None:
+    if l is None:
         return None
     return {
-        tuple(map(Node.from_list, literal_eval(n))): {
+        (Node.from_list(n0), Node.from_list(n1)): {
             OpType(int(ot)): err for ot, err in errs.items()
         }
-        for n, errs in d.items()
+        for (n0, n1), errs in l
     }
 
 
 def _serialize_all_readout_errors(
     d: Optional[Dict[Node, List[List[float]]]]
-) -> Optional[Dict[str, List[List[float]]]]:
+) -> Optional[List[Tuple[List, List[List[float]]]]]:
     if d is None:
         return None
-    return {str(n.to_list()): errs for n, errs in d.items()}
+    return [(n.to_list(), errs) for n, errs in d.items()]
 
 
 def _deserialize_all_readout_errors(
-    d: Optional[Dict[str, List[List[float]]]]
+    l: Optional[List[Tuple[List, List[List[float]]]]]
 ) -> Optional[Dict[Node, List[List[float]]]]:
-    if d is None:
+    if l is None:
         return None
-    return {Node.from_list(literal_eval(n)): errs for n, errs in d.items()}
+    return {Node.from_list(n): errs for n, errs in l}
 
 
 def _serialize_averaged_node_gate_errors(
     d: Optional[Dict[Node, float]]
-) -> Optional[Dict[str, float]]:
+) -> Optional[List[Tuple[List, float]]]:
     if d is None:
         return None
-    return {str(n.to_list()): err for n, err in d.items()}
+    return [(n.to_list(), err) for n, err in d.items()]
 
 
 def _deserialize_averaged_node_gate_errors(
-    d: Optional[Dict[str, float]]
+    l: Optional[List[Tuple[List, float]]]
 ) -> Optional[Dict[Node, float]]:
-    if d is None:
+    if l is None:
         return None
-    return {Node.from_list(literal_eval(n)): err for n, err in d.items()}
+    return {Node.from_list(n): err for n, err in l}
 
 
 def _serialize_averaged_edge_gate_errors(
     d: Optional[Dict[Tuple[Node, Node], float]]
-) -> Optional[Dict[str, float]]:
+) -> Optional[List[Tuple[Tuple[List, List], float]]]:
     if d is None:
         return None
-    return {str((n0.to_list(), n1.to_list())): err for (n0, n1), err in d.items()}
+    return [((n0.to_list(), n1.to_list()), err) for (n0, n1), err in d.items()]
 
 
 def _deserialize_averaged_edge_gate_errors(
-    d: Optional[Dict[str, float]]
+    l: Optional[List[Tuple[Tuple[List, List], float]]]
 ) -> Optional[Dict[Tuple, float]]:
-    if d is None:
+    if l is None:
         return None
-    return {tuple(map(Node.from_list, literal_eval(n))): err for n, err in d.items()}
+    return {(Node.from_list(n0), Node.from_list(n1)): err for (n0, n1), err in l}
 
 
 def _serialize_averaged_readout_errors(
     d: Optional[Dict[Node, float]]
-) -> Optional[Dict[str, float]]:
+) -> Optional[List[Tuple[List, float]]]:
     if d is None:
         return None
-    return {str(n.to_list()): err for n, err in d.items()}
+    return [(n.to_list(), err) for n, err in d.items()]
 
 
 def _deserialize_averaged_readout_errors(
-    d: Optional[Dict[str, float]]
+    l: Optional[List[Tuple[List, float]]]
 ) -> Optional[Dict[Node, float]]:
-    if d is None:
+    if l is None:
         return None
-    return {Node.from_list(literal_eval(n)): err for n, err in d.items()}
+    return {Node.from_list(n): err for n, err in l}
 
 
 @dataclass

--- a/pytket/pytket/backends/backendinfo.py
+++ b/pytket/pytket/backends/backendinfo.py
@@ -155,7 +155,7 @@ class BackendInfo:
     :param all_edge_gate_errors: Dictionary between architecture couplings and error
         rate for different two-qubit operations.
     :param all_readout_errors: Dictionary between architecture Node and uncorrelated
-        single qubit readout errors.
+        single qubit readout errors (2x2 readout probability matrix).
     :param averaged_node_gate_errors: Dictionary between architecture Node and averaged
         error rate for all single qubit operations.
     :param averaged_edge_gate_errors: Dictionary between architecture couplings and

--- a/pytket/pytket/backends/backendinfo.py
+++ b/pytket/pytket/backends/backendinfo.py
@@ -22,7 +22,7 @@ from pytket.routing import Architecture, FullyConnected  # type: ignore
 from pytket.circuit import Node, OpType  # type: ignore
 
 
-def serialize_all_node_gate_errors(
+def _serialize_all_node_gate_errors(
     d: Optional[Dict[Node, Dict[OpType, float]]]
 ) -> Optional[Dict[str, Dict[int, float]]]:
     if d is None:
@@ -33,7 +33,7 @@ def serialize_all_node_gate_errors(
     }
 
 
-def deserialize_all_node_gate_errors(
+def _deserialize_all_node_gate_errors(
     d: Optional[Dict[str, Dict[int, float]]]
 ) -> Optional[Dict[Node, Dict[OpType, float]]]:
     if d is None:
@@ -46,7 +46,7 @@ def deserialize_all_node_gate_errors(
     }
 
 
-def serialize_all_edge_gate_errors(
+def _serialize_all_edge_gate_errors(
     d: Optional[Dict[Tuple[Node, Node], Dict[OpType, float]]]
 ) -> Optional[Dict[str, Dict[int, float]]]:
     if d is None:
@@ -57,7 +57,7 @@ def serialize_all_edge_gate_errors(
     }
 
 
-def deserialize_all_edge_gate_errors(
+def _deserialize_all_edge_gate_errors(
     d: Optional[Dict[str, Dict[int, float]]],
 ) -> Optional[Dict[Tuple, Dict[OpType, float]]]:
     if d is None:
@@ -70,7 +70,7 @@ def deserialize_all_edge_gate_errors(
     }
 
 
-def serialize_all_readout_errors(
+def _serialize_all_readout_errors(
     d: Optional[Dict[Node, List[List[float]]]]
 ) -> Optional[Dict[str, List[List[float]]]]:
     if d is None:
@@ -78,7 +78,7 @@ def serialize_all_readout_errors(
     return {str(n.to_list()): errs for n, errs in d.items()}
 
 
-def deserialize_all_readout_errors(
+def _deserialize_all_readout_errors(
     d: Optional[Dict[str, List[List[float]]]]
 ) -> Optional[Dict[Node, List[List[float]]]]:
     if d is None:
@@ -86,7 +86,7 @@ def deserialize_all_readout_errors(
     return {Node.from_list(literal_eval(n)): errs for n, errs in d.items()}
 
 
-def serialize_averaged_node_gate_errors(
+def _serialize_averaged_node_gate_errors(
     d: Optional[Dict[Node, float]]
 ) -> Optional[Dict[str, float]]:
     if d is None:
@@ -94,7 +94,7 @@ def serialize_averaged_node_gate_errors(
     return {str(n.to_list()): err for n, err in d.items()}
 
 
-def deserialize_averaged_node_gate_errors(
+def _deserialize_averaged_node_gate_errors(
     d: Optional[Dict[str, float]]
 ) -> Optional[Dict[Node, float]]:
     if d is None:
@@ -102,7 +102,7 @@ def deserialize_averaged_node_gate_errors(
     return {Node.from_list(literal_eval(n)): err for n, err in d.items()}
 
 
-def serialize_averaged_edge_gate_errors(
+def _serialize_averaged_edge_gate_errors(
     d: Optional[Dict[Tuple[Node, Node], float]]
 ) -> Optional[Dict[str, float]]:
     if d is None:
@@ -110,7 +110,7 @@ def serialize_averaged_edge_gate_errors(
     return {str((n0.to_list(), n1.to_list())): err for (n0, n1), err in d.items()}
 
 
-def deserialize_averaged_edge_gate_errors(
+def _deserialize_averaged_edge_gate_errors(
     d: Optional[Dict[str, float]]
 ) -> Optional[Dict[Tuple, float]]:
     if d is None:
@@ -118,7 +118,7 @@ def deserialize_averaged_edge_gate_errors(
     return {tuple(map(Node.from_list, literal_eval(n))): err for n, err in d.items()}
 
 
-def serialize_averaged_readout_errors(
+def _serialize_averaged_readout_errors(
     d: Optional[Dict[Node, float]]
 ) -> Optional[Dict[str, float]]:
     if d is None:
@@ -126,7 +126,7 @@ def serialize_averaged_readout_errors(
     return {str(n.to_list()): err for n, err in d.items()}
 
 
-def deserialize_averaged_readout_errors(
+def _deserialize_averaged_readout_errors(
     d: Optional[Dict[str, float]]
 ) -> Optional[Dict[Node, float]]:
     if d is None:
@@ -246,22 +246,22 @@ class BackendInfo:
         self_dict = asdict(self)
         self_dict["architecture"] = self_dict["architecture"].to_dict()
         self_dict["gate_set"] = [op.value for op in self_dict["gate_set"]]
-        self_dict["all_node_gate_errors"] = serialize_all_node_gate_errors(
+        self_dict["all_node_gate_errors"] = _serialize_all_node_gate_errors(
             self_dict["all_node_gate_errors"]
         )
-        self_dict["all_edge_gate_errors"] = serialize_all_edge_gate_errors(
+        self_dict["all_edge_gate_errors"] = _serialize_all_edge_gate_errors(
             self_dict["all_edge_gate_errors"]
         )
-        self_dict["all_readout_errors"] = serialize_all_readout_errors(
+        self_dict["all_readout_errors"] = _serialize_all_readout_errors(
             self_dict["all_readout_errors"]
         )
-        self_dict["averaged_node_gate_errors"] = serialize_averaged_node_gate_errors(
+        self_dict["averaged_node_gate_errors"] = _serialize_averaged_node_gate_errors(
             self_dict["averaged_node_gate_errors"]
         )
-        self_dict["averaged_edge_gate_errors"] = serialize_averaged_edge_gate_errors(
+        self_dict["averaged_edge_gate_errors"] = _serialize_averaged_edge_gate_errors(
             self_dict["averaged_edge_gate_errors"]
         )
-        self_dict["averaged_readout_errors"] = serialize_averaged_readout_errors(
+        self_dict["averaged_readout_errors"] = _serialize_averaged_readout_errors(
             self_dict["averaged_readout_errors"]
         )
         return self_dict
@@ -282,22 +282,22 @@ class BackendInfo:
         else:
             args["architecture"] = FullyConnected.from_dict(args["architecture"])
         args["gate_set"] = {OpType(op) for op in args["gate_set"]}
-        args["all_node_gate_errors"] = deserialize_all_node_gate_errors(
+        args["all_node_gate_errors"] = _deserialize_all_node_gate_errors(
             args["all_node_gate_errors"]
         )
-        args["all_edge_gate_errors"] = deserialize_all_edge_gate_errors(
+        args["all_edge_gate_errors"] = _deserialize_all_edge_gate_errors(
             args["all_edge_gate_errors"]
         )
-        args["all_readout_errors"] = deserialize_all_readout_errors(
+        args["all_readout_errors"] = _deserialize_all_readout_errors(
             args["all_readout_errors"]
         )
-        args["averaged_node_gate_errors"] = deserialize_averaged_node_gate_errors(
+        args["averaged_node_gate_errors"] = _deserialize_averaged_node_gate_errors(
             args["averaged_node_gate_errors"]
         )
-        args["averaged_edge_gate_errors"] = deserialize_averaged_edge_gate_errors(
+        args["averaged_edge_gate_errors"] = _deserialize_averaged_edge_gate_errors(
             args["averaged_edge_gate_errors"]
         )
-        args["averaged_readout_errors"] = deserialize_averaged_readout_errors(
+        args["averaged_readout_errors"] = _deserialize_averaged_readout_errors(
             args["averaged_readout_errors"]
         )
         return cls(**args)

--- a/pytket/pytket/backends/backendinfo.py
+++ b/pytket/pytket/backends/backendinfo.py
@@ -22,7 +22,9 @@ from pytket.routing import Architecture, FullyConnected  # type: ignore
 from pytket.circuit import Node, OpType  # type: ignore
 
 
-def serialize_all_node_gate_errors(d):
+def serialize_all_node_gate_errors(
+    d: Optional[Dict[Node, Dict[OpType, float]]]
+) -> Optional[Dict[str, Dict[int, float]]]:
     if d is None:
         return None
     return {
@@ -31,7 +33,9 @@ def serialize_all_node_gate_errors(d):
     }
 
 
-def deserialize_all_node_gate_errors(d):
+def deserialize_all_node_gate_errors(
+    d: Optional[Dict[str, Dict[int, float]]]
+) -> Optional[Dict[Node, Dict[OpType, float]]]:
     if d is None:
         return None
     return {
@@ -42,7 +46,9 @@ def deserialize_all_node_gate_errors(d):
     }
 
 
-def serialize_all_edge_gate_errors(d):
+def serialize_all_edge_gate_errors(
+    d: Optional[Dict[Tuple[Node, Node], Dict[OpType, float]]]
+) -> Optional[Dict[str, Dict[int, float]]]:
     if d is None:
         return None
     return {
@@ -51,7 +57,9 @@ def serialize_all_edge_gate_errors(d):
     }
 
 
-def deserialize_all_edge_gate_errors(d):
+def deserialize_all_edge_gate_errors(
+    d: Optional[Dict[str, Dict[int, float]]],
+) -> Optional[Dict[Tuple, Dict[OpType, float]]]:
     if d is None:
         return None
     return {
@@ -62,49 +70,65 @@ def deserialize_all_edge_gate_errors(d):
     }
 
 
-def serialize_all_readout_errors(d):
+def serialize_all_readout_errors(
+    d: Optional[Dict[Node, List[List[float]]]]
+) -> Optional[Dict[str, List[List[float]]]]:
     if d is None:
         return None
     return {str(n.to_list()): errs for n, errs in d.items()}
 
 
-def deserialize_all_readout_errors(d):
+def deserialize_all_readout_errors(
+    d: Optional[Dict[str, List[List[float]]]]
+) -> Optional[Dict[Node, List[List[float]]]]:
     if d is None:
         return None
     return {Node.from_list(literal_eval(n)): errs for n, errs in d.items()}
 
 
-def serialize_averaged_node_gate_errors(d):
+def serialize_averaged_node_gate_errors(
+    d: Optional[Dict[Node, float]]
+) -> Optional[Dict[str, float]]:
     if d is None:
         return None
     return {str(n.to_list()): err for n, err in d.items()}
 
 
-def deserialize_averaged_node_gate_errors(d):
+def deserialize_averaged_node_gate_errors(
+    d: Optional[Dict[str, float]]
+) -> Optional[Dict[Node, float]]:
     if d is None:
         return None
     return {Node.from_list(literal_eval(n)): err for n, err in d.items()}
 
 
-def serialize_averaged_edge_gate_errors(d):
+def serialize_averaged_edge_gate_errors(
+    d: Optional[Dict[Tuple[Node, Node], float]]
+) -> Optional[Dict[str, float]]:
     if d is None:
         return None
     return {str((n0.to_list(), n1.to_list())): err for (n0, n1), err in d.items()}
 
 
-def deserialize_averaged_edge_gate_errors(d):
+def deserialize_averaged_edge_gate_errors(
+    d: Optional[Dict[str, float]]
+) -> Optional[Dict[Tuple, float]]:
     if d is None:
         return None
     return {tuple(map(Node.from_list, literal_eval(n))): err for n, err in d.items()}
 
 
-def serialize_averaged_readout_errors(d):
+def serialize_averaged_readout_errors(
+    d: Optional[Dict[Node, float]]
+) -> Optional[Dict[str, float]]:
     if d is None:
         return None
     return {str(n.to_list()): err for n, err in d.items()}
 
 
-def deserialize_averaged_readout_errors(d):
+def deserialize_averaged_readout_errors(
+    d: Optional[Dict[str, float]]
+) -> Optional[Dict[Node, float]]:
     if d is None:
         return None
     return {Node.from_list(literal_eval(n)): err for n, err in d.items()}

--- a/pytket/pytket/backends/backendinfo.py
+++ b/pytket/pytket/backends/backendinfo.py
@@ -138,7 +138,8 @@ class BackendInfo:
         averaged error rate for all two-qubit operations.
     :param averaged_readout_errors: Dictionary between architecture Node and averaged
         readout errors.
-    :param misc: key-value map with further provider-specific information
+    :param misc: key-value map with further provider-specific information (must be
+        JSON-serializable)
     """
 
     # identifying information

--- a/pytket/pytket/backends/backendinfo.py
+++ b/pytket/pytket/backends/backendinfo.py
@@ -20,9 +20,12 @@ from typing import Any, Dict, List, Optional, Set, cast, Tuple, Union
 from pytket.routing import Architecture, FullyConnected  # type: ignore
 from pytket.circuit import Node, OpType  # type: ignore
 
+_OpTypeErrs = Dict[OpType, float]
+_Edge = Tuple[Node, Node]
+
 
 def _serialize_all_node_gate_errors(
-    d: Optional[Dict[Node, Dict[OpType, float]]]
+    d: Optional[Dict[Node, _OpTypeErrs]]
 ) -> Optional[List[List]]:
     if d is None:
         return None
@@ -34,7 +37,7 @@ def _serialize_all_node_gate_errors(
 
 def _deserialize_all_node_gate_errors(
     l: Optional[List[List]],
-) -> Optional[Dict[Node, Dict[OpType, float]]]:
+) -> Optional[Dict[Node, _OpTypeErrs]]:
     if l is None:
         return None
     return {
@@ -44,7 +47,7 @@ def _deserialize_all_node_gate_errors(
 
 
 def _serialize_all_edge_gate_errors(
-    d: Optional[Dict[Tuple[Node, Node], Dict[OpType, float]]]
+    d: Optional[Dict[_Edge, _OpTypeErrs]]
 ) -> Optional[List]:
     if d is None:
         return None
@@ -56,7 +59,7 @@ def _serialize_all_edge_gate_errors(
 
 def _deserialize_all_edge_gate_errors(
     l: Optional[List],
-) -> Optional[Dict[Tuple, Dict[OpType, float]]]:
+) -> Optional[Dict[_Edge, _OpTypeErrs]]:
     if l is None:
         return None
     return {
@@ -100,7 +103,7 @@ def _deserialize_averaged_node_gate_errors(
 
 
 def _serialize_averaged_edge_gate_errors(
-    d: Optional[Dict[Tuple[Node, Node], float]]
+    d: Optional[Dict[_Edge, float]]
 ) -> Optional[List[List]]:
     if d is None:
         return None

--- a/pytket/pytket/backends/backendinfo.py
+++ b/pytket/pytket/backends/backendinfo.py
@@ -23,45 +23,45 @@ from pytket.circuit import Node, OpType  # type: ignore
 
 def _serialize_all_node_gate_errors(
     d: Optional[Dict[Node, Dict[OpType, float]]]
-) -> Optional[List[Tuple[List, Dict[int, float]]]]:
+) -> Optional[List[Tuple[List, Dict[str, float]]]]:
     if d is None:
         return None
     return [
-        (n.to_list(), {ot.value: err for ot, err in errs.items()})
+        (n.to_list(), {ot.name: err for ot, err in errs.items()})
         for n, errs in d.items()
     ]
 
 
 def _deserialize_all_node_gate_errors(
-    l: Optional[List[Tuple[List, Dict[int, float]]]]
+    l: Optional[List[Tuple[List, Dict[str, float]]]]
 ) -> Optional[Dict[Node, Dict[OpType, float]]]:
     if l is None:
         return None
     return {
-        Node.from_list(n): {OpType(int(ot)): err for ot, err in errs.items()}
+        Node.from_list(n): {OpType.from_name(ot): err for ot, err in errs.items()}
         for n, errs in l
     }
 
 
 def _serialize_all_edge_gate_errors(
     d: Optional[Dict[Tuple[Node, Node], Dict[OpType, float]]]
-) -> Optional[List[Tuple[Tuple[List, List], Dict[int, float]]]]:
+) -> Optional[List[Tuple[Tuple[List, List], Dict[str, float]]]]:
     if d is None:
         return None
     return [
-        ((n0.to_list(), n1.to_list()), {ot.value: err for ot, err in errs.items()})
+        ((n0.to_list(), n1.to_list()), {ot.name: err for ot, err in errs.items()})
         for (n0, n1), errs in d.items()
     ]
 
 
 def _deserialize_all_edge_gate_errors(
-    l: Optional[List[Tuple[Tuple[List, List], Dict[int, float]]]],
+    l: Optional[List[Tuple[Tuple[List, List], Dict[str, float]]]],
 ) -> Optional[Dict[Tuple, Dict[OpType, float]]]:
     if l is None:
         return None
     return {
         (Node.from_list(n0), Node.from_list(n1)): {
-            OpType(int(ot)): err for ot, err in errs.items()
+            OpType.from_name(ot): err for ot, err in errs.items()
         }
         for (n0, n1), errs in l
     }

--- a/pytket/tests/backendinfo_test.py
+++ b/pytket/tests/backendinfo_test.py
@@ -132,6 +132,13 @@ def test_to_json() -> None:
         supports_fast_feedforward=True,
         supports_reset=True,
         supports_midcircuit_measurement=True,
+        all_node_gate_errors={Node(0): {OpType.Rx: 0.1}},
+        all_edge_gate_errors={(Node(0), Node(1)): {OpType.Rx: 0.1}},
+        all_readout_errors={Node(0): [[0.1]]},
+        averaged_node_gate_errors={Node(0): 0.1},
+        averaged_edge_gate_errors={(Node(0), Node(1)): 0.1},
+        averaged_readout_errors={Node(0): 0.1},
+        misc={"region": "UK"},
     )
     bi_dict = bi.to_dict()
     json_bi = dumps(bi_dict)

--- a/pytket/tests/backendinfo_test.py
+++ b/pytket/tests/backendinfo_test.py
@@ -124,14 +124,14 @@ def test_serialization() -> None:
 
 def test_to_json() -> None:
     bi = BackendInfo(
-        "name",
-        "device_name",
-        "version",
-        SquareGrid(3, 4),
-        {OpType.CX, OpType.Rx},
-        True,
-        True,
-        True,
+        name="name",
+        device_name="device_name",
+        version="version",
+        architecture=SquareGrid(3, 4),
+        gate_set={OpType.CX, OpType.Rx},
+        supports_fast_feedforward=True,
+        supports_reset=True,
+        supports_midcircuit_measurement=True,
     )
     bi_dict = bi.to_dict()
     json_bi = dumps(bi_dict)

--- a/pytket/tests/strategies.py
+++ b/pytket/tests/strategies.py
@@ -45,7 +45,7 @@ def qubits(
     draw: Callable,
     name: SearchStrategy[str] = st.from_regex(reg_name_regex, fullmatch=True),
     index: SearchStrategy[int] = uint32,
-) -> Bit:
+) -> Qubit:
     return Qubit(draw(name), draw(index))
 
 

--- a/pytket/tests/strategies.py
+++ b/pytket/tests/strategies.py
@@ -50,6 +50,15 @@ def qubits(
 
 
 @st.composite
+def nodes(
+    draw: Callable,
+    name: SearchStrategy[str] = st.from_regex(reg_name_regex, fullmatch=True),
+    index: SearchStrategy[int] = uint32,
+) -> Node:
+    return Node(draw(name), draw(index))
+
+
+@st.composite
 def circuits(
     draw: Callable[[SearchStrategy[Any]], Any],
     n_qubits: SearchStrategy[int] = st.integers(min_value=0, max_value=4),
@@ -133,29 +142,62 @@ def architecture(
 
 
 @st.composite
+def optypes(draw: Callable[[SearchStrategy[Any]], Any]) -> OpType:
+    return OpType(draw(st.integers(min_value=6, max_value=49)))
+
+
+@st.composite
+def errors(draw: Callable[[SearchStrategy[Any]], Any]) -> Any:
+    return draw(st.floats(min_value=0.0, max_value=1.0))
+
+
+@st.composite
+def optype_errors(draw: Callable[[SearchStrategy[Any]], Any]) -> Any:
+    return draw(st.dictionaries(optypes(), errors()))
+
+
+@st.composite
+def edges(draw: Callable[[SearchStrategy[Any]], Any]) -> Any:
+    return draw(st.tuples(nodes(), nodes()))
+
+
+@st.composite
 def backendinfo(
     draw: Callable[[SearchStrategy[Any]], Any],
 ) -> BackendInfo:
-    optypes = [OpType(i) for i in range(6, 54)]
     name = draw(st.text(min_size=1, max_size=30))
     device_name = draw(st.text(min_size=1, max_size=30))
     version = draw(st.text(min_size=1, max_size=5))
     # hardware constraints
     arc = draw(architecture())
-    gate_set = draw(st.sets(st.sampled_from(optypes)))
+    gate_set = draw(st.sets(optypes()))
     supports_fast_feedforward = draw(st.booleans())
     supports_reset = draw(st.booleans())
     supports_midcircuit_measurement = draw(st.booleans())
+    all_node_gate_errors = draw(st.dictionaries(nodes(), optype_errors()))
+    all_edge_gate_errors = draw(st.dictionaries(edges(), optype_errors()))
+    all_readout_errors = draw(st.dictionaries(nodes(), st.lists(st.lists(errors()))))
+    averaged_node_gate_errors = draw(st.dictionaries(nodes(), errors()))
+    averaged_edge_gate_errors = draw(st.dictionaries(edges(), errors()))
+    averaged_readout_errors = draw(st.dictionaries(nodes(), errors()))
+    misc = draw(st.dictionaries(st.text(), st.text()))
 
     return BackendInfo(
-        name,
-        device_name,
-        version,
-        arc,
-        gate_set,
-        supports_fast_feedforward,
-        supports_reset,
-        supports_midcircuit_measurement,
+        name=name,
+        device_name=device_name,
+        version=version,
+        architecture=arc,
+        gate_set=gate_set,
+        supports_fast_feedforward=supports_fast_feedforward,
+        supports_reset=supports_reset,
+        supports_midcircuit_measurement=supports_midcircuit_measurement,
+        all_node_gate_errors=all_node_gate_errors,
+        all_edge_gate_errors=all_edge_gate_errors,
+        all_readout_errors=all_readout_errors,
+        averaged_node_gate_errors=averaged_node_gate_errors,
+        averaged_edge_gate_errors=averaged_edge_gate_errors,
+        averaged_readout_errors=averaged_readout_errors,
+        misc=misc,
     )
 
 


### PR DESCRIPTION
This partially addresses #192 . The remaining issue is for the `misc` field, which is https://github.com/CQCL/pytket-extensions/issues/288 .