### PR TITLE
Upload spdlog package to tket/stable

### DIFF
--- a/.github/workflows/build_spdlog.yml
+++ b/.github/workflows/build_spdlog.yml
@@ -1,0 +1,193 @@
+name: build spdlog
+on:
+  push:
+    branches:
+      - develop
+  pull_request:
+    branches:
+      - develop
+jobs:
+  changes:
+    runs-on: ubuntu-20.04
+    outputs:
+      recipes_spdlog: ${{ steps.filter.outputs.recipes_spdlog }}
+    steps:
+    - uses: actions/checkout@v2
+    - uses: dorny/paths-filter@v2
+      id: filter
+      with:
+        base: ${{ github.ref }}
+        filters: |
+          recipes_spdlog:
+            - 'recipes/spdlog/**'
+  linux:
+    name: build spdlog (linux)
+    needs: changes
+    if: needs.changes.outputs.recipes_spdlog == 'true'
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        build_type: ['Release', 'Debug']
+        shared: ['True', 'False']
+    env:
+      CC: gcc-10
+      CXX: g++-10
+      CONAN_REVISIONS_ENABLED: 1
+    steps:
+    - uses: actions/checkout@v2
+    - name: install conan
+      run: pip install conan
+    - name: create profile
+      run: |
+        conan profile new tket --detect
+        conan profile update settings.compiler.libcxx=libstdc++11 tket
+    - name: build spdlog
+      run: conan create --profile=tket -s build_type=${{ matrix.build_type }} -o spdlog:shared=${{ matrix.shared }} recipes/spdlog tket/stable
+    - name: add remote
+      run: conan remote add tket-conan https://tket.jfrog.io/artifactory/api/conan/tket-conan
+    - name: authenticate to repository
+      run: conan user -p ${{ secrets.JFROG_ARTIFACTORY_TOKEN_1 }} -r tket-conan ${{ secrets.JFROG_ARTIFACTORY_USER_1 }}
+    - name: get version
+      run: |
+        spdlog_ver=$(conan inspect --raw version recipes/spdlog/)
+        echo "SPDLOG_VER=${spdlog_ver}" >> $GITHUB_ENV
+    - name: upload package (dry run)
+      if: github.event_name == 'pull_request'
+      run: conan upload spdlog/${SPDLOG_VER}@tket/stable --all -r=tket-conan --skip-upload
+    - name: upload package
+      if: github.event_name == 'push'
+      run: conan upload spdlog/${SPDLOG_VER}@tket/stable --all -r=tket-conan
+  macos:
+    name: build spdlog (macos)
+    needs: changes
+    if: needs.changes.outputs.recipes_spdlog == 'true'
+    runs-on: macos-11
+    strategy:
+      matrix:
+        build_type: ['Release', 'Debug']
+        shared: ['True', 'False']
+    env:
+      CONAN_REVISIONS_ENABLED: 1
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.9
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.9'
+    - name: install conan
+      run: pip install conan
+    - name: create profile
+      run: conan profile new tket --detect
+    - name: build spdlog
+      run: conan create --profile=tket -s build_type=${{ matrix.build_type }} -o spdlog:shared=${{ matrix.shared }} recipes/spdlog tket/stable
+    - name: add remote
+      run: conan remote add tket-conan https://tket.jfrog.io/artifactory/api/conan/tket-conan
+    - name: authenticate to repository
+      run: conan user -p ${{ secrets.JFROG_ARTIFACTORY_TOKEN_1 }} -r tket-conan ${{ secrets.JFROG_ARTIFACTORY_USER_1 }}
+    - name: get version
+      run: |
+        spdlog_ver=$(conan inspect --raw version recipes/spdlog/)
+        echo "SPDLOG_VER=${spdlog_ver}" >> $GITHUB_ENV
+    - name: upload package (dry run)
+      if: github.event_name == 'pull_request'
+      run: conan upload spdlog/${SPDLOG_VER}@tket/stable --all -r=tket-conan --skip-upload
+    - name: upload package
+      if: github.event_name == 'push'
+      run: conan upload spdlog/${SPDLOG_VER}@tket/stable --all -r=tket-conan
+  macos-m1:
+    name: build spdlog (macos-m1)
+    needs: changes
+    if: needs.changes.outputs.recipes_spdlog == 'true'
+    runs-on: [self-hosted, macos, M1]
+    strategy:
+      matrix:
+        build_type: ['Release', 'Debug']
+        shared: ['True', 'False']
+    env:
+      CONAN_REVISIONS_ENABLED: 1
+    steps:
+    - uses: actions/checkout@v2
+    - name: install conan
+      run: pip install -U conan
+    - name: create profile
+      run: conan profile new tket --detect --force
+    - name: build spdlog
+      run: conan create --profile=tket -s build_type=${{ matrix.build_type }} -o spdlog:shared=${{ matrix.shared }} recipes/spdlog tket/stable
+    - name: add remote
+      run: conan remote add tket-conan https://tket.jfrog.io/artifactory/api/conan/tket-conan --force
+    - name: authenticate to repository
+      run: conan user -p ${{ secrets.JFROG_ARTIFACTORY_TOKEN_1 }} -r tket-conan ${{ secrets.JFROG_ARTIFACTORY_USER_1 }}
+    - name: get version
+      run: |
+        spdlog_ver=$(conan inspect --raw version recipes/spdlog/)
+        echo "SPDLOG_VER=${spdlog_ver}" >> $GITHUB_ENV
+    - name: upload package (dry run)
+      if: github.event_name == 'pull_request'
+      run: conan upload spdlog/${SPDLOG_VER}@tket/stable --all -r=tket-conan --skip-upload
+    - name: upload package
+      if: github.event_name == 'push'
+      run: conan upload spdlog/${SPDLOG_VER}@tket/stable --all -r=tket-conan
+  windows:
+    name: build spdlog (windows)
+    needs: changes
+    if: needs.changes.outputs.recipes_spdlog == 'true'
+    runs-on: windows-2019
+    strategy:
+      matrix:
+        build_type: ['Release', 'Debug']
+        shared: ['True', 'False']
+    env:
+      CONAN_REVISIONS_ENABLED: 1
+    steps:
+    - uses: actions/checkout@v2
+    - name: install conan
+      run: pip install conan
+    - name: create profile
+      run: conan profile new tket --detect
+    - name: normalize line endings in conanfile
+      run: |
+        $conanfile ='recipes/spdlog/conanfile.py'
+        $normalized_file = [IO.File]::ReadAllText($conanfile) -replace "`r`n", "`n"
+        [IO.File]::WriteAllText($conanfile, $normalized_file)
+    - name: build spdlog
+      run: conan create --profile=tket -s build_type=${{ matrix.build_type }} -o spdlog:shared=${{ matrix.shared }} recipes/spdlog tket/stable
+    - name: add remote
+      run: conan remote add tket-conan https://tket.jfrog.io/artifactory/api/conan/tket-conan
+    - name: authenticate to repository
+      run: conan user -p ${{ secrets.JFROG_ARTIFACTORY_TOKEN_1 }} -r tket-conan ${{ secrets.JFROG_ARTIFACTORY_USER_1 }}
+    - name: get version
+      run: |
+        $spdlog_ver = conan inspect --raw version recipes/spdlog/
+        echo "SPDLOG_VER=${spdlog_ver}" >> $env:GITHUB_ENV
+    - name: upload package (dry run)
+      if: github.event_name == 'pull_request'
+      run: conan upload spdlog/${{ env.SPDLOG_VER }}@tket/stable --all -r=tket-conan --skip-upload
+    - name: upload package
+      if: github.event_name == 'push'
+      run: conan upload spdlog/${{ env.SPDLOG_VER }}@tket/stable --all -r=tket-conan
+  manylinux:
+    name: build spdlog (manylinux)
+    needs: changes
+    if: needs.changes.outputs.recipes_spdlog == 'true'
+    runs-on: ubuntu-20.04
+    env:
+      UPLOAD_PACKAGE: "NO"
+    steps:
+    - uses: actions/checkout@v2
+    - name: set up container
+      run: |
+        docker create --name linux_build -i -v /:/host quay.io/pypa/manylinux2014_x86_64:latest /bin/bash
+        docker cp ./recipes/spdlog linux_build:/
+        docker cp ./.github/workflows/linuxbuildspdlog linux_build:/
+    - name: determine whether to upload package
+      if: github.event_name == 'push'
+      run: echo "UPLOAD_PACKAGE=YES" >> ${GITHUB_ENV}
+    - name: build spdlog
+      run: |
+        docker start linux_build
+        cat <<EOF > env-vars
+        UPLOAD_PACKAGE=${UPLOAD_PACKAGE}
+        JFROG_ARTIFACTORY_TOKEN_1=${{ secrets.JFROG_ARTIFACTORY_TOKEN_1 }}
+        JFROG_ARTIFACTORY_USER_1=${{ secrets.JFROG_ARTIFACTORY_USER_1 }}
+        EOF
+        docker exec --env-file env-vars linux_build /bin/bash -c "/linuxbuildspdlog"

--- a/.github/workflows/linuxbuildspdlog
+++ b/.github/workflows/linuxbuildspdlog
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+# Copyright 2019-2022 Cambridge Quantum Computing
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -evu
+
+# Choose a Python to install conan
+export PYBIN=/opt/python/cp39-cp39/bin
+
+export CONAN_REVISIONS_ENABLED=1
+
+${PYBIN}/pip install --upgrade pip
+${PYBIN}/pip install --upgrade conan
+
+export CONAN_CMD=${PYBIN}/conan
+
+${CONAN_CMD} profile new tket --detect
+
+${CONAN_CMD} remote add tket-conan https://tket.jfrog.io/artifactory/api/conan/tket-conan
+
+${CONAN_CMD} user -p ${JFROG_ARTIFACTORY_TOKEN_1} -r tket-conan ${JFROG_ARTIFACTORY_USER_1}
+
+SPDLOG_VER=$(${CONAN_CMD} inspect --raw version spdlog/)
+
+${CONAN_CMD} create --profile=tket -o spdlog:shared=False spdlog tket/stable
+${CONAN_CMD} create --profile=tket -o spdlog:shared=True spdlog tket/stable
+
+if [ ${UPLOAD_PACKAGE} == "YES" ]
+then
+    ${CONAN_CMD} upload spdlog/${SPDLOG_VER}@tket/stable --all -r=tket-conan
+else
+    ${CONAN_CMD} upload spdlog/${SPDLOG_VER}@tket/stable --all -r=tket-conan --skip-upload
+fi

--- a/recipes/spdlog/CMakeLists.txt
+++ b/recipes/spdlog/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 2.8.11)
+project(cmake_wrapper)
+
+include(conanbuildinfo.cmake)
+conan_basic_setup()
+
+add_subdirectory(source_subfolder)

--- a/recipes/spdlog/conandata.yml
+++ b/recipes/spdlog/conandata.yml
@@ -1,0 +1,40 @@
+sources:
+  "1.10.0":
+    url: "https://github.com/gabime/spdlog/archive/v1.10.0.tar.gz"
+    sha256: "697f91700237dbae2326b90469be32b876b2b44888302afbc7aceb68bcfe8224"
+  "1.9.2":
+    url: "https://github.com/gabime/spdlog/archive/v1.9.2.tar.gz"
+    sha256: "6fff9215f5cb81760be4cc16d033526d1080427d236e86d70bb02994f85e3d38"
+  "1.9.1":
+    url: "https://github.com/gabime/spdlog/archive/v1.9.1.tar.gz"
+    sha256: "9a452cfa24408baccc9b2bc2d421d68172a7630c99e9504a14754be840d31a62"
+  "1.9.0":
+    url: "https://github.com/gabime/spdlog/archive/v1.9.0.tar.gz"
+    sha256: "9ad181d75aaedbf47c8881e7b947a47cac3d306997e39de24dba60db633e70a7"
+  "1.8.5":
+    url: "https://github.com/gabime/spdlog/archive/v1.8.5.tar.gz"
+    sha256: "944d0bd7c763ac721398dca2bb0f3b5ed16f67cef36810ede5061f35a543b4b8"
+  "1.8.2":
+    url: "https://github.com/gabime/spdlog/archive/v1.8.2.tar.gz"
+    sha256: "e20e6bd8f57e866eaf25a5417f0a38a116e537f1a77ac7b5409ca2b180cec0d5"
+  "1.8.1":
+    url: "https://github.com/gabime/spdlog/archive/v1.8.1.tar.gz"
+    sha256: "5197b3147cfcfaa67dd564db7b878e4a4b3d9f3443801722b3915cdeced656cb"
+  "1.8.0":
+    url: "https://github.com/gabime/spdlog/archive/v1.8.0.tar.gz"
+    sha256: "1e68e9b40cf63bb022a4b18cdc1c9d88eb5d97e4fd64fa981950a9cacf57a4bf"
+  "1.7.0":
+    url: "https://github.com/gabime/spdlog/archive/v1.7.0.tar.gz"
+    sha256: "f0114a4d3c88be9e696762f37a7c379619443ce9d668546c61b21d41affe5b62"
+  "1.6.1":
+    url: "https://github.com/gabime/spdlog/archive/v1.6.1.tar.gz"
+    sha256: "378a040d91f787aec96d269b0c39189f58a6b852e4cbf9150ccfacbe85ebbbfc"
+  "1.6.0":
+    url: "https://github.com/gabime/spdlog/archive/v1.6.0.tar.gz"
+    sha256: "0421667c9f2fc78e6548d44f7bc5921be0f03e612df384294c16cedb93d967f8"
+  "1.5.0":
+    url: "https://github.com/gabime/spdlog/archive/v1.5.0.tar.gz"
+    sha256: "b38e0bbef7faac2b82fed550a0c19b0d4e7f6737d5321d4fd8f216b80f8aee8a"
+  "1.4.2":
+    url: "https://github.com/gabime/spdlog/archive/v1.4.2.tar.gz"
+    sha256: "821c85b120ad15d87ca2bc44185fa9091409777c756029125a02f81354072157"

--- a/recipes/spdlog/conanfile.py
+++ b/recipes/spdlog/conanfile.py
@@ -21,6 +21,7 @@ required_conan_version = ">=1.43.0"
 
 class SpdlogConan(ConanFile):
     name = "spdlog"
+    version = "1.10.0"
     description = "Fast C++ logging library"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/gabime/spdlog"

--- a/recipes/spdlog/conanfile.py
+++ b/recipes/spdlog/conanfile.py
@@ -1,0 +1,199 @@
+# Copyright 2019-2022 Cambridge Quantum Computing
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from conans import CMake, ConanFile, tools
+from conans.errors import ConanInvalidConfiguration
+import os
+
+required_conan_version = ">=1.43.0"
+
+
+class SpdlogConan(ConanFile):
+    name = "spdlog"
+    description = "Fast C++ logging library"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/gabime/spdlog"
+    topics = ("spdlog", "logging", "header-only")
+    license = "MIT"
+
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+        "header_only": [True, False],
+        "wchar_support": [True, False],
+        "wchar_filenames": [True, False],
+        "no_exceptions": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+        "header_only": False,
+        "wchar_support": False,
+        "wchar_filenames": False,
+        "no_exceptions": False,
+    }
+
+    exports_sources = "CMakeLists.txt"
+    generators = "cmake", "cmake_find_package", "cmake_find_package_multi"
+    _cmake = None
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def configure(self):
+        if self.options.shared:
+            del self.options.fPIC
+        if self.options.header_only:
+            del self.options.shared
+            del self.options.fPIC
+
+    def requirements(self):
+        if tools.Version(self.version) >= "1.9.0":
+            self.requires("fmt/8.0.1")
+        elif tools.Version(self.version) >= "1.7.0":
+            self.requires("fmt/7.1.3")
+        elif tools.Version(self.version) >= "1.5.0":
+            self.requires("fmt/6.2.1")
+        else:
+            self.requires("fmt/6.0.0")
+
+    def validate(self):
+        if self.settings.os != "Windows" and (
+            self.options.wchar_support or self.options.wchar_filenames
+        ):
+            raise ConanInvalidConfiguration("wchar is only supported under windows")
+        if self.options.get_safe("shared", False):
+            if self.settings.os == "Windows" and tools.Version(self.version) < "1.6.0":
+                raise ConanInvalidConfiguration(
+                    "spdlog shared lib is not yet supported under windows"
+                )
+            if (
+                self.settings.compiler == "Visual Studio"
+                and "MT" in self.settings.compiler.runtime
+            ):
+                raise ConanInvalidConfiguration(
+                    "Visual Studio build for shared library with MT runtime is not supported"
+                )
+
+    def package_id(self):
+        if self.options.header_only:
+            self.info.header_only()
+
+    def source(self):
+        tools.get(
+            **self.conan_data["sources"][self.version],
+            destination=self._source_subfolder,
+            strip_root=True
+        )
+
+    def _configure_cmake(self):
+        if self._cmake:
+            return self._cmake
+        self._cmake = CMake(self)
+        self._cmake.definitions["SPDLOG_BUILD_EXAMPLE"] = False
+        self._cmake.definitions["SPDLOG_BUILD_EXAMPLE_HO"] = False
+        self._cmake.definitions["SPDLOG_BUILD_TESTS"] = False
+        self._cmake.definitions["SPDLOG_BUILD_TESTS_HO"] = False
+        self._cmake.definitions["SPDLOG_BUILD_BENCH"] = False
+        self._cmake.definitions["SPDLOG_FMT_EXTERNAL"] = True
+        self._cmake.definitions["SPDLOG_FMT_EXTERNAL_HO"] = self.options[
+            "fmt"
+        ].header_only
+        self._cmake.definitions["SPDLOG_BUILD_SHARED"] = (
+            not self.options.header_only and self.options.shared
+        )
+        self._cmake.definitions["SPDLOG_WCHAR_SUPPORT"] = self.options.wchar_support
+        self._cmake.definitions["SPDLOG_WCHAR_FILENAMES"] = self.options.wchar_filenames
+        self._cmake.definitions["SPDLOG_INSTALL"] = True
+        self._cmake.definitions["SPDLOG_NO_EXCEPTIONS"] = self.options.no_exceptions
+        if self.settings.os in ("iOS", "tvOS", "watchOS"):
+            self._cmake.definitions["SPDLOG_NO_TLS"] = True
+        if tools.cross_building(self):
+            # Workaround to find CMake config files in some cross-build scenario
+            # TODO: to remove if something like https://github.com/conan-io/conan/issues/9427#issuecomment-993685376
+            # is implemented
+            self._cmake.definitions["CMAKE_FIND_ROOT_PATH_MODE_PACKAGE"] = "BOTH"
+        self._cmake.configure()
+        return self._cmake
+
+    def _disable_werror(self):
+        tools.replace_in_file(
+            os.path.join(self._source_subfolder, "cmake", "utils.cmake"), "/WX", ""
+        )
+
+    def build(self):
+        if (
+            tools.Version(self.version) < "1.7"
+            and tools.Version(self.deps_cpp_info["fmt"].version) >= "7"
+        ):
+            raise ConanInvalidConfiguration(
+                "The project {}/{} requires fmt < 7.x".format(self.name, self.version)
+            )
+
+        self._disable_werror()
+        if not self.options.header_only:
+            cmake = self._configure_cmake()
+            cmake.build()
+
+    def package(self):
+        self.copy("LICENSE", dst="licenses", src=self._source_subfolder)
+        if self.options.header_only:
+            self.copy(
+                pattern="*.h",
+                dst="include",
+                src=os.path.join(self._source_subfolder, "include"),
+            )
+        else:
+            cmake = self._configure_cmake()
+            cmake.install()
+            tools.rmdir(os.path.join(self.package_folder, "lib", "cmake"))
+            tools.rmdir(os.path.join(self.package_folder, "lib", "pkgconfig"))
+            tools.rmdir(os.path.join(self.package_folder, "lib", "spdlog", "cmake"))
+
+    def package_info(self):
+        target = "spdlog_header_only" if self.options.header_only else "spdlog"
+        self.cpp_info.set_property("cmake_file_name", "spdlog")
+        self.cpp_info.set_property("cmake_target_name", "spdlog::{}".format(target))
+        self.cpp_info.set_property("pkg_config_name", "spdlog")
+
+        self.cpp_info.names["cmake_find_package"] = "spdlog"
+        self.cpp_info.names["cmake_find_package_multi"] = "spdlog"
+        self.cpp_info.components["libspdlog"].names["cmake_find_package"] = target
+        self.cpp_info.components["libspdlog"].names["cmake_find_package_multi"] = target
+
+        self.cpp_info.components["libspdlog"].defines.append("SPDLOG_FMT_EXTERNAL")
+        self.cpp_info.components["libspdlog"].requires = ["fmt::fmt"]
+        if not self.options.header_only:
+            self.cpp_info.components["libspdlog"].libs = tools.collect_libs(self)
+            self.cpp_info.components["libspdlog"].defines.append("SPDLOG_COMPILED_LIB")
+        if self.options.wchar_support:
+            self.cpp_info.components["libspdlog"].defines.append(
+                "SPDLOG_WCHAR_TO_UTF8_SUPPORT"
+            )
+        if self.options.wchar_filenames:
+            self.cpp_info.components["libspdlog"].defines.append(
+                "SPDLOG_WCHAR_FILENAMES"
+            )
+        if self.options.no_exceptions:
+            self.cpp_info.components["libspdlog"].defines.append("SPDLOG_NO_EXCEPTIONS")
+        if self.settings.os in ["Linux", "FreeBSD"]:
+            self.cpp_info.components["libspdlog"].system_libs = ["pthread"]
+        if self.options.header_only and self.settings.os in ("iOS", "tvOS", "watchOS"):
+            self.cpp_info.components["libspdlog"].defines.append("SPDLOG_NO_TLS")

--- a/recipes/spdlog/conanfile.py
+++ b/recipes/spdlog/conanfile.py
@@ -65,14 +65,7 @@ class SpdlogConan(ConanFile):
             del self.options.fPIC
 
     def requirements(self):
-        if tools.Version(self.version) >= "1.9.0":
-            self.requires("fmt/8.0.1")
-        elif tools.Version(self.version) >= "1.7.0":
-            self.requires("fmt/7.1.3")
-        elif tools.Version(self.version) >= "1.5.0":
-            self.requires("fmt/6.2.1")
-        else:
-            self.requires("fmt/6.0.0")
+        pass
 
     def validate(self):
         if self.settings.os != "Windows" and (
@@ -112,10 +105,6 @@ class SpdlogConan(ConanFile):
         self._cmake.definitions["SPDLOG_BUILD_TESTS"] = False
         self._cmake.definitions["SPDLOG_BUILD_TESTS_HO"] = False
         self._cmake.definitions["SPDLOG_BUILD_BENCH"] = False
-        self._cmake.definitions["SPDLOG_FMT_EXTERNAL"] = True
-        self._cmake.definitions["SPDLOG_FMT_EXTERNAL_HO"] = self.options[
-            "fmt"
-        ].header_only
         self._cmake.definitions["SPDLOG_BUILD_SHARED"] = (
             not self.options.header_only and self.options.shared
         )
@@ -139,14 +128,6 @@ class SpdlogConan(ConanFile):
         )
 
     def build(self):
-        if (
-            tools.Version(self.version) < "1.7"
-            and tools.Version(self.deps_cpp_info["fmt"].version) >= "7"
-        ):
-            raise ConanInvalidConfiguration(
-                "The project {}/{} requires fmt < 7.x".format(self.name, self.version)
-            )
-
         self._disable_werror()
         if not self.options.header_only:
             cmake = self._configure_cmake()
@@ -178,8 +159,6 @@ class SpdlogConan(ConanFile):
         self.cpp_info.components["libspdlog"].names["cmake_find_package"] = target
         self.cpp_info.components["libspdlog"].names["cmake_find_package_multi"] = target
 
-        self.cpp_info.components["libspdlog"].defines.append("SPDLOG_FMT_EXTERNAL")
-        self.cpp_info.components["libspdlog"].requires = ["fmt::fmt"]
         if not self.options.header_only:
             self.cpp_info.components["libspdlog"].libs = tools.collect_libs(self)
             self.cpp_info.components["libspdlog"].defines.append("SPDLOG_COMPILED_LIB")


### PR DESCRIPTION
Follows the pattern of the symengine workflow.

This version of `spdlog` differs from the version on conan-center in that it does not have `fmt` as an external dependency.

In a [follow-up PR](https://github.com/CQCL/tket/pull/323) I will make tket depend on this version.