### PR TITLE
Remove PlacementPredicate from routing_pass

### DIFF
--- a/tket/src/Predicates/PassGenerators.cpp
+++ b/tket/src/Predicates/PassGenerators.cpp
@@ -250,11 +250,9 @@ PassPtr gen_routing_pass(
   Transform t = Transform(trans);
 
   PredicatePtr twoqbpred = std::make_shared<MaxTwoQubitGatesPredicate>();
-  PredicatePtr placedpred = std::make_shared<PlacementPredicate>(arc);
   PredicatePtr n_qubit_pred =
       std::make_shared<MaxNQubitsPredicate>(arc.n_nodes());
   PredicatePtrMap precons{
-      CompilationUnit::make_type_pair(placedpred),
       CompilationUnit::make_type_pair(twoqbpred),
       CompilationUnit::make_type_pair(n_qubit_pred)};
 


### PR DESCRIPTION
Generic routing doesn't require all logical qubits to be assigned to architecture qubits, it can dynamically assign them.