### PR TITLE
TK2 synthesis pass

### DIFF
--- a/pytket/binders/circuit/library.cpp
+++ b/pytket/binders/circuit/library.cpp
@@ -34,6 +34,9 @@ void init_library(py::module &m) {
       "_BRIDGE_using_CX_1", &CircPool::BRIDGE_using_CX_1,
       "Equivalent to BRIDGE, using four CX, first CX has control on qubit 1");
   library_m.def(
+      "_CX_using_TK2", &CircPool::CX_using_TK2,
+      "Equivalent to CX, using a TK2 and single-qubit gates");
+  library_m.def(
       "_CX_using_flipped_CX", &CircPool::CX_using_flipped_CX,
       "Equivalent to CX[0,1], using a CX[1,0] and four H gates");
   library_m.def(
@@ -137,14 +140,26 @@ void init_library(py::module &m) {
       "_ZZMax_using_CX", &CircPool::ZZMax_using_CX,
       "Equivalent to ZZMax, using CX, Rz and U3 gates ");
   library_m.def(
+      "_CRz_using_TK2", &CircPool::CRz_using_TK2,
+      "Equivalent to CRz, using a TK2 and TK1 gates");
+  library_m.def(
       "_CRz_using_CX", &CircPool::CRz_using_CX,
       "Equivalent to CRz, using CX and Rz gates");
+  library_m.def(
+      "_CRx_using_TK2", &CircPool::CRx_using_TK2,
+      "Equivalent to CRx, using a TK2 and TK1 gates");
   library_m.def(
       "_CRx_using_CX", &CircPool::CRx_using_CX,
       "Equivalent to CRx, using CX, H and Rx gates");
   library_m.def(
+      "_CRy_using_TK2", &CircPool::CRy_using_TK2,
+      "Equivalent to CRy, using a TK2 and TK1 gates");
+  library_m.def(
       "_CRy_using_CX", &CircPool::CRy_using_CX,
       "Equivalent to CRy, using CX and Ry gates");
+  library_m.def(
+      "_CU1_using_TK2", &CircPool::CU1_using_TK2,
+      "Equivalent to CU1, using a TK2 and TK1 gates");
   library_m.def(
       "_CU1_using_CX", &CircPool::CU1_using_CX,
       "Equivalent to CU1, using CX and U1 gates");
@@ -152,26 +167,50 @@ void init_library(py::module &m) {
       "_CU3_using_CX", &CircPool::CU3_using_CX,
       "Equivalent to CU1, using CX, U1 and U3 gates");
   library_m.def(
+      "_ISWAP_using_TK2", &CircPool::ISWAP_using_TK2,
+      "Equivalent to ISWAP, using a TK2 gate");
+  library_m.def(
       "_ISWAP_using_CX", &CircPool::ISWAP_using_CX,
       "Equivalent to ISWAP, using CX, U3 and Rz gates");
+  library_m.def(
+      "_XXPhase_using_TK2", &CircPool::XXPhase_using_TK2,
+      "Equivalent to XXPhase, using a TK2 gate");
   library_m.def(
       "_XXPhase_using_CX", &CircPool::XXPhase_using_CX,
       "Equivalent to XXPhase, using CX and U3 gates ");
   library_m.def(
+      "_YYPhase_using_TK2", &CircPool::YYPhase_using_TK2,
+      "Equivalent to YYPhase, using a TK2 gate");
+  library_m.def(
       "_YYPhase_using_CX", &CircPool::YYPhase_using_CX,
       "Equivalent to YYPhase, using CX, Rz and U3 gates");
+  library_m.def(
+      "_ZZPhase_using_TK2", &CircPool::ZZPhase_using_TK2,
+      "Equivalent to ZZPhase, using a TK2 gate");
   library_m.def(
       "_ZZPhase_using_CX", &CircPool::ZZPhase_using_CX,
       "Equivalent to ZZPhase, using CX and Rz gates");
   library_m.def(
+      "_XXPhase3_using_TK2", &CircPool::XXPhase3_using_TK2,
+      "Equivalent to XXPhase3, using three TK2 gates");
+  library_m.def(
       "_XXPhase3_using_CX", &CircPool::XXPhase3_using_CX,
       "Equivalent to 3-qubit MS interaction, using CX and U3 gates");
+  library_m.def(
+      "_ESWAP_using_TK2", &CircPool::ESWAP_using_TK2,
+      "Equivalent to ESWAP, using a TK2 and (Clifford) TK1 gates");
   library_m.def(
       "_ESWAP_using_CX", &CircPool::XXPhase3_using_CX,
       "Equivalent to ESWAP, using CX, X, S, Ry and U1 gates");
   library_m.def(
+      "_FSim_using_TK2", &CircPool::FSim_using_TK2,
+      "Equivalent to FSim, using a TK2 and TK1 gates");
+  library_m.def(
       "_FSim_using_CX", &CircPool::FSim_using_CX,
       "Equivalent to Fsim, using CX, X, S, U1 and U3 gates ");
+  library_m.def(
+      "_PhasedISWAP_using_TK2", &CircPool::PhasedISWAP_using_TK2,
+      "Equivalent to PhasedISWAP, using a TK2 and Rz gates");
   library_m.def(
       "_PhasedISWAP_using_CX", &CircPool::PhasedISWAP_using_CX,
       "Equivalent to PhasedISWAP, using CX, U3 and Rz gates");

--- a/pytket/binders/circuit/library.cpp
+++ b/pytket/binders/circuit/library.cpp
@@ -176,7 +176,7 @@ void init_library(py::module &m) {
       "_PhasedISWAP_using_CX", &CircPool::PhasedISWAP_using_CX,
       "Equivalent to PhasedISWAP, using CX, U3 and Rz gates");
   library_m.def(
-      "_NPhasedX_using_CX", &CircPool::NPhasedX_using_CX,
+      "_NPhasedX_using_PhasedX", &CircPool::NPhasedX_using_PhasedX,
       "Unwrap NPhasedX, into number_of_qubits PhasedX gates");
 
   library_m.def(

--- a/pytket/binders/passes.cpp
+++ b/pytket/binders/passes.cpp
@@ -386,6 +386,9 @@ PYBIND11_MODULE(passes, m) {
       "Optimises and converts a circuit consisting of CX and single-qubit "
       "gates into one containing only ZZMax, PhasedX and Rz.");
   m.def(
+      "SynthesiseTK", &SynthesiseTK,
+      "Optimises and converts all gates to TK2 and TK1 gates.");
+  m.def(
       "SynthesiseTket", &SynthesiseTket,
       "Optimises and converts all gates to CX and TK1 gates.");
   m.def(

--- a/pytket/binders/transform.cpp
+++ b/pytket/binders/transform.cpp
@@ -188,6 +188,11 @@ PYBIND11_MODULE(transform, m) {
 
       /* OPTIMISATION TRANSFORMS */
       .def_static(
+          "OptimiseStandard", &Transforms::synthesise_tk,
+          "Fast optimisation pass, performing basic simplifications. "
+          "Works on any circuit, giving the result in TK1 and TK2 gates. "
+          "Preserves connectivity of circuit.")
+      .def_static(
           "OptimisePostRouting", &Transforms::synthesise_tket,
           "Fast optimisation pass, performing basic simplifications. "
           "Works on any circuit, giving the result in TK1 and CX gates. "

--- a/pytket/docs/changelog.rst
+++ b/pytket/docs/changelog.rst
@@ -9,7 +9,8 @@ Minor new features:
 * Added explicit constructors for various Python classes.
 * New ``measure_register`` method for measuring registers.
 * Added ``OpType.TK2``, a three-parameter two-qubit gate.
-* New pass and transform to synthesize TK2 gates.
+* New pass ``SynthesiseTK`` and transform ``OptimiseStandard`` to synthesize
+  TK2 gates.
 * Add ``Optype.WASM``, adding a classical wasm function call to the circuit
 
 1.1.0 (April 2022)

--- a/pytket/docs/changelog.rst
+++ b/pytket/docs/changelog.rst
@@ -9,6 +9,7 @@ Minor new features:
 * Added explicit constructors for various Python classes.
 * New ``measure_register`` method for measuring registers.
 * Added ``OpType.TK2``, a three-parameter two-qubit gate.
+* New pass and transform to synthesize TK2 gates.
 * Add ``Optype.WASM``, adding a classical wasm function call to the circuit
 
 1.1.0 (April 2022)

--- a/pytket/pytket/utils/symbolic.py
+++ b/pytket/pytket/utils/symbolic.py
@@ -126,7 +126,7 @@ def symb_tk1(params: ParamsType) -> ImmutableMatrix:
 
 
 def symb_tk2(params: ParamsType) -> ImmutableMatrix:
-    return (
+    return (  # type: ignore
         symb_xxphase([params[0]])
         * symb_yyphase([params[1]])
         * symb_zzphase([params[2]])

--- a/pytket/pytket/utils/symbolic.py
+++ b/pytket/pytket/utils/symbolic.py
@@ -125,6 +125,14 @@ def symb_tk1(params: ParamsType) -> ImmutableMatrix:
     return symb_rz([params[0]]) * symb_rx([params[1]]) * symb_rz([params[2]])  # type: ignore
 
 
+def symb_tk2(params: ParamsType) -> ImmutableMatrix:
+    return (
+        symb_xxphase([params[0]])
+        * symb_yyphase([params[1]])
+        * symb_zzphase([params[2]])
+    )
+
+
 def symb_iswap(params: ParamsType) -> ImmutableMatrix:
     alpha = params[0]
     costerm = sympy.cos((sympy.pi / 2) * alpha)
@@ -256,6 +264,7 @@ class SymGateRegister:
         OpType.Ry: symb_ry,
         OpType.Rz: symb_rz,
         OpType.TK1: symb_tk1,
+        OpType.TK2: symb_tk2,
         OpType.U1: symb_u1,
         OpType.U2: symb_u2,
         OpType.U3: symb_u3,

--- a/tket/proptests/proptest.cpp
+++ b/tket/proptests/proptest.cpp
@@ -27,6 +27,7 @@
 using namespace tket;
 
 #define ALL_PASSES(DO)                    \
+  DO(SynthesiseTK)                        \
   DO(SynthesiseTket)                      \
   DO(SynthesiseHQS)                       \
   DO(SynthesiseUMD)                       \

--- a/tket/src/Circuit/CircPool.cpp
+++ b/tket/src/Circuit/CircPool.cpp
@@ -850,6 +850,17 @@ Circuit ESWAP_using_CX(Expr alpha) {
   return c;
 }
 
+Circuit FSim_using_TK2(Expr alpha, Expr beta) {
+  Circuit c(2);
+  c.add_op<unsigned>(OpType::TK1, {-0.5, 0.5, -1}, {0});
+  c.add_op<unsigned>(OpType::TK1, {0.5, 0.5, 1}, {1});
+  c.add_op<unsigned>(OpType::TK2, {-0.5 * beta, -alpha, alpha}, {0, 1});
+  c.add_op<unsigned>(OpType::TK1, {-0.5 * beta, 0.5, -0.5}, {0});
+  c.add_op<unsigned>(OpType::TK1, {-0.5 * beta, 0.5, 0.5}, {1});
+  c.add_phase(-0.25 * beta);
+  return c;
+}
+
 Circuit FSim_using_CX(Expr alpha, Expr beta) {
   Circuit c(2);
   c.add_op<unsigned>(OpType::U3, {0.5, 0.5, 0.5}, {0});

--- a/tket/src/Circuit/CircPool.cpp
+++ b/tket/src/Circuit/CircPool.cpp
@@ -730,6 +730,12 @@ Circuit CU3_using_CX(Expr theta, Expr phi, Expr lambda) {
   return c;
 }
 
+Circuit ISWAP_using_TK2(Expr alpha) {
+  Circuit c(2);
+  c.add_op<unsigned>(OpType::TK2, {-0.5 * alpha, -0.5 * alpha, 0}, {0, 1});
+  return c;
+}
+
 Circuit ISWAP_using_CX(Expr alpha) {
   Circuit c(2);
   c.add_op<unsigned>(OpType::U3, {0.5, -0.5, 0.5}, {0});

--- a/tket/src/Circuit/CircPool.cpp
+++ b/tket/src/Circuit/CircPool.cpp
@@ -647,6 +647,17 @@ const Circuit &ZZMax_using_CX() {
   return *C;
 }
 
+Circuit CRz_using_TK2(Expr alpha) {
+  Circuit c(2);
+  c.add_op<unsigned>(OpType::TK1, {0.5, 0.5, 1}, {0});
+  c.add_op<unsigned>(OpType::TK1, {0.5, 0.5, 0}, {1});
+  c.add_op<unsigned>(OpType::TK2, {-0.5 * alpha, 0, 0}, {0, 1});
+  c.add_op<unsigned>(OpType::TK1, {0, 0.5, 0.5}, {0});
+  c.add_op<unsigned>(OpType::TK1, {-1 + 0.5 * alpha, 0.5, 0.5}, {1});
+  c.add_phase(1);
+  return c;
+}
+
 Circuit CRz_using_CX(Expr alpha) {
   Circuit c(2);
   if (equiv_expr(alpha, 1.)) {

--- a/tket/src/Circuit/CircPool.cpp
+++ b/tket/src/Circuit/CircPool.cpp
@@ -836,6 +836,16 @@ Circuit FSim_using_CX(Expr alpha, Expr beta) {
   return c;
 }
 
+Circuit PhasedISWAP_using_TK2(Expr p, Expr t) {
+  Circuit c(2);
+  c.add_op<unsigned>(OpType::Rz, p, {0});
+  c.add_op<unsigned>(OpType::Rz, -p, {1});
+  c.add_op<unsigned>(OpType::TK2, {-0.5 * t, -0.5 * t, 0}, {0, 1});
+  c.add_op<unsigned>(OpType::Rz, -p, {0});
+  c.add_op<unsigned>(OpType::Rz, p, {1});
+  return c;
+}
+
 Circuit PhasedISWAP_using_CX(Expr p, Expr t) {
   Circuit c(2);
   c.add_op<unsigned>(OpType::U3, {0.5, -0.5, 0.5 + p}, {0});

--- a/tket/src/Circuit/CircPool.cpp
+++ b/tket/src/Circuit/CircPool.cpp
@@ -699,6 +699,17 @@ Circuit CRx_using_CX(Expr alpha) {
   return c;
 }
 
+Circuit CRy_using_TK2(Expr alpha) {
+  Circuit c(2);
+  c.add_op<unsigned>(OpType::TK1, {0.5, 0.5, 0.5}, {0});
+  c.add_op<unsigned>(OpType::TK1, {0, 0.5, -0.5}, {1});
+  c.add_op<unsigned>(OpType::TK2, {-0.5 * alpha, 0, 0}, {0, 1});
+  c.add_op<unsigned>(OpType::TK1, {0.5, 0.5, 0.5}, {0});
+  c.add_op<unsigned>(OpType::TK1, {-0.5, 0.5 - 0.5 * alpha, 1}, {1});
+  c.add_phase(-1);
+  return c;
+}
+
 Circuit CRy_using_CX(Expr alpha) {
   Circuit c(2);
   if (equiv_expr(alpha, 1.)) {

--- a/tket/src/Circuit/CircPool.cpp
+++ b/tket/src/Circuit/CircPool.cpp
@@ -856,6 +856,14 @@ Circuit TK2_using_CX(Expr alpha, Expr beta, Expr gamma) {
   return c;
 }
 
+Circuit XXPhase3_using_TK2(Expr alpha) {
+  Circuit c(3);
+  c.add_op<unsigned>(OpType::TK2, {alpha, 0, 0}, {0, 1});
+  c.add_op<unsigned>(OpType::TK2, {alpha, 0, 0}, {1, 2});
+  c.add_op<unsigned>(OpType::TK2, {alpha, 0, 0}, {0, 2});
+  return c;
+}
+
 Circuit XXPhase3_using_CX(Expr alpha) {
   Circuit c(3);
   Circuit rep1 = XXPhase_using_CX(alpha);

--- a/tket/src/Circuit/CircPool.cpp
+++ b/tket/src/Circuit/CircPool.cpp
@@ -44,6 +44,21 @@ const Circuit &BRIDGE_using_CX_1() {
   return *C;
 }
 
+const Circuit &CX_using_TK2() {
+  static std::unique_ptr<const Circuit> C = std::make_unique<Circuit>([]() {
+    Circuit c(2);
+    c.add_op<unsigned>(tket::OpType::V, {0});
+    c.add_op<unsigned>(tket::OpType::S, {0});
+    c.add_op<unsigned>(tket::OpType::V, {1});
+    c.add_op<unsigned>(tket::OpType::Z, {1});
+    c.add_op<unsigned>(tket::OpType::TK2, {-0.5, 0, 0}, {0, 1});
+    c.add_op<unsigned>(tket::OpType::H, {0});
+    c.add_op<unsigned>(tket::OpType::Y, {1});
+    return c;
+  }());
+  return *C;
+}
+
 const Circuit &CX_using_flipped_CX() {
   static std::unique_ptr<const Circuit> C = std::make_unique<Circuit>([]() {
     Circuit c(2);

--- a/tket/src/Circuit/CircPool.cpp
+++ b/tket/src/Circuit/CircPool.cpp
@@ -749,11 +749,23 @@ Circuit ISWAP_using_CX(Expr alpha) {
   return c;
 }
 
+Circuit XXPhase_using_TK2(Expr alpha) {
+  Circuit c(2);
+  c.add_op<unsigned>(OpType::TK2, {alpha, 0, 0}, {0, 1});
+  return c;
+}
+
 Circuit XXPhase_using_CX(Expr alpha) {
   Circuit c(2);
   c.add_op<unsigned>(OpType::CX, {0, 1});
   c.add_op<unsigned>(OpType::U3, {alpha, -0.5, 0.5}, {0});
   c.add_op<unsigned>(OpType::CX, {0, 1});
+  return c;
+}
+
+Circuit YYPhase_using_TK2(Expr alpha) {
+  Circuit c(2);
+  c.add_op<unsigned>(OpType::TK2, {0, alpha, 0}, {0, 1});
   return c;
 }
 
@@ -766,6 +778,12 @@ Circuit YYPhase_using_CX(Expr alpha) {
   c.add_op<unsigned>(OpType::CX, {0, 1});
   c.add_op<unsigned>(OpType::U3, {-0.5, -0.5, 0.5}, {0});
   c.add_op<unsigned>(OpType::U3, {-0.5, -0.5, 0.5}, {1});
+  return c;
+}
+
+Circuit ZZPhase_using_TK2(Expr alpha) {
+  Circuit c(2);
+  c.add_op<unsigned>(OpType::TK2, {0, 0, alpha}, {0, 1});
   return c;
 }
 
@@ -859,7 +877,7 @@ Circuit PhasedISWAP_using_CX(Expr p, Expr t) {
   return c;
 }
 
-Circuit NPhasedX_using_CX(
+Circuit NPhasedX_using_PhasedX(
     unsigned int number_of_qubits, Expr alpha, Expr beta) {
   Circuit c(number_of_qubits);
   for (unsigned int i = 0; i < number_of_qubits; ++i) {

--- a/tket/src/Circuit/CircPool.cpp
+++ b/tket/src/Circuit/CircPool.cpp
@@ -822,6 +822,18 @@ Circuit XXPhase3_using_CX(Expr alpha) {
   return c;
 }
 
+Circuit ESWAP_using_TK2(Expr alpha) {
+  Circuit c(2);
+  c.add_op<unsigned>(OpType::TK1, {0.5, 0.5, -0.5}, {0});
+  c.add_op<unsigned>(OpType::TK1, {-0.5, 0.5, -0.5}, {1});
+  c.add_op<unsigned>(
+      OpType::TK2, {-0.5 * alpha, -0.5 * alpha, 0.5 * alpha}, {0, 1});
+  c.add_op<unsigned>(OpType::TK1, {-0.5, 0.5, 0.5}, {0});
+  c.add_op<unsigned>(OpType::TK1, {-0.5, 0.5, -0.5}, {1});
+  c.add_phase(1 - 0.25 * alpha);
+  return c;
+}
+
 Circuit ESWAP_using_CX(Expr alpha) {
   Circuit c(2);
   c.add_op<unsigned>(OpType::S, {0});

--- a/tket/src/Circuit/CircPool.cpp
+++ b/tket/src/Circuit/CircPool.cpp
@@ -741,6 +741,17 @@ Circuit CRy_using_CX(Expr alpha) {
   return c;
 }
 
+Circuit CU1_using_TK2(Expr alpha) {
+  Circuit c(2);
+  c.add_op<unsigned>(OpType::TK1, {0.5, 0.5, 1}, {0});
+  c.add_op<unsigned>(OpType::TK1, {0.5, 0.5, 0}, {1});
+  c.add_op<unsigned>(OpType::TK2, {-0.5 * alpha, 0, 0}, {0, 1});
+  c.add_op<unsigned>(OpType::TK1, {0.5 * alpha, 0.5, 0.5}, {0});
+  c.add_op<unsigned>(OpType::TK1, {-1 + 0.5 * alpha, 0.5, 0.5}, {1});
+  c.add_phase(-1 + 0.25 * alpha);
+  return c;
+}
+
 Circuit CU1_using_CX(Expr lambda) {
   Circuit c(2);
   c.add_op<unsigned>(OpType::U1, lambda / 2, {0});

--- a/tket/src/Circuit/CircPool.cpp
+++ b/tket/src/Circuit/CircPool.cpp
@@ -667,6 +667,16 @@ Circuit CRz_using_CX(Expr alpha) {
   return c;
 }
 
+Circuit CRx_using_TK2(Expr alpha) {
+  Circuit c(2);
+  c.add_op<unsigned>(OpType::TK1, {-0.5, 0.5, 0}, {0});
+  c.add_op<unsigned>(OpType::TK1, {1, 0.5, 0}, {1});
+  c.add_op<unsigned>(OpType::TK2, {-0.5 * alpha, 0, 0}, {0, 1});
+  c.add_op<unsigned>(OpType::TK1, {-1, 0.5, -0.5}, {0});
+  c.add_op<unsigned>(OpType::TK1, {1, 0.5 - 0.5 * alpha, 0}, {1});
+  return c;
+}
+
 Circuit CRx_using_CX(Expr alpha) {
   Circuit c(2);
   if (equiv_expr(alpha, 1.)) {

--- a/tket/src/Circuit/CircUtils.cpp
+++ b/tket/src/Circuit/CircUtils.cpp
@@ -453,6 +453,8 @@ Circuit with_TK2(Gate_ptr op) {
       return CircPool::ZZPhase_using_TK2(params[0]);
     case OpType::NPhasedX:
       return CircPool::NPhasedX_using_PhasedX(n, params[0], params[1]);
+    case OpType::ESWAP:
+      return CircPool::ESWAP_using_TK2(params[0]);
     case OpType::CCX:
     case OpType::CSWAP:
     case OpType::BRIDGE:
@@ -463,7 +465,6 @@ Circuit with_TK2(Gate_ptr op) {
     case OpType::CU3:
     case OpType::PhaseGadget:
     case OpType::XXPhase3:
-    case OpType::ESWAP:
     case OpType::FSim: {
       // As a first, inefficient, solution, decompose these into CX and then
       // replace each CX with a TK2 (and some single-qubit gates).

--- a/tket/src/Circuit/CircUtils.cpp
+++ b/tket/src/Circuit/CircUtils.cpp
@@ -443,6 +443,8 @@ Circuit with_TK2(Gate_ptr op) {
   switch (op->get_type()) {
     case OpType::ISWAP:
       return CircPool::ISWAP_using_TK2(params[0]);
+    case OpType::PhasedISWAP:
+      return CircPool::PhasedISWAP_using_TK2(params[0], params[1]);
     case OpType::CCX:
     case OpType::CSWAP:
     case OpType::BRIDGE:
@@ -458,7 +460,6 @@ Circuit with_TK2(Gate_ptr op) {
     case OpType::XXPhase3:
     case OpType::ESWAP:
     case OpType::FSim:
-    case OpType::PhasedISWAP:
     case OpType::NPhasedX: {
       // As a first, inefficient, solution, decompose these into CX and then
       // replace each CX with a TK2 (and some single-qubit gates).

--- a/tket/src/Circuit/CircUtils.cpp
+++ b/tket/src/Circuit/CircUtils.cpp
@@ -445,6 +445,14 @@ Circuit with_TK2(Gate_ptr op) {
       return CircPool::ISWAP_using_TK2(params[0]);
     case OpType::PhasedISWAP:
       return CircPool::PhasedISWAP_using_TK2(params[0], params[1]);
+    case OpType::XXPhase:
+      return CircPool::XXPhase_using_TK2(params[0]);
+    case OpType::YYPhase:
+      return CircPool::YYPhase_using_TK2(params[0]);
+    case OpType::ZZPhase:
+      return CircPool::ZZPhase_using_TK2(params[0]);
+    case OpType::NPhasedX:
+      return CircPool::NPhasedX_using_PhasedX(n, params[0], params[1]);
     case OpType::CCX:
     case OpType::CSWAP:
     case OpType::BRIDGE:
@@ -454,13 +462,9 @@ Circuit with_TK2(Gate_ptr op) {
     case OpType::CU1:
     case OpType::CU3:
     case OpType::PhaseGadget:
-    case OpType::XXPhase:
-    case OpType::YYPhase:
-    case OpType::ZZPhase:
     case OpType::XXPhase3:
     case OpType::ESWAP:
-    case OpType::FSim:
-    case OpType::NPhasedX: {
+    case OpType::FSim: {
       // As a first, inefficient, solution, decompose these into CX and then
       // replace each CX with a TK2 (and some single-qubit gates).
       // TODO Find more efficient decompositions for these gates.
@@ -551,7 +555,7 @@ Circuit with_CX(Gate_ptr op) {
     case OpType::PhasedISWAP:
       return CircPool::PhasedISWAP_using_CX(params[0], params[1]);
     case OpType::NPhasedX:
-      return CircPool::NPhasedX_using_CX(n, params[0], params[1]);
+      return CircPool::NPhasedX_using_PhasedX(n, params[0], params[1]);
     default:
       throw CircuitInvalidity("Cannot decompose " + op->get_name());
   }

--- a/tket/src/Circuit/CircUtils.cpp
+++ b/tket/src/Circuit/CircUtils.cpp
@@ -459,10 +459,11 @@ Circuit with_TK2(Gate_ptr op) {
       return CircPool::FSim_using_TK2(params[0], params[1]);
     case OpType::CRx:
       return CircPool::CRx_using_TK2(params[0]);
+    case OpType::CRy:
+      return CircPool::CRy_using_TK2(params[0]);
     case OpType::CCX:
     case OpType::CSWAP:
     case OpType::BRIDGE:
-    case OpType::CRy:
     case OpType::CRz:
     case OpType::CU1:
     case OpType::CU3:

--- a/tket/src/Circuit/CircUtils.cpp
+++ b/tket/src/Circuit/CircUtils.cpp
@@ -465,12 +465,13 @@ Circuit with_TK2(Gate_ptr op) {
       return CircPool::CRz_using_TK2(params[0]);
     case OpType::CU1:
       return CircPool::CU1_using_TK2(params[0]);
+    case OpType::XXPhase3:
+      return CircPool::XXPhase3_using_TK2(params[0]);
     case OpType::CCX:
     case OpType::CSWAP:
     case OpType::BRIDGE:
     case OpType::CU3:
-    case OpType::PhaseGadget:
-    case OpType::XXPhase3: {
+    case OpType::PhaseGadget: {
       // As a first, inefficient, solution, decompose these into CX and then
       // replace each CX with a TK2 (and some single-qubit gates).
       // TODO Find more efficient decompositions for these gates.

--- a/tket/src/Circuit/CircUtils.cpp
+++ b/tket/src/Circuit/CircUtils.cpp
@@ -455,6 +455,8 @@ Circuit with_TK2(Gate_ptr op) {
       return CircPool::NPhasedX_using_PhasedX(n, params[0], params[1]);
     case OpType::ESWAP:
       return CircPool::ESWAP_using_TK2(params[0]);
+    case OpType::FSim:
+      return CircPool::FSim_using_TK2(params[0], params[1]);
     case OpType::CCX:
     case OpType::CSWAP:
     case OpType::BRIDGE:
@@ -464,8 +466,7 @@ Circuit with_TK2(Gate_ptr op) {
     case OpType::CU1:
     case OpType::CU3:
     case OpType::PhaseGadget:
-    case OpType::XXPhase3:
-    case OpType::FSim: {
+    case OpType::XXPhase3: {
       // As a first, inefficient, solution, decompose these into CX and then
       // replace each CX with a TK2 (and some single-qubit gates).
       // TODO Find more efficient decompositions for these gates.

--- a/tket/src/Circuit/CircUtils.cpp
+++ b/tket/src/Circuit/CircUtils.cpp
@@ -463,10 +463,11 @@ Circuit with_TK2(Gate_ptr op) {
       return CircPool::CRy_using_TK2(params[0]);
     case OpType::CRz:
       return CircPool::CRz_using_TK2(params[0]);
+    case OpType::CU1:
+      return CircPool::CU1_using_TK2(params[0]);
     case OpType::CCX:
     case OpType::CSWAP:
     case OpType::BRIDGE:
-    case OpType::CU1:
     case OpType::CU3:
     case OpType::PhaseGadget:
     case OpType::XXPhase3: {

--- a/tket/src/Circuit/CircUtils.cpp
+++ b/tket/src/Circuit/CircUtils.cpp
@@ -457,10 +457,11 @@ Circuit with_TK2(Gate_ptr op) {
       return CircPool::ESWAP_using_TK2(params[0]);
     case OpType::FSim:
       return CircPool::FSim_using_TK2(params[0], params[1]);
+    case OpType::CRx:
+      return CircPool::CRx_using_TK2(params[0]);
     case OpType::CCX:
     case OpType::CSWAP:
     case OpType::BRIDGE:
-    case OpType::CRx:
     case OpType::CRy:
     case OpType::CRz:
     case OpType::CU1:

--- a/tket/src/Circuit/CircUtils.cpp
+++ b/tket/src/Circuit/CircUtils.cpp
@@ -409,10 +409,9 @@ Circuit with_TK2(Gate_ptr op) {
         OpType::TK1, {angles_K2a.begin(), angles_K2a.end() - 1}, {0});
     c.add_op<unsigned>(
         OpType::TK1, {angles_K2b.begin(), angles_K2b.end() - 1}, {1});
-    constexpr double f = -2 / PI;
-    double alpha = f * std::get<0>(A);
-    double beta = f * std::get<1>(A);
-    double gamma = f * std::get<2>(A);
+    double alpha = std::get<0>(A);
+    double beta = std::get<1>(A);
+    double gamma = std::get<2>(A);
     c.add_op<unsigned>(OpType::TK2, {alpha, beta, gamma}, {0, 1});
     c.add_op<unsigned>(
         OpType::TK1, {angles_K1a.begin(), angles_K1a.end() - 1}, {0});

--- a/tket/src/Circuit/CircUtils.cpp
+++ b/tket/src/Circuit/CircUtils.cpp
@@ -441,6 +441,8 @@ Circuit with_TK2(Gate_ptr op) {
   }
   // Now the non-trivial cases.
   switch (op->get_type()) {
+    case OpType::ISWAP:
+      return CircPool::ISWAP_using_TK2(params[0]);
     case OpType::CCX:
     case OpType::CSWAP:
     case OpType::BRIDGE:
@@ -450,7 +452,6 @@ Circuit with_TK2(Gate_ptr op) {
     case OpType::CU1:
     case OpType::CU3:
     case OpType::PhaseGadget:
-    case OpType::ISWAP:
     case OpType::XXPhase:
     case OpType::YYPhase:
     case OpType::ZZPhase:

--- a/tket/src/Circuit/CircUtils.cpp
+++ b/tket/src/Circuit/CircUtils.cpp
@@ -461,10 +461,11 @@ Circuit with_TK2(Gate_ptr op) {
       return CircPool::CRx_using_TK2(params[0]);
     case OpType::CRy:
       return CircPool::CRy_using_TK2(params[0]);
+    case OpType::CRz:
+      return CircPool::CRz_using_TK2(params[0]);
     case OpType::CCX:
     case OpType::CSWAP:
     case OpType::BRIDGE:
-    case OpType::CRz:
     case OpType::CU1:
     case OpType::CU3:
     case OpType::PhaseGadget:

--- a/tket/src/Circuit/include/Circuit/CircPool.hpp
+++ b/tket/src/Circuit/include/Circuit/CircPool.hpp
@@ -204,6 +204,9 @@ Circuit CRy_using_TK2(Expr alpha);
 /** Equivalent to CRy, using CX and Ry gates */
 Circuit CRy_using_CX(Expr alpha);
 
+/** Equivalent to CU1, using a TK2 and TK1 gates */
+Circuit CU1_using_TK2(Expr lambda);
+
 /** Equivalent to CU1, using CX and U1 gates */
 Circuit CU1_using_CX(Expr lambda);
 

--- a/tket/src/Circuit/include/Circuit/CircPool.hpp
+++ b/tket/src/Circuit/include/Circuit/CircPool.hpp
@@ -240,6 +240,9 @@ Circuit ZZPhase_using_CX(Expr alpha);
 /** Equivalent to TK2, using CX and single-qubit gates */
 Circuit TK2_using_CX(Expr alpha, Expr beta, Expr gamma);
 
+/** Equivalent to XXPhase3, using three TK2 gates */
+Circuit XXPhase3_using_TK2(Expr alpha);
+
 /** Equivalent to 3-qubit MS interaction, using CX and U3 gates */
 Circuit XXPhase3_using_CX(Expr alpha);
 

--- a/tket/src/Circuit/include/Circuit/CircPool.hpp
+++ b/tket/src/Circuit/include/Circuit/CircPool.hpp
@@ -186,6 +186,9 @@ const Circuit &ECR_using_CX();
 /** Equivalent to ZZMax, using CX, Rz and U3 gates */
 const Circuit &ZZMax_using_CX();
 
+/** Equivalent to CRz, using a TK2 and TK1 gates */
+Circuit CRz_using_TK2(Expr alpha);
+
 /** Equivalent to CRz, using CX and Rz gates */
 Circuit CRz_using_CX(Expr alpha);
 

--- a/tket/src/Circuit/include/Circuit/CircPool.hpp
+++ b/tket/src/Circuit/include/Circuit/CircPool.hpp
@@ -189,6 +189,9 @@ const Circuit &ZZMax_using_CX();
 /** Equivalent to CRz, using CX and Rz gates */
 Circuit CRz_using_CX(Expr alpha);
 
+/** Equivalent to CRx, using a TK2 and TK1 gates */
+Circuit CRx_using_TK2(Expr alpha);
+
 /** Equivalent to CRx, using CX, H and Rx gates */
 Circuit CRx_using_CX(Expr alpha);
 

--- a/tket/src/Circuit/include/Circuit/CircPool.hpp
+++ b/tket/src/Circuit/include/Circuit/CircPool.hpp
@@ -27,6 +27,9 @@ const Circuit &BRIDGE_using_CX_0();
 /** Equivalent to BRIDGE, using four CX, first CX has control on qubit 1 */
 const Circuit &BRIDGE_using_CX_1();
 
+/** Equivalent to CX, using a TK2 and single-qubit gates */
+const Circuit &CX_using_TK2();
+
 /** Equivalent to CX[0,1], using a CX[1,0] and four H gates */
 const Circuit &CX_using_flipped_CX();
 

--- a/tket/src/Circuit/include/Circuit/CircPool.hpp
+++ b/tket/src/Circuit/include/Circuit/CircPool.hpp
@@ -201,6 +201,9 @@ Circuit CU1_using_CX(Expr lambda);
 /** Equivalent to CU1, using CX, U1 and U3 gates */
 Circuit CU3_using_CX(Expr theta, Expr phi, Expr lambda);
 
+/** Equivalent to ISWAP, using a TK2 gate */
+Circuit ISWAP_using_TK2(Expr alpha);
+
 /** Equivalent to ISWAP, using CX, U3 and Rz gates */
 Circuit ISWAP_using_CX(Expr alpha);
 

--- a/tket/src/Circuit/include/Circuit/CircPool.hpp
+++ b/tket/src/Circuit/include/Circuit/CircPool.hpp
@@ -237,7 +237,10 @@ Circuit ESWAP_using_TK2(Expr alpha);
 /** Equivalent to ESWAP, using CX, X, S, Ry and U1 gates */
 Circuit ESWAP_using_CX(Expr alpha);
 
-/** Equivalent to Fsim, using CX, X, S, U1 and U3 gates */
+/** Equivalent to FSim, using a TK2 and TK1 gates */
+Circuit FSim_using_TK2(Expr alpha, Expr beta);
+
+/** Equivalent to FSim, using CX, X, S, U1 and U3 gates */
 Circuit FSim_using_CX(Expr alpha, Expr beta);
 
 /** Equivalent to PhasedISWAP, using a TK2 and Rz gates */

--- a/tket/src/Circuit/include/Circuit/CircPool.hpp
+++ b/tket/src/Circuit/include/Circuit/CircPool.hpp
@@ -195,6 +195,9 @@ Circuit CRx_using_TK2(Expr alpha);
 /** Equivalent to CRx, using CX, H and Rx gates */
 Circuit CRx_using_CX(Expr alpha);
 
+/** Equivalent to CRy, using a TK2 and TK1 gates */
+Circuit CRy_using_TK2(Expr alpha);
+
 /** Equivalent to CRy, using CX and Ry gates */
 Circuit CRy_using_CX(Expr alpha);
 

--- a/tket/src/Circuit/include/Circuit/CircPool.hpp
+++ b/tket/src/Circuit/include/Circuit/CircPool.hpp
@@ -207,11 +207,20 @@ Circuit ISWAP_using_TK2(Expr alpha);
 /** Equivalent to ISWAP, using CX, U3 and Rz gates */
 Circuit ISWAP_using_CX(Expr alpha);
 
+/** Equivalent to XXPhase, using a TK2 gate */
+Circuit XXPhase_using_TK2(Expr alpha);
+
 /** Equivalent to XXPhase, using CX and U3 gates */
 Circuit XXPhase_using_CX(Expr alpha);
 
+/** Equivalent to YYPhase, using a TK2 gate */
+Circuit YYPhase_using_TK2(Expr alpha);
+
 /** Equivalent to YYPhase, using CX, Rz and U3 gates */
 Circuit YYPhase_using_CX(Expr alpha);
+
+/** Equivalent to ZZPhase, using a TK2 gate */
+Circuit ZZPhase_using_TK2(Expr alpha);
 
 /** Equivalent to ZZPhase, using CX and Rz gates */
 Circuit ZZPhase_using_CX(Expr alpha);
@@ -235,7 +244,8 @@ Circuit PhasedISWAP_using_TK2(Expr p, Expr t);
 Circuit PhasedISWAP_using_CX(Expr p, Expr t);
 
 /** Unwrap NPhasedX, into number_of_qubits PhasedX gates */
-Circuit NPhasedX_using_CX(unsigned int number_of_qubits, Expr alpha, Expr beta);
+Circuit NPhasedX_using_PhasedX(
+    unsigned int number_of_qubits, Expr alpha, Expr beta);
 
 // converts a TK1 gate to a PhasedXRz gate
 Circuit tk1_to_PhasedXRz(

--- a/tket/src/Circuit/include/Circuit/CircPool.hpp
+++ b/tket/src/Circuit/include/Circuit/CircPool.hpp
@@ -228,6 +228,9 @@ Circuit ESWAP_using_CX(Expr alpha);
 /** Equivalent to Fsim, using CX, X, S, U1 and U3 gates */
 Circuit FSim_using_CX(Expr alpha, Expr beta);
 
+/** Equivalent to PhasedISWAP, using a TK2 and Rz gates */
+Circuit PhasedISWAP_using_TK2(Expr p, Expr t);
+
 /** Equivalent to PhasedISWAP, using CX, U3 and Rz gates */
 Circuit PhasedISWAP_using_CX(Expr p, Expr t);
 

--- a/tket/src/Circuit/include/Circuit/CircPool.hpp
+++ b/tket/src/Circuit/include/Circuit/CircPool.hpp
@@ -231,6 +231,9 @@ Circuit TK2_using_CX(Expr alpha, Expr beta, Expr gamma);
 /** Equivalent to 3-qubit MS interaction, using CX and U3 gates */
 Circuit XXPhase3_using_CX(Expr alpha);
 
+/** Equivalent to ESWAP, using a TK2 and (Clifford) TK1 gates */
+Circuit ESWAP_using_TK2(Expr alpha);
+
 /** Equivalent to ESWAP, using CX, X, S, Ry and U1 gates */
 Circuit ESWAP_using_CX(Expr alpha);
 

--- a/tket/src/Circuit/include/Circuit/CircUtils.hpp
+++ b/tket/src/Circuit/include/Circuit/CircUtils.hpp
@@ -136,6 +136,22 @@ Circuit pauli_gadget(
     CXConfigType cx_config = CXConfigType::Snake);
 
 /**
+ * Utility function to replace all CX gates with TK2 and single-qubit gates.
+ *
+ * @param c circuit to modify
+ */
+void replace_CX_with_TK2(Circuit& c);
+
+/**
+ * Express a gate as a circuit using TK2 as the only multi-qubit gate.
+ *
+ * @param op operation
+ *
+ * @return circuit representing the operation
+ */
+Circuit with_TK2(Gate_ptr op);
+
+/**
  * Express a gate as a circuit using CX as the only multi-qubit gate.
  *
  * @param op operation

--- a/tket/src/Predicates/CompilerPass.cpp
+++ b/tket/src/Predicates/CompilerPass.cpp
@@ -386,6 +386,8 @@ void from_json(const nlohmann::json& j, PassPtr& pp) {
       pp = RemoveRedundancies();
     } else if (passname == "SynthesiseHQS") {
       pp = SynthesiseHQS();
+    } else if (passname == "SynthesiseTK") {
+      pp = SynthesiseTK();
     } else if (passname == "SynthesiseTket") {
       pp = SynthesiseTket();
     } else if (passname == "SynthesiseOQC") {

--- a/tket/src/Predicates/PassLibrary.cpp
+++ b/tket/src/Predicates/PassLibrary.cpp
@@ -56,6 +56,12 @@ static PassPtr gate_translation_pass(
   return ptr;
 }
 
+const PassPtr &SynthesiseTK() {
+  static const PassPtr pp(gate_translation_pass(
+      Transforms::synthesise_tk(), {OpType::TK1, OpType::TK2}, true,
+      "SynthesiseTK"));
+  return pp;
+}
 const PassPtr &SynthesiseTket() {
   static const PassPtr pp(gate_translation_pass(
       Transforms::synthesise_tket(), {OpType::TK1, OpType::CX}, true,

--- a/tket/src/Predicates/include/Predicates/PassLibrary.hpp
+++ b/tket/src/Predicates/include/Predicates/PassLibrary.hpp
@@ -18,6 +18,7 @@
 
 namespace tket {
 
+const PassPtr &SynthesiseTK();
 const PassPtr &SynthesiseTket();
 const PassPtr &SynthesiseHQS();
 const PassPtr &SynthesiseOQC();

--- a/tket/src/Transformations/Decomposition.cpp
+++ b/tket/src/Transformations/Decomposition.cpp
@@ -38,6 +38,32 @@ static bool convert_to_zyz(Circuit &circ);
 static bool convert_to_xyx(Circuit &circ);
 
 /**
+ * Decompose all multi-qubit unitary gates into TK2 and single-qubit gates.
+ *
+ * This function does not decompose boxes.
+ */
+static bool convert_multiqs_TK2(Circuit &circ) {
+  bool success = false;
+  VertexList bin;
+  BGL_FORALL_VERTICES(v, circ.dag, DAG) {
+    Op_ptr op = circ.get_Op_ptr_from_Vertex(v);
+    OpType optype = op->get_type();
+    if (is_gate_type(optype) && !is_projective_type(optype) &&
+        op->n_qubits() >= 2 && (optype != OpType::TK2)) {
+      Circuit in_circ = TK2_circ_from_multiq(op);
+      Subcircuit sub = {
+          {circ.get_in_edges(v)}, {circ.get_all_out_edges(v)}, {v}};
+      bin.push_back(v);
+      circ.substitute(in_circ, sub, Circuit::VertexDeletion::No);
+      success = true;
+    }
+  }
+  circ.remove_vertices(
+      bin, Circuit::GraphRewiring::No, Circuit::VertexDeletion::Yes);
+  return success;
+}
+
+/**
  * Decompose all multi-qubit unitary gates into CX and single-qubit gates.
  *
  * This function does not decompose boxes.
@@ -129,6 +155,10 @@ static bool convert_to_xyx(Circuit &circ) {
   circ.remove_vertices(
       bin, Circuit::GraphRewiring::No, Circuit::VertexDeletion::Yes);
   return success;
+}
+
+Transform decompose_multi_qubits_TK2() {
+  return Transform(convert_multiqs_TK2);
 }
 
 Transform decompose_multi_qubits_CX() { return Transform(convert_multiqs_CX); }

--- a/tket/src/Transformations/OptimisationPass.cpp
+++ b/tket/src/Transformations/OptimisationPass.cpp
@@ -59,6 +59,17 @@ Transform clifford_simp(bool allow_swaps) {
          squash_1qb_to_tk1();
 }
 
+Transform synthesise_tk() {
+  Transform seq = commute_through_multis() >> remove_redundancies();
+  Transform rep = repeat(seq);
+  Transform synth = decompose_multi_qubits_TK2() >> remove_redundancies() >>
+                    rep >> squash_1qb_to_tk1();
+  Transform small_part = remove_redundancies() >> rep >> squash_1qb_to_tk1();
+  Transform repeat_synth = repeat_with_metric(
+      small_part, [](const Circuit &circ) { return circ.n_vertices(); });
+  return synth >> repeat_synth;
+}
+
 Transform synthesise_tket() {
   Transform seq = commute_through_multis() >> remove_redundancies();
   Transform rep = repeat(seq);

--- a/tket/src/Transformations/Replacement.cpp
+++ b/tket/src/Transformations/Replacement.cpp
@@ -25,6 +25,37 @@ namespace tket {
 
 using namespace Transforms;
 
+Circuit TK2_circ_from_multiq(const Op_ptr op) {
+  OpDesc desc = op->get_desc();
+  if (!desc.is_gate())
+    throw NotImplemented(
+        "Can only build replacement circuits for basic gates; given " +
+        desc.name());
+  unsigned n_qubits = op->n_qubits();
+  switch (desc.type()) {
+    case OpType::CnRy: {
+      // TODO We should be able to do better than this.
+      Circuit c = decomposed_CnRy(op, n_qubits);
+      replace_CX_with_TK2(c);
+      return c;
+    }
+    case OpType::CnX:
+      if (n_qubits >= 6 && n_qubits <= 8) {
+        // TODO We should be able to do better than this.
+        Circuit c = cnx_gray_decomp(n_qubits - 1);
+        replace_CX_with_TK2(c);
+        return c;
+      } else {
+        // TODO We should be able to do better than this.
+        Circuit c = cnx_normal_decomp(n_qubits - 1);
+        replace_CX_with_TK2(c);
+        return c;
+      }
+    default:
+      return with_TK2(as_gate_ptr(op));
+  }
+}
+
 Circuit CX_circ_from_multiq(const Op_ptr op) {
   OpDesc desc = op->get_desc();
   if (!desc.is_gate())

--- a/tket/src/Transformations/include/Transformations/Decomposition.hpp
+++ b/tket/src/Transformations/include/Transformations/Decomposition.hpp
@@ -22,6 +22,16 @@ namespace tket {
 namespace Transforms {
 
 /**
+ * Decomposes all multi-qubit unitary gates into TK2 and single-qubit gates.
+ *
+ * Ignores boxes.
+ *
+ * Expects: any gates
+ * Produces: TK2 and any single-qubit gates
+ */
+Transform decompose_multi_qubits_TK2();
+
+/**
  * Decomposes all multi-qubit unitary gates into CX and single-qubit gates.
  *
  * Ignores boxes.

--- a/tket/src/Transformations/include/Transformations/OptimisationPass.hpp
+++ b/tket/src/Transformations/include/Transformations/OptimisationPass.hpp
@@ -62,6 +62,11 @@ Transform clifford_simp(bool allow_swaps = true);
 /*Synthesis passes preserve connectivity */
 
 /**
+ * Synthesise a circuit consisting of TK2 and TK1 gates only.
+ */
+Transform synthesise_tk();
+
+/**
  * Synthesise a circuit consisting of CX and TK1 gates only.
  */
 Transform synthesise_tket();

--- a/tket/src/Transformations/include/Transformations/Replacement.hpp
+++ b/tket/src/Transformations/include/Transformations/Replacement.hpp
@@ -19,6 +19,19 @@
 namespace tket {
 
 /**
+ * Replace a multi-qubit operation with an equivalent circuit using TK2 gates
+ *
+ * @param op operation
+ *
+ * @return equivalent circuit
+ *
+ * @pre \p op is a multi-qubit operation
+ *
+ * @post The only multi-qubit gates in the replacement circuit are TK2
+ */
+Circuit TK2_circ_from_multiq(const Op_ptr op);
+
+/**
  * Replace a multi-qubit operation with an equivalent circuit using CX gates
  *
  * @param op operation

--- a/tket/src/Utils/MatrixAnalysis.cpp
+++ b/tket/src/Utils/MatrixAnalysis.cpp
@@ -306,6 +306,10 @@ static double get_CX_fidelity(
 
   TKET_ASSERT(nb_cx < 4);
   auto [a, b, c] = k;
+  constexpr double g = -PI / 2;
+  a *= g;
+  b *= g;
+  c *= g;
 
   // gate fidelity achievable with 0,...,3 cnots
   // this is fully determined by the information content k and is optimal
@@ -333,7 +337,11 @@ std::vector<std::tuple<Eigen::Matrix2cd, Eigen::Matrix2cd>> expgate_as_CX(
         "Expected CX fidelity cx_fidelity must be between 0 and 1");
   }
 
-  const auto [k_a, k_b, k_c] = k;
+  auto [k_a, k_b, k_c] = k;
+  constexpr double g = -PI / 2;
+  k_a *= g;
+  k_b *= g;
+  k_c *= g;
   Mat2 PauliX, PauliY, PauliZ;
   PauliX << 0, 1, 1, 0;
   PauliY << 0, -i_, i_, 0;
@@ -595,7 +603,8 @@ get_information_content(const Eigen::Matrix4cd &X) {
   K1 *= norm_X;
 
   // Finally, we got our ks
-  ExpGate A(k(0), k(1), k(2));
+  constexpr double f = -2 / PI;
+  ExpGate A(f * k(0), f * k(1), f * k(2));
 
   // K1,K2 in SU(2)xSU(2), A = Exp(i aσ_XX + i bσ_YY + i cσ_ZZ)
   return std::tuple<Mat4, ExpGate, Mat4>{K1, A, K2};

--- a/tket/src/Utils/include/Utils/MatrixAnalysis.hpp
+++ b/tket/src/Utils/include/Utils/MatrixAnalysis.hpp
@@ -81,10 +81,10 @@ std::vector<std::pair<unsigned, unsigned>> gaussian_elimination_row_ops(
  * Given a unitary \f$ X \f$, returns
  * \f$ (K_1, (k_\mathrm{XX},k_\mathrm{YY},k_\mathrm{ZZ}, K_2) \f$
  * such that
- * \f$ X = K_1 \cdot \exp(\sum_{i \in \{\mathrm{XX}, \mathrm{YY}, \mathrm{ZZ}\}}
- * k_i \sigma_i) \cdot K_2 \f$. The \f$ k_i \f$ are called information content
- * and partition \f$ \mathrm{SU}(4) \f$ into equivalence classes modulo local
- * transformations.
+ * \f$ X = K_1 \cdot \exp(-\frac12 i \pi \sum_{w \in \{\mathrm{XX}, \mathrm{YY},
+ * \mathrm{ZZ}\}} k_w \sigma_w) \cdot K_2 \f$.
+ * The \f$ k_w \f$ are called information content and partition
+ * \f$ \mathrm{SU}(4) \f$ into equivalence classes modulo local transformations.
  *
  * See arXiv quant-ph/0507171 for details
  *

--- a/tket/tests/Ops/test_Ops.cpp
+++ b/tket/tests/Ops/test_Ops.cpp
@@ -547,7 +547,7 @@ SCENARIO("Two-qubit entangling gates") {
     REQUIRE(test_unitary_comparison(c0, c1));
     // Rebase
     CompilationUnit cu(c1);
-    SynthesiseTket()->apply(cu);
+    SynthesiseTK()->apply(cu);
     REQUIRE(test_unitary_comparison(c0, cu.get_circ_ref()));
   }
   GIVEN("FSim") {
@@ -569,7 +569,7 @@ SCENARIO("Two-qubit entangling gates") {
     REQUIRE(test_unitary_comparison(c0, c1));
     // Rebase
     CompilationUnit cu(c1);
-    SynthesiseTket()->apply(cu);
+    SynthesiseTK()->apply(cu);
     REQUIRE(test_unitary_comparison(c0, cu.get_circ_ref()));
   }
   GIVEN("Sycamore") {

--- a/tket/tests/Passes/test_SynthesiseTK.cpp
+++ b/tket/tests/Passes/test_SynthesiseTK.cpp
@@ -1,0 +1,127 @@
+// Copyright 2019-2022 Cambridge Quantum Computing
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <catch2/catch.hpp>
+
+#include "../testutil.hpp"
+#include "Circuit/Circuit.hpp"
+#include "OpType/OpType.hpp"
+#include "Predicates/CompilationUnit.hpp"
+#include "Predicates/PassLibrary.hpp"
+#include "Utils/Expression.hpp"
+
+namespace tket {
+namespace test_SynthesiseTK {
+
+void check_synthesise_tk(const Circuit& c) {
+  Circuit c0 = c;
+  CompilationUnit cu(c0);
+  SynthesiseTK()->apply(cu);
+  Circuit c1 = cu.get_circ_ref();
+
+  // Substitute "arbitrary" values for symbols in both circuits
+  const SymSet symbols = c.free_symbols();
+  symbol_map_t smap;
+  unsigned i = 0;
+  for (const Sym& s : symbols) {
+    smap[s] = PI * (i + 1) / ((i + 2) * (i + 3));
+    i++;
+  }
+  c0.symbol_substitution(smap);
+  c1.symbol_substitution(smap);
+
+  REQUIRE(test_unitary_comparison(c0, c1));
+
+  OpTypeSet tk_types = {OpType::TK1, OpType::TK2};
+  GateSetPredicate pred(tk_types);
+  REQUIRE(pred.verify(c1));
+}
+
+SCENARIO("SynthesiseTK correctness") {
+  GIVEN("A simple circuit") {
+    Circuit c(2);
+    c.add_op<unsigned>(OpType::H, {0});
+    c.add_op<unsigned>(OpType::CX, {0, 1});
+    check_synthesise_tk(c);
+  }
+  GIVEN("A bigger circuit") {
+    Circuit c(2);
+    c.add_op<unsigned>(OpType::H, {0});
+    c.add_op<unsigned>(OpType::CX, {0, 1});
+    c.add_op<unsigned>(OpType::X, {0});
+    c.add_op<unsigned>(OpType::CY, {1, 0});
+    c.add_op<unsigned>(OpType::Y, {1});
+    c.add_op<unsigned>(OpType::CZ, {0, 1});
+    c.add_op<unsigned>(OpType::T, {0});
+    c.add_op<unsigned>(OpType::SWAP, {0, 1});
+    c.add_op<unsigned>(OpType::S, {1});
+    c.add_op<unsigned>(OpType::CH, {1, 0});
+    c.add_op<unsigned>(OpType::Sdg, {0});
+    c.add_op<unsigned>(OpType::CV, {1, 0});
+    c.add_op<unsigned>(OpType::Tdg, {1});
+    c.add_op<unsigned>(OpType::CVdg, {0, 1});
+    c.add_op<unsigned>(OpType::Vdg, {0});
+    c.add_op<unsigned>(OpType::CSX, {1, 0});
+    c.add_op<unsigned>(OpType::SX, {1});
+    c.add_op<unsigned>(OpType::CSXdg, {0, 1});
+    c.add_op<unsigned>(OpType::SXdg, {0});
+    c.add_op<unsigned>(OpType::ECR, {1, 0});
+    c.add_op<unsigned>(OpType::noop, {1});
+    c.add_op<unsigned>(OpType::ZZMax, {0, 1});
+    c.add_op<unsigned>(OpType::Sycamore, {1, 0});
+    c.add_op<unsigned>(OpType::ISWAPMax, {0, 1});
+    check_synthesise_tk(c);
+  }
+  GIVEN("A circuit with (>2)-qubit gates") {
+    Circuit c(4);
+    c.add_op<unsigned>(OpType::CCX, {0, 1, 2});
+    c.add_op<unsigned>(OpType::CnX, {0, 1, 2, 3});
+    c.add_op<unsigned>(OpType::CnRy, 0.25, {0, 1, 2, 3});
+    c.add_op<unsigned>(OpType::CSWAP, {1, 2, 3});
+    c.add_op<unsigned>(OpType::BRIDGE, {1, 3, 0});
+    check_synthesise_tk(c);
+  }
+  GIVEN("A circuit with symbolic gates") {
+    Sym asym = SymEngine::symbol("a");
+    Expr a(asym);
+    Circuit c(3);
+    c.add_op<unsigned>(OpType::Rx, a, {0});
+    c.add_op<unsigned>(OpType::Ry, a + 0.1, {0});
+    c.add_op<unsigned>(OpType::Rz, a + 0.2, {1});
+    c.add_op<unsigned>(OpType::XXPhase, a + 0.3, {0, 1});
+    c.add_op<unsigned>(OpType::YYPhase, a + 0.1, {1, 0});
+    c.add_op<unsigned>(OpType::ZZPhase, a + 0.2, {0, 1});
+    c.add_op<unsigned>(OpType::U1, a, {1});
+    c.add_op<unsigned>(OpType::U2, {a + 0.1, a + 0.2}, {0});
+    c.add_op<unsigned>(OpType::U3, {a + 0.3, a + 0.4, a + 0.5}, {1});
+    c.add_op<unsigned>(OpType::TK1, {a + 0.2, a + 0.3, a + 0.4}, {0});
+    c.add_op<unsigned>(OpType::CRz, a, {0, 1});
+    c.add_op<unsigned>(OpType::CRx, a + 0.1, {1, 0});
+    c.add_op<unsigned>(OpType::CRy, a + 0.2, {0, 1});
+    c.add_op<unsigned>(OpType::CU1, a + 0.3, {1, 0});
+    c.add_op<unsigned>(OpType::CU3, {a + 0.1, a + 0.2, a}, {0, 1});
+    c.add_op<unsigned>(OpType::ISWAP, a, {0, 1});
+    c.add_op<unsigned>(OpType::PhasedISWAP, {a, a - 0.1}, {1, 0});
+    c.add_op<unsigned>(OpType::XXPhase3, a, {0, 1, 2});
+    c.add_op<unsigned>(OpType::PhasedX, {a, a + 0.2}, {0});
+    c.add_op<unsigned>(OpType::NPhasedX, {a + 0.3, a}, {0, 1, 2});
+    c.add_op<unsigned>(OpType::CnRy, a - 0.3, {1, 2, 0});
+    c.add_op<unsigned>(OpType::ESWAP, a, {1, 2});
+    c.add_op<unsigned>(OpType::FSim, {a + 0.1, a + 0.2}, {2, 0});
+    check_synthesise_tk(c);
+  }
+}
+
+}  // namespace test_SynthesiseTK
+}  // namespace tket

--- a/tket/tests/test_CompilerPass.cpp
+++ b/tket/tests/test_CompilerPass.cpp
@@ -221,7 +221,7 @@ SCENARIO("Test making (mostly routing) passes using PassGenerators") {
     PassPtr pz_rebase = gen_rebase_pass(
         {OpType::CX, OpType::PhasedX, OpType::Rz}, cx,
         CircPool::tk1_to_PhasedXRz);
-    PassPtr all_passes = SynthesiseTket() >> cp_route >> pz_rebase;
+    PassPtr all_passes = SynthesiseTK() >> cp_route >> pz_rebase;
 
     REQUIRE(all_passes->apply(cu));
     REQUIRE(cu.check_all_predicates());
@@ -230,7 +230,7 @@ SCENARIO("Test making (mostly routing) passes using PassGenerators") {
       REQUIRE(cu.check_all_predicates());
     }
     WHEN("Make incorrect sequence") {
-      PassPtr bad_pass = cp_route >> SynthesiseTket();
+      PassPtr bad_pass = cp_route >> SynthesiseTK();
       bad_pass->apply(cu);
       REQUIRE(!cu.check_all_predicates());
     }
@@ -243,7 +243,7 @@ SCENARIO("Test making (mostly routing) passes using PassGenerators") {
     circ.add_op<unsigned>(OpType::CnX, {0, 1, 2, 3});
     circ.add_op<unsigned>(OpType::CZ, {0, 1});
     circ.add_op<unsigned>(OpType::X, {4});
-    OpTypeSet ots = {OpType::CX, OpType::TK1, OpType::SWAP};
+    OpTypeSet ots = {OpType::TK2, OpType::TK1, OpType::SWAP};
     PredicatePtr gsp = std::make_shared<GateSetPredicate>(ots);
     SquareGrid grid(2, 3);
 
@@ -262,7 +262,7 @@ SCENARIO("Test making (mostly routing) passes using PassGenerators") {
          std::make_shared<LexiRouteRoutingMethod>()});
 
     PassPtr all_passes = SynthesiseHQS() >> SynthesiseOQC() >>
-                         SynthesiseUMD() >> SynthesiseTket() >> cp_route;
+                         SynthesiseUMD() >> SynthesiseTK() >> cp_route;
     REQUIRE(all_passes->apply(cu));
     REQUIRE(cu.check_all_predicates());
   }
@@ -414,7 +414,7 @@ SCENARIO("Construct sequence pass") {
 
 SCENARIO("Construct invalid sequence passes from vector") {
   std::vector<PassPtr> invalid_pass_to_combo{
-      SynthesiseHQS(), SynthesiseOQC(), SynthesiseUMD(), SynthesiseTket()};
+      SynthesiseHQS(), SynthesiseOQC(), SynthesiseUMD(), SynthesiseTK()};
   for (const PassPtr& pass : invalid_pass_to_combo) {
     std::vector<PassPtr> passes = {pass};
     OpTypeSet ots = {OpType::CX};
@@ -468,14 +468,14 @@ SCENARIO("Test RepeatWithMetricPass") {
 }
 
 SCENARIO("Track initial and final maps throughout compilation") {
-  GIVEN("SynthesiseTket should not affect them") {
+  GIVEN("SynthesiseTK should not affect them") {
     Circuit circ(5);
     add_2qb_gates(circ, OpType::CY, {{0, 3}, {1, 4}, {1, 0}, {2, 1}});
     circ.add_op<unsigned>(OpType::SWAP, {3, 4});
     circ.add_op<unsigned>(OpType::Z, {4});
     circ.replace_SWAPs();
     CompilationUnit cu(circ);
-    SynthesiseTket()->apply(cu);
+    SynthesiseTK()->apply(cu);
     for (auto pair : cu.get_initial_map_ref().left) {
       REQUIRE(pair.first == pair.second);
     }

--- a/tket/tests/test_CompilerPass.cpp
+++ b/tket/tests/test_CompilerPass.cpp
@@ -1121,6 +1121,15 @@ SCENARIO("RemoveRedundancies and phase") {
     REQUIRE(c1.get_commands().size() == 0);
     REQUIRE(equiv_val(c1.get_phase(), 1.));
   }
+  GIVEN("A circuit with a trivial TK2 gate and nonzero phase") {
+    Circuit c(2);
+    c.add_op<unsigned>(OpType::TK2, {0., 2., 4.}, {0, 1});
+    CompilationUnit cu(c);
+    REQUIRE(RemoveRedundancies()->apply(cu));
+    const Circuit& c1 = cu.get_circ_ref();
+    REQUIRE(c1.get_commands().size() == 0);
+    REQUIRE(equiv_val(c1.get_phase(), 1.));
+  }
 }
 
 // Check whether a circuit maps all basis states to basis states.

--- a/tket/tests/test_TwoQubitCanonical.cpp
+++ b/tket/tests/test_TwoQubitCanonical.cpp
@@ -35,10 +35,10 @@ static void check_get_information_content(const Eigen::Matrix4cd &U) {
   PauliZ << 1, 0, 0, -1;
   const auto [K1, A, K2] = get_information_content(U);
   const auto [a, b, c] = A;
-  const Eigen::Matrix4cd arg =
-      i_ * (a * Eigen::kroneckerProduct(PauliX, PauliX) +
-            b * Eigen::kroneckerProduct(PauliY, PauliY) +
-            c * Eigen::kroneckerProduct(PauliZ, PauliZ));
+  const Eigen::Matrix4cd arg = -0.5 * PI * i_ *
+                               (a * Eigen::kroneckerProduct(PauliX, PauliX) +
+                                b * Eigen::kroneckerProduct(PauliY, PauliY) +
+                                c * Eigen::kroneckerProduct(PauliZ, PauliZ));
   Eigen::Matrix4cd res = K1 * arg.exp() * K2;
   REQUIRE(res.isApprox(U));
 }
@@ -133,10 +133,10 @@ SCENARIO("Testing two-qubit canonical forms") {
 
     const auto [K1, A, K2] = get_information_content(U);
     const auto [a, b, c] = A;
-    const Eigen::Matrix4cd arg =
-        i_ * (a * Eigen::kroneckerProduct(PauliX, PauliX) +
-              b * Eigen::kroneckerProduct(PauliY, PauliY) +
-              c * Eigen::kroneckerProduct(PauliZ, PauliZ));
+    const Eigen::Matrix4cd arg = -0.5 * PI * i_ *
+                                 (a * Eigen::kroneckerProduct(PauliX, PauliX) +
+                                  b * Eigen::kroneckerProduct(PauliY, PauliY) +
+                                  c * Eigen::kroneckerProduct(PauliZ, PauliZ));
     Eigen::Matrix4cd res = K1 * arg.exp() * K2;
     REQUIRE(res.isApprox(U));
   }
@@ -162,10 +162,10 @@ SCENARIO("Testing two-qubit canonical forms") {
 
     const auto [K1, A, K2] = get_information_content(U);
     const auto [a, b, c] = A;
-    const Eigen::Matrix4cd arg =
-        i_ * (a * Eigen::kroneckerProduct(PauliX, PauliX) +
-              b * Eigen::kroneckerProduct(PauliY, PauliY) +
-              c * Eigen::kroneckerProduct(PauliZ, PauliZ));
+    const Eigen::Matrix4cd arg = -0.5 * PI * i_ *
+                                 (a * Eigen::kroneckerProduct(PauliX, PauliX) +
+                                  b * Eigen::kroneckerProduct(PauliY, PauliY) +
+                                  c * Eigen::kroneckerProduct(PauliZ, PauliZ));
     Eigen::Matrix4cd res = K1 * arg.exp() * K2;
     REQUIRE(res.isApprox(U));
   }
@@ -187,10 +187,10 @@ SCENARIO("Testing two-qubit canonical forms") {
 
     const auto [K1, AA, K2] = get_information_content(U);
     const auto [a, b, c] = AA;
-    const Eigen::Matrix4cd arg =
-        i_ * (a * Eigen::kroneckerProduct(PauliX, PauliX) +
-              b * Eigen::kroneckerProduct(PauliY, PauliY) +
-              c * Eigen::kroneckerProduct(PauliZ, PauliZ));
+    const Eigen::Matrix4cd arg = -0.5 * PI * i_ *
+                                 (a * Eigen::kroneckerProduct(PauliX, PauliX) +
+                                  b * Eigen::kroneckerProduct(PauliY, PauliY) +
+                                  c * Eigen::kroneckerProduct(PauliZ, PauliZ));
     Eigen::Matrix4cd res = K1 * arg.exp() * K2;
     REQUIRE(res.isApprox(U));
   }
@@ -222,12 +222,12 @@ SCENARIO("Testing two-qubit canonical forms") {
     PauliX << 0, 1, 1, 0;
     PauliY << 0, -i_, i_, 0;
     PauliZ << 1, 0, 0, -1;
-    const double a = PI / 4, b = 0, c = 0;  // this is = CX decomposition
+    const double a = -0.5 * PI, b = 0, c = 0;  // this is = CX decomposition
     const std::tuple<double, double, double> A(a, b, c);
-    const Eigen::Matrix4cd arg =
-        i_ * (a * Eigen::kroneckerProduct(PauliX, PauliX) +
-              b * Eigen::kroneckerProduct(PauliY, PauliY) +
-              c * Eigen::kroneckerProduct(PauliZ, PauliZ));
+    const Eigen::Matrix4cd arg = -0.5 * PI * i_ *
+                                 (a * Eigen::kroneckerProduct(PauliX, PauliX) +
+                                  b * Eigen::kroneckerProduct(PauliY, PauliY) +
+                                  c * Eigen::kroneckerProduct(PauliZ, PauliZ));
     const Eigen::Matrix4cd U = arg.exp();
     const auto gates = expgate_as_CX(A, 1.);
     Circuit circ_out = Circuit(2);
@@ -257,10 +257,10 @@ SCENARIO("Testing two-qubit canonical forms") {
     PauliZ << 1, 0, 0, -1;
     const double a = 0.7, b = 0.5342, c = -0.3;  // some arbitrary constants
     const std::tuple<double, double, double> A(a, b, c);
-    const Eigen::Matrix4cd arg =
-        i_ * (a * Eigen::kroneckerProduct(PauliX, PauliX) +
-              b * Eigen::kroneckerProduct(PauliY, PauliY) +
-              c * Eigen::kroneckerProduct(PauliZ, PauliZ));
+    const Eigen::Matrix4cd arg = -0.5 * PI * i_ *
+                                 (a * Eigen::kroneckerProduct(PauliX, PauliX) +
+                                  b * Eigen::kroneckerProduct(PauliY, PauliY) +
+                                  c * Eigen::kroneckerProduct(PauliZ, PauliZ));
     const Eigen::Matrix4cd U = arg.exp();
     const auto gates = expgate_as_CX(A, 1.);
     Circuit circ_out = Circuit(2);
@@ -286,12 +286,12 @@ SCENARIO("Testing two-qubit canonical forms") {
     PauliX << 0, 1, 1, 0;
     PauliY << 0, -i_, i_, 0;
     PauliZ << 1, 0, 0, -1;
-    const double a = PI / 4, b = PI / 4, c = 0;
+    const double a = -0.5, b = -0.5, c = 0;
     const std::tuple<double, double, double> A(a, b, c);
-    const Eigen::Matrix4cd arg =
-        i_ * (a * Eigen::kroneckerProduct(PauliX, PauliX) +
-              b * Eigen::kroneckerProduct(PauliY, PauliY) +
-              c * Eigen::kroneckerProduct(PauliZ, PauliZ));
+    const Eigen::Matrix4cd arg = -0.5 * PI * i_ *
+                                 (a * Eigen::kroneckerProduct(PauliX, PauliX) +
+                                  b * Eigen::kroneckerProduct(PauliY, PauliY) +
+                                  c * Eigen::kroneckerProduct(PauliZ, PauliZ));
     const Eigen::Matrix4cd U = arg.exp();
     const auto gates = expgate_as_CX(A, 1.);
     Circuit circ_out = Circuit(2);

--- a/tket/tests/test_TwoQubitCanonical.cpp
+++ b/tket/tests/test_TwoQubitCanonical.cpp
@@ -28,6 +28,21 @@
 namespace tket {
 namespace test_TwoQubitCanonical {
 
+static void check_get_information_content(const Eigen::Matrix4cd &U) {
+  Eigen::Matrix2cd PauliX, PauliY, PauliZ;
+  PauliX << 0, 1, 1, 0;
+  PauliY << 0, -i_, i_, 0;
+  PauliZ << 1, 0, 0, -1;
+  const auto [K1, A, K2] = get_information_content(U);
+  const auto [a, b, c] = A;
+  const Eigen::Matrix4cd arg =
+      i_ * (a * Eigen::kroneckerProduct(PauliX, PauliX) +
+            b * Eigen::kroneckerProduct(PauliY, PauliY) +
+            c * Eigen::kroneckerProduct(PauliZ, PauliZ));
+  Eigen::Matrix4cd res = K1 * arg.exp() * K2;
+  REQUIRE(res.isApprox(U));
+}
+
 SCENARIO("Testing two-qubit canonical forms") {
   GIVEN("Decomposing a kronecker product of matrices (0)") {
     Eigen::Matrix2cd testA, testB, resA, resB;
@@ -85,21 +100,19 @@ SCENARIO("Testing two-qubit canonical forms") {
   }
 
   GIVEN("Performing a KAK decomposition (0)") {
-    Eigen::Matrix2cd PauliX, PauliY, PauliZ;
-    PauliX << 0, 1, 1, 0;
-    PauliY << 0, -i_, i_, 0;
-    PauliZ << 1, 0, 0, -1;
     Eigen::Matrix4cd test;
     test << 1, 0, 0, 0, 0, 0, exp(i_), 0, 0, exp(i_), 0, 0, 0, 0, 0,
         exp(i_ * 2.814);
-    const auto [K1, A, K2] = get_information_content(test);
-    const auto [a, b, c] = A;
-    const Eigen::Matrix4cd arg =
-        i_ * (a * Eigen::kroneckerProduct(PauliX, PauliX) +
-              b * Eigen::kroneckerProduct(PauliY, PauliY) +
-              c * Eigen::kroneckerProduct(PauliZ, PauliZ));
-    Eigen::Matrix4cd res = K1 * arg.exp() * K2;
-    REQUIRE(res.isApprox(test));
+    check_get_information_content(test);
+
+    Eigen::Matrix4cd CX;
+    CX << 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 1, 0;
+    check_get_information_content(CX);
+
+    for (unsigned i = 0; i < 100; i++) {
+      Eigen::Matrix4cd U = random_unitary(4, i);
+      check_get_information_content(U);
+    }
   }
 
   GIVEN("Performing a KAK decomposition (1)") {

--- a/tket/tests/test_json.cpp
+++ b/tket/tests/test_json.cpp
@@ -574,6 +574,7 @@ SCENARIO("Test compiler pass serializations") {
   COMPPASSJSONTEST(RebaseUFR, RebaseUFR())
   COMPPASSJSONTEST(RemoveRedundancies, RemoveRedundancies())
   COMPPASSJSONTEST(SynthesiseHQS, SynthesiseHQS())
+  COMPPASSJSONTEST(SynthesiseTK, SynthesiseTK())
   COMPPASSJSONTEST(SynthesiseTket, SynthesiseTket())
   COMPPASSJSONTEST(SynthesiseOQC, SynthesiseOQC())
   COMPPASSJSONTEST(SynthesiseUMD, SynthesiseUMD())

--- a/tket/tests/tkettestsfiles.cmake
+++ b/tket/tests/tkettestsfiles.cmake
@@ -57,6 +57,7 @@ set(TEST_SOURCES
     ${TKET_TESTS_DIR}/Ops/test_ClassicalOps.cpp
     ${TKET_TESTS_DIR}/Ops/test_Expression.cpp
     ${TKET_TESTS_DIR}/Ops/test_Ops.cpp
+    ${TKET_TESTS_DIR}/Passes/test_SynthesiseTK.cpp
     ${TKET_TESTS_DIR}/Gate/test_GateUnitaryMatrix.cpp
     ${TKET_TESTS_DIR}/Simulation/test_CircuitSimulator.cpp
     ${TKET_TESTS_DIR}/Simulation/test_PauliExpBoxUnitaryCalculator.cpp


### PR DESCRIPTION
Add a new transform and pass to efficiently convert to the TK1/TK2 basis.

This is "best effort" at finding efficient TK2 decompositions of standard gates. I have left TODO comments where we should be able to do better but I have not been able to figure out how: I will raise a new issue for those cases.