### PR TITLE
[TKET-1915] Add PhasePolyBox creation from circuit to Python

### DIFF
--- a/pytket/binders/circuit/boxes.cpp
+++ b/pytket/binders/circuit/boxes.cpp
@@ -186,7 +186,45 @@ void init_boxes(py::module &m) {
             boost::bimap<Qubit, unsigned> bmap;
             for (const auto &pair : q_ind) {
               bmap.insert({pair.first, pair.second});
+              if (pair.second >= n_qb) {
+                throw std::invalid_argument(
+                    "The creation of a phasepolybox failed: index in qubit "
+                    "list is out of range");
+              }
             }
+
+            for (auto const &ps : p_p) {
+              if (ps.first.size() != n_qb) {
+                throw std::invalid_argument(
+                    "The creation of a phasepolybox failed: PhasePolynomial "
+                    "does not match the given number of qubits");
+              }
+              bool found_element = false;
+              for (bool e : ps.first) {
+                if (e) {
+                  found_element = true;
+                  break;
+                }
+              }
+              if (!found_element) {
+                throw std::invalid_argument(
+                    "The creation of a phasepolybox failed: PhasePolynomial "
+                    "contains unvalid element");
+              }
+            }
+
+            if (lin_trans.rows() != n_qb) {
+              throw std::invalid_argument(
+                  "The creation of a phasepolybox failed: row size of the "
+                  "linear transformation does not match the number of qubits");
+            }
+
+            if (lin_trans.cols() != n_qb) {
+              throw std::invalid_argument(
+                  "The creation of a phasepolybox failed: cols size of the "
+                  "linear transformation does not match the number of qubits");
+            }
+
             return PhasePolyBox(n_qb, bmap, p_p, lin_trans);
           }),
           "Construct from the number of qubits, the mapping from "
@@ -194,6 +232,11 @@ void init_boxes(py::module &m) {
           "to phase) and the linear transformation (boolean matrix)",
           py::arg("n_qubits"), py::arg("qubit_indices"),
           py::arg("phase_polynomial"), py::arg("linear_transformation"))
+      .def(
+          py::init([](const Circuit &circ) { return PhasePolyBox(circ); }),
+          "Construct a PhasePolyBox from a given circuit containing only Rz "
+          "and CNot gates.",
+          py::arg("circuit"))
       .def_property_readonly(
           "n_qubits", &PhasePolyBox::get_n_qubits,
           "Number of gates the polynomial acts on.")
@@ -211,6 +254,9 @@ void init_boxes(py::module &m) {
       .def_property_readonly(
           "linear_transformation", &PhasePolyBox::get_linear_transformation,
           "Boolean matrix corresponding to linear transformation.")
+      .def(
+          "get_circuit", [](PhasePolyBox &ppb) { return *ppb.to_circuit(); },
+          ":return: the :py:class:`Circuit` described by the box.")
       .def_property_readonly(
           "qubit_indices",
           [](PhasePolyBox &ppoly) {

--- a/pytket/binders/passes.cpp
+++ b/pytket/binders/passes.cpp
@@ -78,6 +78,16 @@ static PassPtr gen_default_aas_routing_pass(
   return gen_full_mapping_pass_phase_poly(arc, lookahead, cnotsynthtype);
 }
 
+static PassPtr gen_composephasepolybox_pass(py::kwargs kwargs) {
+  unsigned min_size = 0;
+
+  if (kwargs.contains("min_size")) {
+    min_size = py::cast<unsigned>(kwargs["min_size"]);
+  }
+
+  return RebaseUFR() >> ComposePhasePolyBoxes(min_size);
+}
+
 const PassPtr &DecomposeClassicalExp() {
   // a special box decomposer for Circuits containing
   // ClassicalExpBox<py::object>
@@ -539,6 +549,16 @@ PYBIND11_MODULE(passes, m) {
       "\n:param \\**kwargs: parameters for routing (described above)"
       "\n:return: a pass to perform the remapping",
       py::arg("arc"));
+
+  m.def(
+      "ComposePhasePolyBoxes", &gen_composephasepolybox_pass,
+      "Pass to convert a given circuit to the CX, Rz, H gateset and composes "
+      "phasepolyboxes from the groups of the CX+Rz gates."
+      "\n\n- (unsigned) min_size=0: minimal number of cnots in each phase "
+      "polynominal box, groups with a smaler number of CX gates are not "
+      "effected by this transformation"
+      "\n:param \\**kwargs: parameters for composition (described above)"
+      "\n:return: a pass to perform the composition");
 
   m.def(
       "CXMappingPass", &gen_cx_mapping_pass_kwargs,

--- a/pytket/tests/architecture_aware_synthesis_test.py
+++ b/pytket/tests/architecture_aware_synthesis_test.py
@@ -14,7 +14,7 @@
 
 from pytket.circuit import Circuit, OpType  # type: ignore
 from pytket.architecture import Architecture  # type: ignore
-from pytket.passes import AASRouting, CNotSynthType  # type: ignore
+from pytket.passes import AASRouting, CNotSynthType, ComposePhasePolyBoxes  # type: ignore
 from pytket.predicates import CompilationUnit  # type: ignore
 
 
@@ -202,6 +202,15 @@ def test_noncontiguous_arc_phase_poly() -> None:
     assert c.n_gates_of_type(OpType.CX) == 0
 
 
+def test_compose_ppb() -> None:
+    circ = Circuit(5).CZ(0, 1).CZ(1, 2).CX(2, 3).CX(3, 4)
+    pass1 = ComposePhasePolyBoxes(min_size=2)
+    cu = CompilationUnit(circ)
+    assert pass1.apply(cu)
+    out_circ = cu.circuit
+    assert out_circ.depth() == 6
+
+
 if __name__ == "__main__":
     test_AAS()
     test_AAS_2()
@@ -219,3 +228,4 @@ if __name__ == "__main__":
     test_AAS_14()
     test_AAS_15()
     test_noncontiguous_arc_phase_poly()
+    test_compose_ppb()

--- a/pytket/tests/circuit_test.py
+++ b/pytket/tests/circuit_test.py
@@ -693,17 +693,96 @@ def test_opgroups() -> None:
 def test_phase_polybox() -> None:
     c = Circuit(1, 1)
     n_qb = 1
-    qubit_indices = {Qubit(0): 1}
-    phase_polynomial = {(True,): 0.1, (False,): 0.1}
-    linear_transformation = np.array([[1, 0], [0, 1]])
+    qubit_indices = {Qubit(0): 0}
+    phase_polynomial = {(True,): 0.1}
+    linear_transformation = np.array([[1]])
     p_box = PhasePolyBox(n_qb, qubit_indices, phase_polynomial, linear_transformation)
+
+    b = p_box.get_circuit()
+
+    p_box_ii = PhasePolyBox(b)
 
     c.add_phasepolybox(p_box, [0])
     c.add_phasepolybox(p_box, [Qubit(0)])
+
+    c.add_phasepolybox(p_box_ii, [0])
+
     assert p_box.n_qubits == n_qb
+    assert p_box_ii.n_qubits == n_qb
     assert p_box.qubit_indices == qubit_indices
+    assert p_box_ii.qubit_indices == qubit_indices
     assert p_box.phase_polynomial == phase_polynomial
+    assert p_box_ii.phase_polynomial == phase_polynomial
     assert np.array_equal(p_box.linear_transformation, linear_transformation)
+    assert np.array_equal(p_box_ii.linear_transformation, linear_transformation)
+    assert DecomposeBoxes().apply(c)
+
+
+def test_phase_polybox_II() -> None:
+    c = Circuit(1, 1)
+    n_qb = 1
+    qubit_indices = {Qubit(0): 0}
+    phase_polynomial = {(True,): 0.1, (True,): 0.3}
+    linear_transformation = np.array([[1]])
+    p_box = PhasePolyBox(n_qb, qubit_indices, phase_polynomial, linear_transformation)
+
+    b = p_box.get_circuit()
+
+    p_box_ii = PhasePolyBox(b)
+
+    c.add_phasepolybox(p_box, [0])
+    c.add_phasepolybox(p_box, [Qubit(0)])
+
+    c.add_phasepolybox(p_box_ii, [0])
+
+    assert p_box.n_qubits == n_qb
+    assert p_box_ii.n_qubits == n_qb
+    assert p_box.qubit_indices == qubit_indices
+    assert p_box_ii.qubit_indices == qubit_indices
+    assert p_box.phase_polynomial == phase_polynomial
+    assert p_box_ii.phase_polynomial == phase_polynomial
+    assert np.array_equal(p_box.linear_transformation, linear_transformation)
+    assert np.array_equal(p_box_ii.linear_transformation, linear_transformation)
+    assert DecomposeBoxes().apply(c)
+
+
+def test_phase_polybox_error() -> None:
+    # uses a unvalid qubit_indices not staring at 0
+    c = Circuit(1, 1)
+    n_qb = 1
+    qubit_indices = {Qubit(0): 1}
+    phase_polynomial = {(True,): 0.1, (True,): 0.3}
+    linear_transformation = np.array([[1]])
+    with pytest.raises(Exception) as e:
+        p_box = PhasePolyBox(
+            n_qb, qubit_indices, phase_polynomial, linear_transformation
+        )
+
+
+def test_phase_polybox_error_ii() -> None:
+    # uses a unvalid phase_polynomial
+    c = Circuit(1, 1)
+    n_qb = 1
+    qubit_indices = {Qubit(0): 0}
+    phase_polynomial = {(False,): 0.1, (True,): 0.3}
+    linear_transformation = np.array([[1]])
+    with pytest.raises(Exception) as e:
+        p_box = PhasePolyBox(
+            n_qb, qubit_indices, phase_polynomial, linear_transformation
+        )
+
+
+def test_phase_polybox_error_iii() -> None:
+    # uses a linear_transformation with a dimension not matching the qubit list
+    c = Circuit(1, 1)
+    n_qb = 1
+    qubit_indices = {Qubit(0): 0}
+    phase_polynomial = {(True,): 0.3}
+    linear_transformation = np.array([[1, 0], [0, 1]])
+    with pytest.raises(Exception) as e:
+        p_box = PhasePolyBox(
+            n_qb, qubit_indices, phase_polynomial, linear_transformation
+        )
 
 
 def test_phase_polybox_big() -> None:
@@ -713,16 +792,25 @@ def test_phase_polybox_big() -> None:
     phase_polynomial = {
         (True, False, True): 0.333,
         (False, False, True): 0.05,
-        (False, False, False): 1.05,
+        (False, True, False): 1.05,
     }
-    linear_transformation = np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]])
+    linear_transformation = np.array([[1, 1, 0], [0, 1, 0], [0, 0, 1]])
     p_box = PhasePolyBox(n_qb, qubit_indices, phase_polynomial, linear_transformation)
 
+    b = p_box.get_circuit()
+
+    p_box_ii = PhasePolyBox(b)
+
     c.add_phasepolybox(p_box, [0, 1, 2])
+    c.add_phasepolybox(p_box_ii, [0, 1, 2])
     assert p_box.n_qubits == n_qb
+    assert p_box_ii.n_qubits == n_qb
     assert p_box.qubit_indices == qubit_indices
+    assert p_box_ii.qubit_indices == qubit_indices
     assert p_box.phase_polynomial == phase_polynomial
+    assert p_box_ii.phase_polynomial == phase_polynomial
     assert np.array_equal(p_box.linear_transformation, linear_transformation)
+    assert np.array_equal(p_box_ii.linear_transformation, linear_transformation)
     assert DecomposeBoxes().apply(c)
 
 

--- a/pytket/tests/predicates_test.py
+++ b/pytket/tests/predicates_test.py
@@ -37,6 +37,7 @@ from pytket.passes import (  # type: ignore
     FullMappingPass,
     DefaultMappingPass,
     AASRouting,
+    ComposePhasePolyBoxes,
     DecomposeSwapsToCXs,
     DecomposeSwapsToCircuit,
     PauliSimp,
@@ -744,6 +745,14 @@ def test_generated_pass_config() -> None:
     assert rebase_pass.to_dict()["StandardPass"]["name"] == "RebaseUFR"
     comppb_pass = aas_pass_00.get_sequence()[1]
     assert comppb_pass.to_dict()["StandardPass"]["name"] == "ComposePhasePolyBoxes"
+    # ComposePhasePolyBoxes
+    ppb_pass = ComposePhasePolyBoxes(min_size=3)
+    assert ppb_pass.to_dict()["pass_class"] == "SequencePass"
+    ppb_pass_0 = ppb_pass.get_sequence()[0]
+    ppb_pass_1 = ppb_pass.get_sequence()[1]
+    assert ppb_pass_0.to_dict()["StandardPass"]["name"] == "RebaseUFR"
+    assert ppb_pass_1.to_dict()["StandardPass"]["name"] == "ComposePhasePolyBoxes"
+    assert ppb_pass_1.to_dict()["StandardPass"]["min_size"] == 3
     # CXMappingPass
     cxm_pass = CXMappingPass(arc, placer, directed_cx=True, delay_measures=True)
     assert cxm_pass.to_dict()["pass_class"] == "SequencePass"

--- a/tket/src/Converters/include/Converters/PhasePoly.hpp
+++ b/tket/src/Converters/include/Converters/PhasePoly.hpp
@@ -115,7 +115,8 @@ class CircToPhasePolyConversion {
    * @throw not implemented for unsupported gates
    * @param circ circuit to be converted
    */
-  explicit CircToPhasePolyConversion(const Circuit &circ);
+  explicit CircToPhasePolyConversion(
+      const Circuit &circ, unsigned min_size = 0);
   void convert();
   Circuit get_circuit() const;
 
@@ -124,6 +125,8 @@ class CircToPhasePolyConversion {
   void add_phase_poly_box();
   unsigned nq_;
   unsigned nb_;
+  unsigned min_size_;
+  unsigned box_size_;
   std::map<Qubit, unsigned> qubit_indices_;
   std::map<Bit, unsigned> bit_indices_;
   std::vector<QubitType> qubit_types_;

--- a/tket/src/Predicates/CompilerPass.cpp
+++ b/tket/src/Predicates/CompilerPass.cpp
@@ -408,7 +408,7 @@ void from_json(const nlohmann::json& j, PassPtr& pp) {
     } else if (passname == "RemoveBarriers") {
       pp = RemoveBarriers();
     } else if (passname == "ComposePhasePolyBoxes") {
-      pp = ComposePhasePolyBoxes();
+      pp = ComposePhasePolyBoxes(content.at("min_size").get<unsigned>());
     } else if (passname == "RebaseCustom") {
       throw NotImplemented(
           "Deserialization of RebaseCustom not yet implemented.");

--- a/tket/src/Predicates/include/Predicates/PassLibrary.hpp
+++ b/tket/src/Predicates/include/Predicates/PassLibrary.hpp
@@ -37,7 +37,7 @@ const PassPtr &DecomposeBoxes();
  * converts a circuit containing all possible gates to a circuit containing only
  * phase poly boxes + H gates (and measure + reset + collapse + barrier)
  */
-const PassPtr &ComposePhasePolyBoxes();
+PassPtr ComposePhasePolyBoxes(const unsigned min_size = 0);
 
 /** Squash sequences of single-qubit gates to TK1 gates. */
 const PassPtr &SquashTK1();

--- a/tket/src/Transformations/Decomposition.cpp
+++ b/tket/src/Transformations/Decomposition.cpp
@@ -745,8 +745,8 @@ Transform decomp_boxes() {
   return Transform([](Circuit &circ) { return circ.decompose_boxes(); });
 }
 
-Transform compose_phase_poly_boxes() {
-  return Transform([](Circuit &circ) {
+Transform compose_phase_poly_boxes(const unsigned min_size) {
+  return Transform([=](Circuit &circ) {
     // replace wireswaps with three CX
     while (circ.has_implicit_wireswaps()) {
       qubit_map_t perm = circ.implicit_qubit_permutation();
@@ -758,7 +758,7 @@ Transform compose_phase_poly_boxes() {
       }
     }
 
-    CircToPhasePolyConversion conv = CircToPhasePolyConversion(circ);
+    CircToPhasePolyConversion conv = CircToPhasePolyConversion(circ, min_size);
     conv.convert();
     circ = conv.get_circuit();
     return true;

--- a/tket/src/Transformations/include/Transformations/Decomposition.hpp
+++ b/tket/src/Transformations/include/Transformations/Decomposition.hpp
@@ -113,7 +113,7 @@ Transform decomp_boxes();
  * Expects: only CX + Rz + H (and measure + reset + collapse + barrier)
  * returns: H + PhasePolyBox
  */
-Transform compose_phase_poly_boxes();
+Transform compose_phase_poly_boxes(const unsigned min_size = 0);
 
 // converts all SWAP gates to given replacement circuit (not checked to
 // preserve unitary) Expects: SWAP gates, replacement circuit Produces:

--- a/tket/tests/test_CompilerPass.cpp
+++ b/tket/tests/test_CompilerPass.cpp
@@ -853,6 +853,80 @@ SCENARIO("rebase and decompose PhasePolyBox test") {
     REQUIRE(test_unitary_comparison(result, circ));
     REQUIRE(NoWireSwapsPredicate().verify(result));
   }
+  GIVEN("NoWireSwapsPredicate for ComposePhasePolyBoxes min size") {
+    Circuit circ(5);
+    add_2qb_gates(circ, OpType::CX, {{0, 3}, {1, 4}});
+    circ.add_op<unsigned>(OpType::SWAP, {3, 4});
+    circ.add_op<unsigned>(OpType::CX, {2, 3});
+    circ.add_op<unsigned>(OpType::Z, {3});
+    circ.add_op<unsigned>(OpType::H, {3});
+    circ.add_op<unsigned>(OpType::CX, {2, 3});
+    circ.add_op<unsigned>(OpType::SWAP, {0, 1});
+    circ.add_op<unsigned>(OpType::CX, {1, 4});
+    circ.add_op<unsigned>(OpType::Z, {4});
+    circ.add_op<unsigned>(OpType::CX, {1, 4});
+    circ.add_op<unsigned>(OpType::H, {3});
+    circ.add_op<unsigned>(OpType::SWAP, {1, 2});
+    circ.add_op<unsigned>(OpType::SWAP, {2, 3});
+    circ.add_op<unsigned>(OpType::CX, {0, 1});
+    circ.add_op<unsigned>(OpType::CX, {1, 2});
+    circ.add_op<unsigned>(OpType::H, {3});
+    circ.add_op<unsigned>(OpType::CX, {2, 3});
+
+    REQUIRE(NoWireSwapsPredicate().verify(circ));
+    circ.replace_SWAPs();
+    REQUIRE(!NoWireSwapsPredicate().verify(circ));
+
+    CompilationUnit cu(circ);
+    REQUIRE(ComposePhasePolyBoxes(5)->apply(cu));
+    Circuit result = cu.get_circ_ref();
+
+    REQUIRE(result.count_gates(OpType::H) == 3);
+    REQUIRE(result.count_gates(OpType::CX) == 2);
+    REQUIRE(result.count_gates(OpType::SWAP) == 0);
+    REQUIRE(result.count_gates(OpType::Z) == 0);
+    REQUIRE(result.count_gates(OpType::PhasePolyBox) == 2);
+
+    REQUIRE(test_unitary_comparison(result, circ));
+    REQUIRE(NoWireSwapsPredicate().verify(result));
+  }
+  GIVEN("NoWireSwapsPredicate for ComposePhasePolyBoxes min size ii") {
+    Circuit circ(5);
+    add_2qb_gates(circ, OpType::CX, {{0, 3}, {1, 4}});
+    circ.add_op<unsigned>(OpType::SWAP, {3, 4});
+    circ.add_op<unsigned>(OpType::CX, {2, 3});
+    circ.add_op<unsigned>(OpType::Z, {3});
+    circ.add_op<unsigned>(OpType::H, {3});
+    circ.add_op<unsigned>(OpType::CX, {2, 3});
+    circ.add_op<unsigned>(OpType::SWAP, {0, 1});
+    circ.add_op<unsigned>(OpType::CX, {1, 4});
+    circ.add_op<unsigned>(OpType::Z, {4});
+    circ.add_op<unsigned>(OpType::CX, {1, 4});
+    circ.add_op<unsigned>(OpType::H, {3});
+    circ.add_op<unsigned>(OpType::SWAP, {1, 2});
+    circ.add_op<unsigned>(OpType::SWAP, {2, 3});
+    circ.add_op<unsigned>(OpType::CX, {0, 1});
+    circ.add_op<unsigned>(OpType::CX, {1, 2});
+    circ.add_op<unsigned>(OpType::H, {3});
+    circ.add_op<unsigned>(OpType::CX, {2, 3});
+
+    REQUIRE(NoWireSwapsPredicate().verify(circ));
+    circ.replace_SWAPs();
+    REQUIRE(!NoWireSwapsPredicate().verify(circ));
+
+    CompilationUnit cu(circ);
+    REQUIRE(ComposePhasePolyBoxes(6)->apply(cu));
+    Circuit result = cu.get_circ_ref();
+
+    REQUIRE(result.count_gates(OpType::H) == 3);
+    REQUIRE(result.count_gates(OpType::CX) == 7);
+    REQUIRE(result.count_gates(OpType::SWAP) == 0);
+    REQUIRE(result.count_gates(OpType::Z) == 0);
+    REQUIRE(result.count_gates(OpType::PhasePolyBox) == 1);
+
+    REQUIRE(test_unitary_comparison(result, circ));
+    REQUIRE(NoWireSwapsPredicate().verify(result));
+  }
   GIVEN("NoWireSwapsPredicate for aas I") {
     std::vector<Node> nodes = {Node(0), Node(1), Node(2), Node(3), Node(4)};
     Architecture architecture(

--- a/tket/tests/test_PhasePolynomials.cpp
+++ b/tket/tests/test_PhasePolynomials.cpp
@@ -355,7 +355,7 @@ SCENARIO("Test conversion of circuit to circuit with phase poly boxes") {
     circ.add_op<unsigned>(OpType::H, {0});
     circ.add_op<unsigned>(OpType::H, {1});
 
-    CircToPhasePolyConversion conv = CircToPhasePolyConversion(circ);
+    CircToPhasePolyConversion conv = CircToPhasePolyConversion(circ, 1);
     conv.convert();
     Circuit result = conv.get_circuit();
 
@@ -570,6 +570,109 @@ SCENARIO("Test conversion of circuit to circuit with phase poly boxes") {
         ++countmeasure;
       }
 
+      REQUIRE(ot == qubit_types[count]);
+      ++count;
+    }
+  }
+  GIVEN("convert_to_phase_poly minimal box size") {
+    unsigned n = 2;
+    Circuit circ(n);
+
+    circ.add_op<unsigned>(OpType::H, {0});
+    circ.add_op<unsigned>(OpType::H, {1});
+
+    circ.add_op<unsigned>(OpType::Rz, 0.01, {0});
+    for (unsigned i = 1; i < n; ++i) {
+      circ.add_op<unsigned>(OpType::CX, {i, 0});
+      circ.add_op<unsigned>(OpType::Rz, 0.1 * i, {0});
+    }
+
+    circ.add_op<unsigned>(OpType::H, {0});
+    circ.add_op<unsigned>(OpType::H, {1});
+    circ.add_barrier({0, 1});
+
+    circ.add_op<unsigned>(OpType::Rz, 0.01, {0});
+    for (unsigned i = 1; i < n; ++i) {
+      circ.add_op<unsigned>(OpType::CX, {i, 0});
+      circ.add_op<unsigned>(OpType::Rz, 0.1 * i, {0});
+    }
+
+    circ.add_op<unsigned>(OpType::H, {0});
+    circ.add_op<unsigned>(OpType::H, {1});
+
+    CircToPhasePolyConversion conv = CircToPhasePolyConversion(circ, 2);
+    conv.convert();
+    Circuit result = conv.get_circuit();
+
+    std::vector<OpType> qubit_types = std::vector<OpType>(13, OpType::H);
+
+    qubit_types[2] = OpType::Rz;
+    qubit_types[3] = OpType::CX;
+    qubit_types[4] = OpType::Rz;
+    qubit_types[7] = OpType::Barrier;
+    qubit_types[8] = OpType::Rz;
+    qubit_types[9] = OpType::CX;
+    qubit_types[10] = OpType::Rz;
+
+    int count = 0;
+
+    for (const Command& com : result) {
+      OpType ot = com.get_op_ptr()->get_type();
+      REQUIRE(ot == qubit_types[count]);
+      ++count;
+    }
+  }
+  GIVEN("convert_to_phase_poly minimal box size II") {
+    unsigned n = 4;
+    Circuit circ(n);
+
+    circ.add_op<unsigned>(OpType::H, {0});
+    circ.add_op<unsigned>(OpType::H, {1});
+    circ.add_op<unsigned>(OpType::H, {2});
+    circ.add_op<unsigned>(OpType::H, {3});
+
+    circ.add_op<unsigned>(OpType::Rz, 0.01, {0});
+    for (unsigned i = 1; i < n; ++i) {
+      circ.add_op<unsigned>(OpType::CX, {i, 0});
+      circ.add_op<unsigned>(OpType::Rz, 0.1 * i, {0});
+    }
+
+    circ.add_op<unsigned>(OpType::H, {0});
+    circ.add_op<unsigned>(OpType::H, {1});
+    circ.add_barrier({0, 1});
+
+    circ.add_op<unsigned>(OpType::Rz, 0.01, {0});
+    for (unsigned i = 1; i < n; ++i) {
+      circ.add_op<unsigned>(OpType::CX, {i, 0});
+      circ.add_op<unsigned>(OpType::Rz, 0.1 * i, {0});
+    }
+
+    circ.add_op<unsigned>(OpType::H, {0});
+    circ.add_op<unsigned>(OpType::H, {1});
+    circ.add_op<unsigned>(OpType::H, {2});
+    circ.add_op<unsigned>(OpType::H, {3});
+
+    circ.add_op<unsigned>(OpType::CX, {0, 1});
+    circ.add_op<unsigned>(OpType::Rz, 0.1 * 2, {0});
+    circ.add_op<unsigned>(OpType::Rz, 0.1 * 3, {1});
+
+    CircToPhasePolyConversion conv = CircToPhasePolyConversion(circ, 2);
+    conv.convert();
+    Circuit result = conv.get_circuit();
+
+    std::vector<OpType> qubit_types = std::vector<OpType>(16, OpType::H);
+
+    qubit_types[4] = OpType::PhasePolyBox;
+    qubit_types[7] = OpType::Barrier;
+    qubit_types[8] = OpType::PhasePolyBox;
+    qubit_types[13] = OpType::CX;
+    qubit_types[14] = OpType::Rz;
+    qubit_types[15] = OpType::Rz;
+
+    int count = 0;
+
+    for (const Command& com : result) {
+      OpType ot = com.get_op_ptr()->get_type();
       REQUIRE(ot == qubit_types[count]);
       ++count;
     }


### PR DESCRIPTION
This PR adds the ppb creation to the python layer using the direct interface from c++ for the box creation and exposing the c++ pass for the box creation. This also fixes the problem with the creation of invalid boxes from the interface available so far.