### PR TITLE
[feature] Decompose CRx/y/z using 1xCX if possible

### DIFF
--- a/tket/src/Circuit/CircPool.cpp
+++ b/tket/src/Circuit/CircPool.cpp
@@ -632,32 +632,63 @@ const Circuit &ZZMax_using_CX() {
 
 Circuit CRz_using_CX(Expr alpha) {
   Circuit c(2);
-  c.add_op<unsigned>(OpType::Rz, alpha / 2, {1});
-  c.add_op<unsigned>(OpType::CX, {0, 1});
-  c.add_op<unsigned>(OpType::Rz, -alpha / 2, {1});
-  c.add_op<unsigned>(OpType::CX, {0, 1});
+  if (equiv_expr(alpha, 1.)) {
+    c.add_op<unsigned>(OpType::H, {1});
+    c.add_op<unsigned>(OpType::CX, {0, 1});
+    c.add_op<unsigned>(OpType::H, {1});
+    if (equiv_expr(alpha, 1., 4)) {
+      c.add_op<unsigned>(OpType::Sdg, {0});
+    } else {
+      c.add_op<unsigned>(OpType::S, {0});
+    }
+  } else {
+    c.add_op<unsigned>(OpType::Rz, alpha / 2, {1});
+    c.add_op<unsigned>(OpType::CX, {0, 1});
+    c.add_op<unsigned>(OpType::Rz, -alpha / 2, {1});
+    c.add_op<unsigned>(OpType::CX, {0, 1});
+  }
   return c;
 }
 
 Circuit CRx_using_CX(Expr alpha) {
   Circuit c(2);
-  c.add_op<unsigned>(OpType::Rx, alpha / 2, {1});
-  c.add_op<unsigned>(OpType::H, {1});
-  c.add_op<unsigned>(OpType::CX, {0, 1});
-  c.add_op<unsigned>(OpType::H, {1});
-  c.add_op<unsigned>(OpType::Rx, -alpha / 2, {1});
-  c.add_op<unsigned>(OpType::H, {1});
-  c.add_op<unsigned>(OpType::CX, {0, 1});
-  c.add_op<unsigned>(OpType::H, {1});
+  if (equiv_expr(alpha, 1.)) {
+    c.add_op<unsigned>(OpType::CX, {0, 1});
+    if (equiv_expr(alpha, 1., 4)) {
+      c.add_op<unsigned>(OpType::Sdg, {0});
+    } else {
+      c.add_op<unsigned>(OpType::S, {0});
+    }
+  } else {
+    c.add_op<unsigned>(OpType::Rx, alpha / 2, {1});
+    c.add_op<unsigned>(OpType::H, {1});
+    c.add_op<unsigned>(OpType::CX, {0, 1});
+    c.add_op<unsigned>(OpType::H, {1});
+    c.add_op<unsigned>(OpType::Rx, -alpha / 2, {1});
+    c.add_op<unsigned>(OpType::H, {1});
+    c.add_op<unsigned>(OpType::CX, {0, 1});
+    c.add_op<unsigned>(OpType::H, {1});
+  }
   return c;
 }
 
 Circuit CRy_using_CX(Expr alpha) {
   Circuit c(2);
-  c.add_op<unsigned>(OpType::Ry, alpha / 2, {1});
-  c.add_op<unsigned>(OpType::CX, {0, 1});
-  c.add_op<unsigned>(OpType::Ry, -alpha / 2, {1});
-  c.add_op<unsigned>(OpType::CX, {0, 1});
+  if (equiv_expr(alpha, 1.)) {
+    c.add_op<unsigned>(OpType::Sdg, {1});
+    c.add_op<unsigned>(OpType::CX, {0, 1});
+    c.add_op<unsigned>(OpType::S, {1});
+    if (equiv_expr(alpha, 1., 4)) {
+      c.add_op<unsigned>(OpType::Sdg, {0});
+    } else {
+      c.add_op<unsigned>(OpType::S, {0});
+    }
+  } else {
+    c.add_op<unsigned>(OpType::Ry, alpha / 2, {1});
+    c.add_op<unsigned>(OpType::CX, {0, 1});
+    c.add_op<unsigned>(OpType::Ry, -alpha / 2, {1});
+    c.add_op<unsigned>(OpType::CX, {0, 1});
+  }
   return c;
 }
 

--- a/tket/tests/Circuit/test_Circ.cpp
+++ b/tket/tests/Circuit/test_Circ.cpp
@@ -1752,19 +1752,6 @@ SCENARIO("Decomposing a multi-qubit operation into CXs") {
     const auto u_correct = tket_sim::get_unitary(circ);
     REQUIRE((u - u_correct).cwiseAbs().sum() < ERR_EPS);
   }
-  GIVEN("A CRz(pi) gate") {
-    Circuit circ(2);
-    Vertex v = circ.add_op<unsigned>(OpType::CRz, 1., {0, 1});
-    const Op_ptr op = circ.get_Op_ptr_from_Vertex(v);
-    Circuit rep;
-    WHEN("Default circuit replacement") { rep = CX_circ_from_multiq(op); }
-
-    REQUIRE(rep.count_gates(OpType::CX) == 1);
-
-    const auto u = tket_sim::get_unitary(rep);
-    const auto u_correct = tket_sim::get_unitary(circ);
-    REQUIRE((u - u_correct).cwiseAbs().sum() < ERR_EPS);
-  }
   GIVEN("A CV gate") {
     Circuit circ(2);
     Vertex v = circ.add_op<unsigned>(OpType::CV, {0, 1});

--- a/tket/tests/Circuit/test_Circ.cpp
+++ b/tket/tests/Circuit/test_Circ.cpp
@@ -1667,6 +1667,22 @@ SCENARIO("Decomposing a multi-qubit operation into CXs") {
             0, 0, 0, sq + sq * i_;
     // clang-format on
     REQUIRE((u - correct).cwiseAbs().sum() < ERR_EPS);
+    REQUIRE(rep.count_gates(OpType::CX) == 2);
+  }
+  GIVEN("A CRz(+-pi) gate") {
+    Circuit circ(2);
+    Vertex v;
+    WHEN("CRz(+pi)") { v = circ.add_op<unsigned>(OpType::CRz, 1., {0, 1}); }
+    WHEN("CRz(-pi)") { v = circ.add_op<unsigned>(OpType::CRz, -1., {0, 1}); }
+    const Op_ptr op = circ.get_Op_ptr_from_Vertex(v);
+    Circuit rep;
+    rep = CX_circ_from_multiq(op);
+
+    REQUIRE(rep.count_gates(OpType::CX) == 1);
+
+    const auto u = tket_sim::get_unitary(rep);
+    const auto u_correct = tket_sim::get_unitary(circ);
+    REQUIRE((u - u_correct).cwiseAbs().sum() < ERR_EPS);
   }
   GIVEN("A CRx gate") {
     Circuit circ(2);
@@ -1685,6 +1701,22 @@ SCENARIO("Decomposing a multi-qubit operation into CXs") {
             0, 0, -sq* i_, sq;
     // clang-format on
     REQUIRE((u - correct).cwiseAbs().sum() < ERR_EPS);
+    REQUIRE(rep.count_gates(OpType::CX) == 2);
+  }
+  GIVEN("A CRx(+-pi) gate") {
+    Circuit circ(2);
+    Vertex v;
+    WHEN("CRx(+pi)") { v = circ.add_op<unsigned>(OpType::CRx, 1., {0, 1}); }
+    WHEN("CRx(-pi)") { v = circ.add_op<unsigned>(OpType::CRx, -1., {0, 1}); }
+    const Op_ptr op = circ.get_Op_ptr_from_Vertex(v);
+    Circuit rep;
+    rep = CX_circ_from_multiq(op);
+
+    REQUIRE(rep.count_gates(OpType::CX) == 1);
+
+    const auto u = tket_sim::get_unitary(rep);
+    const auto u_correct = tket_sim::get_unitary(circ);
+    REQUIRE((u - u_correct).cwiseAbs().sum() < ERR_EPS);
   }
   GIVEN("A CRy gate") {
     Circuit circ(2);
@@ -1703,6 +1735,35 @@ SCENARIO("Decomposing a multi-qubit operation into CXs") {
             0, 0, sq, sq;
     // clang-format on
     REQUIRE((u - correct).cwiseAbs().sum() < ERR_EPS);
+    REQUIRE(rep.count_gates(OpType::CX) == 2);
+  }
+  GIVEN("A CRy(+-pi) gate") {
+    Circuit circ(2);
+    Vertex v;
+    WHEN("CRy(+pi)") { v = circ.add_op<unsigned>(OpType::CRy, 1., {0, 1}); }
+    WHEN("CRy(-pi)") { v = circ.add_op<unsigned>(OpType::CRy, -1., {0, 1}); }
+    const Op_ptr op = circ.get_Op_ptr_from_Vertex(v);
+    Circuit rep;
+    rep = CX_circ_from_multiq(op);
+
+    REQUIRE(rep.count_gates(OpType::CX) == 1);
+
+    const auto u = tket_sim::get_unitary(rep);
+    const auto u_correct = tket_sim::get_unitary(circ);
+    REQUIRE((u - u_correct).cwiseAbs().sum() < ERR_EPS);
+  }
+  GIVEN("A CRz(pi) gate") {
+    Circuit circ(2);
+    Vertex v = circ.add_op<unsigned>(OpType::CRz, 1., {0, 1});
+    const Op_ptr op = circ.get_Op_ptr_from_Vertex(v);
+    Circuit rep;
+    WHEN("Default circuit replacement") { rep = CX_circ_from_multiq(op); }
+
+    REQUIRE(rep.count_gates(OpType::CX) == 1);
+
+    const auto u = tket_sim::get_unitary(rep);
+    const auto u_correct = tket_sim::get_unitary(circ);
+    REQUIRE((u - u_correct).cwiseAbs().sum() < ERR_EPS);
   }
   GIVEN("A CV gate") {
     Circuit circ(2);


### PR DESCRIPTION
When the rotation angle is pi mod 2pi, the `CRx`, `CRy` and `CRz` optypes can be decomposed using a single CX gate.