### PR TITLE
[TKET-1958] Update `FullyConnected` docs and add `place_fully_connected`

### DIFF
--- a/pytket/binders/architecture.cpp
+++ b/pytket/binders/architecture.cpp
@@ -98,7 +98,7 @@ PYBIND11_MODULE(architecture, m) {
       .def(py::self == py::self);
   py::class_<SquareGrid, std::shared_ptr<SquareGrid>, Architecture>(
       m, "SquareGrid",
-      "Architecture class for qubits arranged in a square lattice of "
+      "Inherited Architecture class for qubits arranged in a square lattice of "
       "given number of rows and columns. Qubits are arranged with qubits "
       "values increasing first along rows then along columns i.e. for a "
       "3 x 3 grid:\n\n 0 1 2\n\n 3 4 5\n\n 6 7 8")
@@ -147,7 +147,7 @@ PYBIND11_MODULE(architecture, m) {
       });
   py::class_<RingArch, std::shared_ptr<RingArch>, Architecture>(
       m, "RingArch",
-      "Architecture class for number of qubits arranged in a ring.")
+      "Inherited Architecture class for number of qubits arranged in a ring.")
       .def(
           py::init<const unsigned>(),
           "The constructor for a RingArchitecture with some undirected "
@@ -158,7 +158,9 @@ PYBIND11_MODULE(architecture, m) {
       });
   py::class_<FullyConnected>(
       m, "FullyConnected",
-      "An architecture with full connectivity between qubits.")
+      "A specialised non-Architecture object emulating an architecture with "
+      "all qubits connected. "
+      "Not compatible with Routing or Placement methods.")
       .def(
           py::init<unsigned>(),
           "Construct a fully-connected architecture."

--- a/pytket/binders/placement.cpp
+++ b/pytket/binders/placement.cpp
@@ -71,6 +71,21 @@ void place_with_map(Circuit &circ, qubit_mapping_t &qmap) {
   plobj.place_with_map(circ, qmap);
 }
 
+void place_fully_connected(
+    Circuit &circ, const FullyConnected &fully_connected) {
+  if (circ.n_qubits() > fully_connected.n_nodes()) {
+    throw std::logic_error(
+        "Circuit has more qubits than the FullyConnected graph has nodes");
+  }
+  qubit_mapping_t qmap;
+  unsigned index = 0;
+  for (const Qubit &q : circ.all_qubits()) {
+    qmap[q] = Node("fcNode", index);
+    index++;
+  }
+  place_with_map(circ, qmap);
+}
+
 PYBIND11_MODULE(placement, m) {
   py::class_<Placement, std::shared_ptr<Placement>>(
             m, "Placement",
@@ -220,5 +235,14 @@ PYBIND11_MODULE(placement, m) {
       "\n\n:param circuit: The Circuit being relabelled. \n:param qmap: "
       "The map from logical to physical qubits to apply.",
       py::arg("circuit"), py::arg("qmap"));
+
+  m.def(
+      "place_fully_connected", &place_fully_connected,
+      "Relabels all Circuit Qubits to the Node objects of a FullyConnected "
+      "object. "
+      "\n\n:param circuit: The Circuit being relabelled. \n:param "
+      "fully_connected: "
+      "FullyConnected object Qubits being relabelled to match.",
+      py::arg("circuit"), py::arg("fully_connected"));
 }
 }  // namespace tket

--- a/pytket/tests/placement_test.py
+++ b/pytket/tests/placement_test.py
@@ -15,13 +15,14 @@
 from pathlib import Path
 from pytket import Circuit  # type: ignore
 from pytket.circuit import Node, Qubit  # type: ignore
-from pytket.architecture import Architecture  # type: ignore
+from pytket.architecture import Architecture, FullyConnected  # type: ignore
 from pytket.placement import (  # type: ignore
     Placement,
     LinePlacement,
     GraphPlacement,
     NoiseAwarePlacement,
     place_with_map,
+    place_fully_connected,
 )
 from pytket.passes import PauliSimp, DefaultMappingPass  # type: ignore
 from pytket.mapping import MappingManager, LexiRouteRoutingMethod, LexiLabellingMethod  # type: ignore
@@ -189,6 +190,18 @@ def test_place_with_map_twice() -> None:
     assert all(qb.reg_name == "unplaced" for qb in c.qubits)
 
 
+def test_place_fully_connected() -> None:
+    c = Circuit(5)
+    fc5 = FullyConnected(5)
+    place_fully_connected(c, fc5)
+    qbs = c.qubits
+    assert qbs[0].reg_name == "fcNode"
+    assert qbs[1].reg_name == "fcNode"
+    assert qbs[2].reg_name == "fcNode"
+    assert qbs[3].reg_name == "fcNode"
+    assert qbs[4].reg_name == "fcNode"
+
+
 def test_big_placement() -> None:
     # TKET-1275
     c = circuit_from_qasm(
@@ -249,3 +262,4 @@ if __name__ == "__main__":
     test_convert_index_mapping()
     test_place_with_map_twice()
     test_big_placement()
+    test_place_fully_connected()


### PR DESCRIPTION
Despite being imported from `pytket.architecture`, `FullyConnected` is not an `Architecture` object and so cannot be used with `Routing` and `Placement` methods. 

This PR makes this clear via updating the docs. It also adds a basic new method to `pytket.placement`, `place_fully_connected`, for automatically reassigning `Circuit` `Qubit` to `FullyConnected` `Node`.