### PR TITLE
Cache diameter returned by `Architecture::get_diameter()`

### DIFF
--- a/tket/src/Architecture/DistancesFromArchitecture.cpp
+++ b/tket/src/Architecture/DistancesFromArchitecture.cpp
@@ -78,9 +78,8 @@ size_t DistancesFromArchitecture::operator()(size_t vertex1, size_t vertex2) {
         distance_entry > 0 ||
         AssertMessage() << "DistancesFromArchitecture: architecture has "
                         << arch.n_nodes() << " vertices, "
-                        << arch.n_connections() << " edges; returned diameter "
-                        << arch.get_diameter() << " and d(" << vertex1 << ","
-                        << vertex2
+                        << arch.n_connections() << " edges; "
+                        << " and d(" << vertex1 << "," << vertex2
                         << ")=0. "
                            "Is the graph connected?");
     // GCOVR_EXCL_STOP

--- a/tket/src/Architecture/include/Architecture/Architecture.hpp
+++ b/tket/src/Architecture/include/Architecture/Architecture.hpp
@@ -206,7 +206,7 @@ class SquareGrid : public Architecture {
   unsigned layers;
 };
 
-typedef std::shared_ptr<const Architecture> ArchitecturePtr;
+typedef std::shared_ptr<Architecture> ArchitecturePtr;
 
 int tri_lexicographical_comparison(
     const dist_vec &dist1, const dist_vec &dist2);

--- a/tket/src/Graphs/include/Graphs/AbstractGraph.hpp
+++ b/tket/src/Graphs/include/Graphs/AbstractGraph.hpp
@@ -14,11 +14,11 @@
 
 #pragma once
 
+#include <optional>
 #include <set>
 #include <stdexcept>
 #include <utility>
 #include <vector>
-#include <optional>
 
 namespace tket::graphs {
 

--- a/tket/src/Graphs/include/Graphs/AbstractGraph.hpp
+++ b/tket/src/Graphs/include/Graphs/AbstractGraph.hpp
@@ -41,6 +41,7 @@ class AbstractGraph {
  protected:
   using Edge = std::pair<T, T>;
   std::set<T> nodes_;
+  std::optional<unsigned> diameter_;
 
  public:
   /** Construct an empty graph */
@@ -79,7 +80,7 @@ class AbstractGraph {
   virtual unsigned get_distance(const T &node1, const T &node2) const = 0;
 
   /** Diameter of graph. */
-  virtual unsigned get_diameter() const = 0;
+  virtual unsigned get_diameter() = 0;
 
   virtual ~AbstractGraph() {}
 };

--- a/tket/src/Graphs/include/Graphs/AbstractGraph.hpp
+++ b/tket/src/Graphs/include/Graphs/AbstractGraph.hpp
@@ -18,6 +18,7 @@
 #include <stdexcept>
 #include <utility>
 #include <vector>
+#include <optional>
 
 namespace tket::graphs {
 

--- a/tket/src/Graphs/include/Graphs/CompleteGraph.hpp
+++ b/tket/src/Graphs/include/Graphs/CompleteGraph.hpp
@@ -67,7 +67,7 @@ class CompleteGraph : public AbstractGraph<T> {
     return 1;
   }
 
-  unsigned get_diameter() const override {
+  unsigned get_diameter() override {
     switch (n_nodes()) {
       case 0:
         throw std::logic_error("Graph is empty.");

--- a/tket/src/Graphs/include/Graphs/DirectedGraph.hpp
+++ b/tket/src/Graphs/include/Graphs/DirectedGraph.hpp
@@ -433,20 +433,22 @@ class DirectedGraph : public DirectedGraphBase<T> {
     return d;
   }
 
-  unsigned get_diameter() const override {
+  unsigned get_diameter() override {
     unsigned N = n_nodes();
     if (N == 0) {
       throw std::logic_error("Graph is empty.");
     }
-    unsigned max = 0;
-    const std::vector<T> nodes = get_all_nodes_vec();
-    for (unsigned i = 0; i < N; i++) {
-      for (unsigned j = i + 1; j < N; j++) {
-        unsigned d = get_distance(nodes[i], nodes[j]);
-        if (d > max) max = d;
+    if (!this->diameter_) {
+      this->diameter_ = 0;
+      const std::vector<T> nodes = get_all_nodes_vec();
+      for (unsigned i = 0; i < N; i++) {
+        for (unsigned j = i + 1; j < N; j++) {
+          unsigned d = get_distance(nodes[i], nodes[j]);
+          if (d > *this->diameter_) this->diameter_ = d;
+        }
       }
     }
-    return max;
+    return *this->diameter_;
   }
 
   /** Returns all nodes at a given distance from a given 'source' node */


### PR DESCRIPTION
In its underlying graph classes. The graph classes finds the graph diameter by getting the distance between every pair of nodes in the graph, tracking which is largest and then returning it. This value isn't cached, meaning every time `get_diameter` is called this process is repeated, something which is done liberally in routing and a cause of some nasty overhead. This small fix massively improves routing runtime, especially on larger connectivity graphs.