### PR TITLE
Sort qubit list when computing matrix without user-supplied list.

### DIFF
--- a/pytket/docs/changelog.rst
+++ b/pytket/docs/changelog.rst
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+1.x.y (unreleased)
+------------------
+
+Fixes:
+
+* Fix qubit order in ``QubitPauliOperator.to_sparse_matrix()``.
+
 1.0.1 (March 2022)
 ------------------
 

--- a/pytket/pytket/utils/operators.py
+++ b/pytket/pytket/utils/operators.py
@@ -268,7 +268,7 @@ class QubitPauliOperator:
         """
         qubits_ = qubits
         if qubits is None:
-            qubits_ = list(self._all_qubits)
+            qubits_ = sorted(list(self._all_qubits))
         return sum(
             complex(coeff) * pauli.to_sparse_matrix(qubits_)
             for pauli, coeff in self._dict.items()

--- a/pytket/tests/qubitpaulioperator_test.py
+++ b/pytket/tests/qubitpaulioperator_test.py
@@ -135,6 +135,11 @@ def test_QubitPauliOperator_matrices() -> None:
         named_op.to_sparse_matrix(named_qbs + [Qubit("a", 1)]).toarray(),
     )
 
+    # https://github.com/CQCL/tket/issues/294
+    P = QubitPauliString({Qubit(0): Pauli.Z, Qubit(1): Pauli.I})
+    H = QubitPauliOperator({P: 1})
+    assert np.allclose(P.to_sparse_matrix().todense(), H.to_sparse_matrix().todense())
+
 
 def test_QubitPauliOperator_compression() -> None:
     qbs = [Qubit(i) for i in range(2)]


### PR DESCRIPTION
Fixes #294 .