### PR TITLE
Add new conan remote and use pre-built symengine package

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Standardize line endings across platforms.
+# This ensures that conan recipe hashes match.
+*	text eol=lf
+

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -180,7 +180,7 @@ jobs:
         export CC=`which conan`
         echo "CONAN_CMD=${CC}" >> $GITHUB_ENV
     - name: add remote
-      run: conan remote add tket-conan https://tket.jfrog.io/artifactory/api/conan/tket-conan
+      run: conan remote add tket-conan https://tket.jfrog.io/artifactory/api/conan/tket-conan --force
     - name: Install boost
       run: conan install --profile=tket boost/1.78.0@ --build=missing
     - name: Build tket

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -20,6 +20,7 @@ jobs:
     env:
       CC: gcc-10
       CXX: g++-10
+      CONAN_REVISIONS_ENABLED: 1
       PYTKET_SKIP_REGISTRATION: "true"
     steps:
     - uses: actions/checkout@v2
@@ -54,10 +55,10 @@ jobs:
         ${conan_cmd} profile update settings.compiler.libcxx=libstdc++11 tket
         ${conan_cmd} profile update options.tket:shared=True tket
         echo "CONAN_CMD=${conan_cmd}" >> $GITHUB_ENV
+    - name: add remote
+      run: ${CONAN_CMD} remote add tket-conan https://tket.jfrog.io/artifactory/api/conan/tket-conan
     - name: Install ninja and ccache
       run: sudo apt-get install ninja-build ccache
-    - name: Build symengine
-      run: ${CONAN_CMD} create --profile=tket recipes/symengine
     - name: Build tket
       run: ${CONAN_CMD} create --profile=tket recipes/tket
     - name: Install runtime test requirements
@@ -132,6 +133,7 @@ jobs:
     name: Build and test (MacOS)
     runs-on: macos-11
     env:
+      CONAN_REVISIONS_ENABLED: 1
       PYTKET_SKIP_REGISTRATION: "true"
     steps:
     - uses: actions/checkout@v2
@@ -177,10 +179,10 @@ jobs:
         conan profile update options.tket:shared=True tket
         export CC=`which conan`
         echo "CONAN_CMD=${CC}" >> $GITHUB_ENV
+    - name: add remote
+      run: conan remote add tket-conan https://tket.jfrog.io/artifactory/api/conan/tket-conan
     - name: Install boost
       run: conan install --profile=tket boost/1.78.0@ --build=missing
-    - name: Build symengine
-      run: conan create --profile=tket recipes/symengine
     - name: Build tket
       run: conan create --profile=tket recipes/tket --build=spdlog --build=tket
     - name: Build and run tket tests
@@ -256,6 +258,7 @@ jobs:
       run:
         shell: "/usr/bin/arch -arch arm64e /bin/bash {0}"
     env:
+      CONAN_REVISIONS_ENABLED: 1
       PYTKET_SKIP_REGISTRATION: "true"
     steps:
     - uses: actions/checkout@v2
@@ -269,10 +272,10 @@ jobs:
         conan profile update options.tket:shared=True tket
         export CC=`which conan`
         echo "CONAN_CMD=${CC}" >> $GITHUB_ENV
+    - name: add remote
+      run: conan remote add tket-conan https://tket.jfrog.io/artifactory/api/conan/tket-conan --force
     - name: Install boost
       run: conan install --profile=tket boost/1.78.0@ --build=missing
-    - name: Build symengine
-      run: conan create --profile=tket recipes/symengine
     - name: Build tket
       run: conan create --profile=tket recipes/tket --build=spdlog --build=tket
     - name: Build and run tket tests
@@ -334,6 +337,7 @@ jobs:
     name: Build and test (Windows)
     runs-on: windows-2019
     env:
+      CONAN_REVISIONS_ENABLED: 1
       PYTKET_SKIP_REGISTRATION: "true"
     steps:
     - uses: actions/checkout@v2
@@ -366,14 +370,14 @@ jobs:
         conan profile update options.tket:shared=True tket
         $conan_cmd = (gcm conan).Path
         echo "CONAN_CMD=${conan_cmd}" >> $GITHUB_ENV
+    - name: add remote
+      run: conan remote add tket-conan https://tket.jfrog.io/artifactory/api/conan/tket-conan
     - name: Cache tket build
       id: cache-tket
       uses: actions/cache@v2
       with:
         path: C:\Users\runneradmin\.conan\data\tket
         key: ${{ runner.os }}-tket-tket-${{ steps.hash_tket_source.outputs.tket_hash }}-14
-    - name: Build symengine
-      run: conan create --profile=tket recipes/symengine
     - name: Build tket
       if: steps.cache-tket.outputs.cache-hit != 'true'
       run: conan create --profile=tket recipes/tket

--- a/.github/workflows/build_symengine.yml
+++ b/.github/workflows/build_symengine.yml
@@ -1,0 +1,164 @@
+name: build symengine
+on:
+  push:
+    branches:
+      - develop
+  pull_request:
+    branches:
+      - develop
+jobs:
+  changes:
+    runs-on: ubuntu-20.04
+    outputs:
+      recipes_symengine: ${{ steps.filter.outputs.recipes_symengine }}
+    steps:
+    - uses: actions/checkout@v2
+    - uses: dorny/paths-filter@v2
+      id: filter
+      with:
+        base: ${{ github.ref }}
+        filters: |
+          recipes_symengine:
+            - 'recipes/symengine/**'
+  linux:
+    name: build symengine (linux)
+    needs: changes
+    if: needs.changes.outputs.recipes_symengine == 'true'
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        build_type: ['Release', 'Debug']
+        shared: ['True', 'False']
+    env:
+      CC: gcc-10
+      CXX: g++-10
+      CONAN_REVISIONS_ENABLED: 1
+    steps:
+    - uses: actions/checkout@v2
+    - name: install conan
+      run: pip install conan
+    - name: create profile
+      run: |
+        conan profile new tket --detect
+        conan profile update settings.compiler.libcxx=libstdc++11 tket
+    - name: build symengine
+      run: conan create --profile=tket -s build_type=${{ matrix.build_type }} -o symengine:shared=${{ matrix.shared }} recipes/symengine tket/stable
+    - name: add remote
+      run: conan remote add tket-conan https://tket.jfrog.io/artifactory/api/conan/tket-conan
+    - name: authenticate to repository
+      run: conan user -p ${{ secrets.JFROG_ARTIFACTORY_TOKEN_1 }} -r tket-conan ${{ secrets.JFROG_ARTIFACTORY_USER_1 }}
+    - name: get version
+      run: |
+        symengine_ver=$(conan inspect --raw version recipes/symengine/)
+        echo "SYMENGINE_VER=${symengine_ver}" >> $GITHUB_ENV
+    - name: upload package (dry run)
+      if: github.event_name == 'pull_request'
+      run: conan upload symengine/${SYMENGINE_VER}@tket/stable --all -r=tket-conan --skip-upload
+    - name: upload package
+      if: github.event_name == 'push'
+      run: conan upload symengine/${SYMENGINE_VER}@tket/stable --all -r=tket-conan
+  macos:
+    name: build symengine (macos)
+    needs: changes
+    if: needs.changes.outputs.recipes_symengine == 'true'
+    runs-on: macos-11
+    strategy:
+      matrix:
+        build_type: ['Release', 'Debug']
+        shared: ['True', 'False']
+    env:
+      CONAN_REVISIONS_ENABLED: 1
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.9
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.9'
+    - name: install conan
+      run: pip install conan
+    - name: create profile
+      run: conan profile new tket --detect
+    - name: install boost
+      run: conan install --profile=tket -s build_type=${{ matrix.build_type }} boost/1.78.0@ --build=missing
+    - name: build symengine
+      run: conan create --profile=tket -s build_type=${{ matrix.build_type }} -o symengine:shared=${{ matrix.shared }} recipes/symengine tket/stable
+    - name: add remote
+      run: conan remote add tket-conan https://tket.jfrog.io/artifactory/api/conan/tket-conan
+    - name: authenticate to repository
+      run: conan user -p ${{ secrets.JFROG_ARTIFACTORY_TOKEN_1 }} -r tket-conan ${{ secrets.JFROG_ARTIFACTORY_USER_1 }}
+    - name: get version
+      run: |
+        symengine_ver=$(conan inspect --raw version recipes/symengine/)
+        echo "SYMENGINE_VER=${symengine_ver}" >> $GITHUB_ENV
+    - name: upload package (dry run)
+      if: github.event_name == 'pull_request'
+      run: conan upload symengine/${SYMENGINE_VER}@tket/stable --all -r=tket-conan --skip-upload
+    - name: upload package
+      if: github.event_name == 'push'
+      run: conan upload symengine/${SYMENGINE_VER}@tket/stable --all -r=tket-conan
+  macos-m1:
+    name: build symengine (macos-m1)
+    needs: changes
+    if: needs.changes.outputs.recipes_symengine == 'true'
+    runs-on: [self-hosted, macos, M1]
+    strategy:
+      matrix:
+        build_type: ['Release', 'Debug']
+        shared: ['True', 'False']
+    env:
+      CONAN_REVISIONS_ENABLED: 1
+    steps:
+    - uses: actions/checkout@v2
+    - name: install conan
+      run: pip install -U conan
+    - name: create profile
+      run: conan profile new tket --detect --force
+    - name: build symengine
+      run: conan create --profile=tket -s build_type=${{ matrix.build_type }} -o symengine:shared=${{ matrix.shared }} recipes/symengine tket/stable
+    - name: add remote
+      run: conan remote add tket-conan https://tket.jfrog.io/artifactory/api/conan/tket-conan --force
+    - name: authenticate to repository
+      run: conan user -p ${{ secrets.JFROG_ARTIFACTORY_TOKEN_1 }} -r tket-conan ${{ secrets.JFROG_ARTIFACTORY_USER_1 }}
+    - name: get version
+      run: |
+        symengine_ver=$(conan inspect --raw version recipes/symengine/)
+        echo "SYMENGINE_VER=${symengine_ver}" >> $GITHUB_ENV
+    - name: upload package (dry run)
+      if: github.event_name == 'pull_request'
+      run: conan upload symengine/${SYMENGINE_VER}@tket/stable --all -r=tket-conan --skip-upload
+    - name: upload package
+      if: github.event_name == 'push'
+      run: conan upload symengine/${SYMENGINE_VER}@tket/stable --all -r=tket-conan
+  windows:
+    name: build symengine (windows)
+    needs: changes
+    if: needs.changes.outputs.recipes_symengine == 'true'
+    runs-on: windows-2019
+    strategy:
+      matrix:
+        build_type: ['Release', 'Debug']
+        shared: ['True', 'False']
+    env:
+      CONAN_REVISIONS_ENABLED: 1
+    steps:
+    - uses: actions/checkout@v2
+    - name: install conan
+      run: pip install conan
+    - name: create profile
+      run: conan profile new tket --detect
+    - name: build symengine
+      run: conan create --profile=tket -s build_type=${{ matrix.build_type }} -o symengine:shared=${{ matrix.shared }} recipes/symengine tket/stable
+    - name: add remote
+      run: conan remote add tket-conan https://tket.jfrog.io/artifactory/api/conan/tket-conan
+    - name: authenticate to repository
+      run: conan user -p ${{ secrets.JFROG_ARTIFACTORY_TOKEN_1 }} -r tket-conan ${{ secrets.JFROG_ARTIFACTORY_USER_1 }}
+    - name: get version
+      run: |
+        $symengine_ver = conan inspect --raw version recipes/symengine/
+        echo "SYMENGINE_VER=${symengine_ver}" >> $env:GITHUB_ENV
+    - name: upload package (dry run)
+      if: github.event_name == 'pull_request'
+      run: conan upload symengine/${{ env.SYMENGINE_VER }}@tket/stable --all -r=tket-conan --skip-upload
+    - name: upload package
+      if: github.event_name == 'push'
+      run: conan upload symengine/${{ env.SYMENGINE_VER }}@tket/stable --all -r=tket-conan

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -32,6 +32,7 @@ jobs:
     env:
       CC: gcc-10
       CXX: g++-10
+      CONAN_REVISIONS_ENABLED: 1
     steps:
     - uses: actions/checkout@v2
       with:
@@ -59,13 +60,12 @@ jobs:
         ${conan_cmd} profile update options.tket:shared=True tket
         ${conan_cmd} profile update settings.build_type=Debug tket
         echo "CONAN_CMD=${conan_cmd}" >> $GITHUB_ENV
+    - name: add remote
+      run: ${CONAN_CMD} remote add tket-conan https://tket.jfrog.io/artifactory/api/conan/tket-conan
     - name: Install ninja and ccache
       run: |
         sudo apt-get update
         sudo apt-get install ninja-build ccache
-    - name: Build symengine
-      run:
-        ${CONAN_CMD} create --profile=tket recipes/symengine
     - name: Build tket
       run: |
         ${CONAN_CMD} install recipes/tket --install-folder=build/tket --profile=tket -o tket:profile_coverage=True

--- a/.github/workflows/linuxbuildwheel
+++ b/.github/workflows/linuxbuildwheel
@@ -22,12 +22,13 @@ export PYBIN=/opt/python/cp39-cp39/bin
 ${PYBIN}/pip install conan
 
 export CONAN_CMD=${PYBIN}/conan
+export CONAN_REVISIONS_ENABLED=1
 
 cd /tket
 
 ${CONAN_CMD} profile new tket --detect
 ${CONAN_CMD} profile update options.tket:shared=True tket
-${CONAN_CMD} create --profile=tket recipes/symengine
+${CONAN_CMD} remote add tket-conan https://tket.jfrog.io/artifactory/api/conan/tket-conan
 # Use header-only version of spdlog:
 # https://github.com/conan-io/conan-docker-tools/issues/303#issuecomment-922492130
 ${CONAN_CMD} create --profile=tket --test-folder=None -o tket:spdlog_ho=True recipes/tket

--- a/.github/workflows/pytket_docs.yml
+++ b/.github/workflows/pytket_docs.yml
@@ -10,6 +10,7 @@ jobs:
     name: build docs
     runs-on: ubuntu-20.04
     env:
+      CONAN_REVISIONS_ENABLED: 1
       PYTKET_SKIP_REGISTRATION: "true"
     strategy:
       matrix:
@@ -58,8 +59,8 @@ jobs:
         conan profile new tket --detect
         conan profile update options.tket:shared=True tket
         conan profile update settings.compiler.libcxx=libstdc++11 tket
-    - name: Build symengine
-      run: conan create --profile=tket recipes/symengine
+    - name: add remote
+      run: conan remote add tket-conan https://tket.jfrog.io/artifactory/api/conan/tket-conan
     - name: Build tket
       run: conan create --profile=tket recipes/tket
     - name: Install pybind11

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,7 @@ jobs:
         pip install conan
         conan profile new tket --detect --force
         conan profile update options.tket:shared=True tket
-        conan remote add tket-conan https://tket.jfrog.io/artifactory/api/conan/tket-conan
+        conan remote add tket-conan https://tket.jfrog.io/artifactory/api/conan/tket-conan --force
         conan install --profile=tket boost/1.78.0@ --build=missing
         conan create --profile=tket recipes/tket
     - name: Install pybind11

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,8 @@ jobs:
   build_macos_wheels:
     name: Build macos wheels
     runs-on: macos-11
+    env:
+      CONAN_REVISIONS_ENABLED: 1
     steps:
     - uses: actions/checkout@v2
       with:
@@ -65,8 +67,8 @@ jobs:
         pip install conan
         conan profile new tket --detect --force
         conan profile update options.tket:shared=True tket
+        conan remote add tket-conan https://tket.jfrog.io/artifactory/api/conan/tket-conan
         conan install --profile=tket boost/1.78.0@ --build=missing
-        conan create --profile=tket recipes/symengine
         conan create --profile=tket recipes/tket
     - name: Install pybind11
       run: conan create --profile=tket recipes/pybind11
@@ -98,6 +100,8 @@ jobs:
   build_macos_M1_wheels:
     name: Build macos (M1) wheels
     runs-on: [self-hosted, macos, M1]
+    env:
+      CONAN_REVISIONS_ENABLED: 1
     defaults:
       run:
         shell: "/usr/bin/arch -arch arm64e /bin/bash {0}"
@@ -112,8 +116,8 @@ jobs:
         pyenv shell tket-3.8
         conan profile new tket --detect --force
         conan profile update options.tket:shared=True tket
+        conan remote add tket-conan https://tket.jfrog.io/artifactory/api/conan/tket-conan --force
         conan install --profile=tket boost/1.78.0@ --build=missing
-        conan create --profile=tket recipes/symengine
         conan create --profile=tket recipes/tket
         conan create --profile=tket recipes/pybind11
         .github/workflows/build_macos_m1_wheel
@@ -129,6 +133,8 @@ jobs:
   build_Windows_wheels:
     name: Build Windows wheels
     runs-on: windows-2019
+    env:
+      CONAN_REVISIONS_ENABLED: 1
     steps:
     - uses: actions/checkout@v2
       with:
@@ -160,14 +166,14 @@ jobs:
         conan profile update options.tket:shared=True tket
         $conan_cmd = (gcm conan).Path
         echo "CONAN_CMD=${conan_cmd}" >> $GITHUB_ENV
+    - name: add remote
+      run: conan remote add tket-conan https://tket.jfrog.io/artifactory/api/conan/tket-conan
     - name: Cache tket build
       id: cache-tket
       uses: actions/cache@v2
       with:
         path: C:\Users\runneradmin\.conan\data\tket
         key: ${{ runner.os }}-tket-tket-${{ steps.hash_tket_source.outputs.tket_hash }}-8
-    - name: Build symengine
-      run: conan create --profile=tket recipes/symengine
     - name: Build tket
       if: steps.cache-tket.outputs.cache-hit != 'true'
       run: conan create --profile=tket recipes/tket

--- a/README.md
+++ b/README.md
@@ -147,9 +147,9 @@ The `symengine` dependency is built from a local conan recipe. Run:
 conan create --profile=tket recipes/symengine
 ```
 
-to build it. If you are using a conan configuration supported by the CI, this is
-unnecessary as a pre-built package will be downloaded from the `tket-conan`
-repository when you build `tket`.
+to build it. If you are using a conan configuration supported by the CI
+(see above under "Build tools"), this is unnecessary as a pre-built package
+will be downloaded from the `tket-conan` repository when you build `tket`.
 
 ### Building tket
 

--- a/README.md
+++ b/README.md
@@ -82,6 +82,18 @@ recommended in the warning message:
 conan profile update settings.compiler.libcxx=libstdc++11 tket
 ```
 
+Add the `tket.conan` repository to your remotes:
+
+```shell
+conan remote add tket-conan https://tket.jfrog.io/artifactory/api/conan/tket-conan
+```
+
+Enable revisions:
+
+```shell
+conan config set general.revisions_enabled=1
+```
+
 We want to build shared rather than static libraries, so set this in the
 profile:
 

--- a/README.md
+++ b/README.md
@@ -147,7 +147,9 @@ The `symengine` dependency is built from a local conan recipe. Run:
 conan create --profile=tket recipes/symengine
 ```
 
-to build it.
+to build it. If you are using a conan configuration supported by the CI, this is
+unnecessary as a pre-built package will be downloaded from the `tket-conan`
+repository when you build `tket`.
 
 ### Building tket
 

--- a/recipes/tket/conanfile.py
+++ b/recipes/tket/conanfile.py
@@ -41,7 +41,7 @@ class TketConan(ConanFile):
     exports = ["patches/*"]
     requires = (
         "boost/1.78.0",
-        "symengine/0.8.1.1",
+        "symengine/0.8.1.1@tket/stable",
         "eigen/3.4.0",
         "spdlog/1.9.2",
         "nlohmann_json/3.10.4",

--- a/recipes/tket/conanfile.py
+++ b/recipes/tket/conanfile.py
@@ -41,6 +41,7 @@ class TketConan(ConanFile):
     exports = ["patches/*"]
     requires = (
         "boost/1.78.0",
+        # symengine from remote: https://tket.jfrog.io/artifactory/api/conan/tket-conan
         "symengine/0.8.1.1@tket/stable",
         "eigen/3.4.0",
         "spdlog/1.9.2",


### PR DESCRIPTION
The plan is to have tket components individually versioned, packaged and hosted on tket.jfrog.io in a new `tket-conan` repository. This should help make tket more modular and extensible, as well as reducing build times.

As a "warm-up", and to save having to build symengine on the CI, I have:
* added a workflow that builds symengine (from our own recipe) and uploads the packages to `tket-conan`, in several configurations (4 platforms x Release/Debug x shared/static);
* changed the CI workflows that build tket so that they can just download symengine from the new remote instead of having to build it;
* added the necessary credentials as github secrets;
* run the workflows, to test them and populate the repository.

The `build_symengine` workflow is run only for PRs and pushes to `develop` that change the symengine recipe. In the PR workflow the artefacts are not actually uploaded; in the push workflow they are.