### PR TITLE
Use prebuilt symengine for release builds

### DIFF
--- a/.github/workflows/build_symengine.yml
+++ b/.github/workflows/build_symengine.yml
@@ -167,3 +167,29 @@ jobs:
     - name: upload package
       if: github.event_name == 'push'
       run: conan upload symengine/${{ env.SYMENGINE_VER }}@tket/stable --all -r=tket-conan
+  manylinux:
+    name: build symengine (manylinux)
+    needs: changes
+    if: needs.changes.outputs.recipes_symengine == 'true'
+    runs-on: ubuntu-20.04
+    env:
+      UPLOAD_PACKAGE: "NO"
+    steps:
+    - uses: actions/checkout@v2
+    - name: set up container
+      run: |
+        docker create --name linux_build -i -v /:/host quay.io/pypa/manylinux2014_x86_64:latest /bin/bash
+        docker cp ./recipes/symengine linux_build:/
+        docker cp ./.github/workflows/linuxbuildsymengine linux_build:/
+    - name: determine whether to upload package
+      if: github.event_name == 'push'
+      run: echo "UPLOAD_PACKAGE=YES" >> ${GITHUB_ENV}
+    - name: build symengine
+      run: |
+        docker start linux_build
+        at <<EOF > env-vars
+        UPLOAD_PACKAGE=${UPLOAD_PACKAGE}
+        JFROG_ARTIFACTORY_TOKEN_1=${{ secrets.JFROG_ARTIFACTORY_TOKEN_1 }}
+        JFROG_ARTIFACTORY_USER_1=${{ secrets.JFROG_ARTIFACTORY_USER_1 }}
+        EOF
+        docker exec --env-file env-vars linux_build /bin/bash -c "/linuxbuildsymengine"

--- a/.github/workflows/linuxbuildsymengine
+++ b/.github/workflows/linuxbuildsymengine
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+# Copyright 2019-2022 Cambridge Quantum Computing
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -evu
+
+# Choose a Python to install conan
+export PYBIN=/opt/python/cp39-cp39/bin
+
+export CONAN_REVISIONS_ENABLED=1
+
+${PYBIN}/pip install --upgrade pip
+${PYBIN}/pip install --upgrade conan
+
+export CONAN_CMD=${PYBIN}/conan
+
+${CONAN_CMD} profile new tket --detect
+
+${CONAN_CMD} remote add tket-conan https://tket.jfrog.io/artifactory/api/conan/tket-conan
+
+${CONAN_CMD} user -p ${JFROG_ARTIFACTORY_TOKEN_1} -r tket-conan ${JFROG_ARTIFACTORY_USER_1}
+
+SYMENGINE_VER=$(${CONAN_CMD} inspect --raw version symengine/)
+
+${CONAN_CMD} create --profile=tket -o symengine:shared=False symengine tket/stable
+${CONAN_CMD} create --profile=tket -o symengine:shared=True symengine tket/stable
+
+if [ ${UPLOAD_PACKAGE} == "YES" ]
+then
+    ${CONAN_CMD} upload symengine/${SYMENGINE_VER}@tket/stable --all -r=tket-conan
+else
+    ${CONAN_CMD} upload symengine/${SYMENGINE_VER}@tket/stable --all -r=tket-conan --skip-upload
+fi

--- a/.github/workflows/linuxbuildwheel
+++ b/.github/workflows/linuxbuildwheel
@@ -22,12 +22,13 @@ export PYBIN=/opt/python/cp39-cp39/bin
 ${PYBIN}/pip install conan
 
 export CONAN_CMD=${PYBIN}/conan
+export CONAN_REVISIONS_ENABLED=1
 
 cd /tket
 
 ${CONAN_CMD} profile new tket --detect
 ${CONAN_CMD} profile update options.tket:shared=True tket
-${CONAN_CMD} create --profile=tket recipes/symengine tket/stable
+${CONAN_CMD} remote add tket-conan https://tket.jfrog.io/artifactory/api/conan/tket-conan --force
 # Use header-only version of spdlog:
 # https://github.com/conan-io/conan-docker-tools/issues/303#issuecomment-922492130
 ${CONAN_CMD} create --profile=tket --test-folder=None -o tket:spdlog_ho=True recipes/tket


### PR DESCRIPTION
Note, packages have been uploaded already, by [this](https://github.com/CQCL/tket/actions/runs/2109259738) test run.
Release workflow using prebuilt package: https://github.com/CQCL/tket/actions/runs/2109353901