### PR TITLE
Don't invoke `setup.py` directly

### DIFF
--- a/.github/workflows/build_macos_m1_wheel
+++ b/.github/workflows/build_macos_m1_wheel
@@ -16,9 +16,8 @@
 
 set -evu
 
-pip install conan delocate wheel
 cd $GITHUB_WORKSPACE/pytket
 export PYVER=`python -c 'import sys; print(".".join(map(str, sys.version_info[:3])))'`
-python -m pip install -U pip setuptools_scm
-python setup.py bdist_wheel -d "$GITHUB_WORKSPACE/tmp/tmpwheel_${PYVER}"
+python -m pip install -U pip build delocate
+python -m build --outdir "$GITHUB_WORKSPACE/tmp/tmpwheel_${PYVER}"
 delocate-wheel -v -w "$GITHUB_WORKSPACE/wheelhouse/${PYVER}/" "$GITHUB_WORKSPACE/tmp/tmpwheel_${PYVER}/pytket-"*".whl"

--- a/.github/workflows/build_macos_wheel
+++ b/.github/workflows/build_macos_wheel
@@ -16,9 +16,10 @@
 
 set -evu
 
-pip install conan delocate wheel
 cd $GITHUB_WORKSPACE/pytket
 export PYVER=`python -c 'import sys; print(".".join(map(str, sys.version_info[:3])))'`
-python -m pip install -U pip setuptools_scm
-python setup.py bdist_wheel -d "$GITHUB_WORKSPACE/tmp/tmpwheel_${PYVER}" --plat-name=macosx_10_14_x86_64
+# Ensure wheels are compatible with MacOS 10.14 and later:
+export WHEEL_PLAT_NAME=macosx_10_14_x86_64
+python -m pip install -U pip build delocate
+python -m build --outdir "$GITHUB_WORKSPACE/tmp/tmpwheel_${PYVER}"
 delocate-wheel -v -w "$GITHUB_WORKSPACE/wheelhouse/${PYVER}/" "$GITHUB_WORKSPACE/tmp/tmpwheel_${PYVER}/pytket-"*".whl"

--- a/.github/workflows/linuxbuildwheel
+++ b/.github/workflows/linuxbuildwheel
@@ -42,7 +42,7 @@ do
     cd /tket/pytket
     export PYEX=/opt/python/${pyX}/bin/python
     export PYVER=`${PYEX} -c 'import sys; print(".".join(map(str, sys.version_info[:3])))'`
-    ${PYEX} -m pip install -U pip setuptools_scm
-    ${PYEX} setup.py bdist_wheel -d "tmpwheel_${PYVER}"
+    ${PYEX} -m pip install -U pip build
+    ${PYEX} -m build --outdir "tmpwheel_${PYVER}"
     auditwheel repair "tmpwheel_${PYVER}/pytket-"*".whl" -w "audited/${PYVER}/"
 done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -179,10 +179,9 @@ jobs:
         python-version: '3.8'
     - name: Build wheel (3.8)
       run: |
-        pip install wheel
         cd pytket
-        python -m pip install -U pip setuptools_scm
-        python setup.py bdist_wheel -d "${{ github.workspace }}/wheelhouse/3.8"
+        python -m pip install -U pip build
+        python -m build --outdir "${{ github.workspace }}/wheelhouse/3.8"
     - uses: actions/upload-artifact@v2
       with:
         name: Windows_wheels
@@ -193,10 +192,9 @@ jobs:
         python-version: '3.9'
     - name: Build wheel (3.9)
       run: |
-        pip install wheel
         cd pytket
-        python -m pip install -U pip setuptools_scm
-        python setup.py bdist_wheel -d "${{ github.workspace }}/wheelhouse/3.9"
+        python -m pip install -U pip build
+        python -m build --outdir "${{ github.workspace }}/wheelhouse/3.9"
     - uses: actions/upload-artifact@v2
       with:
         name: Windows_wheels
@@ -207,10 +205,9 @@ jobs:
         python-version: '3.10'
     - name: Build wheel (3.10)
       run: |
-        pip install wheel
         cd pytket
-        python -m pip install -U pip setuptools_scm
-        python setup.py bdist_wheel -d "${{ github.workspace }}/wheelhouse/3.10"
+        python -m pip install -U pip build
+        python -m build --outdir "${{ github.workspace }}/wheelhouse/3.10"
     - uses: actions/upload-artifact@v2
       with:
         name: Windows_wheels

--- a/pytket/pyproject.toml
+++ b/pytket/pyproject.toml
@@ -1,8 +1,3 @@
 [build-system]
-requires = ["setuptools>=45", "wheel", "setuptools_scm>=6.2", "conan"]
+requires = ["setuptools>=45", "wheel", "setuptools_scm>=6.4", "conan"]
 build-backend = "setuptools.build_meta"
-
-[tool.setuptools_scm]
-root = ".."
-write_to = "pytket/pytket/_version.py"
-write_to_template = '__version__ = "{version}"'

--- a/pytket/setup.py
+++ b/pytket/setup.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import io
 import os
 import platform
 import re
@@ -22,12 +21,12 @@ import json
 import shutil
 from multiprocessing import cpu_count
 from distutils.version import LooseVersion
+from concurrent.futures import ThreadPoolExecutor as Pool
+from shutil import which
 import setuptools  # type: ignore
 from setuptools import setup, Extension
 from setuptools.command.build_ext import build_ext  # type: ignore
 from wheel.bdist_wheel import bdist_wheel as _bdist_wheel
-from concurrent.futures import ThreadPoolExecutor as Pool
-from shutil import which
 
 
 class CMakeExtension(Extension):
@@ -241,7 +240,8 @@ setup(
     author_email="seyon.sivarajah@cambridgequantum.com",
     python_requires=">=3.8",
     url="https://cqcl.github.io/pytket",
-    description="Python module for interfacing with the CQC tket library of quantum software",
+    description="Python module for interfacing with the CQC tket library of quantum "
+    "software",
     license="Apache 2",
     packages=setuptools.find_packages(),
     install_requires=[


### PR DESCRIPTION
Use the recommended `python -m build` instead when building wheels.

Tested [here](https://github.com/CQCL/tket/actions/runs/1891988648).

Closes #112 .