### PR TITLE
[TKET-1913] Refactor long running tests

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -98,24 +98,41 @@ jobs:
     - name: Install gcovr
       run: pip install gcovr
     - name: Build coverage report
-      if: github.event_name == 'pull_request' || github.event_name == 'push'
       run: |
         mkdir test-coverage
         gcovr --print-summary --html --html-details -r ./tket/src/ --exclude-lines-by-pattern '.*\bTKET_ASSERT\(.*\);' --object-directory ${PWD}/build/tket/ -o test-coverage/index.html > test-coverage/summary.txt
-    - name: Build coverage report (full suite)
-      if: github.event_name == 'schedule'
-      run: |
-        mkdir test-coverage
-        gcovr --print-summary --html --html-details -r ./tket/src/ --exclude-lines-by-pattern '.*\bTKET_ASSERT\(.*\);' --object-directory ${PWD}/build/tket/ -o test-coverage/index.html > test-coverage/summary-full.txt
     - name: Upload artefact
       uses: actions/upload-artifact@v2
       with:
         name: test_coverage
         path: test-coverage/
 
+  check_coverage:
+    name: Check coverage
+    needs: generate_coverage
+    if: (github.event_name == 'push' && needs.changes.outputs.tket == 'true') || github.event_name == 'schedule'
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2
+    - name: Download artefact
+      uses: actions/download-artifact@v2
+      with:
+        name: test_coverage
+        path: test-coverage/
+    - name: Compare with latest report from develop (short tests)
+      if: github.event_name == 'push'
+      run: |
+        wget https://cqcl.github.io/tket/tket/test-coverage-short/summary.txt
+        ./.github/workflows/compare-coverage summary.txt test-coverage/summary.txt
+    - name: Compare with latest report from develop (full suite)
+      if: github.event_name == 'schedule'
+      run: |
+        wget https://cqcl.github.io/tket/tket/test-coverage/summary.txt
+        ./.github/workflows/compare-coverage summary-full.txt test-coverage/summary-full.txt
+
   publish_coverage:
     name: Publish coverage
-    needs: generate_coverage
+    needs: check_coverage
     concurrency: gh_pages
     if: (github.event_name == 'push' && needs.changes.outputs.tket == 'true') || github.event_name == 'schedule'
     runs-on: ubuntu-20.04
@@ -132,36 +149,21 @@ jobs:
       run: |
         git config --global user.email "tket-bot@cambridgequantum.com"
         git config --global user.name  "«$GITHUB_WORKFLOW» github action"
-    - name: Remove old report
+    - name: Remove old report (short tests)
       if: github.event_name == 'push'
-      run: git rm -r docs/tket/test-coverage
-    - name: Add report to repository
+      run: git rm -r docs/tket/test-coverage-short/*
+    - name: Remove old report (full suite)
+      if: github.event_name == 'schedule'
+      run: git rm -r docs/tket/test-coverage/*
+    - name: Add report to repository (short tests)
       run: |
-        mv test-coverage/ docs/tket/
+        mv test-coverage/* docs/tket/test-coverage-short/
+        git add -f docs/tket/test-coverage-short
+        git commit --allow-empty -m "Add generated coverage report (short tests)."
+    - name: Add report to repository (full suite)
+      run: |
+        mv test-coverage/* docs/tket/test-coverage/
         git add -f docs/tket/test-coverage
-        git commit --allow-empty -m "Add generated coverage report."
+        git commit --allow-empty -m "Add generated coverage report (full suite)."
     - name: Publish report
       run: git push origin gh-pages:gh-pages
-
-  check_coverage:
-    name: Check coverage
-    needs: generate_coverage
-    if: (github.event_name == 'push' && needs.changes.outputs.tket == 'true') || github.event_name == 'schedule'
-    runs-on: ubuntu-20.04
-    steps:
-    - uses: actions/checkout@v2
-    - name: Download artefact
-      uses: actions/download-artifact@v2
-      with:
-        name: test_coverage
-        path: test-coverage/
-    - name: Compare with latest report from develop
-      if: github.event_name == 'push'
-      run: |
-        wget https://cqcl.github.io/tket/tket/test-coverage/summary.txt
-        ./.github/workflows/compare-coverage summary.txt test-coverage/summary.txt
-    - name: Compare with latest (full) report from develop
-      if: github.event_name == 'schedule'
-      run: |
-        wget https://cqcl.github.io/tket/tket/test-coverage/summary.txt
-        ./.github/workflows/compare-coverage summary-full.txt test-coverage/summary-full.txt

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -110,7 +110,7 @@ jobs:
   check_coverage:
     name: Check coverage
     needs: generate_coverage
-    if: (github.event_name == 'push' && needs.changes.outputs.tket == 'true') || github.event_name == 'schedule'
+    if: (github.event_name == 'pull_request' && needs.changes.outputs.tket == 'true') || github.event_name == 'schedule'
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
@@ -120,7 +120,7 @@ jobs:
         name: test_coverage
         path: test-coverage/
     - name: Compare with latest report from develop (short tests)
-      if: github.event_name == 'push'
+      if: github.event_name == 'pull_request'
       run: |
         wget https://cqcl.github.io/tket/tket/test-coverage-short/summary.txt
         ./.github/workflows/compare-coverage summary.txt test-coverage/summary.txt
@@ -132,7 +132,7 @@ jobs:
 
   publish_coverage:
     name: Publish coverage
-    needs: check_coverage
+    needs: generate_coverage
     concurrency: gh_pages
     if: (github.event_name == 'push' && needs.changes.outputs.tket == 'true') || github.event_name == 'schedule'
     runs-on: ubuntu-20.04

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -128,7 +128,7 @@ jobs:
       if: github.event_name == 'schedule'
       run: |
         wget https://cqcl.github.io/tket/tket/test-coverage/summary.txt
-        ./.github/workflows/compare-coverage summary-full.txt test-coverage/summary-full.txt
+        ./.github/workflows/compare-coverage summary.txt test-coverage/summary.txt
 
   publish_coverage:
     name: Publish coverage

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -156,11 +156,13 @@ jobs:
       if: github.event_name == 'schedule'
       run: git rm -r docs/tket/test-coverage/*
     - name: Add report to repository (short tests)
+      if: github.event_name == 'push'
       run: |
         mv test-coverage/* docs/tket/test-coverage-short/
         git add -f docs/tket/test-coverage-short
         git commit --allow-empty -m "Add generated coverage report (short tests)."
     - name: Add report to repository (full suite)
+      if: github.event_name == 'schedule'
       run: |
         mv test-coverage/* docs/tket/test-coverage/
         git add -f docs/tket/test-coverage

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -130,11 +130,11 @@ jobs:
         wget https://cqcl.github.io/tket/tket/test-coverage/summary.txt
         ./.github/workflows/compare-coverage summary.txt test-coverage/summary.txt
 
-  publish_coverage:
-    name: Publish coverage
+  publish_coverage_short:
+    name: Publish coverage (short tests)
     needs: generate_coverage
     concurrency: gh_pages
-    if: (github.event_name == 'push' && needs.changes.outputs.tket == 'true') || github.event_name == 'schedule'
+    if: github.event_name == 'push' && needs.changes.outputs.tket == 'true'
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
@@ -149,20 +149,38 @@ jobs:
       run: |
         git config --global user.email "tket-bot@cambridgequantum.com"
         git config --global user.name  "«$GITHUB_WORKFLOW» github action"
-    - name: Remove old report (short tests)
-      if: github.event_name == 'push'
+    - name: Remove old report
       run: git rm -r docs/tket/test-coverage-short/*
-    - name: Remove old report (full suite)
-      if: github.event_name == 'schedule'
-      run: git rm -r docs/tket/test-coverage/*
-    - name: Add report to repository (short tests)
-      if: github.event_name == 'push'
+    - name: Add report to repository
       run: |
         mv test-coverage/* docs/tket/test-coverage-short/
         git add -f docs/tket/test-coverage-short
         git commit --allow-empty -m "Add generated coverage report (short tests)."
-    - name: Add report to repository (full suite)
-      if: github.event_name == 'schedule'
+    - name: Publish report
+      run: git push origin gh-pages:gh-pages
+
+  publish_coverage_full:
+    name: Publish coverage (full suite)
+    needs: check_coverage
+    concurrency: gh_pages
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        ref: gh-pages
+    - name: Download artefact
+      uses: actions/download-artifact@v2
+      with:
+        name: test_coverage
+        path: test-coverage/
+    - name: Configure git
+      run: |
+        git config --global user.email "tket-bot@cambridgequantum.com"
+        git config --global user.name  "«$GITHUB_WORKFLOW» github action"
+    - name: Remove old report
+      run: git rm -r docs/tket/test-coverage/*
+    - name: Add report to repository
       run: |
         mv test-coverage/* docs/tket/test-coverage/
         git add -f docs/tket/test-coverage

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -7,6 +7,9 @@ on:
   push:
     branches:
       - develop
+  schedule:
+    # 03:00 every Saturday morning
+    - cron: '0 3 * * 6'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -87,13 +90,23 @@ jobs:
         mkdir -p ~/texmf/tex/latex
         wget http://mirrors.ctan.org/graphics/pgf/contrib/quantikz/tikzlibraryquantikz.code.tex -P ~/texmf/tex/latex
     - name: Run tket tests
+      if: github.event_name == 'pull_request' || github.event_name == 'push'
       run: ./build/tket-tests/bin/test_tket
+    - name: Run full tket tests
+      if: github.event_name == 'schedule'
+      run: ./build/tket-tests/bin/test_tket "[long],~[long]"
     - name: Install gcovr
       run: pip install gcovr
     - name: Build coverage report
+      if: github.event_name == 'pull_request' || github.event_name == 'push'
       run: |
         mkdir test-coverage
         gcovr --print-summary --html --html-details -r ./tket/src/ --exclude-lines-by-pattern '.*\bTKET_ASSERT\(.*\);' --object-directory ${PWD}/build/tket/ -o test-coverage/index.html > test-coverage/summary.txt
+    - name: Build coverage report (full suite)
+      if: github.event_name == 'schedule'
+      run: |
+        mkdir test-coverage
+        gcovr --print-summary --html --html-details -r ./tket/src/ --exclude-lines-by-pattern '.*\bTKET_ASSERT\(.*\);' --object-directory ${PWD}/build/tket/ -o test-coverage/index.html > test-coverage/summary-full.txt
     - name: Upload artefact
       uses: actions/upload-artifact@v2
       with:
@@ -104,7 +117,7 @@ jobs:
     name: Publish coverage
     needs: generate_coverage
     concurrency: gh_pages
-    if: github.event_name == 'push' && needs.changes.outputs.tket == 'true'
+    if: (github.event_name == 'push' && needs.changes.outputs.tket == 'true') || github.event_name == 'schedule'
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
@@ -120,6 +133,7 @@ jobs:
         git config --global user.email "tket-bot@cambridgequantum.com"
         git config --global user.name  "«$GITHUB_WORKFLOW» github action"
     - name: Remove old report
+      if: github.event_name == 'push'
       run: git rm -r docs/tket/test-coverage
     - name: Add report to repository
       run: |
@@ -132,7 +146,7 @@ jobs:
   check_coverage:
     name: Check coverage
     needs: generate_coverage
-    if: github.event_name == 'pull_request' && needs.changes.outputs.tket == 'true'
+    if: (github.event_name == 'push' && needs.changes.outputs.tket == 'true') || github.event_name == 'schedule'
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
@@ -142,6 +156,12 @@ jobs:
         name: test_coverage
         path: test-coverage/
     - name: Compare with latest report from develop
+      if: github.event_name == 'push'
       run: |
         wget https://cqcl.github.io/tket/tket/test-coverage/summary.txt
         ./.github/workflows/compare-coverage summary.txt test-coverage/summary.txt
+    - name: Compare with latest (full) report from develop
+      if: github.event_name == 'schedule'
+      run: |
+        wget https://cqcl.github.io/tket/tket/test-coverage/summary.txt
+        ./.github/workflows/compare-coverage summary-full.txt test-coverage/summary-full.txt

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -34,7 +34,7 @@ jobs:
   generate_coverage:
     name: Generate coverage report
     needs: changes
-    if: needs.changes.outputs.tket == 'true'
+    if: needs.changes.outputs.tket == 'true' || github.event_name == 'schedule'
     runs-on: ubuntu-20.04
     env:
       CC: gcc-10

--- a/README.md
+++ b/README.md
@@ -169,12 +169,25 @@ To build and run the tket tests:
 conan create --profile=tket recipes/tket-tests
 ```
 
-If you want to build them without running them, pass `--test-folder None` to the
-`conan` command. (You can still run them manually afterwards.)
+The tests with a running time >=1 second (on a regular modern laptop) are marked as hidden,
+tagged with `"[long]"`, and are not run by default. To run the full suite of tests,
+add `-o tket-tests:full=True` to the above `conan create` command (or to the tket profile).
+The option `-o tket-tests:long=True` can also be used to run only the long tests.
 
-Some tests (those that add significantly to the runtime) are not built by
-default. To build all tests, add `-o tket-tests:full=True` to the above
-`conan create` command.
+If you want to build the tests without running them, pass `--test-folder None` to the
+`conan` command. Then, you can manually run the binary.
+If no arguments are provided only the default (short) tests are run.
+To run the long tests use the `"[long]"` tag as an argument:
+
+```shell
+<package_folder>/bin/test_tket "[long]"
+```
+
+To run the full suite manually you need to include also the short tests, like:
+
+```shell
+<package_folder>/bin/test_tket "[long],~[long]"
+```
 
 There is also a small set of property-based tests which you can build and run
 with:

--- a/recipes/tket-tests/conanfile.py
+++ b/recipes/tket-tests/conanfile.py
@@ -26,12 +26,12 @@ class TketTestsConan(ConanFile):
     description = "Unit tests for tket"
     topics = ("quantum", "computation", "compiler")
     settings = "os", "compiler", "build_type", "arch"
-    options = {"with_coverage": [True, False],
-               "full": [True, False],
-               "long": [True, False]}
-    default_options = {"with_coverage": False,
-                       "full": False,
-                       "long": False}
+    options = {
+        "with_coverage": [True, False],
+        "full": [True, False],
+        "long": [True, False],
+    }
+    default_options = {"with_coverage": False, "full": False, "long": False}
     generators = "cmake"
     exports_sources = "../../tket/tests/*"
     requires = ("tket/1.0.1", "catch2/2.13.8")

--- a/recipes/tket-tests/conanfile.py
+++ b/recipes/tket-tests/conanfile.py
@@ -26,8 +26,12 @@ class TketTestsConan(ConanFile):
     description = "Unit tests for tket"
     topics = ("quantum", "computation", "compiler")
     settings = "os", "compiler", "build_type", "arch"
-    options = {"with_coverage": [True, False], "full": [True, False]}
-    default_options = {"with_coverage": False, "full": False}
+    options = {"with_coverage": [True, False],
+               "full": [True, False],
+               "long": [True, False]}
+    default_options = {"with_coverage": False,
+                       "full": False,
+                       "long": False}
     generators = "cmake"
     exports_sources = "../../tket/tests/*"
     requires = ("tket/1.0.1", "catch2/2.13.8")
@@ -43,7 +47,6 @@ class TketTestsConan(ConanFile):
     def _configure_cmake(self):
         if self._cmake is None:
             self._cmake = CMake(self)
-            self._cmake.definitions["TESTS_FULL"] = self.options.full
             self._cmake.configure()
         return self._cmake
 

--- a/recipes/tket-tests/test_package/conanfile.py
+++ b/recipes/tket-tests/test_package/conanfile.py
@@ -50,6 +50,12 @@ class TketTestsTestConan(ConanFile):
                         os.path.join(self.install_folder, "lib", lib_file),
                         os.path.join("bin", lib_file),
                     )
-            cmd_extra = "" if platform.system() == "Linux" else ' "~[latex]"'
+            ignore_latex_tests = "" if platform.system() == "Linux" else ' "~[latex]"'
+            if self.options["tket-tests"].full:
+                cmd_extra = f"[long]{ignore_latex_tests},~[long]{ignore_latex_tests}"
+            elif self.options["tket-tests"].long:
+                cmd_extra = f"[long]{ignore_latex_tests}"
+            else:
+                cmd_extra = ignore_latex_tests
             os.chdir("bin")
-            self.run(os.path.join(os.curdir, "test_tket" + cmd_extra))
+            self.run(os.path.join(os.curdir, "test_tket " + cmd_extra))

--- a/tket/tests/CMakeLists.txt
+++ b/tket/tests/CMakeLists.txt
@@ -36,12 +36,6 @@ ENDIF()
 
 add_definitions(-DALL_LOGS)
 
-set(TESTS_FULL no CACHE BOOL "Run full set of tests")
-
-if (TESTS_FULL)
-    add_definitions(-DTKET_TESTS_FULL)
-endif()
-
 set(TKET_TESTS_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 
 include(tkettestutilsfiles.cmake)

--- a/tket/tests/Circuit/test_Circ.cpp
+++ b/tket/tests/Circuit/test_Circ.cpp
@@ -2421,7 +2421,7 @@ SCENARIO("Represent symbolic operations correctly") {
   REQUIRE(cmd_1.str() == expected_1);
 }
 
-SCENARIO("Confirm that LaTeX output compiles", "[latex]") {
+SCENARIO("Confirm that LaTeX output compiles", "[latex][.long]") {
   Circuit c(5, 2);
   c.add_conditional_gate<unsigned>(OpType::Z, {}, uvec{0}, {}, 0);
   c.add_conditional_gate<unsigned>(OpType::U1, {0.3}, uvec{1}, {}, 0);

--- a/tket/tests/Placement/test_Placement.cpp
+++ b/tket/tests/Placement/test_Placement.cpp
@@ -663,7 +663,7 @@ SCENARIO(
 
 SCENARIO(
     "Does the timeout config option work as expected with monomorpher "
-    "place?") {
+    "place?", "[.long]") {
   GIVEN("A large architecture, qubit graph and small timeout") {
     const SquareGrid arc(10, 10, 5);
     Circuit circ(40);
@@ -686,6 +686,7 @@ SCENARIO(
     REQUIRE(all_maps.size() < pc.vf2_max_matches);
   }
 }
+
 SCENARIO(
     "Does the NoiseAwarePlacement class correctly modify Circuits and "
     "return "

--- a/tket/tests/Placement/test_Placement.cpp
+++ b/tket/tests/Placement/test_Placement.cpp
@@ -663,7 +663,8 @@ SCENARIO(
 
 SCENARIO(
     "Does the timeout config option work as expected with monomorpher "
-    "place?", "[.long]") {
+    "place?",
+    "[.long]") {
   GIVEN("A large architecture, qubit graph and small timeout") {
     const SquareGrid arc(10, 10, 5);
     Circuit circ(40);

--- a/tket/tests/TokenSwapping/TableLookup/test_SwapSequenceReductions.cpp
+++ b/tket/tests/TokenSwapping/TableLookup/test_SwapSequenceReductions.cpp
@@ -47,11 +47,56 @@ static void check_final_messages(
   }
 }
 
+static void add_solutions(
+    SwapSequenceReductionTester& tester,
+    SwapSequenceReductionTester::Options& options,
+    const unsigned skip_number,
+    const vector<std::string>& seq_codes,
+    SequenceReductionStats& stats) {
+  for (unsigned ii = 0; ii < seq_codes.size(); ++ii) {
+    if (ii % skip_number != 0) {
+      continue;
+    }
+    const auto& code_str = seq_codes[ii];
+    const DecodedProblemData problem_data(code_str);
+    const auto reduced_size =
+        tester.get_checked_solution_size(problem_data, options);
+    stats.add_solution(problem_data.swaps.size(), reduced_size);
+  }
+}
+
+static void run_reduction(
+    SwapSequenceReductionTester& tester,
+    SwapSequenceReductionTester::Options& options,
+    const unsigned skip_number,
+    const FixedSwapSequences& sequences,
+    vector<std::string>& calc_messages) {
+  for (int ii = 0; ii < 2; ++ii) {
+    options.optimise_initial_segment_only = (ii % 2 == 0);
+    {
+      SequenceReductionStats full_tokens_stats;
+      add_solutions(tester, options, skip_number,
+                    sequences.full, full_tokens_stats);
+      add_solutions(tester, options, skip_number,
+                    sequences.full_with_errors, full_tokens_stats);
+      add_message(full_tokens_stats, "Full tokens", options, calc_messages);
+    }
+    {
+      SequenceReductionStats partial_tokens_stats;
+      add_solutions(tester, options, skip_number,
+                    sequences.partial, partial_tokens_stats);
+      add_solutions(tester, options, skip_number,
+                    sequences.partial_with_errors, partial_tokens_stats);
+      add_message(
+          partial_tokens_stats, "Partial tokens", options, calc_messages);
+    }
+  }
+}
+
 // Reduce the fixed swap sequences, with edge set implicitly defined
 // by the swaps themselves.
-SCENARIO("Fixed swap sequences reduction") {
-#ifdef TKET_TESTS_FULL
-  // The long tests take ~5 seconds on a 2021 Windows laptop.
+// This long test take ~5 seconds on a 2021 Windows laptop.
+SCENARIO("Fixed swap sequences reduction - long test", "[.long]") {
   vector<std::string> expected_messages{
       "[n=0, Full tokens: init segm optim? true]\n"
       "[478 equal probs (17115); 2 reduced probs (25 vs 29)]\n"
@@ -68,10 +113,20 @@ SCENARIO("Fixed swap sequences reduction") {
       "[n=3, Partial tokens: init segm optim? false]\n"
       "[658 equal probs (12376); 238 reduced probs (12962 vs 13463)]\n"
       "[Overall reduction 25338 vs 25839: 1%]"};
-
   const unsigned skip_number = 1;
-#else
-  // The shorter tests take ~0.4 seconds.
+  const FixedSwapSequences fixed_sequences;
+  SwapSequenceReductionTester tester;
+  SwapSequenceReductionTester::Options options;
+  vector<std::string> calc_messages;
+
+  run_reduction(tester, options, skip_number, fixed_sequences, calc_messages);
+  check_final_messages(expected_messages, calc_messages);
+}
+
+// Reduce the fixed swap sequences, with edge set implicitly defined
+// by the swaps themselves.
+// This short test take ~0.4 seconds on a 2021 Windows laptop.
+SCENARIO("Fixed swap sequences reduction") {
   vector<std::string> expected_messages{
       "[n=0, Full tokens: init segm optim? true]\n"
       "[25 equal probs (846); 0 reduced probs (0 vs 0)]\n"
@@ -89,83 +144,20 @@ SCENARIO("Fixed swap sequences reduction") {
       "[34 equal probs (461); 12 reduced probs (844 vs 887)]\n"
       "[Overall reduction 1305 vs 1348: 3%]"};
   const unsigned skip_number = 20;
-#endif
-
   const FixedSwapSequences fixed_sequences;
   SwapSequenceReductionTester tester;
   SwapSequenceReductionTester::Options options;
   vector<std::string> calc_messages;
 
-  const auto add_solutions = [&tester, &options, skip_number](
-                                 const vector<std::string>& seq_codes,
-                                 SequenceReductionStats& stats) {
-    for (unsigned ii = 0; ii < seq_codes.size(); ++ii) {
-      if (ii % skip_number != 0) {
-        continue;
-      }
-      const auto& code_str = seq_codes[ii];
-      const DecodedProblemData problem_data(code_str);
-      const auto reduced_size =
-          tester.get_checked_solution_size(problem_data, options);
-      stats.add_solution(problem_data.swaps.size(), reduced_size);
-    }
-  };
-
-  for (int ii = 0; ii < 2; ++ii) {
-    options.optimise_initial_segment_only = (ii % 2 == 0);
-    {
-      SequenceReductionStats full_tokens_stats;
-      add_solutions(fixed_sequences.full, full_tokens_stats);
-      add_solutions(fixed_sequences.full_with_errors, full_tokens_stats);
-      add_message(full_tokens_stats, "Full tokens", options, calc_messages);
-    }
-    {
-      SequenceReductionStats partial_tokens_stats;
-      add_solutions(fixed_sequences.partial, partial_tokens_stats);
-      add_solutions(fixed_sequences.partial_with_errors, partial_tokens_stats);
-      add_message(
-          partial_tokens_stats, "Partial tokens", options, calc_messages);
-    }
-  }
+  run_reduction(tester, options, skip_number, fixed_sequences, calc_messages);
   check_final_messages(expected_messages, calc_messages);
 }
 
-// The actual problem input data: the graph may have extra edges
-// not present in the returned solution.
-SCENARIO("Fixed complete problems") {
-#ifdef TKET_TESTS_FULL
-  // The long tests take ~10 seconds on a 2021 Windows laptop.
-  vector<std::string> expected_messages{
-      "[n=0, Small: init segm optim? false]\n"
-      "[249 equal probs (1353); 29 reduced probs (163 vs 204)]\n"
-      "[Overall reduction 1516 vs 1557: 2%]",
 
-      "[n=1, Medium: init segm optim? false]\n"
-      "[167 equal probs (2650); 60 reduced probs (1107 vs 1234)]\n"
-      "[Overall reduction 3757 vs 3884: 3%]",
-
-      "[n=2, Large: init segm optim? false]\n"
-      "[164 equal probs (12771); 408 reduced probs (43946 vs 45894)]\n"
-      "[Overall reduction 56717 vs 58665: 3%]"};
-
-  const unsigned skip_number = 1;
-#else
-  // The shorter tests take ~0.4 seconds.
-  vector<std::string> expected_messages{
-      "[n=0, Small: init segm optim? false]\n"
-      "[8 equal probs (48); 1 reduced probs (9 vs 10)]\n"
-      "[Overall reduction 57 vs 58: 1%]",
-
-      "[n=1, Medium: init segm optim? false]\n"
-      "[8 equal probs (138); 1 reduced probs (23 vs 24)]\n"
-      "[Overall reduction 161 vs 162: 0%]",
-
-      "[n=2, Large: init segm optim? false]\n"
-      "[10 equal probs (928); 16 reduced probs (1657 vs 1743)]\n"
-      "[Overall reduction 2585 vs 2671: 3%]"};
-  const unsigned skip_number = 20;
-#endif
-
+static void run_complete_problems(
+    const unsigned skip_number,
+    vector<std::string>& calc_messages
+    ) {
   SwapSequenceReductionTester::Options options;
   options.optimise_initial_segment_only = false;
 
@@ -201,10 +193,52 @@ SCENARIO("Fixed complete problems") {
       stats[stats_index].add_solution(problem_data.swaps.size(), reduced_size);
     }
   }
-  vector<std::string> calc_messages;
   add_message(stats[0], "Small", options, calc_messages);
   add_message(stats[1], "Medium", options, calc_messages);
   add_message(stats[2], "Large", options, calc_messages);
+}
+
+// The actual problem input data: the graph may have extra edges
+// not present in the returned solution.
+// The long tests take ~10 seconds on a 2021 Windows laptop.
+SCENARIO("Fixed complete problems - long test", "[.long]") {
+  vector<std::string> expected_messages{
+      "[n=0, Small: init segm optim? false]\n"
+      "[249 equal probs (1353); 29 reduced probs (163 vs 204)]\n"
+      "[Overall reduction 1516 vs 1557: 2%]",
+
+      "[n=1, Medium: init segm optim? false]\n"
+      "[167 equal probs (2650); 60 reduced probs (1107 vs 1234)]\n"
+      "[Overall reduction 3757 vs 3884: 3%]",
+
+      "[n=2, Large: init segm optim? false]\n"
+      "[164 equal probs (12771); 408 reduced probs (43946 vs 45894)]\n"
+      "[Overall reduction 56717 vs 58665: 3%]"};
+  const unsigned skip_number = 1;
+  vector<std::string> calc_messages;
+  run_complete_problems(skip_number, calc_messages);
+  check_final_messages(expected_messages, calc_messages);
+}
+
+// The actual problem input data: the graph may have extra edges
+// not present in the returned solution.
+// The shorter tests take ~0.4 seconds.
+SCENARIO("Fixed complete problems") {
+  vector<std::string> expected_messages{
+      "[n=0, Small: init segm optim? false]\n"
+      "[8 equal probs (48); 1 reduced probs (9 vs 10)]\n"
+      "[Overall reduction 57 vs 58: 1%]",
+
+      "[n=1, Medium: init segm optim? false]\n"
+      "[8 equal probs (138); 1 reduced probs (23 vs 24)]\n"
+      "[Overall reduction 161 vs 162: 0%]",
+
+      "[n=2, Large: init segm optim? false]\n"
+      "[10 equal probs (928); 16 reduced probs (1657 vs 1743)]\n"
+      "[Overall reduction 2585 vs 2671: 3%]"};
+  const unsigned skip_number = 20;
+  vector<std::string> calc_messages;
+  run_complete_problems(skip_number, calc_messages);
   check_final_messages(expected_messages, calc_messages);
 }
 

--- a/tket/tests/TokenSwapping/TableLookup/test_SwapSequenceReductions.cpp
+++ b/tket/tests/TokenSwapping/TableLookup/test_SwapSequenceReductions.cpp
@@ -49,10 +49,8 @@ static void check_final_messages(
 
 static void add_solutions(
     SwapSequenceReductionTester& tester,
-    SwapSequenceReductionTester::Options& options,
-    const unsigned skip_number,
-    const vector<std::string>& seq_codes,
-    SequenceReductionStats& stats) {
+    SwapSequenceReductionTester::Options& options, const unsigned skip_number,
+    const vector<std::string>& seq_codes, SequenceReductionStats& stats) {
   for (unsigned ii = 0; ii < seq_codes.size(); ++ii) {
     if (ii % skip_number != 0) {
       continue;
@@ -67,26 +65,27 @@ static void add_solutions(
 
 static void run_reduction(
     SwapSequenceReductionTester& tester,
-    SwapSequenceReductionTester::Options& options,
-    const unsigned skip_number,
-    const FixedSwapSequences& sequences,
-    vector<std::string>& calc_messages) {
+    SwapSequenceReductionTester::Options& options, const unsigned skip_number,
+    const FixedSwapSequences& sequences, vector<std::string>& calc_messages) {
   for (int ii = 0; ii < 2; ++ii) {
     options.optimise_initial_segment_only = (ii % 2 == 0);
     {
       SequenceReductionStats full_tokens_stats;
-      add_solutions(tester, options, skip_number,
-                    sequences.full, full_tokens_stats);
-      add_solutions(tester, options, skip_number,
-                    sequences.full_with_errors, full_tokens_stats);
+      add_solutions(
+          tester, options, skip_number, sequences.full, full_tokens_stats);
+      add_solutions(
+          tester, options, skip_number, sequences.full_with_errors,
+          full_tokens_stats);
       add_message(full_tokens_stats, "Full tokens", options, calc_messages);
     }
     {
       SequenceReductionStats partial_tokens_stats;
-      add_solutions(tester, options, skip_number,
-                    sequences.partial, partial_tokens_stats);
-      add_solutions(tester, options, skip_number,
-                    sequences.partial_with_errors, partial_tokens_stats);
+      add_solutions(
+          tester, options, skip_number, sequences.partial,
+          partial_tokens_stats);
+      add_solutions(
+          tester, options, skip_number, sequences.partial_with_errors,
+          partial_tokens_stats);
       add_message(
           partial_tokens_stats, "Partial tokens", options, calc_messages);
     }
@@ -153,11 +152,8 @@ SCENARIO("Fixed swap sequences reduction") {
   check_final_messages(expected_messages, calc_messages);
 }
 
-
 static void run_complete_problems(
-    const unsigned skip_number,
-    vector<std::string>& calc_messages
-    ) {
+    const unsigned skip_number, vector<std::string>& calc_messages) {
   SwapSequenceReductionTester::Options options;
   options.optimise_initial_segment_only = false;
 

--- a/tket/tests/TokenSwapping/test_BestTsaFixedSwapSequences.cpp
+++ b/tket/tests/TokenSwapping/test_BestTsaFixedSwapSequences.cpp
@@ -149,12 +149,32 @@ struct Summary {
 };
 }  // namespace
 
-SCENARIO("Best TSA : solve problems from fixed swap sequences") {
+
+static void run_solve_problems_fixed_swap_seqs(
+    FixedSwapSequences& sequences,
+    const std::string full_seq_str,
+    const double full_seq_improvement,
+    const std::string partial_seq_str,
+    const double partial_seq_improvement) {
+  BestTsaTester tester;
+  const Summary full_seqs_summary(sequences.full, tester);
+  CHECK(full_seqs_summary.total_number_of_problems == sequences.full.size());
+  CHECK(full_seqs_summary.str == full_seq_str);
+  full_seqs_summary.check_overall_improvement(full_seq_improvement);
+
+  const Summary partial_seqs_summary(sequences.partial, tester);
+  CHECK(
+      partial_seqs_summary.total_number_of_problems ==
+      sequences.partial.size());
+  CHECK(partial_seqs_summary.str == partial_seq_str);
+  partial_seqs_summary.check_overall_improvement(partial_seq_improvement);
+}
+
+SCENARIO("Best TSA : solve problems from fixed swap sequences - long test", "[.long]") {
   FixedSwapSequences sequences;
   CHECK(sequences.full.size() == 453);
   CHECK(sequences.partial.size() == 755);
 
-#ifdef TKET_TESTS_FULL
   // The "long" tests take ~6 seconds on an ordinary 2021 Windows laptop.
   const std::string full_seq_str =
       "[248 equal (6088); 104 BETTER (4645 vs 4979): av 7% decr\n"
@@ -171,7 +191,18 @@ SCENARIO("Best TSA : solve problems from fixed swap sequences") {
       "[455 equal (6487); 165 BETTER (7044 vs 7457): av 7% decr\n"
       "135 WORSE (9124 vs 8604): av 6% incr]";
   const double partial_seq_improvement = -0.474543;
-#else
+
+  run_solve_problems_fixed_swap_seqs(
+      sequences,
+      full_seq_str, full_seq_improvement,
+      partial_seq_str, partial_seq_improvement);
+}
+
+SCENARIO("Best TSA : solve problems from fixed swap sequences") {
+  FixedSwapSequences sequences;
+  CHECK(sequences.full.size() == 453);
+  CHECK(sequences.partial.size() == 755);
+
   // The reduced tests take ~50 milliseconds
   // (and are also biased towards smaller problems,
   // as the problem strings are sorted by length).
@@ -186,21 +217,13 @@ SCENARIO("Best TSA : solve problems from fixed swap sequences") {
       "[40 equal (166); 0 BETTER (0 vs 0): av 0% decr\n"
       "0 WORSE (0 vs 0): av 0% incr]";
   const double partial_seq_improvement = 0.0;
-#endif
 
-  BestTsaTester tester;
-  const Summary full_seqs_summary(sequences.full, tester);
-  CHECK(full_seqs_summary.total_number_of_problems == sequences.full.size());
-  CHECK(full_seqs_summary.str == full_seq_str);
-  full_seqs_summary.check_overall_improvement(full_seq_improvement);
-
-  const Summary partial_seqs_summary(sequences.partial, tester);
-  CHECK(
-      partial_seqs_summary.total_number_of_problems ==
-      sequences.partial.size());
-  CHECK(partial_seqs_summary.str == partial_seq_str);
-  partial_seqs_summary.check_overall_improvement(partial_seq_improvement);
+  run_solve_problems_fixed_swap_seqs(
+      sequences,
+      full_seq_str, full_seq_improvement,
+      partial_seq_str, partial_seq_improvement);
 }
+
 
 // Now we want to solve complete problems; this is one of
 // our most important tests. It is a bit silly
@@ -284,72 +307,11 @@ class StatisticsGrouper {
 };
 }  // namespace
 
-SCENARIO("Best TSA : solve complete problems") {
-  FixedCompleteSolutions complete_solutions;
 
-  // It's a map, with key the architecture name; this is the number
-  // of architectures, not problems.
-  CHECK(complete_solutions.solutions.size() == 21);
-  vector<unsigned> sizes;
-  for (const auto& entry : complete_solutions.solutions) {
-    sizes.push_back(entry.second.size());
-  }
-  CHECK(sizes == vector<unsigned>{49, 97, 49,  49, 97, 93, 45, 45, 45, 39, 41,
-                                  49, 39, 100, 48, 28, 22, 27, 49, 49, 38});
-
-  // For a good test, very different problems should not be amalgamated
-  // in the statistics. Thus we determine the different categories using length
-  // of encoding string, which presumably roughly corresponds to "problem size"
-  // and problem hardness.
-
-#ifdef TKET_TESTS_FULL
-  // The "long" tests take ~12 seconds on an ordinary 2021 Windows laptop.
-  const vector<std::string> expected_messages{
-      "[210 equal (1018); 19 BETTER (84 vs 111): av 24% decr\n"
-      "2 WORSE (19 vs 15): av 26% incr]",
-
-      "[145 equal (1822); 39 BETTER (451 vs 525): av 13% decr\n"
-      "17 WORSE (269 vs 242): av 11% incr]",
-
-      "[58 equal (1619); 122 BETTER (3465 vs 3832): av 9% decr\n"
-      "34 WORSE (1321 vs 1232): av 6% incr]",
-
-      "[18 equal (1382); 114 BETTER (8322 vs 8856): av 5% decr\n"
-      "83 WORSE (6875 vs 6457): av 5% incr]",
-
-      "[8 equal (1470); 164 BETTER (25183 vs 27141): av 6% decr\n"
-      "44 WORSE (8722 vs 8384): av 3% incr]"};
-
-  const double expected_improvement = 3.25087;
-#else
-  // The reduced tests take ~700 milliseconds.
-  for (auto& entry : complete_solutions.solutions) {
-    auto reduced_size = entry.second.size() / 10;
-    if (reduced_size < 4) {
-      reduced_size = 4;
-    }
-    if (reduced_size < entry.second.size()) {
-      entry.second.resize(reduced_size);
-    }
-  }
-  const vector<std::string> expected_messages{
-      "[18 equal (62); 0 BETTER (0 vs 0): av 0% decr\n"
-      "0 WORSE (0 vs 0): av 0% incr]",
-
-      "[17 equal (82); 0 BETTER (0 vs 0): av 0% decr\n"
-      "0 WORSE (0 vs 0): av 0% incr]",
-
-      "[12 equal (119); 2 BETTER (15 vs 18): av 16% decr\n"
-      "0 WORSE (0 vs 0): av 0% incr]",
-
-      "[6 equal (149); 6 BETTER (164 vs 173): av 5% decr\n"
-      "4 WORSE (115 vs 110): av 5% incr]",
-
-      "[4 equal (163); 10 BETTER (535 vs 571): av 5% decr\n"
-      "5 WORSE (288 vs 273): av 5% incr]"};
-  const double expected_improvement = 1.62791;
-#endif
-
+static void run_solve_complete_problems(
+    FixedCompleteSolutions& complete_solutions,
+    const vector<std::string> expected_messages,
+    const double expected_improvement) {
   vector<unsigned> problem_sizes;
   for (const auto& entry : complete_solutions.solutions) {
     REQUIRE(entry.second.size() >= 2);
@@ -379,6 +341,95 @@ SCENARIO("Best TSA : solve complete problems") {
   // A positive result is good; the fixed complete problems are DIRECTLY
   // comparing our TSA with the solver used to generate them.
   grouper.check_overall_improvement(expected_improvement);
+}
+
+
+SCENARIO("Best TSA : solve complete problems - long test", "[.long]") {
+  FixedCompleteSolutions complete_solutions;
+
+  // It's a map, with key the architecture name; this is the number
+  // of architectures, not problems.
+  CHECK(complete_solutions.solutions.size() == 21);
+  vector<unsigned> sizes;
+  for (const auto& entry : complete_solutions.solutions) {
+    sizes.push_back(entry.second.size());
+  }
+  CHECK(sizes == vector<unsigned>{49, 97, 49,  49, 97, 93, 45, 45, 45, 39, 41,
+                                  49, 39, 100, 48, 28, 22, 27, 49, 49, 38});
+
+  // For a good test, very different problems should not be amalgamated
+  // in the statistics. Thus we determine the different categories using length
+  // of encoding string, which presumably roughly corresponds to "problem size"
+  // and problem hardness.
+
+  // The "long" tests take ~12 seconds on an ordinary 2021 Windows laptop.
+  const vector<std::string> expected_messages{
+      "[210 equal (1018); 19 BETTER (84 vs 111): av 24% decr\n"
+      "2 WORSE (19 vs 15): av 26% incr]",
+
+      "[145 equal (1822); 39 BETTER (451 vs 525): av 13% decr\n"
+      "17 WORSE (269 vs 242): av 11% incr]",
+
+      "[58 equal (1619); 122 BETTER (3465 vs 3832): av 9% decr\n"
+      "34 WORSE (1321 vs 1232): av 6% incr]",
+
+      "[18 equal (1382); 114 BETTER (8322 vs 8856): av 5% decr\n"
+      "83 WORSE (6875 vs 6457): av 5% incr]",
+
+      "[8 equal (1470); 164 BETTER (25183 vs 27141): av 6% decr\n"
+      "44 WORSE (8722 vs 8384): av 3% incr]"};
+
+  const double expected_improvement = 3.25087;
+
+  run_solve_complete_problems(complete_solutions, expected_messages, expected_improvement);
+}
+
+SCENARIO("Best TSA : solve complete problems") {
+  FixedCompleteSolutions complete_solutions;
+
+  // It's a map, with key the architecture name; this is the number
+  // of architectures, not problems.
+  CHECK(complete_solutions.solutions.size() == 21);
+  vector<unsigned> sizes;
+  for (const auto& entry : complete_solutions.solutions) {
+    sizes.push_back(entry.second.size());
+  }
+  CHECK(sizes == vector<unsigned>{49, 97, 49,  49, 97, 93, 45, 45, 45, 39, 41,
+                                  49, 39, 100, 48, 28, 22, 27, 49, 49, 38});
+
+  // For a good test, very different problems should not be amalgamated
+  // in the statistics. Thus we determine the different categories using length
+  // of encoding string, which presumably roughly corresponds to "problem size"
+  // and problem hardness.
+
+  // The reduced tests take ~700 milliseconds.
+  for (auto& entry : complete_solutions.solutions) {
+    auto reduced_size = entry.second.size() / 10;
+    if (reduced_size < 4) {
+      reduced_size = 4;
+    }
+    if (reduced_size < entry.second.size()) {
+      entry.second.resize(reduced_size);
+    }
+  }
+  const vector<std::string> expected_messages{
+      "[18 equal (62); 0 BETTER (0 vs 0): av 0% decr\n"
+      "0 WORSE (0 vs 0): av 0% incr]",
+
+      "[17 equal (82); 0 BETTER (0 vs 0): av 0% decr\n"
+      "0 WORSE (0 vs 0): av 0% incr]",
+
+      "[12 equal (119); 2 BETTER (15 vs 18): av 16% decr\n"
+      "0 WORSE (0 vs 0): av 0% incr]",
+
+      "[6 equal (149); 6 BETTER (164 vs 173): av 5% decr\n"
+      "4 WORSE (115 vs 110): av 5% incr]",
+
+      "[4 equal (163); 10 BETTER (535 vs 571): av 5% decr\n"
+      "5 WORSE (288 vs 273): av 5% incr]"};
+  const double expected_improvement = 1.62791;
+
+  run_solve_complete_problems(complete_solutions, expected_messages, expected_improvement);
 }
 
 }  // namespace tests

--- a/tket/tests/TokenSwapping/test_BestTsaFixedSwapSequences.cpp
+++ b/tket/tests/TokenSwapping/test_BestTsaFixedSwapSequences.cpp
@@ -149,12 +149,9 @@ struct Summary {
 };
 }  // namespace
 
-
 static void run_solve_problems_fixed_swap_seqs(
-    FixedSwapSequences& sequences,
-    const std::string full_seq_str,
-    const double full_seq_improvement,
-    const std::string partial_seq_str,
+    FixedSwapSequences& sequences, const std::string full_seq_str,
+    const double full_seq_improvement, const std::string partial_seq_str,
     const double partial_seq_improvement) {
   BestTsaTester tester;
   const Summary full_seqs_summary(sequences.full, tester);
@@ -170,7 +167,9 @@ static void run_solve_problems_fixed_swap_seqs(
   partial_seqs_summary.check_overall_improvement(partial_seq_improvement);
 }
 
-SCENARIO("Best TSA : solve problems from fixed swap sequences - long test", "[.long]") {
+SCENARIO(
+    "Best TSA : solve problems from fixed swap sequences - long test",
+    "[.long]") {
   FixedSwapSequences sequences;
   CHECK(sequences.full.size() == 453);
   CHECK(sequences.partial.size() == 755);
@@ -193,9 +192,8 @@ SCENARIO("Best TSA : solve problems from fixed swap sequences - long test", "[.l
   const double partial_seq_improvement = -0.474543;
 
   run_solve_problems_fixed_swap_seqs(
-      sequences,
-      full_seq_str, full_seq_improvement,
-      partial_seq_str, partial_seq_improvement);
+      sequences, full_seq_str, full_seq_improvement, partial_seq_str,
+      partial_seq_improvement);
 }
 
 SCENARIO("Best TSA : solve problems from fixed swap sequences") {
@@ -219,11 +217,9 @@ SCENARIO("Best TSA : solve problems from fixed swap sequences") {
   const double partial_seq_improvement = 0.0;
 
   run_solve_problems_fixed_swap_seqs(
-      sequences,
-      full_seq_str, full_seq_improvement,
-      partial_seq_str, partial_seq_improvement);
+      sequences, full_seq_str, full_seq_improvement, partial_seq_str,
+      partial_seq_improvement);
 }
-
 
 // Now we want to solve complete problems; this is one of
 // our most important tests. It is a bit silly
@@ -307,7 +303,6 @@ class StatisticsGrouper {
 };
 }  // namespace
 
-
 static void run_solve_complete_problems(
     FixedCompleteSolutions& complete_solutions,
     const vector<std::string> expected_messages,
@@ -342,7 +337,6 @@ static void run_solve_complete_problems(
   // comparing our TSA with the solver used to generate them.
   grouper.check_overall_improvement(expected_improvement);
 }
-
 
 SCENARIO("Best TSA : solve complete problems - long test", "[.long]") {
   FixedCompleteSolutions complete_solutions;
@@ -381,7 +375,8 @@ SCENARIO("Best TSA : solve complete problems - long test", "[.long]") {
 
   const double expected_improvement = 3.25087;
 
-  run_solve_complete_problems(complete_solutions, expected_messages, expected_improvement);
+  run_solve_complete_problems(
+      complete_solutions, expected_messages, expected_improvement);
 }
 
 SCENARIO("Best TSA : solve complete problems") {
@@ -429,7 +424,8 @@ SCENARIO("Best TSA : solve complete problems") {
       "5 WORSE (288 vs 273): av 5% incr]"};
   const double expected_improvement = 1.62791;
 
-  run_solve_complete_problems(complete_solutions, expected_messages, expected_improvement);
+  run_solve_complete_problems(
+      complete_solutions, expected_messages, expected_improvement);
 }
 
 }  // namespace tests

--- a/tket/tests/test_AASRoute.cpp
+++ b/tket/tests/test_AASRoute.cpp
@@ -291,48 +291,6 @@ SCENARIO("Test aas route in RV3") {
     CompilationUnit cu0(mf->circuit_, preds);
     REQUIRE(cu0.check_all_predicates());
   }
-  GIVEN("AASRouteRoutingMethod - test routing_method III") {
-    Circuit circ(11);
-    std::vector<Qubit> qubits = circ.all_qubits();
-
-    std::map<UnitID, UnitID> rename_map = {
-        {qubits[0], nodes[0]}, {qubits[1], nodes[1]},  {qubits[2], nodes[2]},
-        {qubits[3], nodes[3]}, {qubits[4], nodes[4]},  {qubits[5], nodes[5]},
-        {qubits[6], nodes[6]}, {qubits[7], nodes[7]},  {qubits[8], nodes[8]},
-        {qubits[9], nodes[9]}, {qubits[10], nodes[10]}};
-
-    Circuit ppb_circ(11);
-
-    ppb_circ.add_op<UnitID>(OpType::CX, {qubits[0], qubits[4]});
-    ppb_circ.add_op<UnitID>(OpType::CX, {qubits[6], qubits[7]});
-    ppb_circ.add_op<UnitID>(OpType::CX, {qubits[1], qubits[10]});
-    ppb_circ.add_op<UnitID>(OpType::CX, {qubits[8], qubits[5]});
-    ppb_circ.add_op<UnitID>(OpType::CX, {qubits[3], qubits[9]});
-
-    PhasePolyBox ppbox(ppb_circ);
-    circ.add_box(ppbox, qubits);
-
-    circ.rename_units(rename_map);
-
-    Circuit circ_copy(circ);
-
-    std::shared_ptr<MappingFrontier> mf =
-        std::make_shared<MappingFrontier>(circ);
-
-    AASRouteRoutingMethod aasrm(1, aas::CNotSynthType::Rec);
-
-    REQUIRE(aasrm.routing_method(mf, shared_arc).first);
-
-    // aasrm.routing_method(mf, shared_arc);
-
-    REQUIRE(test_unitary_comparison(mf->circuit_, circ_copy));
-
-    PredicatePtr routed_correctly =
-        std::make_shared<ConnectivityPredicate>(architecture);
-    PredicatePtrMap preds{CompilationUnit::make_type_pair(routed_correctly)};
-    CompilationUnit cu0(mf->circuit_, preds);
-    REQUIRE(cu0.check_all_predicates());
-  }
   GIVEN("AASRouteRoutingMethod  and LexiRouteRoutingMethod I") {
     std::vector<Node> nodes_mixed = {
         Node("node_test", 0), Node("test_node", 1), Node("node_test", 2)};
@@ -874,4 +832,68 @@ SCENARIO("Test aas route in RV3") {
     REQUIRE(circ.count_gates(OpType::SWAP) == 28);
   }
 }
+
+SCENARIO("Test aas route in RV3 - long test", "[.long]") {
+  std::vector<Node> nodes = {
+      Node("test_node", 0), Node("test_node", 1), Node("test_node", 2),
+      Node("node_test", 3), Node("node_test", 4), Node("node_test", 5),
+      Node("test_node", 6), Node("node_test", 7), Node("node_test", 8),
+      Node("node_test", 9), Node("node_test", 10)};
+
+  Architecture architecture(
+      {{nodes[0], nodes[1]},
+       {nodes[1], nodes[2]},
+       {nodes[2], nodes[3]},
+       {nodes[3], nodes[4]},
+       {nodes[2], nodes[5]},
+       {nodes[5], nodes[6]},
+       {nodes[4], nodes[7]},
+       {nodes[7], nodes[8]},
+       {nodes[8], nodes[9]},
+       {nodes[9], nodes[10]}});
+  ArchitecturePtr shared_arc = std::make_shared<Architecture>(architecture);
+  GIVEN("AASRouteRoutingMethod - test routing_method III") {
+    Circuit circ(11);
+    std::vector<Qubit> qubits = circ.all_qubits();
+
+    std::map<UnitID, UnitID> rename_map = {
+        {qubits[0], nodes[0]}, {qubits[1], nodes[1]},  {qubits[2], nodes[2]},
+        {qubits[3], nodes[3]}, {qubits[4], nodes[4]},  {qubits[5], nodes[5]},
+        {qubits[6], nodes[6]}, {qubits[7], nodes[7]},  {qubits[8], nodes[8]},
+        {qubits[9], nodes[9]}, {qubits[10], nodes[10]}};
+
+    Circuit ppb_circ(11);
+
+    ppb_circ.add_op<UnitID>(OpType::CX, {qubits[0], qubits[4]});
+    ppb_circ.add_op<UnitID>(OpType::CX, {qubits[6], qubits[7]});
+    ppb_circ.add_op<UnitID>(OpType::CX, {qubits[1], qubits[10]});
+    ppb_circ.add_op<UnitID>(OpType::CX, {qubits[8], qubits[5]});
+    ppb_circ.add_op<UnitID>(OpType::CX, {qubits[3], qubits[9]});
+
+    PhasePolyBox ppbox(ppb_circ);
+    circ.add_box(ppbox, qubits);
+
+    circ.rename_units(rename_map);
+
+    Circuit circ_copy(circ);
+
+    std::shared_ptr<MappingFrontier> mf =
+        std::make_shared<MappingFrontier>(circ);
+
+    AASRouteRoutingMethod aasrm(1, aas::CNotSynthType::Rec);
+
+    REQUIRE(aasrm.routing_method(mf, shared_arc).first);
+
+    // aasrm.routing_method(mf, shared_arc);
+
+    REQUIRE(test_unitary_comparison(mf->circuit_, circ_copy));
+
+    PredicatePtr routed_correctly =
+        std::make_shared<ConnectivityPredicate>(architecture);
+    PredicatePtrMap preds{CompilationUnit::make_type_pair(routed_correctly)};
+    CompilationUnit cu0(mf->circuit_, preds);
+    REQUIRE(cu0.check_all_predicates());
+  }
+}
+
 }  // namespace tket

--- a/tket/tests/test_ControlDecomp.cpp
+++ b/tket/tests/test_ControlDecomp.cpp
@@ -178,6 +178,16 @@ SCENARIO("Test switch statement") {
       REQUIRE(circ.count_gates(OpType::Ry) == 6);
       REQUIRE(verify_n_qubits_for_ops(circ));
     }
+  }
+}
+
+SCENARIO("Test switch statement long", "[.long]") {
+  Circuit test(1);
+  test.add_op<unsigned>(OpType::Ry, 1.95, {0});
+  const Eigen::Matrix2cd correct_block = tket_sim::get_unitary(test);
+  GIVEN("A circuit and a CnRy(Pi/2)") {
+    Circuit circ;
+    const double p = 0.5;
     WHEN("N-qubit CnRy gates") {
       THEN("Test with params nonzero") {
         for (unsigned N = 4; N < 10; ++N) {
@@ -216,6 +226,7 @@ SCENARIO("Test switch statement") {
     }
   }
 }
+
 
 SCENARIO("Test incrementer using n borrowed qubits") {
   GIVEN("0 qbs") {
@@ -370,7 +381,7 @@ SCENARIO("Test incrementer using 1 borrowed qubit") {
   }
 }
 
-SCENARIO("Test a CnX is decomposed correctly when bootstrapped") {
+SCENARIO("Test a CnX is decomposed correctly when bootstrapped", "[.long]") {
   GIVEN("Test CnX unitary for 3 to 9 controls") {
     for (unsigned n = 3; n < 10; ++n) {
       Circuit circ = Transforms::cnx_normal_decomp(n);

--- a/tket/tests/test_ControlDecomp.cpp
+++ b/tket/tests/test_ControlDecomp.cpp
@@ -227,7 +227,6 @@ SCENARIO("Test switch statement long", "[.long]") {
   }
 }
 
-
 SCENARIO("Test incrementer using n borrowed qubits") {
   GIVEN("0 qbs") {
     Circuit inc = Transforms::incrementer_borrow_n_qubits(0);

--- a/tket/tests/test_LexiRoute.cpp
+++ b/tket/tests/test_LexiRoute.cpp
@@ -1131,7 +1131,8 @@ SCENARIO("Dense CX circuits route succesfully") {
 
 SCENARIO(
     "Dense CX circuits route succesfully on undirected Ring with "
-    "placement.", "[.long]") {
+    "placement.",
+    "[.long]") {
   GIVEN("Complex CX circuits, big ring") {
     Circuit circ(29);
     for (unsigned x = 0; x < 29; ++x) {

--- a/tket/tests/test_LexiRoute.cpp
+++ b/tket/tests/test_LexiRoute.cpp
@@ -1131,7 +1131,7 @@ SCENARIO("Dense CX circuits route succesfully") {
 
 SCENARIO(
     "Dense CX circuits route succesfully on undirected Ring with "
-    "placement.") {
+    "placement.", "[.long]") {
   GIVEN("Complex CX circuits, big ring") {
     Circuit circ(29);
     for (unsigned x = 0; x < 29; ++x) {

--- a/tket/tests/test_RoutingPasses.cpp
+++ b/tket/tests/test_RoutingPasses.cpp
@@ -408,6 +408,11 @@ SCENARIO(
     REQUIRE(all_coms[1].get_args()[0] == circ.all_bits()[0]);
     REQUIRE(all_coms[1].get_args()[1] == circ.all_bits()[1]);
   }
+}
+
+SCENARIO(
+    "Methods related to correct routing and decomposition of circuits with "
+    "classical wires - long test.", "[.long]") {
   GIVEN(
       "A large circuit, with a mixture of conditional CX and CZ with "
       "multiple classical wires, non conditional CX and CZ, and single "

--- a/tket/tests/test_RoutingPasses.cpp
+++ b/tket/tests/test_RoutingPasses.cpp
@@ -412,7 +412,8 @@ SCENARIO(
 
 SCENARIO(
     "Methods related to correct routing and decomposition of circuits with "
-    "classical wires - long test.", "[.long]") {
+    "classical wires - long test.",
+    "[.long]") {
   GIVEN(
       "A large circuit, with a mixture of conditional CX and CZ with "
       "multiple classical wires, non conditional CX and CZ, and single "

--- a/tket/tests/test_SteinerForest.cpp
+++ b/tket/tests/test_SteinerForest.cpp
@@ -402,7 +402,7 @@ SCENARIO("check error in steiner Forest") {
         aas::best_operations_lookahead(ph, sf, 1), std::logic_error);
   }
 }
-SCENARIO("Synthesise a phase polynomial for a given architecture") {
+SCENARIO("Synthesise a phase polynomial for a given architecture", "[.long]") {
   GIVEN("phase_poly_synthesis 1") {
     const Architecture archi(
         {{Node(0), Node(1)}, {Node(1), Node(2)}, {Node(2), Node(3)}});


### PR DESCRIPTION
This PR is a refactoring of the current tests and CI so those tests that have a running time >= 1 second (on a regular modern laptop) are executed only once a week. It includes the following changes:
- The long tests have the `"[.long]"` tag, which means that they are by default _hidden_, and can be run by specifying the `"[long]"` tag to the test_tket binary. **NOTE:** making a scenario hidden has the side-effect that its tags are not reported if you run the catch2 binary with `-t` to list the tags. 
- Remove the `TKET_TESTS_FULL` compilation flag so now all the tests are built at once.
- Refactor some of the tests so only the long running `GIVEN` cases are assigned the `"[.long]"` flag.
- Add the `tket-tests:long` option to run only the long tests.
- Change the coverage.yml to generate and check 2 different coverage reports, one for the _normal_ tests, and one for the _full suite_ tests.