### PR TITLE
Pin jinja2 and gcovr versions.

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -96,7 +96,8 @@ jobs:
       if: github.event_name == 'schedule'
       run: ./build/tket-tests/bin/test_tket "[long],~[long]"
     - name: Install gcovr
-      run: pip install gcovr
+      # gcovr 5.0 is incompatible with jinja2 3.1.0
+      run: pip install jinja2==3.0.3 gcovr==5.0
     - name: Build coverage report
       run: |
         mkdir test-coverage


### PR DESCRIPTION
Works around incompatibility between gcovr 5.0 and jinja2 3.1.0 (see https://github.com/CQCL/tket/runs/5688235924 for error).