### PR TITLE
[WIP] [feature] Add stubs to tket

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.egg-info
 *.o
 *.so
+*.pyi
 .cache
 .eggs
 .hypothesis

--- a/pytket/binders/circuit/Circuit/add_classical_op.cpp
+++ b/pytket/binders/circuit/Circuit/add_classical_op.cpp
@@ -384,9 +384,8 @@ void init_circuit_add_classical_op(
           "\n:param args_in: input bits"
           "\n:param arg_out: output bit (distinct from input bits)"
           "\n:return: the new :py:class:`Circuit`",
-          py::arg("minval") = 0,
-          py::arg("maxval") = std::numeric_limits<uint32_t>::max(),
-          py::arg("args_in"), py::arg("arg_out"))
+          py::arg("minval"), py::arg("maxval"), py::arg("args_in"),
+          py::arg("arg_out"))
       .def(
           "add_c_and_to_registers",
           [](Circuit &circ, const BitRegister &reg0_in,

--- a/pytket/binders/circuit/Circuit/add_classical_op.cpp
+++ b/pytket/binders/circuit/Circuit/add_classical_op.cpp
@@ -54,11 +54,13 @@ void init_circuit_add_classical_op(
   c.def(
        "add_c_transform",
        [](Circuit &circ, const std::vector<uint32_t> &values,
-          const std::vector<unsigned> &args, const std::string &name) {
+          const std::vector<unsigned> &args,
+          const std::string &name) -> Circuit & {
          unsigned n_args = args.size();
          std::shared_ptr<ClassicalTransformOp> op =
              std::make_shared<ClassicalTransformOp>(n_args, values, name);
-         return circ.add_op(op, args);
+         circ.add_op(op, args);
+         return circ;
        },
        "Appends a purely classical transformation, defined by a table of "
        "values, to "
@@ -76,20 +78,23 @@ void init_circuit_add_classical_op(
       .def(
           "add_c_transform",
           [](Circuit &circ, const std::vector<uint32_t> &values,
-             const std::vector<Bit> &args, const std::string &name) {
+             const std::vector<Bit> &args,
+             const std::string &name) -> Circuit & {
             unsigned n_args = args.size();
             std::shared_ptr<ClassicalTransformOp> op =
                 std::make_shared<ClassicalTransformOp>(n_args, values, name);
-            return circ.add_op(op, args);
+            circ.add_op(op, args);
+            return circ;
           },
           "See :py:meth:`add_c_transform`.", py::arg("values"), py::arg("args"),
           py::arg("name") = "ClassicalTransform")
       .def(
           "add_c_setbits",
           [](Circuit &circ, const std::vector<bool> &values,
-             const std::vector<unsigned> args) {
+             const std::vector<unsigned> args) -> Circuit & {
             std::shared_ptr<SetBitsOp> op = std::make_shared<SetBitsOp>(values);
-            return circ.add_op(op, args);
+            circ.add_op(op, args);
+            return circ;
           },
           "Appends an operation to set some bit values."
           "\n\n:param values: values to set"
@@ -99,21 +104,23 @@ void init_circuit_add_classical_op(
       .def(
           "add_c_setbits",
           [](Circuit &circ, const std::vector<bool> &values,
-             const std::vector<Bit> args) {
+             const std::vector<Bit> args) -> Circuit & {
             std::shared_ptr<SetBitsOp> op = std::make_shared<SetBitsOp>(values);
-            return circ.add_op(op, args);
+            circ.add_op(op, args);
+            return circ;
           },
           "See :py:meth:`add_c_setbits`.", py::arg("values"), py::arg("args"))
       .def(
           "add_c_copybits",
           [](Circuit &circ, const std::vector<unsigned> &args_in,
-             const std::vector<unsigned> &args_out) {
+             const std::vector<unsigned> &args_out) -> Circuit & {
             unsigned n_args_in = args_in.size();
             std::shared_ptr<CopyBitsOp> op =
                 std::make_shared<CopyBitsOp>(n_args_in);
             std::vector<unsigned> args = args_in;
             args.insert(args.end(), args_out.begin(), args_out.end());
-            return circ.add_op(op, args);
+            circ.add_op(op, args);
+            return circ;
           },
           "Appends a classical copy operation"
           "\n\n:param args_in: source bits"
@@ -123,13 +130,14 @@ void init_circuit_add_classical_op(
       .def(
           "add_c_copybits",
           [](Circuit &circ, const std::vector<Bit> &args_in,
-             const std::vector<Bit> &args_out) {
+             const std::vector<Bit> &args_out) -> Circuit & {
             unsigned n_args_in = args_in.size();
             std::shared_ptr<CopyBitsOp> op =
                 std::make_shared<CopyBitsOp>(n_args_in);
             std::vector<Bit> args = args_in;
             args.insert(args.end(), args_out.begin(), args_out.end());
-            return circ.add_op(op, args);
+            circ.add_op(op, args);
+            return circ;
           },
           "See :py:meth:`add_c_copybits`.", py::arg("args_in"),
           py::arg("args_out"))
@@ -137,13 +145,14 @@ void init_circuit_add_classical_op(
           "add_c_predicate",
           [](Circuit &circ, const std::vector<bool> &values,
              const std::vector<unsigned> &args_in, unsigned arg_out,
-             const std::string &name) {
+             const std::string &name) -> Circuit & {
             unsigned n_args_in = args_in.size();
             std::shared_ptr<ExplicitPredicateOp> op =
                 std::make_shared<ExplicitPredicateOp>(n_args_in, values, name);
             std::vector<unsigned> args = args_in;
             args.push_back(arg_out);
-            return circ.add_op(op, args);
+            circ.add_op(op, args);
+            return circ;
           },
           "Appends a classical predicate, defined by a truth table, to the end "
           "of the "
@@ -161,13 +170,14 @@ void init_circuit_add_classical_op(
           "add_c_predicate",
           [](Circuit &circ, const std::vector<bool> &values,
              const std::vector<Bit> &args_in, Bit arg_out,
-             const std::string &name) {
+             const std::string &name) -> Circuit & {
             unsigned n_args_in = args_in.size();
             std::shared_ptr<ExplicitPredicateOp> op =
                 std::make_shared<ExplicitPredicateOp>(n_args_in, values, name);
             std::vector<Bit> args = args_in;
             args.push_back(arg_out);
-            return circ.add_op(op, args);
+            circ.add_op(op, args);
+            return circ;
           },
           "See :py:meth:`add_c_predicate`.", py::arg("values"),
           py::arg("args_in"), py::arg("arg_out"),
@@ -176,13 +186,14 @@ void init_circuit_add_classical_op(
           "add_c_modifier",
           [](Circuit &circ, const std::vector<bool> &values,
              const std::vector<unsigned> &args_in, unsigned arg_inout,
-             const std::string &name) {
+             const std::string &name) -> Circuit & {
             unsigned n_args_in = args_in.size();
             std::shared_ptr<ExplicitModifierOp> op =
                 std::make_shared<ExplicitModifierOp>(n_args_in, values, name);
             std::vector<unsigned> args = args_in;
             args.push_back(arg_inout);
-            return circ.add_op(op, args);
+            circ.add_op(op, args);
+            return circ;
           },
           "Appends a classical modifying operation, defined by a truth table, "
           "to the "
@@ -202,13 +213,14 @@ void init_circuit_add_classical_op(
           "add_c_modifier",
           [](Circuit &circ, const std::vector<bool> &values,
              const std::vector<Bit> &args_in, Bit arg_inout,
-             const std::string &name) {
+             const std::string &name) -> Circuit & {
             unsigned n_args_in = args_in.size();
             std::shared_ptr<ExplicitModifierOp> op =
                 std::make_shared<ExplicitModifierOp>(n_args_in, values, name);
             std::vector<Bit> args = args_in;
             args.push_back(arg_inout);
-            return circ.add_op(op, args);
+            circ.add_op(op, args);
+            return circ;
           },
           "See :py:meth:`add_c_modifier`.", py::arg("values"),
           py::arg("args_in"), py::arg("arg_inout"),
@@ -216,15 +228,15 @@ void init_circuit_add_classical_op(
       .def(
           "add_c_and",
           [](Circuit &circ, unsigned arg0_in, unsigned arg1_in,
-             unsigned arg_out) {
+             unsigned arg_out) -> Circuit & {
             if (arg0_in == arg_out) {
-              return circ.add_op<unsigned>(AndWithOp(), {arg1_in, arg_out});
+              circ.add_op<unsigned>(AndWithOp(), {arg1_in, arg_out});
             } else if (arg1_in == arg_out) {
-              return circ.add_op<unsigned>(AndWithOp(), {arg0_in, arg_out});
+              circ.add_op<unsigned>(AndWithOp(), {arg0_in, arg_out});
             } else {
-              return circ.add_op<unsigned>(
-                  AndOp(), {arg0_in, arg1_in, arg_out});
+              circ.add_op<unsigned>(AndOp(), {arg0_in, arg1_in, arg_out});
             }
+            return circ;
           },
           "Appends a binary AND operation to the end of the circuit."
           "\n\n:param arg0_in: first input bit"
@@ -234,28 +246,31 @@ void init_circuit_add_classical_op(
           py::arg("arg0_in"), py::arg("arg1_in"), py::arg("arg_out"))
       .def(
           "add_c_and",
-          [](Circuit &circ, Bit arg0_in, Bit arg1_in, Bit arg_out) {
+          [](Circuit &circ, Bit arg0_in, Bit arg1_in,
+             Bit arg_out) -> Circuit & {
             if (arg0_in == arg_out) {
-              return circ.add_op<Bit>(AndWithOp(), {arg1_in, arg_out});
+              circ.add_op<Bit>(AndWithOp(), {arg1_in, arg_out});
             } else if (arg1_in == arg_out) {
-              return circ.add_op<Bit>(AndWithOp(), {arg0_in, arg_out});
+              circ.add_op<Bit>(AndWithOp(), {arg0_in, arg_out});
             } else {
-              return circ.add_op<Bit>(AndOp(), {arg0_in, arg1_in, arg_out});
+              circ.add_op<Bit>(AndOp(), {arg0_in, arg1_in, arg_out});
             }
+            return circ;
           },
           "See :py:meth:`add_c_and`.", py::arg("arg0_in"), py::arg("arg1_in"),
           py::arg("arg_out"))
       .def(
           "add_c_or",
           [](Circuit &circ, unsigned arg0_in, unsigned arg1_in,
-             unsigned arg_out) {
+             unsigned arg_out) -> Circuit & {
             if (arg0_in == arg_out) {
-              return circ.add_op<unsigned>(OrWithOp(), {arg1_in, arg_out});
+              circ.add_op<unsigned>(OrWithOp(), {arg1_in, arg_out});
             } else if (arg1_in == arg_out) {
-              return circ.add_op<unsigned>(OrWithOp(), {arg0_in, arg_out});
+              circ.add_op<unsigned>(OrWithOp(), {arg0_in, arg_out});
             } else {
-              return circ.add_op<unsigned>(OrOp(), {arg0_in, arg1_in, arg_out});
+              circ.add_op<unsigned>(OrOp(), {arg0_in, arg1_in, arg_out});
             }
+            return circ;
           },
           "Appends a binary OR operation to the end of the circuit."
           "\n\n:param arg0_in: first input bit"
@@ -265,29 +280,31 @@ void init_circuit_add_classical_op(
           py::arg("arg0_in"), py::arg("arg1_in"), py::arg("arg_out"))
       .def(
           "add_c_or",
-          [](Circuit &circ, Bit arg0_in, Bit arg1_in, Bit arg_out) {
+          [](Circuit &circ, Bit arg0_in, Bit arg1_in,
+             Bit arg_out) -> Circuit & {
             if (arg0_in == arg_out) {
-              return circ.add_op<Bit>(OrWithOp(), {arg1_in, arg_out});
+              circ.add_op<Bit>(OrWithOp(), {arg1_in, arg_out});
             } else if (arg1_in == arg_out) {
-              return circ.add_op<Bit>(OrWithOp(), {arg0_in, arg_out});
+              circ.add_op<Bit>(OrWithOp(), {arg0_in, arg_out});
             } else {
-              return circ.add_op<Bit>(OrOp(), {arg0_in, arg1_in, arg_out});
+              circ.add_op<Bit>(OrOp(), {arg0_in, arg1_in, arg_out});
             }
+            return circ;
           },
           "See :py:meth:`add_c_or`.", py::arg("arg0_in"), py::arg("arg1_in"),
           py::arg("arg_out"))
       .def(
           "add_c_xor",
           [](Circuit &circ, unsigned arg0_in, unsigned arg1_in,
-             unsigned arg_out) {
+             unsigned arg_out) -> Circuit & {
             if (arg0_in == arg_out) {
-              return circ.add_op<unsigned>(XorWithOp(), {arg1_in, arg_out});
+              circ.add_op<unsigned>(XorWithOp(), {arg1_in, arg_out});
             } else if (arg1_in == arg_out) {
-              return circ.add_op<unsigned>(XorWithOp(), {arg0_in, arg_out});
+              circ.add_op<unsigned>(XorWithOp(), {arg0_in, arg_out});
             } else {
-              return circ.add_op<unsigned>(
-                  XorOp(), {arg0_in, arg1_in, arg_out});
+              circ.add_op<unsigned>(XorOp(), {arg0_in, arg1_in, arg_out});
             }
+            return circ;
           },
           "Appends a binary XOR operation to the end of the circuit."
           "\n\n:param arg0_in: first input bit"
@@ -297,21 +314,24 @@ void init_circuit_add_classical_op(
           py::arg("arg0_in"), py::arg("arg1_in"), py::arg("arg_out"))
       .def(
           "add_c_xor",
-          [](Circuit &circ, Bit arg0_in, Bit arg1_in, Bit arg_out) {
+          [](Circuit &circ, Bit arg0_in, Bit arg1_in,
+             Bit arg_out) -> Circuit & {
             if (arg0_in == arg_out) {
-              return circ.add_op<Bit>(XorWithOp(), {arg1_in, arg_out});
+              circ.add_op<Bit>(XorWithOp(), {arg1_in, arg_out});
             } else if (arg1_in == arg_out) {
-              return circ.add_op<Bit>(XorWithOp(), {arg0_in, arg_out});
+              circ.add_op<Bit>(XorWithOp(), {arg0_in, arg_out});
             } else {
-              return circ.add_op<Bit>(XorOp(), {arg0_in, arg1_in, arg_out});
+              circ.add_op<Bit>(XorOp(), {arg0_in, arg1_in, arg_out});
             }
+            return circ;
           },
           "See :py:meth:`add_c_xor`.", py::arg("arg0_in"), py::arg("arg1_in"),
           py::arg("arg_out"))
       .def(
           "add_c_not",
-          [](Circuit &circ, unsigned arg_in, unsigned arg_out) {
-            return circ.add_op<unsigned>(NotOp(), {arg_in, arg_out});
+          [](Circuit &circ, unsigned arg_in, unsigned arg_out) -> Circuit & {
+            circ.add_op<unsigned>(NotOp(), {arg_in, arg_out});
+            return circ;
           },
           "Appends a NOT operation to the end of the circuit."
           "\n\n:param arg_in: input bit"
@@ -320,20 +340,23 @@ void init_circuit_add_classical_op(
           py::arg("arg_in"), py::arg("arg_out"))
       .def(
           "add_c_not",
-          [](Circuit &circ, Bit arg_in, Bit arg_out) {
-            return circ.add_op<Bit>(NotOp(), {arg_in, arg_out});
+          [](Circuit &circ, Bit arg_in, Bit arg_out) -> Circuit & {
+            circ.add_op<Bit>(NotOp(), {arg_in, arg_out});
+            return circ;
           },
           "See :py:meth:`add_c_not`.", py::arg("arg_in"), py::arg("arg_out"))
       .def(
           "add_c_range_predicate",
           [](Circuit &circ, uint32_t a, uint32_t b,
-             const std::vector<unsigned> &args_in, unsigned arg_out) {
+             const std::vector<unsigned> &args_in,
+             unsigned arg_out) -> Circuit & {
             unsigned n_args_in = args_in.size();
             std::shared_ptr<RangePredicateOp> op =
                 std::make_shared<RangePredicateOp>(n_args_in, a, b);
             std::vector<unsigned> args = args_in;
             args.push_back(arg_out);
-            return circ.add_op(op, args);
+            circ.add_op(op, args);
+            return circ;
           },
           "Appends a range-predicate operation to the end of the circuit."
           "\n\n:param minval: lower bound of input in little-endian encoding"
@@ -341,19 +364,19 @@ void init_circuit_add_classical_op(
           "\n:param args_in: input bits"
           "\n:param arg_out: output bit (distinct from input bits)"
           "\n:return: the new :py:class:`Circuit`",
-          py::arg("minval") = 0,
-          py::arg("maxval") = std::numeric_limits<uint32_t>::max(),
-          py::arg("args_in"), py::arg("arg_out"))
+          py::arg("minval"), py::arg("maxval"), py::arg("args_in"),
+          py::arg("arg_out"))
       .def(
           "add_c_range_predicate",
           [](Circuit &circ, uint32_t a, uint32_t b,
-             const std::vector<Bit> &args_in, Bit arg_out) {
+             const std::vector<Bit> &args_in, Bit arg_out) -> Circuit & {
             unsigned n_args_in = args_in.size();
             std::shared_ptr<RangePredicateOp> op =
                 std::make_shared<RangePredicateOp>(n_args_in, a, b);
             std::vector<Bit> args = args_in;
             args.push_back(arg_out);
-            return circ.add_op(op, args);
+            circ.add_op(op, args);
+            return circ;
           },
           "Appends a range-predicate operation to the end of the circuit."
           "\n\n:param minval: lower bound of input in little-endian encoding"
@@ -442,7 +465,7 @@ void init_circuit_add_classical_op(
       .def(
           "add_c_not_to_registers",
           [](Circuit &circ, const BitRegister &reg_in,
-             const BitRegister &reg_out) {
+             const BitRegister &reg_out) -> Circuit & {
             apply_classical_op_to_registers(circ, NotOp(), {reg_in, reg_out});
             return circ;
           },

--- a/pytket/binders/circuit/Circuit/add_op.cpp
+++ b/pytket/binders/circuit/Circuit/add_op.cpp
@@ -409,11 +409,11 @@ void init_circuit_add_op(py::class_<Circuit, std::shared_ptr<Circuit>> &c) {
           py::arg("expression"), py::arg("target"))
       .def(
           "add_custom_gate",
-          [](Circuit *circ, const composite_def_ptr_t &def,
+          [](Circuit *circ, const composite_def_ptr_t &definition,
              const std::vector<Expr> &params,
              const std::vector<unsigned> &qubits, const py::kwargs &kwargs) {
             return add_box_method<unsigned>(
-                circ, std::make_shared<CustomGate>(def, params), qubits,
+                circ, std::make_shared<CustomGate>(definition, params), qubits,
                 kwargs);
           },
           "Append an instance of a :py:class:`CustomGateDef` to the "
@@ -422,7 +422,7 @@ void init_circuit_add_op(py::class_<Circuit, std::shared_ptr<Circuit>> &c) {
           "instantiate the gate with, in halfturns\n:param qubits: "
           "Indices of the qubits to append the box to"
           "\n:return: the new :py:class:`Circuit`",
-          py::arg("def"), py::arg("params"), py::arg("qubits"))
+          py::arg("definition"), py::arg("params"), py::arg("qubits"))
       .def(
           "add_barrier",
           [](Circuit *circ, const unit_vector_t &units) {
@@ -538,11 +538,11 @@ void init_circuit_add_op(py::class_<Circuit, std::shared_ptr<Circuit>> &c) {
           py::arg("phasepolybox"), py::arg("qubits"))
       .def(
           "add_custom_gate",
-          [](Circuit *circ, const composite_def_ptr_t &def,
+          [](Circuit *circ, const composite_def_ptr_t &definition,
              const std::vector<Expr> &params, const qubit_vector_t &qubits,
              const py::kwargs &kwargs) {
             return add_box_method<UnitID>(
-                circ, std::make_shared<CustomGate>(def, params),
+                circ, std::make_shared<CustomGate>(definition, params),
                 {qubits.begin(), qubits.end()}, kwargs);
           },
           "Append an instance of a :py:class:`CustomGateDef` to the "

--- a/pytket/binders/circuit/Circuit/add_op.cpp
+++ b/pytket/binders/circuit/Circuit/add_op.cpp
@@ -551,13 +551,13 @@ void init_circuit_add_op(py::class_<Circuit, std::shared_ptr<Circuit>> &c) {
           "instantiate the gate with, in halfturns\n:param qubits: "
           "The qubits to append the box to"
           "\n:return: the new :py:class:`Circuit`",
-          py::arg("def"), py::arg("params"), py::arg("qubits"))
+          py::arg("definition"), py::arg("params"), py::arg("qubits"))
       .def(
           "add_assertion",
           [](Circuit *circ, const ProjectorAssertionBox &box,
              const std::vector<unsigned> &qubits,
              const std::optional<unsigned> &ancilla,
-             const std::optional<std::string> &name) {
+             const std::optional<std::string> &name) -> Circuit * {
             std::vector<Qubit> qubits_;
             for (unsigned i = 0; i < qubits.size(); ++i) {
               qubits_.push_back(Qubit(qubits[i]));
@@ -568,7 +568,8 @@ void init_circuit_add_op(py::class_<Circuit, std::shared_ptr<Circuit>> &c) {
             } else {
               ancilla_ = Qubit(ancilla.value());
             }
-            return circ->add_assertion(box, qubits_, ancilla_, name);
+            circ->add_assertion(box, qubits_, ancilla_, name);
+            return circ;
           },
           "Append a :py:class:`ProjectorAssertionBox` to the circuit."
           "\n\n:param box: ProjectorAssertionBox to append"
@@ -583,8 +584,9 @@ void init_circuit_add_op(py::class_<Circuit, std::shared_ptr<Circuit>> &c) {
           [](Circuit *circ, const ProjectorAssertionBox &box,
              const std::vector<Qubit> &qubits,
              const std::optional<Qubit> &ancilla,
-             const std::optional<std::string> &name) {
-            return circ->add_assertion(box, qubits, ancilla, name);
+             const std::optional<std::string> &name) -> Circuit * {
+            circ->add_assertion(box, qubits, ancilla, name);
+            return circ;
           },
           "Append a :py:class:`ProjectorAssertionBox` to the circuit."
           "\n\n:param box: ProjectorAssertionBox to append"
@@ -598,13 +600,14 @@ void init_circuit_add_op(py::class_<Circuit, std::shared_ptr<Circuit>> &c) {
           "add_assertion",
           [](Circuit *circ, const StabiliserAssertionBox &box,
              const std::vector<unsigned> &qubits, const unsigned &ancilla,
-             const std::optional<std::string> &name) {
+             const std::optional<std::string> &name) -> Circuit * {
             std::vector<Qubit> qubits_;
             for (unsigned i = 0; i < qubits.size(); ++i) {
               qubits_.push_back(Qubit(qubits[i]));
             }
             Qubit ancilla_(ancilla);
-            return circ->add_assertion(box, qubits_, ancilla_, name);
+            circ->add_assertion(box, qubits_, ancilla_, name);
+            return circ;
           },
           "Append a :py:class:`StabiliserAssertionBox` to the circuit."
           "\n\n:param box: StabiliserAssertionBox to append"
@@ -618,8 +621,9 @@ void init_circuit_add_op(py::class_<Circuit, std::shared_ptr<Circuit>> &c) {
           "add_assertion",
           [](Circuit *circ, const StabiliserAssertionBox &box,
              const std::vector<Qubit> &qubits, const Qubit &ancilla,
-             const std::optional<std::string> &name) {
-            return circ->add_assertion(box, qubits, ancilla, name);
+             const std::optional<std::string> &name) -> Circuit * {
+            circ->add_assertion(box, qubits, ancilla, name);
+            return circ;
           },
           "Append a :py:class:`StabiliserAssertionBox` to the circuit."
           "\n\n:param box: StabiliserAssertionBox to append"

--- a/pytket/binders/circuit/Circuit/main.cpp
+++ b/pytket/binders/circuit/Circuit/main.cpp
@@ -82,6 +82,11 @@ void init_circuit(py::module &m) {
           py::arg("name") = std::nullopt)
       .def("__eq__", &Circuit::operator==)
       .def(
+          "__eq__",
+          [](const py::object, const py::object) -> bool {
+            throw py::type_error("Equality is only defined between Circuits");
+          })
+      .def(
           "__str__",
           [](const Circuit &circ) {
             return "<tket::Circuit, qubits=" + std::to_string(circ.n_qubits()) +

--- a/pytket/binders/circuit/boxes.cpp
+++ b/pytket/binders/circuit/boxes.cpp
@@ -158,7 +158,8 @@ void init_boxes(py::module &m) {
       .def_property_readonly(
           "name", &CompositeGateDef::get_name, "The readable name of the gate")
       .def_property_readonly(
-          "def", &CompositeGateDef::get_def, "Return definition as a circuit.")
+          "definition", &CompositeGateDef::get_def,
+          "Return definition as a circuit.")
       .def_property_readonly(
           "arity", &CompositeGateDef::n_args,
           "The number of real parameters for the gate");

--- a/pytket/binders/circuit/main.cpp
+++ b/pytket/binders/circuit/main.cpp
@@ -73,6 +73,11 @@ PYBIND11_MODULE(circuit, m) {
           "get_name", &Op::get_name, "String representation of op",
           py::arg("latex") = false)
       .def("__eq__", &Op::operator==)
+      .def(
+          "__eq__",
+          [](const py::object, const py::object) -> bool {
+            throw py::type_error("Equality is only defined between Ops");
+          })
       .def("__repr__", [](const Op &op) { return op.get_name(); })
       .def("free_symbols", [](const Op &op) { return op.free_symbols(); })
       .def(
@@ -474,6 +479,11 @@ PYBIND11_MODULE(circuit, m) {
       "A single quantum command in the circuit, defined by the Op, the "
       "qubits it acts on, and the op group name if any.")
       .def("__eq__", &Command::operator==)
+      .def(
+          "__eq__",
+          [](const py::object, const py::object) -> bool {
+            throw py::type_error("Equality is only defined between Commands");
+          })
       .def("__repr__", &Command::to_str)
       .def_property_readonly(
           "op", &Command::get_op_ptr, "Operation for this command.")

--- a/pytket/binders/circuit/main.cpp
+++ b/pytket/binders/circuit/main.cpp
@@ -494,9 +494,9 @@ PYBIND11_MODULE(circuit, m) {
           [](const Command &com) { return com.get_op_ptr()->free_symbols(); },
           ":return: set of symbolic parameters for the command");
 
-  init_circuit(m);
   init_boxes(m);
   init_classical(m);
+  init_circuit(m);
 
   m.def(
       "fresh_symbol", &SymTable::fresh_symbol,

--- a/pytket/binders/circuit/unitid.cpp
+++ b/pytket/binders/circuit/unitid.cpp
@@ -43,6 +43,12 @@ void declare_register(py::module &m, const std::string &typestr) {
       .def("__getitem__", &UnitRegister<T>::operator[])
       .def("__lt__", &UnitRegister<T>::operator<)
       .def("__eq__", &UnitRegister<T>::operator==)
+      .def(
+          "__eq__",
+          [](const py::object, const py::object) -> bool {
+            throw py::type_error(
+                "Equality is only defined between UnitIRegisters");
+          })
       .def("__contains__", &UnitRegister<T>::contains)
       .def("__len__", &UnitRegister<T>::size)
       .def("__str__", &UnitRegister<T>::name)
@@ -86,6 +92,11 @@ void init_unitid(py::module &m) {
   py::class_<UnitID>(
       m, "UnitID", "A handle to a computational unit (e.g. qubit, bit)")
       .def("__eq__", &UnitID::operator==)
+      .def(
+          "__eq__",
+          [](const py::object, const py::object) -> bool {
+            throw py::type_error("Equality is only defined between UnitIDs");
+          })
       .def("__lt__", &UnitID::operator<)
       .def("__repr__", &UnitID::repr)
       .def("__hash__", [](const UnitID &id) { return hash_value(id); })

--- a/pytket/binders/routing.cpp
+++ b/pytket/binders/routing.cpp
@@ -141,7 +141,10 @@ PYBIND11_MODULE(routing, m) {
             return "<tket::Architecture, nodes=" +
                    std::to_string(arc.n_nodes()) + ">";
           })
-      .def(py::self == py::self);
+      .def(py::self == py::self)
+      .def("__eq__", [](const py::object, const py::object) -> bool {
+        throw py::type_error("Equality is only defined between Architectures");
+      });
   py::class_<SquareGrid, Architecture, graphs::AbstractGraph<Node>>(
       m, "SquareGrid",
       "Architecture class for qubits arranged in a square lattice of "
@@ -217,6 +220,12 @@ PYBIND11_MODULE(routing, m) {
                    std::to_string(arc.n_nodes()) + ">";
           })
       .def(py::self == py::self)
+      .def(
+          "__eq__",
+          [](const py::object, const py::object) -> bool {
+            throw py::type_error(
+                "Equality is only defined between FullyConnected objects");
+          })
       .def_property_readonly(
           "nodes", &FullyConnected::get_all_nodes_vec,
           "All nodes of the architecture as :py:class:`Node` objects.")

--- a/pytket/binders/type_aliases.py
+++ b/pytket/binders/type_aliases.py
@@ -1,0 +1,6 @@
+from sympy import Expr as Expression  # type: ignore
+from sympy import Symbol  # type: ignore
+
+from typing import Union, List, Dict, Set
+
+json = Union[List, Dict]

--- a/pytket/binders/zx/diagram.cpp
+++ b/pytket/binders/zx/diagram.cpp
@@ -468,6 +468,12 @@ PYBIND11_MODULE(zx, m) {
       ":py:class:`ZXDiagram`.")
       .def("__repr__", &ZXVertWrapper::to_string)
       .def("__eq__", &ZXVertWrapper::operator==)
+      .def(
+          "__eq__",
+          [](const py::object, const py::object) -> bool {
+            throw py::type_error(
+                "Equality is only defined between ZXVertWrapper");
+          })
       .def("__hash__", [](const ZXVertWrapper& v) {
         return py::hash(py::str(v.to_string()));
       });
@@ -479,6 +485,11 @@ PYBIND11_MODULE(zx, m) {
       "functions on a :py:class:`ZXWire` that is not present in the given "
       ":py:class:`ZXDiagram`.")
       .def("__eq__", [](const Wire& a, const Wire& b) { return a == b; })
+      .def(
+          "__eq__",
+          [](const py::object, const py::object) -> bool {
+            throw py::type_error("Equality is only defined between ZXWires");
+          })
       .def("__hash__", [](const Wire& w) {
         std::stringstream st;
         st << w;
@@ -507,6 +518,12 @@ PYBIND11_MODULE(zx, m) {
           "qtype", &ZXGen::get_qtype,
           "The :py:class:`QuantumType` of the generator (if applicable).")
       .def("__eq__", &ZXGen::operator==)
+      .def(
+          "__eq__",
+          [](const py::object, const py::object) -> bool {
+            throw py::type_error(
+                "Equality is only defined between QuantumTypes");
+          })
       .def("__repr__", [](const ZXGen& gen) { return gen.get_name(); });
   py::class_<BasicGen, std::shared_ptr<BasicGen>, ZXGen>(
       m, "BasicGen",

--- a/pytket/binders/zx/diagram.cpp
+++ b/pytket/binders/zx/diagram.cpp
@@ -74,8 +74,8 @@ void ZXDiagramPybind::init_zxdiagram(py::module& m) {
           ":param out: Number of quantum outputs.\n"
           ":param classical_in: Number of classical inputs.\n"
           ":param classical_out: Number of classical outputs.",
-          py::arg("in"), py::arg("out"), py::arg("classical_in"),
-          py::arg("classical_out"))
+          py::arg("inputs"), py::arg("outputs"), py::arg("classical_inputs"),
+          py::arg("classical_outputs"))
       .def(
           py::init<const ZXDiagram&>(),
           "Constructs a copy of an existing ZX diagram.\n\n"

--- a/pytket/cleanup_stubs.sh
+++ b/pytket/cleanup_stubs.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+for file in $(ls -d pytket/_tket/*.pyi)
+do
+    echo "cleaning up $file"
+    echo "from .type_aliases import *" > tmp_pyi
+    cat $file >> tmp_pyi
+    sed 's/numpy\.ndarray\[[^]]*\]\]/numpy.ndarray/g' tmp_pyi | grep -v -F -f stub_blacklist.txt > $file
+done
+
+cp binders/type_aliases.py pytket/_tket/type_aliases.pyi
+rm tmp_pyi

--- a/pytket/pyproject.toml
+++ b/pytket/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=45", "wheel", "setuptools_scm>=6.2", "conan"]
+requires = ["setuptools>=45", "wheel", "setuptools_scm>=6.2", "conan", "mypy>=0.900"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]

--- a/pytket/pytket/circuit/__init__.py
+++ b/pytket/pytket/circuit/__init__.py
@@ -17,12 +17,12 @@
   This module is provided in binary form during the PyPI installation."""
 from typing import Any, Tuple, Type, Union, cast, Callable
 
-from pytket._tket.circuit import *  # type: ignore
+from pytket._tket.circuit import *
 from pytket._tket.circuit import Bit, BitRegister
 
 # prefixes for assertion bits
-from pytket._tket.circuit import _DEBUG_ZERO_REG_PREFIX, _DEBUG_ONE_REG_PREFIX  # type: ignore
-from pytket._tket.pauli import Pauli  # type: ignore
+from pytket._tket.circuit import _DEBUG_ZERO_REG_PREFIX, _DEBUG_ONE_REG_PREFIX
+from pytket._tket.pauli import Pauli
 
 from .logic_exp import (
     BitLogicExp,

--- a/pytket/pytket/circuit/add_condition.py
+++ b/pytket/pytket/circuit/add_condition.py
@@ -15,8 +15,8 @@
 """Enable adding of gates with conditions on Bit or BitRegister expressions."""
 from typing import Tuple, Union, cast
 
-from pytket.circuit import Bit, Circuit, BitRegister  # type: ignore
-from pytket._tket.circuit import (  # type: ignore
+from pytket.circuit import Bit, Circuit, BitRegister
+from pytket._tket.circuit import (
     _TEMP_REG_SIZE,
     _TEMP_BIT_NAME,
     _TEMP_BIT_REG_BASE,

--- a/pytket/pytket/circuit/logic_exp.py
+++ b/pytket/pytket/circuit/logic_exp.py
@@ -141,12 +141,12 @@ class LogicExp:
         var_type = Bit if isinstance(self, BitLogicExp) else BitRegister
         for arg in self.args:
             if isinstance(arg, var_type):
-                outset.add(arg)
+                outset.add(cast(Union[Bit, BitRegister], arg))
             elif isinstance(arg, LogicExp):
                 outset.update(arg.all_inputs())
         return outset
 
-    def __eq__(self, other: ArgType) -> bool:
+    def __eq__(self, other: Any) -> bool:
         if not isinstance(other, LogicExp):
             return False
         return (self.op == other.op) and (self.args == other.args)

--- a/pytket/pytket/zx/tensor_eval.py
+++ b/pytket/pytket/zx/tensor_eval.py
@@ -100,6 +100,7 @@ def _tensor_from_basic_diagram(diag: ZXDiagram) -> np.ndarray:
         if gen.type in _boundary_types:
             # Boundaries already handled above
             continue
+        assert type(gen) is BasicGen
         v_ind = []
         for w in diag.adj_wires(v):
             v_ind.append(indices[w])
@@ -200,6 +201,7 @@ def fix_boundaries_to_binary_states(
             raise ValueError("Can only fix boundary states to |0> and |1>.")
         new_b = b_lookup[b]
         qtype = diag.get_qtype(b)
+        assert qtype is not None
         fix_b = new_diag.add_vertex(ZXType.XSpider, float(val), qtype)
         bw = new_diag.adj_wires(new_b)[0]
         adj = new_diag.other_end(bw, new_b)

--- a/pytket/setup.py
+++ b/pytket/setup.py
@@ -28,6 +28,8 @@ from setuptools.command.build_ext import build_ext  # type: ignore
 from concurrent.futures import ThreadPoolExecutor as Pool
 from shutil import which
 
+from mypy.stubgenc import generate_stub_for_c_module
+
 
 class CMakeExtension(Extension):
     def __init__(self, name, sourcedir=""):
@@ -133,6 +135,13 @@ class CMakeBuild(build_ext):
             ]
             for tket_lib in tket_libs:
                 shutil.copy(os.path.join(directory, "lib", libfile(tket_lib)), extdir)
+
+        # add stub files for mypy
+        for binder in binders:
+            mod = f"pytket._tket.{binder}"
+            target = f"pytket/_tket/{binder}.pyi"
+            generate_stub_for_c_module(mod, target)
+        subprocess.check_call("./cleanup_stubs.sh")
 
     def cmake_config(self, extdir, extsource):
 

--- a/pytket/stub_blacklist.txt
+++ b/pytket/stub_blacklist.txt
@@ -1,0 +1,4 @@
+__doc__: ClassVar
+__hash__: ClassVar
+__eq__: ClassVar
+def __init__(self, *args, **kwargs)


### PR DESCRIPTION
Adding type stubs to tket requires a few changes to the pytket API. This should probably be done before pytket 1.0. I have already solved a significant chunk of the issues in the commits below, but there are more issues to be discussed and resolved.

The stubs are automatically generated using mypy's `stubgen` in `setup.py`.

Most problems that arose in these generated stubs are addressed by changes to the `binders`. However some problems could not be solved that way (bugs in mypy, or maybe in some cases I haven't figured how), so I also need to patch the stubs after generation.