### PR TITLE
Handle non-real non-symbolic expressions in eval_expr()

### DIFF
--- a/tket/src/Utils/Expression.cpp
+++ b/tket/src/Utils/Expression.cpp
@@ -13,9 +13,11 @@
 // limitations under the License.
 
 #include "Expression.hpp"
+#include <optional>
 
 #include "Constants.hpp"
 #include "Symbols.hpp"
+#include "symengine/symengine_exception.h"
 
 namespace tket {
 
@@ -57,7 +59,11 @@ std::optional<double> eval_expr(const Expr& e) {
   if (!SymEngine::free_symbols(e).empty()) {
     return std::nullopt;
   } else {
-    return SymEngine::eval_double(e);
+    try {
+      return SymEngine::eval_double(e);
+    } catch (SymEngine::NotImplementedError&) {
+      return std::nullopt;
+    }
   }
 }
 

--- a/tket/src/Utils/Expression.cpp
+++ b/tket/src/Utils/Expression.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "Expression.hpp"
+
 #include <optional>
 
 #include "Constants.hpp"

--- a/tket/tests/Circuit/test_Boxes.cpp
+++ b/tket/tests/Circuit/test_Boxes.cpp
@@ -381,7 +381,7 @@ SCENARIO("Pauli gadgets", "[boxes]") {
     REQUIRE((u - Eigen::Matrix4cd::Identity()).cwiseAbs().sum() < ERR_EPS);
   }
   GIVEN("complex coefficient") {
-    Expr ei {SymEngine::I};
+    Expr ei{SymEngine::I};
     PauliExpBox pebox({Pauli::Z}, ei);
     Expr p = pebox.get_phase();
     REQUIRE(p == ei);

--- a/tket/tests/Circuit/test_Boxes.cpp
+++ b/tket/tests/Circuit/test_Boxes.cpp
@@ -380,6 +380,12 @@ SCENARIO("Pauli gadgets", "[boxes]") {
     Eigen::MatrixXcd u = tket_sim::get_unitary(c);
     REQUIRE((u - Eigen::Matrix4cd::Identity()).cwiseAbs().sum() < ERR_EPS);
   }
+  GIVEN("complex coefficient") {
+    Expr ei {SymEngine::I};
+    PauliExpBox pebox({Pauli::Z}, ei);
+    Expr p = pebox.get_phase();
+    REQUIRE(p == ei);
+  }
 }
 
 SCENARIO("box daggers", "[boxes]") {


### PR DESCRIPTION
Even though non-physical, there is no reason to disallow non-real parameters in operations. The current code already allows such operations to be included in circuits; the problem is that it then throws exceptions when evaluating them. This patch catches those exceptions, so that `eval_expr()` returns `std::nullopt` as expected.