### PR TITLE
Add StandardPass for basic qubit relabelling

### DIFF
--- a/pytket/binders/passes.cpp
+++ b/pytket/binders/passes.cpp
@@ -495,6 +495,14 @@ PYBIND11_MODULE(passes, m) {
       "\n:return: a pass to relabel :py:class:`Circuit` Qubits to "
       ":py:class:`Architecture` Nodes",
       py::arg("placer"));
+    
+  m.def(
+      "NaivePlacementPass", &gen_naive_placement_pass,
+      ":param architecture: The Architecture used for relabelling."
+      "\n:return: a pass to relabel :py:class:`Circuit` Qubits to "
+      ":py:class:`Architecture` Nodes",
+      py::arg("arc"));
+
 
   m.def(
       "RenameQubitsPass", &gen_rename_qubits_pass, "Rename some or all qubits.",

--- a/pytket/tests/predicates_test.py
+++ b/pytket/tests/predicates_test.py
@@ -32,6 +32,7 @@ from pytket.passes import (  # type: ignore
     RoutingPass,
     CXMappingPass,
     PlacementPass,
+    NaivePlacementPass,
     RenameQubitsPass,
     FullMappingPass,
     DefaultMappingPass,
@@ -202,14 +203,29 @@ def test_routing_and_placement_pass() -> None:
     pl = Placement(arc)
     routing = RoutingPass(arc)
     placement = PlacementPass(pl)
+    nplacement = NaivePlacementPass(arc)
     cu = CompilationUnit(circ.copy())
     assert placement.apply(cu)
     assert routing.apply(cu)
+    assert nplacement.apply(cu)
     expected_map = {q[0]: n1, q[1]: n0, q[2]: n2, q[3]: n5, q[4]: n3}
     assert cu.initial_map == expected_map
 
+    cu1 = CompilationUnit(circ.copy())
+    assert nplacement.apply(cu1)
+    arcnodes = arc.nodes
+    expected_nmap = {
+        q[0]: arcnodes[0],
+        q[1]: arcnodes[1],
+        q[2]: arcnodes[2],
+        q[3]: arcnodes[3],
+        q[4]: arcnodes[4],
+    }
+    assert cu1.initial_map == expected_nmap
     # check composition works ok
-    seq_pass = SequencePass([SynthesiseTket(), placement, routing, SynthesiseUMD()])
+    seq_pass = SequencePass(
+        [SynthesiseTket(), placement, routing, nplacement, SynthesiseUMD()]
+    )
     cu2 = CompilationUnit(circ.copy())
     assert seq_pass.apply(cu2)
     assert cu2.initial_map == expected_map
@@ -223,7 +239,7 @@ def test_routing_and_placement_pass() -> None:
 
 def test_default_mapping_pass() -> None:
     circ = Circuit()
-    q = circ.add_q_register("q", 5)
+    q = circ.add_q_register("q", 6)
     circ.CX(0, 1)
     circ.H(0)
     circ.Z(1)
@@ -233,14 +249,17 @@ def test_default_mapping_pass() -> None:
     circ.X(2)
     circ.CX(1, 4)
     circ.CX(0, 4)
+    circ.H(5)
     n0 = Node("b", 0)
     n1 = Node("b", 1)
     n2 = Node("b", 2)
     n3 = Node("a", 0)
     n4 = Node("f", 0)
-    arc = Architecture([[n0, n1], [n1, n2], [n2, n3], [n3, n4]])
+    n5 = Node("g", 7)
+    arc = Architecture([[n0, n1], [n1, n2], [n2, n3], [n3, n4], [n4, n5]])
     pl = GraphPlacement(arc)
 
+    nplacement = NaivePlacementPass(arc)
     routing = RoutingPass(arc)
     placement = PlacementPass(pl)
     default = DefaultMappingPass(arc)
@@ -249,6 +268,7 @@ def test_default_mapping_pass() -> None:
 
     assert placement.apply(cu_rp)
     assert routing.apply(cu_rp)
+    assert nplacement.apply(cu_rp)
     assert default.apply(cu_def)
     assert cu_rp.circuit == cu_def.circuit
 
@@ -650,6 +670,10 @@ def test_generated_pass_config() -> None:
     assert p_pass.to_dict()["StandardPass"]["name"] == "PlacementPass"
     assert p_pass.to_dict()["StandardPass"]["placement"]["type"] == "GraphPlacement"
     assert p_pass.to_dict()["StandardPass"]["placement"]["config"]["depth_limit"] == 5
+    # NaivePlacementPass
+    np_pass = NaivePlacementPass(arc)
+    assert np_pass.to_dict()["StandardPass"]["name"] == "NaivePlacementPass"
+    assert check_arc_dict(arc, np_pass.to_dict()["StandardPass"]["architecture"])
     # RenameQubitsPass
     qm = {Qubit("a", 0): Qubit("b", 1), Qubit("a", 1): Qubit("b", 0)}
     rn_pass = RenameQubitsPass(qm)
@@ -660,10 +684,19 @@ def test_generated_pass_config() -> None:
     # FullMappingPass
     fm_pass = FullMappingPass(arc, placer, config=[LexiRouteRoutingMethod()])
     assert fm_pass.to_dict()["pass_class"] == "SequencePass"
+    # # for x in fm_pass.get_sequence():
+    # #     print(x)
+    # fm_pass_seq = fm_pass.get_sequence()
+    # for x in fm_pass_seq[0].get_sequence():
+    #     print(x.to_dict())
+    # print(fm_pass_seq[1].to_dict())
+
     p_pass = fm_pass.get_sequence()[0]
     r_pass = fm_pass.get_sequence()[1]
-    assert p_pass.to_dict()["StandardPass"]["name"] == "PlacementPass"
+    np_pass = fm_pass.get_sequence()[2]
+    assert np_pass.to_dict()["StandardPass"]["name"] == "NaivePlacementPass"
     assert r_pass.to_dict()["StandardPass"]["name"] == "RoutingPass"
+    assert p_pass.to_dict()["StandardPass"]["name"] == "PlacementPass"
     assert check_arc_dict(arc, r_pass.to_dict()["StandardPass"]["architecture"])
     assert p_pass.to_dict()["StandardPass"]["placement"]["type"] == "GraphPlacement"
     # DefaultMappingPass
@@ -671,20 +704,24 @@ def test_generated_pass_config() -> None:
     assert dm_pass.to_dict()["pass_class"] == "SequencePass"
     p_pass = dm_pass.get_sequence()[0].get_sequence()[0]
     r_pass = dm_pass.get_sequence()[0].get_sequence()[1]
+    np_pass = dm_pass.get_sequence()[0].get_sequence()[2]
     d_pass = dm_pass.get_sequence()[1]
     assert d_pass.to_dict()["StandardPass"]["name"] == "DelayMeasures"
     assert p_pass.to_dict()["StandardPass"]["name"] == "PlacementPass"
+    assert np_pass.to_dict()["StandardPass"]["name"] == "NaivePlacementPass"
     assert r_pass.to_dict()["StandardPass"]["name"] == "RoutingPass"
     assert check_arc_dict(arc, r_pass.to_dict()["StandardPass"]["architecture"])
     assert p_pass.to_dict()["StandardPass"]["placement"]["type"] == "GraphPlacement"
     # DefaultMappingPass with delay_measures=False
     dm_pass = DefaultMappingPass(arc, False)
     assert dm_pass.to_dict()["pass_class"] == "SequencePass"
-    assert len(dm_pass.get_sequence()) == 2
+    assert len(dm_pass.get_sequence()) == 3
     p_pass = dm_pass.get_sequence()[0]
     r_pass = dm_pass.get_sequence()[1]
+    np_pass = dm_pass.get_sequence()[2]
     assert p_pass.to_dict()["StandardPass"]["name"] == "PlacementPass"
     assert r_pass.to_dict()["StandardPass"]["name"] == "RoutingPass"
+    assert np_pass.to_dict()["StandardPass"]["name"] == "NaivePlacementPass"
     assert check_arc_dict(arc, r_pass.to_dict()["StandardPass"]["architecture"])
     assert p_pass.to_dict()["StandardPass"]["placement"]["type"] == "GraphPlacement"
     # AASRouting

--- a/schemas/compiler_pass_v1.json
+++ b/schemas/compiler_pass_v1.json
@@ -407,6 +407,20 @@
           "if": {
             "properties": {
               "name": {
+                "const": "NaivePlacementPass"
+              }
+            }
+          },
+          "then": {
+            "required": [
+              "architecture"
+            ]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "name": {
                 "const": "RoutingPass"
               }
             }

--- a/tket/src/Placement/include/Placement/Placement.hpp
+++ b/tket/src/Placement/include/Placement/Placement.hpp
@@ -269,6 +269,16 @@ class Placement {
   Architecture arc_;
 };
 
+class NaivePlacement : public Placement {
+ public:
+  explicit NaivePlacement(const Architecture& _arc) { arc_ = _arc; }
+
+  qubit_mapping_t get_placement_map(const Circuit& circ_) const override;
+
+  std::vector<qubit_mapping_t> get_all_placement_maps(
+      const Circuit& circ_) const override;
+};
+
 class LinePlacement : public Placement {
  public:
   explicit LinePlacement(const Architecture& _arc) { arc_ = _arc; }

--- a/tket/src/Predicates/CompilerPass.cpp
+++ b/tket/src/Predicates/CompilerPass.cpp
@@ -438,6 +438,8 @@ void from_json(const nlohmann::json& j, PassPtr& pp) {
 
     } else if (passname == "PlacementPass") {
       pp = gen_placement_pass(content.at("placement").get<PlacementPtr>());
+    } else if (passname == "NaivePlacementPass") {
+      pp = gen_naive_placement_pass(content.at("architecture").get<Architecture>());
     } else if (passname == "RenameQubitsPass") {
       pp = gen_rename_qubits_pass(
           content.at("qubit_map").get<std::map<Qubit, Qubit>>());

--- a/tket/src/Predicates/PassGenerators.cpp
+++ b/tket/src/Predicates/PassGenerators.cpp
@@ -182,10 +182,34 @@ PassPtr gen_placement_pass(const PlacementPtr& placement_ptr) {
   return std::make_shared<StandardPass>(precons, t, pc, j);
 }
 
+PassPtr gen_naive_placement_pass(const Architecture& arc) {
+  Transform::Transformation trans = [=](Circuit& circ,
+                                        std::shared_ptr<unit_bimaps_t> maps) {
+    NaivePlacement np(arc);
+    return np.place(circ, maps);
+  };
+  Transform t = Transform(trans);
+  PredicatePtr n_qubit_pred = std::make_shared<MaxNQubitsPredicate>(arc.n_nodes());
+
+  PredicatePtrMap precons{
+      CompilationUnit::make_type_pair(n_qubit_pred)};
+  PredicatePtr placement_pred = std::make_shared<PlacementPredicate>(arc);
+  PredicatePtrMap s_postcons{CompilationUnit::make_type_pair(placement_pred)};
+  PostConditions pc{s_postcons, {}, Guarantee::Preserve};
+  // record pass config
+  nlohmann::json j;
+  j["name"] = "NaivePlacementPass";
+  j["architecture"] = arc;
+  return std::make_shared<StandardPass>(precons, t, pc, j);
+}
+
 PassPtr gen_full_mapping_pass(
     const Architecture& arc, const PlacementPtr& placement_ptr,
     const std::vector<RoutingMethodPtr>& config) {
-  return gen_placement_pass(placement_ptr) >> gen_routing_pass(arc, config);
+    
+    std::vector<PassPtr> vpp = {gen_placement_pass(placement_ptr), gen_routing_pass(arc, config),
+         gen_naive_placement_pass(arc)};
+  return std::make_shared<SequencePass>(vpp);
 }
 
 PassPtr gen_default_mapping_pass(const Architecture& arc, bool delay_measures) {

--- a/tket/src/Predicates/include/Predicates/PassGenerators.hpp
+++ b/tket/src/Predicates/include/Predicates/PassGenerators.hpp
@@ -45,6 +45,8 @@ PassPtr gen_clifford_simp_pass(bool allow_swaps = true);
 PassPtr gen_rename_qubits_pass(const std::map<Qubit, Qubit>& qm);
 
 PassPtr gen_placement_pass(const PlacementPtr& placement_ptr);
+
+PassPtr gen_naive_placement_pass(const Architecture& arc);
 /* This higher order function generates a Routing pass using the
 std::vector<RoutingMethodPtr> object */
 PassPtr gen_full_mapping_pass(

--- a/tket/tests/test_CompilerPass.cpp
+++ b/tket/tests/test_CompilerPass.cpp
@@ -234,12 +234,13 @@ SCENARIO("Test making (mostly routing) passes using PassGenerators") {
     }
   }
   GIVEN("Synthesise Passes in a row then routing") {
-    Circuit circ(4);
+    Circuit circ(5);
     circ.add_op<unsigned>(OpType::H, {0});
     circ.add_op<unsigned>(OpType::CZ, {0, 1});
     circ.add_op<unsigned>(OpType::CH, {0, 2});
     circ.add_op<unsigned>(OpType::CnX, {0, 1, 2, 3});
     circ.add_op<unsigned>(OpType::CZ, {0, 1});
+    circ.add_op<unsigned>(OpType::X, {4});
     OpTypeSet ots = {OpType::CX, OpType::TK1, OpType::SWAP};
     PredicatePtr gsp = std::make_shared<GateSetPredicate>(ots);
     SquareGrid grid(2, 3);

--- a/tket/tests/test_Placement.cpp
+++ b/tket/tests/test_Placement.cpp
@@ -434,16 +434,6 @@ SCENARIO("Check Monomorpher satisfies correct placement conditions") {
       }
 
       Monomorpher morph(test_circ, arc, {}, {10, arc.n_connections()});
-      /*std::vector<MapCost> results = morph.place(1);
-      THEN("The circuit is placed in the highly connected region.") {
-          std::set<Vertex> middle_nodes = {5, 6, 9, 10};
-          for (auto map : results) {
-              for (auto mapping : map.map) {
-                  REQUIRE(middle_nodes.find(arc.map_node(
-                                  mapping.second)) != middle_nodes.end());
-              }
-          }
-      }*/
     }
   }
 }
@@ -497,9 +487,68 @@ SCENARIO(
     REQUIRE(potential_maps.size() > 0);
   }
 }
+SCENARIO("Test NaivePlacement class") {
+  Architecture test_arc({{0, 1}, {1, 2}, {2, 3}, {3, 4}, {4, 5}, {5, 6}});
+  GIVEN(
+      "No Qubits placed in Circuit, same number of qubits and architecture "
+      "nodes.") {
+    Circuit test_circ(7);
+    NaivePlacement np(test_arc);
+    qubit_mapping_t p = np.get_placement_map(test_circ);
+    REQUIRE(p[Qubit(0)] == Node(0));
+    REQUIRE(p[Qubit(1)] == Node(1));
+    REQUIRE(p[Qubit(2)] == Node(2));
+    REQUIRE(p[Qubit(3)] == Node(3));
+    REQUIRE(p[Qubit(4)] == Node(4));
+    REQUIRE(p[Qubit(5)] == Node(5));
+    REQUIRE(p[Qubit(6)] == Node(6));
+  }
+  GIVEN("No Qubits placed in Circuit, less qubits than architecture nodes.") {
+    Circuit test_circ(6);
+    NaivePlacement np(test_arc);
+    qubit_mapping_t p = np.get_placement_map(test_circ);
+    REQUIRE(p[Qubit(0)] == Node(0));
+    REQUIRE(p[Qubit(1)] == Node(1));
+    REQUIRE(p[Qubit(2)] == Node(2));
+    REQUIRE(p[Qubit(3)] == Node(3));
+    REQUIRE(p[Qubit(4)] == Node(4));
+    REQUIRE(p[Qubit(5)] == Node(5));
+  }
+  GIVEN(
+      "Some Qubits placed in Circuit, same number of qubits and architecture "
+      "nodes.") {
+    Circuit test_circ(4);
+    test_circ.add_qubit(Node(0));
+    test_circ.add_qubit(Node(1));
+    test_circ.add_qubit(Node(2));
+    NaivePlacement np(test_arc);
+    qubit_mapping_t p = np.get_placement_map(test_circ);
+
+    REQUIRE(p[Qubit(0)] == Node(3));
+    REQUIRE(p[Qubit(1)] == Node(4));
+    REQUIRE(p[Qubit(2)] == Node(5));
+    REQUIRE(p[Qubit(3)] == Node(6));
+    REQUIRE(p[Node(0)] == Node(0));
+    REQUIRE(p[Node(1)] == Node(1));
+    REQUIRE(p[Node(2)] == Node(2));
+  }
+  GIVEN("Some Qubits placed in Circuit, less qubits than architecture nodes.") {
+    Circuit test_circ(2);
+    test_circ.add_qubit(Node(0));
+    test_circ.add_qubit(Node(1));
+    test_circ.add_qubit(Node(2));
+    NaivePlacement np(test_arc);
+    qubit_mapping_t p = np.get_placement_map(test_circ);
+
+    REQUIRE(p[Qubit(0)] == Node(3));
+    REQUIRE(p[Qubit(1)] == Node(4));
+    REQUIRE(p[Node(0)] == Node(0));
+    REQUIRE(p[Node(1)] == Node(1));
+    REQUIRE(p[Node(2)] == Node(2));
+  }
+}
 
 // Tests for new placement method wrappers
-
 SCENARIO(
     "Does the base Placement class correctly modify Circuits and return "
     "maps?") {

--- a/tket/tests/test_json.cpp
+++ b/tket/tests/test_json.cpp
@@ -619,6 +619,7 @@ SCENARIO("Test compiler pass serializations") {
   COMPPASSJSONTEST(PlacementPass, gen_placement_pass(place))
   // TKET-1419
   COMPPASSJSONTEST(NoiseAwarePlacement, gen_placement_pass(na_place))
+  COMPPASSJSONTEST(NaivePlacementPass, gen_naive_placement_pass(arc))
 #undef COMPPASSJSONTEST
   GIVEN("RoutingPass") {
     // Can only be applied to placed circuits


### PR DESCRIPTION
Via the NaivePlacement class and NaiveMappingPass.

Current Placement pass will relabel all qubits (whether they are already an architecture qubit or not) and frequently will leave some as "unplaced", prompting Routing to label it later.

Mapping confirms that all two-qubit constraints are satisfied -> if a Qubit is unlabelled and only has single qubit gates it will remain unlabelled.

Compilation should not leave these qubits unlabelled -> this PR adds a placement method for naively assigning any unlabelled qubit to any unassigned architecture qubit. Its use in `FullMappingPass` is reasonable as we can assume that any unlabelled qubits have only single qubit gates and so this assignment is fine.