### PR TITLE
Generic QIR generation for custom gate set. 

### DIFF
--- a/pytket/pytket/qir/qir.py
+++ b/pytket/pytket/qir/qir.py
@@ -119,7 +119,7 @@ class ExtendedModule:
 
 def _get_optype_and_params(op: Op) -> Tuple[OpType, Optional[List[float]]]:
     optype = op.type
-    params = op.params if optype in _tk_to_qir_params else None
+    params = op.params if optype in _tk_to_qir_params_1q else None
     if optype == OpType.TK1:
         # convert to U3
         optype = OpType.U3

--- a/pytket/pytket/qir/qir.py
+++ b/pytket/pytket/qir/qir.py
@@ -139,7 +139,7 @@ def circuit_from_qir(input_file) -> None:
     pass
 
 
-def circuit_to_qir_str(circ: Circuit, root: str) -> str:
+def circuit_to_qir_str(circ: Circuit, root: str, gateset: GateSet) -> str:
     """A method to generate a QIR string from a pytket circuit."""
     if any(
         circ.n_gates_of_type(typ)

--- a/pytket/pytket/qir/qir.py
+++ b/pytket/pytket/qir/qir.py
@@ -195,10 +195,26 @@ def circuit_to_qir_str(
             else:
                 get_gate(*qubits)
     return str(mod.ir())
+
+
+def circuit_to_qir(
+    circ: Circuit, output_file: str, gateset: Optional[GateSet] = None
+) -> None:
     """A method to generate a qir file from a tket circuit."""
     root, ext = os.path.splitext(os.path.basename(output_file))
     if ext != ".ll":
         raise ValueError("The file extension should be '.ll'.")
-    circ_qir_str = circuit_to_qir_str(circ, root, gateset)
+    if gateset is not None:
+        module = ExtendedModule(
+            name=root,
+            num_qubits=circ.n_qubits,
+            num_results=len(circ.bits),
+            gateset=gateset,
+        )
+    else:
+        module = SimpleModule(
+            name=root, num_qubits=circ.n_qubits, num_results=len(circ.bits)
+        )
+    circ_qir_str = circuit_to_qir_str(circ, module)
     with open(output_file, "w") as out:
         out.write(circ_qir_str)

--- a/pytket/pytket/qir/qir.py
+++ b/pytket/pytket/qir/qir.py
@@ -101,6 +101,22 @@ class QIRUnsupportedError(Exception):
     pass
 
 
+class ExtendedModule:
+    """Module extensions to account for H series gate set."""
+
+    
+    def __init__(self, name: str, num_qubits: int, num_results: int, gateset: GateSet) -> None:
+        self.module = SimpleModule(name, num_qubits, num_results)
+        for k, v in gateset.gateset.items():
+            self.__setattr__(
+                str(k),
+                self.module.add_external_function(
+                    gateset.template.substitute(name=k),
+                    types.Function(v.function, types.VOID)
+                )
+            )
+
+
 def _get_optype_and_params(op: Op) -> Tuple[OpType, Optional[List[float]]]:
     optype = op.type
     params = op.params if optype in _tk_to_qir_params else None

--- a/pytket/pytket/qir/qir.py
+++ b/pytket/pytket/qir/qir.py
@@ -108,6 +108,7 @@ class ExtendedModule:
         self, name: str, num_qubits: int, num_results: int, gateset: GateSet
     ) -> None:
         self.module = SimpleModule(name, num_qubits, num_results)
+        self.gateset = gateset
         for k, v in gateset.gateset.items():
             self.__setattr__(
                 str(k),

--- a/pytket/pytket/qir/qir.py
+++ b/pytket/pytket/qir/qir.py
@@ -143,7 +143,9 @@ def circuit_from_qir(input_file) -> None:
     pass
 
 
-def circuit_to_qir_str(circ: Circuit, root: str, gateset: GateSet) -> str:
+def circuit_to_qir_str(
+    circ: Circuit, module: Union[ExtendedModule, SimpleModule]
+) -> str:
     """A method to generate a QIR string from a pytket circuit."""
     if any(
         circ.n_gates_of_type(typ)

--- a/pytket/pytket/qir/qir.py
+++ b/pytket/pytket/qir/qir.py
@@ -183,7 +183,18 @@ def circuit_to_qir_str(
             qis = BasicQisBuilder(module.builder)
             qubits = _to_qis_qubits(command.qubits, module)
             results = _to_qis_results(command.bits, module)
-def circuit_to_qir(circ: Circuit, output_file: str, gateset: GateSet) -> None:
+            try:
+                pyqir_gate = _tk_to_pyqir(optype)
+            except KeyError:
+                raise KeyError("Gate not defined in PyQIR gate set.")
+            get_gate = getattr(qis, pyqir_gate)
+            if params:
+                get_gate(*params, *qubits)
+            elif results:
+                get_gate(*qubits, results)
+            else:
+                get_gate(*qubits)
+    return str(mod.ir())
     """A method to generate a qir file from a tket circuit."""
     root, ext = os.path.splitext(os.path.basename(output_file))
     if ext != ".ll":

--- a/pytket/pytket/qir/qir.py
+++ b/pytket/pytket/qir/qir.py
@@ -21,31 +21,80 @@ from pytket import Circuit, OpType, Bit, Qubit
 from pytket.circuit import Op  # type: ignore
 
 
-NOPARAM_COMMANDS = {
-    "cx": OpType.CX,
-    "cz": OpType.CZ,
+PyQIRGate = NamedTuple(
+    "PyQIRGate",
+    [
+        ("function", List[type(types)]), 
+    ]
+)
+
+GateSet = NamedTuple(
+    "GateSet",
+    [
+        ("template", Template),
+        ("gateset", Dict[str, PyQIRGate])
+    ]
+)
+
+QUANTINUUM_GATES = GateSet(
+    template=Template('__quantinuum__qis__${name}__body'),
+    gateset={
+        "h": PyQIRGate(function=[types.QUBIT]),
+        "x": PyQIRGate(function=[types.QUBIT]),
+        "y": PyQIRGate(function=[types.QUBIT]),
+        "z": PyQIRGate(function=[types.QUBIT]),
+        "rx": PyQIRGate(function=[types.DOUBLE, types.QUBIT]),
+        "ry": PyQIRGate(function=[types.DOUBLE, types.QUBIT]),
+        "rz": PyQIRGate(function=[types.DOUBLE, types.QUBIT]),
+        "phx": PyQIRGate(function=[types.DOUBLE, types.DOUBLE, types.QUBIT]),
+        "cnot": PyQIRGate(function=[types.QUBIT, types.QUBIT]),
+        "zzmax": PyQIRGate(function=[types.QUBIT, types.QUBIT]),
+        "zzph": PyQIRGate(function=[types.DOUBLE, types.QUBIT, types.QUBIT]),
+        "mz": PyQIRGate(function=[types.QUBIT, types.RESULT]),
+    }
+)
+
+
+# Natively in pyqir
+QUANTINUUM_NOPARAM_1Q_COMMANDS = {
     "h": OpType.H,
     "m": OpType.Measure,
     "reset": OpType.Reset,
     "s": OpType.S,
-    "s_adj": OpType.Sdg,
     "t": OpType.T,
-    "t_adj": OpType.Tdg,
     "x": OpType.X,
     "y": OpType.Y,
     "z": OpType.Z,
 }
 
 
-PARAM_COMMANDS = {
-    "rx": OpType.Rx,
-    "ry": OpType.Ry,
-    "rz": OpType.Rz,
+NOPARAM_2Q_COMMANDS = {
+    "cx": OpType.CX,
+    "cz": OpType.CZ,
 }
 
 
-_tk_to_qir_noparams = dict(((item[1], item[0]) for item in NOPARAM_COMMANDS.items()))
-_tk_to_qir_params = dict(((item[1], item[0]) for item in PARAM_COMMANDS.items()))
+PARAM_1Q_COMMANDS = {
+    "rx": OpType.Rx,
+    "ry": OpType.Ry,
+    "rz": OpType.Rz,  # Also belongs to H machine gate set 
+}
+
+
+# To be included for the H machines gate set
+NOPARAM_INCLUDED = {
+    "zzmax": OpType.ZZMax
+}
+
+PARAM_INCLUDED = {
+    "U1q": OpType.PhasedX,
+    "rzz": OpType.ZZPhase,
+}
+
+
+_tk_to_qir_noparams_1q = dict(((item[1], item[0]) for item in QUANTINUUM_NOPARAM_1Q_COMMANDS.items()))
+_tk_to_qir_noparams_2q = dict(((item[1], item[0]) for item in NOPARAM_2Q_COMMANDS.items()))
+_tk_to_qir_params_1q = dict(((item[1], item[0]) for item in PARAM_1Q_COMMANDS.items()))
 
 
 class QIRUnsupportedError(Exception):

--- a/pytket/pytket/qir/qir.py
+++ b/pytket/pytket/qir/qir.py
@@ -129,8 +129,8 @@ def _get_optype_and_params(op: Op) -> Tuple[OpType, Optional[List[float]]]:
     return (optype, params)
 
 
-def _to_qis_qubits(qubits: List[Qubit], mod: SimpleModule) -> List:
-    return (mod.qubits[qubit.index[0]] for qubit in qubits)
+def _to_qis_qubits(qubits: List[Qubit], mod: SimpleModule) -> List[types.QUBIT]:
+    return [mod.qubits[qubit.index[0]] for qubit in qubits]
 
 
 def _to_qis_results(bits: List[Bit], mod: SimpleModule) -> SimpleModule.results:

--- a/pytket/pytket/qir/qir.py
+++ b/pytket/pytket/qir/qir.py
@@ -102,7 +102,7 @@ class QIRUnsupportedError(Exception):
 
 
 class ExtendedModule:
-    """Module extensions to account for H series gate set."""
+    """Module extensions to account for any input gate set."""
 
     
     def __init__(self, name: str, num_qubits: int, num_results: int, gateset: GateSet) -> None:

--- a/pytket/pytket/qir/qir.py
+++ b/pytket/pytket/qir/qir.py
@@ -152,7 +152,12 @@ def circuit_to_qir_str(circ: Circuit, root: str, gateset: GateSet) -> str:
         )
     ):
         raise QIRUnsupportedError("Complex classical gates not supported.")
-    module = SimpleModule(root, num_qubits=circ.n_qubits, num_results=len(circ.bits))
+    module = ExtendedModule(
+        name=root,
+        num_qubits=circ.n_qubits,
+        num_results=len(circ.bits),
+        gateset=gateset
+    ).module
     qis = BasicQisBuilder(module.builder)
 
     for command in circ:

--- a/pytket/pytket/qir/qir.py
+++ b/pytket/pytket/qir/qir.py
@@ -114,14 +114,14 @@ class ExtendedModule:
                 str(k),
                 self.module.add_external_function(
                     gateset.template.substitute(name=k),
-                    types.Function(v.function, types.VOID)
-                )
+                    types.Function(v.functions, types.VOID),
+                ),
             )
 
 
 def _get_optype_and_params(op: Op) -> Tuple[OpType, Optional[List[float]]]:
     optype = op.type
-    params = op.params if optype in _tk_to_qir_params_1q else None
+    params = op.params
     if optype == OpType.TK1:
         # convert to U3
         optype = OpType.U3

--- a/pytket/pytket/qir/qir.py
+++ b/pytket/pytket/qir/qir.py
@@ -133,8 +133,10 @@ def _to_qis_qubits(qubits: List[Qubit], mod: SimpleModule) -> List[types.QUBIT]:
     return [mod.qubits[qubit.index[0]] for qubit in qubits]
 
 
-def _to_qis_results(bits: List[Bit], mod: SimpleModule) -> SimpleModule.results:
-    return mod.results[bits[0].index[0]]
+def _to_qis_results(bits: List[Bit], mod: SimpleModule) -> Optional[types.RESULT]:
+    if bits:
+        return mod.results[bits[0].index[0]]
+    return None
 
 
 def circuit_from_qir(input_file) -> None:

--- a/pytket/pytket/qir/qir.py
+++ b/pytket/pytket/qir/qir.py
@@ -104,8 +104,9 @@ class QIRUnsupportedError(Exception):
 class ExtendedModule:
     """Module extensions to account for any input gate set."""
 
-    
-    def __init__(self, name: str, num_qubits: int, num_results: int, gateset: GateSet) -> None:
+    def __init__(
+        self, name: str, num_qubits: int, num_results: int, gateset: GateSet
+    ) -> None:
         self.module = SimpleModule(name, num_qubits, num_results)
         for k, v in gateset.gateset.items():
             self.__setattr__(

--- a/pytket/pytket/qir/qir.py
+++ b/pytket/pytket/qir/qir.py
@@ -13,9 +13,10 @@
 # limitations under the License.
 
 import os
-from typing import List, Optional, Tuple
+from string import Template
+from typing import Dict, List, NamedTuple, Optional, Tuple
 
-from pyqir.generator import SimpleModule, BasicQisBuilder  # type: ignore
+from pyqir.generator import SimpleModule, BasicQisBuilder, types  # type: ignore
 from pytket import Circuit, OpType, Bit, Qubit
 from pytket.circuit import Op  # type: ignore
 

--- a/pytket/pytket/qir/qir.py
+++ b/pytket/pytket/qir/qir.py
@@ -127,8 +127,8 @@ def _get_optype_and_params(op: Op) -> Tuple[OpType, Optional[List[float]]]:
     return (optype, params)
 
 
-def _to_qis_qubit(qubits: List[Qubit], mod: SimpleModule) -> SimpleModule.qubits:
-    return mod.qubits[qubits[0].index[0]]
+def _to_qis_qubits(qubits: List[Qubit], mod: SimpleModule) -> List:
+    return (mod.qubits[qubit.index[0]] for qubit in qubits)
 
 
 def _to_qis_results(bits: List[Bit], mod: SimpleModule) -> SimpleModule.results:

--- a/pytket/pytket/qir/qir.py
+++ b/pytket/pytket/qir/qir.py
@@ -24,7 +24,10 @@ from pytket.circuit import Op  # type: ignore
 CustomPyQIRGate = NamedTuple(
     "CustomPyQIRGate",
     [
-        ("functions", List[Union[types.DOUBLE, types.QUBIT, types.RESULT]]),
+        (
+            "functions",
+            List[Union[type[types.DOUBLE], type[types.QUBIT], type[types.RESULT]]],
+        ),
     ],
 )
 
@@ -129,11 +132,11 @@ def _get_optype_and_params(op: Op) -> Tuple[OpType, Optional[List[float]]]:
     return (optype, params)
 
 
-def _to_qis_qubits(qubits: List[Qubit], mod: SimpleModule) -> List[types.QUBIT]:
+def _to_qis_qubits(qubits: List[Qubit], mod: SimpleModule) -> List[type[types.QUBIT]]:
     return [mod.qubits[qubit.index[0]] for qubit in qubits]
 
 
-def _to_qis_results(bits: List[Bit], mod: SimpleModule) -> Optional[types.RESULT]:
+def _to_qis_results(bits: List[Bit], mod: SimpleModule) -> Optional[type[types.RESULT]]:
     if bits:
         return mod.results[bits[0].index[0]]
     return None

--- a/pytket/tests/conftest.py
+++ b/pytket/tests/conftest.py
@@ -23,15 +23,13 @@ from pytket.circuit import (  # type: ignore
     Circuit,
     OpType,
 )
-from pytket.qir.qir import (
-    circuit_to_qir,
-    ExtendedModule,
-    QUANTINUUM_GATES
-)
+from pytket.qir.qir import circuit_to_qir, ExtendedModule, QUANTINUUM_GATES
+
 
 @fixture
 def file_name() -> str:
     return "SimpleCircuit.ll"
+
 
 @fixture
 def ext_module_quantinuum_gateset() -> ExtendedModule:
@@ -39,63 +37,30 @@ def ext_module_quantinuum_gateset() -> ExtendedModule:
         name="Simple module for Quantinuum gateset.",
         num_qubits=2,
         num_results=1,
-        gateset=QUANTINUUM_GATES
+        gateset=QUANTINUUM_GATES,
     )
     em.module.builder.call(em.h, [em.module.qubits[0]])  # type: ignore
     em.module.builder.call(em.x, [em.module.qubits[1]])  # type: ignore
     em.module.builder.call(em.y, [em.module.qubits[0]])  # type: ignore
     em.module.builder.call(em.z, [em.module.qubits[1]])  # type: ignore
+    em.module.builder.call(em.rx, [0.0, em.module.qubits[1]])  # type: ignore
+    em.module.builder.call(em.ry, [1.0, em.module.qubits[0]])  # type: ignore
+    em.module.builder.call(em.rz, [2.0, em.module.qubits[1]])  # type: ignore
+    em.module.builder.call(em.phx, [1.0, 2.0, em.module.qubits[1]])  # type: ignore
     em.module.builder.call(
-        em.rx, [  # type: ignore
-            0.0,
-            em.module.qubits[1]
-        ]
+        em.cnot, [em.module.qubits[0], em.module.qubits[1]]  # type: ignore
     )
     em.module.builder.call(
-        em.ry, [  # type: ignore
-            1.0,
-            em.module.qubits[0]
-        ]
+        em.zzmax, [em.module.qubits[1], em.module.qubits[0]]  # type: ignore
     )
     em.module.builder.call(
-        em.rz, [  # type: ignore
-            2.0,
-            em.module.qubits[1]
-        ]
+        em.zzph, [1.0, em.module.qubits[0], em.module.qubits[1]]  # type: ignore
     )
     em.module.builder.call(
-        em.phx, [  # type: ignore
-            1.0,
-            2.0,
-            em.module.qubits[1]
-        ]
-    )
-    em.module.builder.call(
-        em.cnot, [  # type: ignore
-            em.module.qubits[0],
-            em.module.qubits[1]
-        ]
-    )
-    em.module.builder.call(
-        em.zzmax, [  # type: ignore
-            em.module.qubits[1],
-            em.module.qubits[0]
-        ]
-    )
-    em.module.builder.call(
-        em.zzph, [  # type: ignore
-            1.0,
-            em.module.qubits[0],
-            em.module.qubits[1]
-        ]
-    )
-    em.module.builder.call(
-        em.mz, [  # type: ignore
-            em.module.qubits[0],
-            em.module.results[0]
-        ]
+        em.mz, [em.module.qubits[0], em.module.results[0]]  # type: ignore
     )
     return em
+
 
 @fixture
 def circuit_quantinuum_gateset(file_name: str) -> Generator:

--- a/pytket/tests/qir_test.py
+++ b/pytket/tests/qir_test.py
@@ -12,84 +12,36 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pytest
 from pytket import Circuit
 
-from pytket.qir.qir import (
-    circuit_to_qir_str,
-    ExtendedModule,
-    QUANTINUUM_GATES
-)
+from pytket.qir.qir import circuit_to_qir, ExtendedModule, QUANTINUUM_GATES
 
 
-def test_extended_module_for_quantinuum_gateset() -> None:
-    em = ExtendedModule(
-        name="Simple module for Quantinuum gateset.",
-        num_qubits=2,
-        num_results=1,
-        gateset=QUANTINUUM_GATES
-    )
-    em.module.builder.call(em.h, [em.module.qubits[0]])
-    em.module.builder.call(em.x, [em.module.qubits[1]])
-    em.module.builder.call(em.y, [em.module.qubits[0]])
-    em.module.builder.call(em.z, [em.module.qubits[1]])
-    em.module.builder.call(
-        em.rx, [
-            0.0,
-            em.module.qubits[1]
-        ]
-    )
-    em.module.builder.call(
-        em.ry, [
-            1.0,
-            em.module.qubits[0]
-        ]
-    )
-    em.module.builder.call(
-        em.rz, [
-            2.0,
-            em.module.qubits[1]
-        ]
-    )
-    em.module.builder.call(
-        em.phx, [
-            1.0,
-            2.0,
-            em.module.qubits[1]
-        ]
-    )
-    em.module.builder.call(
-        em.cnot, [
-            em.module.qubits[0],
-            em.module.qubits[1]
-        ]
-    )
-    em.module.builder.call(
-        em.zzmax, [
-            em.module.qubits[1],
-            em.module.qubits[0]
-        ]
-    )
-    em.module.builder.call(
-        em.zzph, [
-            1.0,
-            em.module.qubits[0],
-            em.module.qubits[1]
-        ]
-    )
-    em.module.builder.call(
-        em.mz, [
-            em.module.qubits[0],
-            em.module.results[0]
-        ]
-    )
+def test_raise_quantinuum_gateset_keyerror() -> None:
+    c = Circuit(2)
+    c.CY(0, 1)
+    with pytest.raises(KeyError):
+        circuit_to_qir(c, "RaiseError.ll", QUANTINUUM_GATES)
+
+
+def test_extended_module_for_quantinuum_gateset(
+    ext_module_quantinuum_gateset: ExtendedModule,
+) -> None:
+    em = ext_module_quantinuum_gateset
     em_ir_str = em.module.ir()
-    print(em_ir_str)
     call_h = f"call void @__quantinuum__qis__h__body(%Qubit* null)"
-    call_x = f"call void @__quantinuum__qis__x__body(%Qubit* inttoptr (i64 1 to %Qubit*))"
+    call_x = (
+        f"call void @__quantinuum__qis__x__body(%Qubit* inttoptr (i64 1 to %Qubit*))"
+    )
     call_y = f"call void @__quantinuum__qis__y__body(%Qubit* null)"
-    call_z = f"call void @__quantinuum__qis__z__body(%Qubit* inttoptr (i64 1 to %Qubit*))"
+    call_z = (
+        f"call void @__quantinuum__qis__z__body(%Qubit* inttoptr (i64 1 to %Qubit*))"
+    )
     call_rx = f"call void @__quantinuum__qis__rx__body(double 0.000000e+00, %Qubit* inttoptr (i64 1 to %Qubit*))"
-    call_ry = f"call void @__quantinuum__qis__ry__body(double 1.000000e+00, %Qubit* null)"
+    call_ry = (
+        f"call void @__quantinuum__qis__ry__body(double 1.000000e+00, %Qubit* null)"
+    )
     call_rz = f"call void @__quantinuum__qis__rz__body(double 2.000000e+00, %Qubit* inttoptr (i64 1 to %Qubit*))"
     call_phx = f"call void @__quantinuum__qis__phx__body(double 1.000000e+00, double 2.000000e+00, %Qubit* inttoptr (i64 1 to %Qubit*))"
     call_cnot = f"call void @__quantinuum__qis__cnot__body(%Qubit* null, %Qubit* inttoptr (i64 1 to %Qubit*))"
@@ -108,38 +60,125 @@ def test_extended_module_for_quantinuum_gateset() -> None:
     assert call_zzmax in em_ir_str
     assert call_zzph in em_ir_str
     assert call_mz in em_ir_str
-    
 
 
+def test_qir_from_pytket_circuit_and_quantinuum_gateset(
+    circuit_quantinuum_gateset, file_name: str
+) -> None:
+    with open(file_name, "r") as input:
+        data = input.read()
+    call_h = f"call void @__quantinuum__qis__h__body(%Qubit* null)"
+    call_x = (
+        f"call void @__quantinuum__qis__x__body(%Qubit* inttoptr (i64 1 to %Qubit*))"
+    )
+    call_y = f"call void @__quantinuum__qis__y__body(%Qubit* null)"
+    call_z = (
+        f"call void @__quantinuum__qis__z__body(%Qubit* inttoptr (i64 1 to %Qubit*))"
+    )
+    call_rx = f"call void @__quantinuum__qis__rx__body(double 0.000000e+00, %Qubit* inttoptr (i64 1 to %Qubit*))"
+    call_ry = (
+        f"call void @__quantinuum__qis__ry__body(double 1.000000e+00, %Qubit* null)"
+    )
+    call_rz = f"call void @__quantinuum__qis__rz__body(double 2.000000e+00, %Qubit* inttoptr (i64 1 to %Qubit*))"
+    call_phx = f"call void @__quantinuum__qis__phx__body(double 1.500000e+00, double 5.000000e-01, %Qubit* inttoptr (i64 1 to %Qubit*))"
+    call_cnot = f"call void @__quantinuum__qis__cnot__body(%Qubit* null, %Qubit* inttoptr (i64 1 to %Qubit*))"
+    call_zzmax = f"call void @__quantinuum__qis__zzmax__body(%Qubit* inttoptr (i64 1 to %Qubit*), %Qubit* null)"
+    call_zzph = f"call void @__quantinuum__qis__zzph__body(double 1.000000e+00, %Qubit* null, %Qubit* inttoptr (i64 1 to %Qubit*))"
+    call_mz = f"call void @__quantinuum__qis__mz__body(%Qubit* inttoptr (i64 1 to %Qubit*), %Result* %zero)"
 
-def test_pyqir_builtin_gates_from_pytket_circuit() -> None:
+    assert call_h in data
+    assert call_x in data
+    assert call_y in data
+    assert call_z in data
+    assert call_rx in data
+    assert call_ry in data
+    assert call_rz in data
+    assert call_phx in data
+    assert call_cnot in data
+    assert call_zzmax in data
+    assert call_zzph in data
+    assert call_mz in data
+
+
+def test_raise_pyqir_gateset_keyerror() -> None:
     c = Circuit(2)
-    c.CX(0, 1)
-    mod_name = "Simple CX circuit"
-    c_qir_str = circuit_to_qir_str(c, mod_name)
-    print(c_qir_str)
-
-def test_qir_str_measure() -> None:
-    c = Circuit(1, 1)
-    c.Measure(0, 0)
-    module_name = "Simple Measure circuit"
-    c_qir_str = circuit_to_qir_str(c, module_name)
-    call = f"call %Result* @__quantum__qis__m__body(%Qubit* null)"
-    assert call in c_qir_str
+    c.CY(0, 1)
+    with pytest.raises(KeyError):
+        circuit_to_qir(c, "RaiseError.ll")
 
 
-def test_qir_str_rz() -> None:
-    c = Circuit(1)
-    c.Rz(0.0, 0)
-    module_name = "Simple Rz circuit"
-    c_qir_str = circuit_to_qir_str(c, module_name)
-    call = f"call void @__quantum__qis__rz__body(double 0.000000e+00, %Qubit* null)"
-    assert call in c_qir_str
+def test_qir_from_pytket_circuit_and_pyqir_gateset(
+    circuit_pyqir_gateset, file_name: str
+):
+    with open(file_name, "r") as input:
+        data = input.read()
+    call_h = f"call void @__quantum__qis__h__body(%Qubit* null)"
+    call_x = f"call void @__quantum__qis__x__body(%Qubit* inttoptr (i64 1 to %Qubit*))"
+    call_y = f"call void @__quantum__qis__y__body(%Qubit* null)"
+    call_z = f"call void @__quantum__qis__z__body(%Qubit* inttoptr (i64 1 to %Qubit*))"
+    call_s = f"call void @__quantum__qis__s__body(%Qubit* null)"
+    call_s_adj = (
+        f"call void @__quantum__qis__s__adj(%Qubit* inttoptr (i64 1 to %Qubit*))"
+    )
+    call_t = f"call void @__quantum__qis__t__body(%Qubit* null)"
+    call_t_adj = (
+        f"call void @__quantum__qis__t__adj(%Qubit* inttoptr (i64 1 to %Qubit*))"
+    )
+    call_reset = f"call void @__quantum__qis__reset__body(%Qubit* null)"
+    call_cnot = f"call void @__quantum__qis__cnot__body(%Qubit* null, %Qubit* inttoptr (i64 1 to %Qubit*))"
+    call_cz = f"call void @__quantum__qis__cz__body(%Qubit* inttoptr (i64 1 to %Qubit*), %Qubit* null)"
+    call_rx = f"call void @__quantum__qis__rx__body(double 0.000000e+00, %Qubit* inttoptr (i64 1 to %Qubit*))"
+    call_ry = f"call void @__quantum__qis__ry__body(double 1.000000e+00, %Qubit* null)"
+    call_rz = f"call void @__quantum__qis__rz__body(double 2.000000e+00, %Qubit* inttoptr (i64 1 to %Qubit*))"
+    call_m = (
+        f"call %Result* @__quantum__qis__m__body(%Qubit* inttoptr (i64 1 to %Qubit*))"
+    )
+
+    assert call_h in data
+    assert call_x in data
+    assert call_y in data
+    assert call_z in data
+    assert call_s in data
+    assert call_s_adj in data
+    assert call_t in data
+    assert call_t_adj in data
+    assert call_reset in data
+    assert call_cnot in data
+    assert call_cz in data
+    assert call_m in data
+    assert call_rx in data
+    assert call_ry in data
+    assert call_rz in data
 
 
-def test_extended_module() -> None:
-    em = ExtendedModule('Extended Module', 2, 1)
-    em.module.builder.call(em.zzmax, [em.module.qubits[0],em.module.qubits[1]])
-    em_ir_str = em.module.ir()
-    call = f"call void @__quantum__qis__zzmax__body(%Qubit* null, %Qubit* inttoptr (i64 1 to %Qubit*))"
-    assert call in em_ir_str
+# def test_pyqir_builtin_gates_from_pytket_circuit() -> None:
+#     c = Circuit(2)
+#     c.CX(0, 1)
+#     mod_name = "Simple CX circuit"
+#     c_qir_str = circuit_to_qir_str(c, mod_name)
+#     print(c_qir_str)
+
+# def test_qir_str_measure() -> None:
+#     c = Circuit(1, 1)
+#     c.Measure(0, 0)
+#     module_name = "Simple Measure circuit"
+#     c_qir_str = circuit_to_qir_str(c, module_name)
+#     call = f"call %Result* @__quantum__qis__m__body(%Qubit* null)"
+#     assert call in c_qir_str
+
+
+# def test_qir_str_rz() -> None:
+#     c = Circuit(1)
+#     c.Rz(0.0, 0)
+#     module_name = "Simple Rz circuit"
+#     c_qir_str = circuit_to_qir_str(c, module_name)
+#     call = f"call void @__quantum__qis__rz__body(double 0.000000e+00, %Qubit* null)"
+#     assert call in c_qir_str
+
+
+# def test_extended_module() -> None:
+#     em = ExtendedModule('Extended Module', 2, 1)
+#     em.module.builder.call(em.zzmax, [em.module.qubits[0],em.module.qubits[1]])
+#     em_ir_str = em.module.ir()
+#     call = f"call void @__quantum__qis__zzmax__body(%Qubit* null, %Qubit* inttoptr (i64 1 to %Qubit*))"
+#     assert call in em_ir_str

--- a/pytket/tests/qir_test.py
+++ b/pytket/tests/qir_test.py
@@ -14,8 +14,110 @@
 
 from pytket import Circuit
 
-from pytket.qir.qir import circuit_to_qir_str, circuit_to_qir_str
+from pytket.qir.qir import (
+    circuit_to_qir_str,
+    ExtendedModule,
+    QUANTINUUM_GATES
+)
 
+
+def test_extended_module_for_quantinuum_gateset() -> None:
+    em = ExtendedModule(
+        name="Simple module for Quantinuum gateset.",
+        num_qubits=2,
+        num_results=1,
+        gateset=QUANTINUUM_GATES
+    )
+    em.module.builder.call(em.h, [em.module.qubits[0]])
+    em.module.builder.call(em.x, [em.module.qubits[1]])
+    em.module.builder.call(em.y, [em.module.qubits[0]])
+    em.module.builder.call(em.z, [em.module.qubits[1]])
+    em.module.builder.call(
+        em.rx, [
+            0.0,
+            em.module.qubits[1]
+        ]
+    )
+    em.module.builder.call(
+        em.ry, [
+            1.0,
+            em.module.qubits[0]
+        ]
+    )
+    em.module.builder.call(
+        em.rz, [
+            2.0,
+            em.module.qubits[1]
+        ]
+    )
+    em.module.builder.call(
+        em.phx, [
+            1.0,
+            2.0,
+            em.module.qubits[1]
+        ]
+    )
+    em.module.builder.call(
+        em.cnot, [
+            em.module.qubits[0],
+            em.module.qubits[1]
+        ]
+    )
+    em.module.builder.call(
+        em.zzmax, [
+            em.module.qubits[1],
+            em.module.qubits[0]
+        ]
+    )
+    em.module.builder.call(
+        em.zzph, [
+            1.0,
+            em.module.qubits[0],
+            em.module.qubits[1]
+        ]
+    )
+    em.module.builder.call(
+        em.mz, [
+            em.module.qubits[0],
+            em.module.results[0]
+        ]
+    )
+    em_ir_str = em.module.ir()
+    print(em_ir_str)
+    call_h = f"call void @__quantinuum__qis__h__body(%Qubit* null)"
+    call_x = f"call void @__quantinuum__qis__x__body(%Qubit* inttoptr (i64 1 to %Qubit*))"
+    call_y = f"call void @__quantinuum__qis__y__body(%Qubit* null)"
+    call_z = f"call void @__quantinuum__qis__z__body(%Qubit* inttoptr (i64 1 to %Qubit*))"
+    call_rx = f"call void @__quantinuum__qis__rx__body(double 0.000000e+00, %Qubit* inttoptr (i64 1 to %Qubit*))"
+    call_ry = f"call void @__quantinuum__qis__ry__body(double 1.000000e+00, %Qubit* null)"
+    call_rz = f"call void @__quantinuum__qis__rz__body(double 2.000000e+00, %Qubit* inttoptr (i64 1 to %Qubit*))"
+    call_phx = f"call void @__quantinuum__qis__phx__body(double 1.000000e+00, double 2.000000e+00, %Qubit* inttoptr (i64 1 to %Qubit*))"
+    call_cnot = f"call void @__quantinuum__qis__cnot__body(%Qubit* null, %Qubit* inttoptr (i64 1 to %Qubit*))"
+    call_zzmax = f"call void @__quantinuum__qis__zzmax__body(%Qubit* inttoptr (i64 1 to %Qubit*), %Qubit* null)"
+    call_zzph = f"call void @__quantinuum__qis__zzph__body(double 1.000000e+00, %Qubit* null, %Qubit* inttoptr (i64 1 to %Qubit*))"
+    call_mz = f"call void @__quantinuum__qis__mz__body(%Qubit* null, %Result* %zero)"
+    assert call_h in em_ir_str
+    assert call_x in em_ir_str
+    assert call_y in em_ir_str
+    assert call_z in em_ir_str
+    assert call_rx in em_ir_str
+    assert call_ry in em_ir_str
+    assert call_rz in em_ir_str
+    assert call_phx in em_ir_str
+    assert call_cnot in em_ir_str
+    assert call_zzmax in em_ir_str
+    assert call_zzph in em_ir_str
+    assert call_mz in em_ir_str
+    
+
+
+
+def test_pyqir_builtin_gates_from_pytket_circuit() -> None:
+    c = Circuit(2)
+    c.CX(0, 1)
+    mod_name = "Simple CX circuit"
+    c_qir_str = circuit_to_qir_str(c, mod_name)
+    print(c_qir_str)
 
 def test_qir_str_measure() -> None:
     c = Circuit(1, 1)
@@ -33,3 +135,11 @@ def test_qir_str_rz() -> None:
     c_qir_str = circuit_to_qir_str(c, module_name)
     call = f"call void @__quantum__qis__rz__body(double 0.000000e+00, %Qubit* null)"
     assert call in c_qir_str
+
+
+def test_extended_module() -> None:
+    em = ExtendedModule('Extended Module', 2, 1)
+    em.module.builder.call(em.zzmax, [em.module.qubits[0],em.module.qubits[1]])
+    em_ir_str = em.module.ir()
+    call = f"call void @__quantum__qis__zzmax__body(%Qubit* null, %Qubit* inttoptr (i64 1 to %Qubit*))"
+    assert call in em_ir_str


### PR DESCRIPTION
This PR addresses the development of QIR generation functionality for arbitrary input gate set. This encompasses:
* The definition of new data structures to define a gate set and conversion from `pytket` optypes to the input gate set.
* The definition of a `ExtendedModule` class that uses the `add_external_function` to define new function calls in QIR for the custom defined gate set.
* Behaviour in both cases:
  * Default: uses `PyQIR` gate set
  * If input gate set, uses `ExtendedModule`
 