### PR TITLE
[infra] Separated test utils from tests

### DIFF
--- a/tket/tests/CMakeLists.txt
+++ b/tket/tests/CMakeLists.txt
@@ -44,9 +44,10 @@ endif()
 
 set(TKET_TESTS_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 
+include(tkettestutilsfiles.cmake)
 include(tkettestsfiles.cmake)
 
-add_executable(test_tket ${TEST_SOURCES})
+add_executable(test_tket ${TESTUTILS_SOURCES} ${TEST_SOURCES})
 
 target_link_libraries(test_tket PRIVATE
     tket-ArchAwareSynth

--- a/tket/tests/tkettestsfiles.cmake
+++ b/tket/tests/tkettestsfiles.cmake
@@ -20,18 +20,10 @@ set(TEST_SOURCES
     # We should test simpler modules (e.g. Op, Circuit) before
     # the more complicated things that rely on them (e.g. Routing,
     # Transform) to help identify exactly where stuff breaks
-    ${TKET_TESTS_DIR}/tests_main.cpp
-    ${TKET_TESTS_DIR}/testutil.cpp
-    ${TKET_TESTS_DIR}/CircuitsForTesting.cpp
     ${TKET_TESTS_DIR}/Utils/test_CosSinDecomposition.cpp
     ${TKET_TESTS_DIR}/Utils/test_HelperFunctions.cpp
     ${TKET_TESTS_DIR}/Utils/test_MatrixAnalysis.cpp
     ${TKET_TESTS_DIR}/Utils/test_RNG.cpp
-    ${TKET_TESTS_DIR}/Graphs/EdgeSequence.cpp
-    ${TKET_TESTS_DIR}/Graphs/EdgeSequenceColouringParameters.cpp
-    ${TKET_TESTS_DIR}/Graphs/GraphTestingRoutines.cpp
-    ${TKET_TESTS_DIR}/Graphs/RandomGraphGeneration.cpp
-    ${TKET_TESTS_DIR}/Graphs/RandomPlanarGraphs.cpp
     ${TKET_TESTS_DIR}/Graphs/test_GraphColouring.cpp
     ${TKET_TESTS_DIR}/Graphs/test_GraphFindComponents.cpp
     ${TKET_TESTS_DIR}/Graphs/test_GraphFindMaxClique.cpp
@@ -42,25 +34,11 @@ set(TEST_SOURCES
     # NOTE: For testing TokenSwapping, it is easier to make use of
     # Architecture to set up test problems, rather than trying
     # to separate TokenSwapping-without-Architecture tests.
-    ${TKET_TESTS_DIR}/TokenSwapping/Data/FixedCompleteSolutions.cpp
-    ${TKET_TESTS_DIR}/TokenSwapping/Data/FixedSwapSequences.cpp
-    ${TKET_TESTS_DIR}/TokenSwapping/TableLookup/NeighboursFromEdges.cpp
-    ${TKET_TESTS_DIR}/TokenSwapping/TableLookup/PermutationTestUtils.cpp
-    ${TKET_TESTS_DIR}/TokenSwapping/TableLookup/SwapSequenceReductionTester.cpp
     ${TKET_TESTS_DIR}/TokenSwapping/TableLookup/test_CanonicalRelabelling.cpp
     ${TKET_TESTS_DIR}/TokenSwapping/TableLookup/test_ExactMappingLookup.cpp
     ${TKET_TESTS_DIR}/TokenSwapping/TableLookup/test_FilteredSwapSequences.cpp
     ${TKET_TESTS_DIR}/TokenSwapping/TableLookup/test_SwapSequenceReductions.cpp
     ${TKET_TESTS_DIR}/TokenSwapping/TableLookup/test_SwapSequenceTable.cpp
-    ${TKET_TESTS_DIR}/TokenSwapping/TestUtils/ArchitectureEdgesReimplementation.cpp
-    ${TKET_TESTS_DIR}/TokenSwapping/TestUtils/BestTsaTester.cpp
-    ${TKET_TESTS_DIR}/TokenSwapping/TestUtils/DebugFunctions.cpp
-    ${TKET_TESTS_DIR}/TokenSwapping/TestUtils/DecodedProblemData.cpp
-    ${TKET_TESTS_DIR}/TokenSwapping/TestUtils/FullTsaTesting.cpp
-    ${TKET_TESTS_DIR}/TokenSwapping/TestUtils/GetRandomSet.cpp
-    ${TKET_TESTS_DIR}/TokenSwapping/TestUtils/PartialTsaTesting.cpp
-    ${TKET_TESTS_DIR}/TokenSwapping/TestUtils/ProblemGeneration.cpp
-    ${TKET_TESTS_DIR}/TokenSwapping/TestUtils/TestStatsStructs.cpp
     ${TKET_TESTS_DIR}/TokenSwapping/TestUtils/test_DebugFunctions.cpp
     ${TKET_TESTS_DIR}/TokenSwapping/TSAUtils/test_SwapFunctions.cpp
     ${TKET_TESTS_DIR}/TokenSwapping/test_ArchitectureMappingEndToEnd.cpp
@@ -78,9 +56,7 @@ set(TEST_SOURCES
     ${TKET_TESTS_DIR}/Ops/test_ClassicalOps.cpp
     ${TKET_TESTS_DIR}/Ops/test_Expression.cpp
     ${TKET_TESTS_DIR}/Ops/test_Ops.cpp
-    ${TKET_TESTS_DIR}/Gate/GatesData.cpp
     ${TKET_TESTS_DIR}/Gate/test_GateUnitaryMatrix.cpp
-    ${TKET_TESTS_DIR}/Simulation/ComparisonFunctions.cpp
     ${TKET_TESTS_DIR}/Simulation/test_CircuitSimulator.cpp
     ${TKET_TESTS_DIR}/Simulation/test_PauliExpBoxUnitaryCalculator.cpp
     ${TKET_TESTS_DIR}/Circuit/test_Boxes.cpp

--- a/tket/tests/tkettestutilsfiles.cmake
+++ b/tket/tests/tkettestutilsfiles.cmake
@@ -1,0 +1,43 @@
+# Copyright 2019-2022 Cambridge Quantum Computing
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# file to store all the files that serve as utils for the tket unit tests
+# new files should be added here
+
+set(TESTUTILS_SOURCES
+    ${TKET_TESTS_DIR}/tests_main.cpp
+    ${TKET_TESTS_DIR}/testutil.cpp
+    ${TKET_TESTS_DIR}/CircuitsForTesting.cpp
+    ${TKET_TESTS_DIR}/Graphs/EdgeSequence.cpp
+    ${TKET_TESTS_DIR}/Graphs/EdgeSequenceColouringParameters.cpp
+    ${TKET_TESTS_DIR}/Graphs/GraphTestingRoutines.cpp
+    ${TKET_TESTS_DIR}/Graphs/RandomGraphGeneration.cpp
+    ${TKET_TESTS_DIR}/Graphs/RandomPlanarGraphs.cpp
+    ${TKET_TESTS_DIR}/TokenSwapping/Data/FixedCompleteSolutions.cpp
+    ${TKET_TESTS_DIR}/TokenSwapping/Data/FixedSwapSequences.cpp
+    ${TKET_TESTS_DIR}/TokenSwapping/TableLookup/NeighboursFromEdges.cpp
+    ${TKET_TESTS_DIR}/TokenSwapping/TableLookup/PermutationTestUtils.cpp
+    ${TKET_TESTS_DIR}/TokenSwapping/TableLookup/SwapSequenceReductionTester.cpp
+    ${TKET_TESTS_DIR}/TokenSwapping/TestUtils/ArchitectureEdgesReimplementation.cpp
+    ${TKET_TESTS_DIR}/TokenSwapping/TestUtils/BestTsaTester.cpp
+    ${TKET_TESTS_DIR}/TokenSwapping/TestUtils/DebugFunctions.cpp
+    ${TKET_TESTS_DIR}/TokenSwapping/TestUtils/DecodedProblemData.cpp
+    ${TKET_TESTS_DIR}/TokenSwapping/TestUtils/FullTsaTesting.cpp
+    ${TKET_TESTS_DIR}/TokenSwapping/TestUtils/GetRandomSet.cpp
+    ${TKET_TESTS_DIR}/TokenSwapping/TestUtils/PartialTsaTesting.cpp
+    ${TKET_TESTS_DIR}/TokenSwapping/TestUtils/ProblemGeneration.cpp
+    ${TKET_TESTS_DIR}/TokenSwapping/TestUtils/TestStatsStructs.cpp
+    ${TKET_TESTS_DIR}/Gate/GatesData.cpp
+    ${TKET_TESTS_DIR}/Simulation/ComparisonFunctions.cpp
+)


### PR DESCRIPTION
I often find myself removing irrelevant tests from my local `tkettestsfiles.cmake` to speed up testing. However it often happens that I delete necessary test utilities in the process, as it is currently hard to distinguish them from ordinary test cases in the list of files. This causes annoying compilation errors and requires me to manually add back entries to the list of files.

I suggest to solve this problem by putting all the test utilities in a separate `tkettestutilsfiles.cmake` file. These group all the files that do not have any `SCENARIO` test cases inside them and are merely used through `#include`s in other test files.

Ideally, I would have explicit dependencies between tests and the utilities they depend on, so that we would only compile the required utilities. However I don't think this would make much of a difference -- these test utilities are often cached already and take hardly any compilation time.