### PR TITLE
Update `typing-extensions` dependency.

### DIFF
--- a/pytket/setup.py
+++ b/pytket/setup.py
@@ -247,7 +247,7 @@ setup(
         "graphviz ~= 0.14",
         "jinja2 ~= 3.0",
         "types-pkg_resources",
-        "typing-extensions ~= 3.7",
+        "typing-extensions ~= 4.2",
     ],
     ext_modules=[
         CMakeExtension("pytket._tket.{}".format(binder)) for binder in binders


### PR DESCRIPTION
This allows us to use more recent versions of some of the typing modules, e.g. `boto3-stubs`.