### PR TITLE
Write conan info to file instead of stdout.

### DIFF
--- a/pytket/setup.py
+++ b/pytket/setup.py
@@ -99,7 +99,7 @@ class CMakeBuild(build_ext):
                 cwd=extsource,
             )
             conaninfo = dict([(comp["reference"], comp) for comp in json.load(f)])
-            os.unlink(f)
+            os.unlink(f.name)
             reqs = conaninfo["conanfile.txt"]["requires"]
             tket_reqs = [req for req in reqs if req.startswith("tket/")]
             assert len(tket_reqs) == 1

--- a/pytket/setup.py
+++ b/pytket/setup.py
@@ -98,7 +98,7 @@ class CMakeBuild(build_ext):
                     ],
                     cwd=extsource,
                 )
-                conaninfo = dict([(comp["reference"], comp) for comp in json.loads(f)])
+                conaninfo = dict([(comp["reference"], comp) for comp in json.load(f)])
             reqs = conaninfo["conanfile.txt"]["requires"]
             tket_reqs = [req for req in reqs if req.startswith("tket/")]
             assert len(tket_reqs) == 1

--- a/pytket/setup.py
+++ b/pytket/setup.py
@@ -84,21 +84,22 @@ class CMakeBuild(build_ext):
         if platform.system() in ["Darwin", "Windows"]:
             # Hack to put the tket library alongside the extension libraries
             conan_tket_profile = os.getenv("CONAN_TKET_PROFILE", default="tket")
-            with NamedTemporaryFile() as f:
-                subprocess.run(
-                    [
-                        "conan",
-                        "info",
-                        "--profile",
-                        conan_tket_profile,
-                        "--path",
-                        "--json",
-                        f.name,
-                        ".",
-                    ],
-                    cwd=extsource,
-                )
-                conaninfo = dict([(comp["reference"], comp) for comp in json.load(f)])
+            f = NamedTemporaryFile(delete=False)
+            subprocess.run(
+                [
+                    "conan",
+                    "info",
+                    "--profile",
+                    conan_tket_profile,
+                    "--path",
+                    "--json",
+                    f.name,
+                    ".",
+                ],
+                cwd=extsource,
+            )
+            conaninfo = dict([(comp["reference"], comp) for comp in json.load(f)])
+            os.unlink(f)
             reqs = conaninfo["conanfile.txt"]["requires"]
             tket_reqs = [req for req in reqs if req.startswith("tket/")]
             assert len(tket_reqs) == 1

--- a/pytket/setup.py
+++ b/pytket/setup.py
@@ -97,9 +97,8 @@ class CMakeBuild(build_ext):
                 ],
                 cwd=extsource,
             )
-            conaninfo = dict(
-                [(comp["reference"], comp) for comp in json.load(jsondump)]
-            )
+            with open(jsondump) as f:
+                conaninfo = dict([(comp["reference"], comp) for comp in json.load(f)])
             os.remove(jsondump)
             reqs = conaninfo["conanfile.txt"]["requires"]
             tket_reqs = [req for req in reqs if req.startswith("tket/")]


### PR DESCRIPTION
Fixes #299 .

The "conan info" command may print informational messages to stdout, in particular about use of compatible packages. Obviously this makes the output invalid json.

This started happening with some recent updates to how conan handles apple-clang versions "13" and "13.0".

Couldn't get the tempfile solution to work on Windows so resorted to a fixed filename.