### PR TITLE
Add `DefaultRoutingPass`

### DIFF
--- a/pytket/binders/passes.cpp
+++ b/pytket/binders/passes.cpp
@@ -53,10 +53,9 @@ static PassPtr gen_cx_mapping_pass_kwargs(
 }
 
 static PassPtr gen_default_routing_pass(const Architecture &arc) {
-  std::vector<RoutingMethodPtr> config = {
-      std::make_shared<LexiLabellingMethod>(),
-      std::make_shared<LexiRouteRoutingMethod>()};
-  return gen_routing_pass(arc, config);
+  return gen_routing_pass(
+      arc, {std::make_shared<LexiLabellingMethod>(),
+            std::make_shared<LexiRouteRoutingMethod>()});
 }
 
 static PassPtr gen_default_aas_routing_pass(
@@ -467,9 +466,18 @@ PYBIND11_MODULE(passes, m) {
       py::arg("q"), py::arg("p"), py::arg("strict") = false);
 
   m.def(
-      "RoutingPass", &gen_default_routing_pass,
+      "RoutingPass", &gen_routing_pass,
       "Construct a pass to route to the connectivity graph of an "
       ":py:class:`Architecture`. Edge direction is ignored."
+      "\n:return: a pass that routes to the given device architecture",
+      py::arg("arc"), py::arg("config"));
+
+  m.def(
+      "DefaultRoutingPass", &gen_default_routing_pass,
+      "Construct a pass to route to the connectivity graph of an "
+      ":py:class:`Architecture`. Edge direction is ignored. "
+      "Uses :py:class:`LexiLabellingMethod` and "
+      ":py:class:`LexiRouteRoutingMethod`."
       "\n:return: a pass that routes to the given device architecture",
       py::arg("arc"));
 

--- a/pytket/tests/predicates_test.py
+++ b/pytket/tests/predicates_test.py
@@ -29,7 +29,7 @@ from pytket.passes import (  # type: ignore
     RepeatWithMetricPass,
     RebaseCustom,
     EulerAngleReduction,
-    RoutingPass,
+    DefaultRoutingPass,
     CXMappingPass,
     PlacementPass,
     NaivePlacementPass,
@@ -209,7 +209,7 @@ def test_routing_and_placement_pass() -> None:
     n5 = Node("f", 2)
     arc = Architecture([[n0, n1], [n1, n2], [n2, n3], [n3, n4], [n1, n5]])
     pl = Placement(arc)
-    routing = RoutingPass(arc)
+    routing = DefaultRoutingPass(arc)
     placement = PlacementPass(pl)
     nplacement = NaivePlacementPass(arc)
     cu = CompilationUnit(circ.copy())
@@ -270,7 +270,7 @@ def test_default_mapping_pass() -> None:
     pl = GraphPlacement(arc)
 
     nplacement = NaivePlacementPass(arc)
-    routing = RoutingPass(arc)
+    routing = DefaultRoutingPass(arc)
     placement = PlacementPass(pl)
     default = DefaultMappingPass(arc)
     cu_rp = CompilationUnit(circ.copy())
@@ -393,7 +393,7 @@ def test_SynthesiseTket_creation() -> None:
     arc = Architecture([(0, 2), (1, 2)])
     pl = Placement(arc)
     pl.place(circ1)
-    routing_pass = RoutingPass(arc)
+    routing_pass = DefaultRoutingPass(arc)
     cu3 = CompilationUnit(circ1)
     cu4 = CompilationUnit(circ1)
     cu5 = CompilationUnit(circ1)
@@ -656,9 +656,9 @@ def test_generated_pass_config() -> None:
     assert euler_pass.to_dict()["StandardPass"]["name"] == "EulerAngleReduction"
     assert euler_pass.to_dict()["StandardPass"]["euler_q"] == "Ry"
     assert euler_pass.to_dict()["StandardPass"]["euler_p"] == "Rx"
-    # RoutingPass
+    # DefaultRoutingPass
     arc = Architecture([[0, 2], [1, 3], [2, 3], [2, 4]])
-    r_pass = RoutingPass(arc)
+    r_pass = DefaultRoutingPass(arc)
     assert r_pass.to_dict()["StandardPass"]["name"] == "RoutingPass"
     assert check_arc_dict(arc, r_pass.to_dict()["StandardPass"]["architecture"])
     # PlacementPass

--- a/pytket/tests/transform_test.py
+++ b/pytket/tests/transform_test.py
@@ -28,7 +28,7 @@ from pytket.passes import (  # type: ignore
     FullPeepholeOptimise,
     DefaultMappingPass,
     FullMappingPass,
-    RoutingPass,
+    DefaultRoutingPass,
     PlacementPass,
     CXMappingPass,
     auto_rebase_pass,
@@ -788,7 +788,7 @@ def test_noncontiguous_DefaultMappingPass_arc() -> None:
     pass1.apply(c)
 
 
-def test_RoutingPass() -> None:
+def test_DefaultRoutingPass() -> None:
     arc = Architecture([[0, 2], [1, 3], [2, 3], [2, 4]])
     circ = Circuit(5)
     circ.CX(0, 1)
@@ -800,7 +800,7 @@ def test_RoutingPass() -> None:
     cu_0 = CompilationUnit(circ)
     placer = GraphPlacement(arc)
     p_pass = PlacementPass(placer)
-    r_pass_0 = RoutingPass(arc)
+    r_pass_0 = DefaultRoutingPass(arc)
     p_pass.apply(cu_0)
     r_pass_0.apply(cu_0)
     out_circ_0 = cu_0.circuit
@@ -1078,7 +1078,7 @@ if __name__ == "__main__":
     test_implicit_swaps_3()
     test_decompose_swap_to_cx()
     test_noncontiguous_DefaultMappingPass_arc()
-    test_RoutingPass()
+    test_DefaultRoutingPass()
     test_DefaultMappingPass()
     test_CXMappingPass()
     test_CXMappingPass_correctness()

--- a/pytket/tests/transform_test.py
+++ b/pytket/tests/transform_test.py
@@ -29,6 +29,7 @@ from pytket.passes import (  # type: ignore
     DefaultMappingPass,
     FullMappingPass,
     DefaultRoutingPass,
+    RoutingPass,
     PlacementPass,
     CXMappingPass,
     auto_rebase_pass,
@@ -788,7 +789,7 @@ def test_noncontiguous_DefaultMappingPass_arc() -> None:
     pass1.apply(c)
 
 
-def test_DefaultRoutingPass() -> None:
+def test_RoutingPass() -> None:
     arc = Architecture([[0, 2], [1, 3], [2, 3], [2, 4]])
     circ = Circuit(5)
     circ.CX(0, 1)
@@ -798,13 +799,18 @@ def test_DefaultRoutingPass() -> None:
     circ.CX(1, 3)
     circ.CX(1, 2)
     cu_0 = CompilationUnit(circ)
+    cu_1 = CompilationUnit(circ)
     placer = GraphPlacement(arc)
     p_pass = PlacementPass(placer)
     r_pass_0 = DefaultRoutingPass(arc)
+    r_pass_1 = RoutingPass(arc, [LexiLabellingMethod(), LexiRouteRoutingMethod()])
     p_pass.apply(cu_0)
     r_pass_0.apply(cu_0)
+    p_pass.apply(cu_1)
+    r_pass_1.apply(cu_1)
     out_circ_0 = cu_0.circuit
     assert out_circ_0.valid_connectivity(arc, False, True)
+    assert out_circ_0 == cu_1.circuit
 
 
 def test_FullMappingPass() -> None:
@@ -1078,7 +1084,7 @@ if __name__ == "__main__":
     test_implicit_swaps_3()
     test_decompose_swap_to_cx()
     test_noncontiguous_DefaultMappingPass_arc()
-    test_DefaultRoutingPass()
+    test_RoutingPass()
     test_DefaultMappingPass()
     test_CXMappingPass()
     test_CXMappingPass_correctness()

--- a/schemas/compiler_pass_v1.json
+++ b/schemas/compiler_pass_v1.json
@@ -436,6 +436,20 @@
           "if": {
             "properties": {
               "name": {
+                "const": "DefaultRoutingPass"
+              }
+            }
+          },
+          "then": {
+            "required": [
+              "architecture",
+            ]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "name": {
                 "const": "DecomposeSwapsToCXs"
               }
             }


### PR DESCRIPTION
Currently there is no option to make a pass for only routing circuits with choice over which `RoutingMethod` are used. This PR adds a `DefaultRoutingPass` which returns a pass which does routing with [`LexiLabellingMethod()`, `LexiRouteRoutingMethod()`] and changes `RoutingPass` to take `List[RoutingMethod]` as an argument.