### PR TITLE
Create symengine 0.9.0.1 requiring boost 1.79.0.

### DIFF
--- a/.github/workflows/build_symengine.yml
+++ b/.github/workflows/build_symengine.yml
@@ -79,7 +79,7 @@ jobs:
     - name: create profile
       run: conan profile new tket --detect
     - name: install boost
-      run: conan install --profile=tket -s build_type=${{ matrix.build_type }} boost/1.78.0@ --build=missing
+      run: conan install --profile=tket -s build_type=${{ matrix.build_type }} boost/1.79.0@ --build=missing
     - name: build symengine
       run: conan create --profile=tket -s build_type=${{ matrix.build_type }} -o symengine:shared=${{ matrix.shared }} recipes/symengine tket/stable
     - name: add remote

--- a/.github/workflows/build_symengine.yml
+++ b/.github/workflows/build_symengine.yml
@@ -187,7 +187,7 @@ jobs:
     - name: build symengine
       run: |
         docker start linux_build
-        at <<EOF > env-vars
+        cat <<EOF > env-vars
         UPLOAD_PACKAGE=${UPLOAD_PACKAGE}
         JFROG_ARTIFACTORY_TOKEN_1=${{ secrets.JFROG_ARTIFACTORY_TOKEN_1 }}
         JFROG_ARTIFACTORY_USER_1=${{ secrets.JFROG_ARTIFACTORY_USER_1 }}

--- a/recipes/symengine/conanfile.py
+++ b/recipes/symengine/conanfile.py
@@ -20,7 +20,8 @@ required_conan_version = ">=1.33.0"
 
 class SymengineConan(ConanFile):
     name = "symengine"
-    version = "0.9.0"
+    version = "0.9.0.1"
+    upstream_version = "0.9.0"
     description = "A fast symbolic manipulation library, written in C++"
     license = "MIT"
     topics = ("symbolic", "algebra")
@@ -44,15 +45,15 @@ class SymengineConan(ConanFile):
 
     def requirements(self):
         if self.options.integer_class == "boostmp":
-            self.requires("boost/1.78.0")
+            self.requires("boost/1.79.0")
         else:
             self.requires("gmp/6.2.1")
 
     def source(self):
         tools.get(
-            f"https://github.com/symengine/symengine/releases/download/v{self.version}/symengine-{self.version}.tar.gz"
+            f"https://github.com/symengine/symengine/releases/download/v{self.upstream_version}/symengine-{self.upstream_version}.tar.gz"
         )
-        os.rename(f"symengine-{self.version}", "symengine")
+        os.rename(f"symengine-{self.upstream_version}", "symengine")
 
     def _configure_cmake(self):
         if self._cmake is None:


### PR DESCRIPTION
Will follow-up with a TKET PR to use this version of symengine and boost, which will allow us to drop one of our build-time patches (already tested locally).