### PR TITLE
[bugfix] small API fixes in `pytket.Circuit`

### DIFF
--- a/pytket/binders/circuit/Circuit/add_classical_op.cpp
+++ b/pytket/binders/circuit/Circuit/add_classical_op.cpp
@@ -384,9 +384,8 @@ void init_circuit_add_classical_op(
           "\n:param args_in: input bits"
           "\n:param arg_out: output bit (distinct from input bits)"
           "\n:return: the new :py:class:`Circuit`",
-          py::arg("minval") = 0,
-          py::arg("maxval") = std::numeric_limits<uint32_t>::max(),
-          py::arg("args_in"), py::arg("arg_out"))
+          py::arg("minval"), py::arg("maxval"), py::arg("args_in"),
+          py::arg("arg_out"))
       .def(
           "add_c_and_to_registers",
           [](Circuit &circ, const BitRegister &reg0_in,

--- a/pytket/binders/circuit/Circuit/add_classical_op.cpp
+++ b/pytket/binders/circuit/Circuit/add_classical_op.cpp
@@ -54,11 +54,13 @@ void init_circuit_add_classical_op(
   c.def(
        "add_c_transform",
        [](Circuit &circ, const std::vector<uint32_t> &values,
-          const std::vector<unsigned> &args, const std::string &name) {
+          const std::vector<unsigned> &args,
+          const std::string &name) -> Circuit & {
          unsigned n_args = args.size();
          std::shared_ptr<ClassicalTransformOp> op =
              std::make_shared<ClassicalTransformOp>(n_args, values, name);
-         return circ.add_op(op, args);
+         circ.add_op(op, args);
+         return circ;
        },
        "Appends a purely classical transformation, defined by a table of "
        "values, to "
@@ -76,20 +78,23 @@ void init_circuit_add_classical_op(
       .def(
           "add_c_transform",
           [](Circuit &circ, const std::vector<uint32_t> &values,
-             const std::vector<Bit> &args, const std::string &name) {
+             const std::vector<Bit> &args,
+             const std::string &name) -> Circuit & {
             unsigned n_args = args.size();
             std::shared_ptr<ClassicalTransformOp> op =
                 std::make_shared<ClassicalTransformOp>(n_args, values, name);
-            return circ.add_op(op, args);
+            circ.add_op(op, args);
+            return circ;
           },
           "See :py:meth:`add_c_transform`.", py::arg("values"), py::arg("args"),
           py::arg("name") = "ClassicalTransform")
       .def(
           "add_c_setbits",
           [](Circuit &circ, const std::vector<bool> &values,
-             const std::vector<unsigned> args) {
+             const std::vector<unsigned> args) -> Circuit & {
             std::shared_ptr<SetBitsOp> op = std::make_shared<SetBitsOp>(values);
-            return circ.add_op(op, args);
+            circ.add_op(op, args);
+            return circ;
           },
           "Appends an operation to set some bit values."
           "\n\n:param values: values to set"
@@ -99,21 +104,23 @@ void init_circuit_add_classical_op(
       .def(
           "add_c_setbits",
           [](Circuit &circ, const std::vector<bool> &values,
-             const std::vector<Bit> args) {
+             const std::vector<Bit> args) -> Circuit & {
             std::shared_ptr<SetBitsOp> op = std::make_shared<SetBitsOp>(values);
-            return circ.add_op(op, args);
+            circ.add_op(op, args);
+            return circ;
           },
           "See :py:meth:`add_c_setbits`.", py::arg("values"), py::arg("args"))
       .def(
           "add_c_copybits",
           [](Circuit &circ, const std::vector<unsigned> &args_in,
-             const std::vector<unsigned> &args_out) {
+             const std::vector<unsigned> &args_out) -> Circuit & {
             unsigned n_args_in = args_in.size();
             std::shared_ptr<CopyBitsOp> op =
                 std::make_shared<CopyBitsOp>(n_args_in);
             std::vector<unsigned> args = args_in;
             args.insert(args.end(), args_out.begin(), args_out.end());
-            return circ.add_op(op, args);
+            circ.add_op(op, args);
+            return circ;
           },
           "Appends a classical copy operation"
           "\n\n:param args_in: source bits"
@@ -123,13 +130,14 @@ void init_circuit_add_classical_op(
       .def(
           "add_c_copybits",
           [](Circuit &circ, const std::vector<Bit> &args_in,
-             const std::vector<Bit> &args_out) {
+             const std::vector<Bit> &args_out) -> Circuit & {
             unsigned n_args_in = args_in.size();
             std::shared_ptr<CopyBitsOp> op =
                 std::make_shared<CopyBitsOp>(n_args_in);
             std::vector<Bit> args = args_in;
             args.insert(args.end(), args_out.begin(), args_out.end());
-            return circ.add_op(op, args);
+            circ.add_op(op, args);
+            return circ;
           },
           "See :py:meth:`add_c_copybits`.", py::arg("args_in"),
           py::arg("args_out"))
@@ -137,13 +145,14 @@ void init_circuit_add_classical_op(
           "add_c_predicate",
           [](Circuit &circ, const std::vector<bool> &values,
              const std::vector<unsigned> &args_in, unsigned arg_out,
-             const std::string &name) {
+             const std::string &name) -> Circuit & {
             unsigned n_args_in = args_in.size();
             std::shared_ptr<ExplicitPredicateOp> op =
                 std::make_shared<ExplicitPredicateOp>(n_args_in, values, name);
             std::vector<unsigned> args = args_in;
             args.push_back(arg_out);
-            return circ.add_op(op, args);
+            circ.add_op(op, args);
+            return circ;
           },
           "Appends a classical predicate, defined by a truth table, to the end "
           "of the "
@@ -161,13 +170,14 @@ void init_circuit_add_classical_op(
           "add_c_predicate",
           [](Circuit &circ, const std::vector<bool> &values,
              const std::vector<Bit> &args_in, Bit arg_out,
-             const std::string &name) {
+             const std::string &name) -> Circuit & {
             unsigned n_args_in = args_in.size();
             std::shared_ptr<ExplicitPredicateOp> op =
                 std::make_shared<ExplicitPredicateOp>(n_args_in, values, name);
             std::vector<Bit> args = args_in;
             args.push_back(arg_out);
-            return circ.add_op(op, args);
+            circ.add_op(op, args);
+            return circ;
           },
           "See :py:meth:`add_c_predicate`.", py::arg("values"),
           py::arg("args_in"), py::arg("arg_out"),
@@ -176,13 +186,14 @@ void init_circuit_add_classical_op(
           "add_c_modifier",
           [](Circuit &circ, const std::vector<bool> &values,
              const std::vector<unsigned> &args_in, unsigned arg_inout,
-             const std::string &name) {
+             const std::string &name) -> Circuit & {
             unsigned n_args_in = args_in.size();
             std::shared_ptr<ExplicitModifierOp> op =
                 std::make_shared<ExplicitModifierOp>(n_args_in, values, name);
             std::vector<unsigned> args = args_in;
             args.push_back(arg_inout);
-            return circ.add_op(op, args);
+            circ.add_op(op, args);
+            return circ;
           },
           "Appends a classical modifying operation, defined by a truth table, "
           "to the "
@@ -202,13 +213,14 @@ void init_circuit_add_classical_op(
           "add_c_modifier",
           [](Circuit &circ, const std::vector<bool> &values,
              const std::vector<Bit> &args_in, Bit arg_inout,
-             const std::string &name) {
+             const std::string &name) -> Circuit & {
             unsigned n_args_in = args_in.size();
             std::shared_ptr<ExplicitModifierOp> op =
                 std::make_shared<ExplicitModifierOp>(n_args_in, values, name);
             std::vector<Bit> args = args_in;
             args.push_back(arg_inout);
-            return circ.add_op(op, args);
+            circ.add_op(op, args);
+            return circ;
           },
           "See :py:meth:`add_c_modifier`.", py::arg("values"),
           py::arg("args_in"), py::arg("arg_inout"),
@@ -216,15 +228,15 @@ void init_circuit_add_classical_op(
       .def(
           "add_c_and",
           [](Circuit &circ, unsigned arg0_in, unsigned arg1_in,
-             unsigned arg_out) {
+             unsigned arg_out) -> Circuit & {
             if (arg0_in == arg_out) {
-              return circ.add_op<unsigned>(AndWithOp(), {arg1_in, arg_out});
+              circ.add_op<unsigned>(AndWithOp(), {arg1_in, arg_out});
             } else if (arg1_in == arg_out) {
-              return circ.add_op<unsigned>(AndWithOp(), {arg0_in, arg_out});
+              circ.add_op<unsigned>(AndWithOp(), {arg0_in, arg_out});
             } else {
-              return circ.add_op<unsigned>(
-                  AndOp(), {arg0_in, arg1_in, arg_out});
+              circ.add_op<unsigned>(AndOp(), {arg0_in, arg1_in, arg_out});
             }
+            return circ;
           },
           "Appends a binary AND operation to the end of the circuit."
           "\n\n:param arg0_in: first input bit"
@@ -234,28 +246,31 @@ void init_circuit_add_classical_op(
           py::arg("arg0_in"), py::arg("arg1_in"), py::arg("arg_out"))
       .def(
           "add_c_and",
-          [](Circuit &circ, Bit arg0_in, Bit arg1_in, Bit arg_out) {
+          [](Circuit &circ, Bit arg0_in, Bit arg1_in,
+             Bit arg_out) -> Circuit & {
             if (arg0_in == arg_out) {
-              return circ.add_op<Bit>(AndWithOp(), {arg1_in, arg_out});
+              circ.add_op<Bit>(AndWithOp(), {arg1_in, arg_out});
             } else if (arg1_in == arg_out) {
-              return circ.add_op<Bit>(AndWithOp(), {arg0_in, arg_out});
+              circ.add_op<Bit>(AndWithOp(), {arg0_in, arg_out});
             } else {
-              return circ.add_op<Bit>(AndOp(), {arg0_in, arg1_in, arg_out});
+              circ.add_op<Bit>(AndOp(), {arg0_in, arg1_in, arg_out});
             }
+            return circ;
           },
           "See :py:meth:`add_c_and`.", py::arg("arg0_in"), py::arg("arg1_in"),
           py::arg("arg_out"))
       .def(
           "add_c_or",
           [](Circuit &circ, unsigned arg0_in, unsigned arg1_in,
-             unsigned arg_out) {
+             unsigned arg_out) -> Circuit & {
             if (arg0_in == arg_out) {
-              return circ.add_op<unsigned>(OrWithOp(), {arg1_in, arg_out});
+              circ.add_op<unsigned>(OrWithOp(), {arg1_in, arg_out});
             } else if (arg1_in == arg_out) {
-              return circ.add_op<unsigned>(OrWithOp(), {arg0_in, arg_out});
+              circ.add_op<unsigned>(OrWithOp(), {arg0_in, arg_out});
             } else {
-              return circ.add_op<unsigned>(OrOp(), {arg0_in, arg1_in, arg_out});
+              circ.add_op<unsigned>(OrOp(), {arg0_in, arg1_in, arg_out});
             }
+            return circ;
           },
           "Appends a binary OR operation to the end of the circuit."
           "\n\n:param arg0_in: first input bit"
@@ -265,29 +280,31 @@ void init_circuit_add_classical_op(
           py::arg("arg0_in"), py::arg("arg1_in"), py::arg("arg_out"))
       .def(
           "add_c_or",
-          [](Circuit &circ, Bit arg0_in, Bit arg1_in, Bit arg_out) {
+          [](Circuit &circ, Bit arg0_in, Bit arg1_in,
+             Bit arg_out) -> Circuit & {
             if (arg0_in == arg_out) {
-              return circ.add_op<Bit>(OrWithOp(), {arg1_in, arg_out});
+              circ.add_op<Bit>(OrWithOp(), {arg1_in, arg_out});
             } else if (arg1_in == arg_out) {
-              return circ.add_op<Bit>(OrWithOp(), {arg0_in, arg_out});
+              circ.add_op<Bit>(OrWithOp(), {arg0_in, arg_out});
             } else {
-              return circ.add_op<Bit>(OrOp(), {arg0_in, arg1_in, arg_out});
+              circ.add_op<Bit>(OrOp(), {arg0_in, arg1_in, arg_out});
             }
+            return circ;
           },
           "See :py:meth:`add_c_or`.", py::arg("arg0_in"), py::arg("arg1_in"),
           py::arg("arg_out"))
       .def(
           "add_c_xor",
           [](Circuit &circ, unsigned arg0_in, unsigned arg1_in,
-             unsigned arg_out) {
+             unsigned arg_out) -> Circuit & {
             if (arg0_in == arg_out) {
-              return circ.add_op<unsigned>(XorWithOp(), {arg1_in, arg_out});
+              circ.add_op<unsigned>(XorWithOp(), {arg1_in, arg_out});
             } else if (arg1_in == arg_out) {
-              return circ.add_op<unsigned>(XorWithOp(), {arg0_in, arg_out});
+              circ.add_op<unsigned>(XorWithOp(), {arg0_in, arg_out});
             } else {
-              return circ.add_op<unsigned>(
-                  XorOp(), {arg0_in, arg1_in, arg_out});
+              circ.add_op<unsigned>(XorOp(), {arg0_in, arg1_in, arg_out});
             }
+            return circ;
           },
           "Appends a binary XOR operation to the end of the circuit."
           "\n\n:param arg0_in: first input bit"
@@ -297,21 +314,24 @@ void init_circuit_add_classical_op(
           py::arg("arg0_in"), py::arg("arg1_in"), py::arg("arg_out"))
       .def(
           "add_c_xor",
-          [](Circuit &circ, Bit arg0_in, Bit arg1_in, Bit arg_out) {
+          [](Circuit &circ, Bit arg0_in, Bit arg1_in,
+             Bit arg_out) -> Circuit & {
             if (arg0_in == arg_out) {
-              return circ.add_op<Bit>(XorWithOp(), {arg1_in, arg_out});
+              circ.add_op<Bit>(XorWithOp(), {arg1_in, arg_out});
             } else if (arg1_in == arg_out) {
-              return circ.add_op<Bit>(XorWithOp(), {arg0_in, arg_out});
+              circ.add_op<Bit>(XorWithOp(), {arg0_in, arg_out});
             } else {
-              return circ.add_op<Bit>(XorOp(), {arg0_in, arg1_in, arg_out});
+              circ.add_op<Bit>(XorOp(), {arg0_in, arg1_in, arg_out});
             }
+            return circ;
           },
           "See :py:meth:`add_c_xor`.", py::arg("arg0_in"), py::arg("arg1_in"),
           py::arg("arg_out"))
       .def(
           "add_c_not",
-          [](Circuit &circ, unsigned arg_in, unsigned arg_out) {
-            return circ.add_op<unsigned>(NotOp(), {arg_in, arg_out});
+          [](Circuit &circ, unsigned arg_in, unsigned arg_out) -> Circuit & {
+            circ.add_op<unsigned>(NotOp(), {arg_in, arg_out});
+            return circ;
           },
           "Appends a NOT operation to the end of the circuit."
           "\n\n:param arg_in: input bit"
@@ -320,20 +340,23 @@ void init_circuit_add_classical_op(
           py::arg("arg_in"), py::arg("arg_out"))
       .def(
           "add_c_not",
-          [](Circuit &circ, Bit arg_in, Bit arg_out) {
-            return circ.add_op<Bit>(NotOp(), {arg_in, arg_out});
+          [](Circuit &circ, Bit arg_in, Bit arg_out) -> Circuit & {
+            circ.add_op<Bit>(NotOp(), {arg_in, arg_out});
+            return circ;
           },
           "See :py:meth:`add_c_not`.", py::arg("arg_in"), py::arg("arg_out"))
       .def(
           "add_c_range_predicate",
           [](Circuit &circ, uint32_t a, uint32_t b,
-             const std::vector<unsigned> &args_in, unsigned arg_out) {
+             const std::vector<unsigned> &args_in,
+             unsigned arg_out) -> Circuit & {
             unsigned n_args_in = args_in.size();
             std::shared_ptr<RangePredicateOp> op =
                 std::make_shared<RangePredicateOp>(n_args_in, a, b);
             std::vector<unsigned> args = args_in;
             args.push_back(arg_out);
-            return circ.add_op(op, args);
+            circ.add_op(op, args);
+            return circ;
           },
           "Appends a range-predicate operation to the end of the circuit."
           "\n\n:param minval: lower bound of input in little-endian encoding"
@@ -341,19 +364,19 @@ void init_circuit_add_classical_op(
           "\n:param args_in: input bits"
           "\n:param arg_out: output bit (distinct from input bits)"
           "\n:return: the new :py:class:`Circuit`",
-          py::arg("minval") = 0,
-          py::arg("maxval") = std::numeric_limits<uint32_t>::max(),
-          py::arg("args_in"), py::arg("arg_out"))
+          py::arg("minval"), py::arg("maxval"), py::arg("args_in"),
+          py::arg("arg_out"))
       .def(
           "add_c_range_predicate",
           [](Circuit &circ, uint32_t a, uint32_t b,
-             const std::vector<Bit> &args_in, Bit arg_out) {
+             const std::vector<Bit> &args_in, Bit arg_out) -> Circuit & {
             unsigned n_args_in = args_in.size();
             std::shared_ptr<RangePredicateOp> op =
                 std::make_shared<RangePredicateOp>(n_args_in, a, b);
             std::vector<Bit> args = args_in;
             args.push_back(arg_out);
-            return circ.add_op(op, args);
+            circ.add_op(op, args);
+            return circ;
           },
           "Appends a range-predicate operation to the end of the circuit."
           "\n\n:param minval: lower bound of input in little-endian encoding"
@@ -442,7 +465,7 @@ void init_circuit_add_classical_op(
       .def(
           "add_c_not_to_registers",
           [](Circuit &circ, const BitRegister &reg_in,
-             const BitRegister &reg_out) {
+             const BitRegister &reg_out) -> Circuit & {
             apply_classical_op_to_registers(circ, NotOp(), {reg_in, reg_out});
             return circ;
           },

--- a/pytket/binders/circuit/Circuit/add_op.cpp
+++ b/pytket/binders/circuit/Circuit/add_op.cpp
@@ -409,11 +409,11 @@ void init_circuit_add_op(py::class_<Circuit, std::shared_ptr<Circuit>> &c) {
           py::arg("expression"), py::arg("target"))
       .def(
           "add_custom_gate",
-          [](Circuit *circ, const composite_def_ptr_t &def,
+          [](Circuit *circ, const composite_def_ptr_t &definition,
              const std::vector<Expr> &params,
              const std::vector<unsigned> &qubits, const py::kwargs &kwargs) {
             return add_box_method<unsigned>(
-                circ, std::make_shared<CustomGate>(def, params), qubits,
+                circ, std::make_shared<CustomGate>(definition, params), qubits,
                 kwargs);
           },
           "Append an instance of a :py:class:`CustomGateDef` to the "
@@ -422,7 +422,7 @@ void init_circuit_add_op(py::class_<Circuit, std::shared_ptr<Circuit>> &c) {
           "instantiate the gate with, in halfturns\n:param qubits: "
           "Indices of the qubits to append the box to"
           "\n:return: the new :py:class:`Circuit`",
-          py::arg("def"), py::arg("params"), py::arg("qubits"))
+          py::arg("definition"), py::arg("params"), py::arg("qubits"))
       .def(
           "add_barrier",
           [](Circuit *circ, const unit_vector_t &units) {
@@ -538,11 +538,11 @@ void init_circuit_add_op(py::class_<Circuit, std::shared_ptr<Circuit>> &c) {
           py::arg("phasepolybox"), py::arg("qubits"))
       .def(
           "add_custom_gate",
-          [](Circuit *circ, const composite_def_ptr_t &def,
+          [](Circuit *circ, const composite_def_ptr_t &definition,
              const std::vector<Expr> &params, const qubit_vector_t &qubits,
              const py::kwargs &kwargs) {
             return add_box_method<UnitID>(
-                circ, std::make_shared<CustomGate>(def, params),
+                circ, std::make_shared<CustomGate>(definition, params),
                 {qubits.begin(), qubits.end()}, kwargs);
           },
           "Append an instance of a :py:class:`CustomGateDef` to the "

--- a/pytket/binders/circuit/Circuit/add_op.cpp
+++ b/pytket/binders/circuit/Circuit/add_op.cpp
@@ -551,13 +551,13 @@ void init_circuit_add_op(py::class_<Circuit, std::shared_ptr<Circuit>> &c) {
           "instantiate the gate with, in halfturns\n:param qubits: "
           "The qubits to append the box to"
           "\n:return: the new :py:class:`Circuit`",
-          py::arg("def"), py::arg("params"), py::arg("qubits"))
+          py::arg("definition"), py::arg("params"), py::arg("qubits"))
       .def(
           "add_assertion",
           [](Circuit *circ, const ProjectorAssertionBox &box,
              const std::vector<unsigned> &qubits,
              const std::optional<unsigned> &ancilla,
-             const std::optional<std::string> &name) {
+             const std::optional<std::string> &name) -> Circuit * {
             std::vector<Qubit> qubits_;
             for (unsigned i = 0; i < qubits.size(); ++i) {
               qubits_.push_back(Qubit(qubits[i]));
@@ -568,7 +568,8 @@ void init_circuit_add_op(py::class_<Circuit, std::shared_ptr<Circuit>> &c) {
             } else {
               ancilla_ = Qubit(ancilla.value());
             }
-            return circ->add_assertion(box, qubits_, ancilla_, name);
+            circ->add_assertion(box, qubits_, ancilla_, name);
+            return circ;
           },
           "Append a :py:class:`ProjectorAssertionBox` to the circuit."
           "\n\n:param box: ProjectorAssertionBox to append"
@@ -583,8 +584,9 @@ void init_circuit_add_op(py::class_<Circuit, std::shared_ptr<Circuit>> &c) {
           [](Circuit *circ, const ProjectorAssertionBox &box,
              const std::vector<Qubit> &qubits,
              const std::optional<Qubit> &ancilla,
-             const std::optional<std::string> &name) {
-            return circ->add_assertion(box, qubits, ancilla, name);
+             const std::optional<std::string> &name) -> Circuit * {
+            circ->add_assertion(box, qubits, ancilla, name);
+            return circ;
           },
           "Append a :py:class:`ProjectorAssertionBox` to the circuit."
           "\n\n:param box: ProjectorAssertionBox to append"
@@ -598,13 +600,14 @@ void init_circuit_add_op(py::class_<Circuit, std::shared_ptr<Circuit>> &c) {
           "add_assertion",
           [](Circuit *circ, const StabiliserAssertionBox &box,
              const std::vector<unsigned> &qubits, const unsigned &ancilla,
-             const std::optional<std::string> &name) {
+             const std::optional<std::string> &name) -> Circuit * {
             std::vector<Qubit> qubits_;
             for (unsigned i = 0; i < qubits.size(); ++i) {
               qubits_.push_back(Qubit(qubits[i]));
             }
             Qubit ancilla_(ancilla);
-            return circ->add_assertion(box, qubits_, ancilla_, name);
+            circ->add_assertion(box, qubits_, ancilla_, name);
+            return circ;
           },
           "Append a :py:class:`StabiliserAssertionBox` to the circuit."
           "\n\n:param box: StabiliserAssertionBox to append"
@@ -618,8 +621,9 @@ void init_circuit_add_op(py::class_<Circuit, std::shared_ptr<Circuit>> &c) {
           "add_assertion",
           [](Circuit *circ, const StabiliserAssertionBox &box,
              const std::vector<Qubit> &qubits, const Qubit &ancilla,
-             const std::optional<std::string> &name) {
-            return circ->add_assertion(box, qubits, ancilla, name);
+             const std::optional<std::string> &name) -> Circuit * {
+            circ->add_assertion(box, qubits, ancilla, name);
+            return circ;
           },
           "Append a :py:class:`StabiliserAssertionBox` to the circuit."
           "\n\n:param box: StabiliserAssertionBox to append"

--- a/pytket/binders/circuit/boxes.cpp
+++ b/pytket/binders/circuit/boxes.cpp
@@ -158,7 +158,8 @@ void init_boxes(py::module &m) {
       .def_property_readonly(
           "name", &CompositeGateDef::get_name, "The readable name of the gate")
       .def_property_readonly(
-          "def", &CompositeGateDef::get_def, "Return definition as a circuit.")
+          "definition", &CompositeGateDef::get_def,
+          "Return definition as a circuit.")
       .def_property_readonly(
           "arity", &CompositeGateDef::n_args,
           "The number of real parameters for the gate");

--- a/pytket/binders/circuit/main.cpp
+++ b/pytket/binders/circuit/main.cpp
@@ -499,9 +499,9 @@ PYBIND11_MODULE(circuit, m) {
           [](const Command &com) { return com.get_op_ptr()->free_symbols(); },
           ":return: set of symbolic parameters for the command");
 
-  init_circuit(m);
   init_boxes(m);
   init_classical(m);
+  init_circuit(m);
 
   m.def(
       "fresh_symbol", &SymTable::fresh_symbol,

--- a/pytket/binders/zx/diagram.cpp
+++ b/pytket/binders/zx/diagram.cpp
@@ -74,8 +74,8 @@ void ZXDiagramPybind::init_zxdiagram(py::module& m) {
           ":param out: Number of quantum outputs.\n"
           ":param classical_in: Number of classical inputs.\n"
           ":param classical_out: Number of classical outputs.",
-          py::arg("in"), py::arg("out"), py::arg("classical_in"),
-          py::arg("classical_out"))
+          py::arg("inputs"), py::arg("outputs"), py::arg("classical_inputs"),
+          py::arg("classical_outputs"))
       .def(
           py::init<const ZXDiagram&>(),
           "Constructs a copy of an existing ZX diagram.\n\n"

--- a/pytket/docs/changelog.rst
+++ b/pytket/docs/changelog.rst
@@ -10,6 +10,8 @@ API changes:
   ``map`` property instead.)
 * The deprecated ``Backend.compile_circuit`` method is removed. (Use
   ``get_compiled_circuit`` instead.)
+* The keyword parameter and property ``def`` is now called ``definition`` in 
+  ``Circuit.add_custom_gate`` and ``CustomGateDef``.
 
 0.19.0 (February 2022)
 ----------------------


### PR DESCRIPTION
1. Fixed the return type of `add_op` and other methods of `pytket.Circuit` to return `self` as advertised in the docs.
2. Removed default values for arguments `minval` and `maxval` of `add_c_range_predicate`.