### PR TITLE
Fixes to compile with gcc-11

### DIFF
--- a/tket/src/CMakeLists.txt
+++ b/tket/src/CMakeLists.txt
@@ -40,6 +40,10 @@ endif()
 
 set(PROFILE_COVERAGE no CACHE BOOL "Build library with profiling for test coverage")
 IF (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    # Bug in Eigen with gcc 11: https://gitlab.com/libeigen/eigen/-/issues/2304
+    IF (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 11)    
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-maybe-uninitialized")
+    ENDIF()
     IF (PROFILE_COVERAGE)
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -fprofile-arcs -ftest-coverage")
         # Bug in gcc 10: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=95353

--- a/tket/src/CMakeLists.txt
+++ b/tket/src/CMakeLists.txt
@@ -40,10 +40,6 @@ endif()
 
 set(PROFILE_COVERAGE no CACHE BOOL "Build library with profiling for test coverage")
 IF (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-    # Bug in Eigen with gcc 11: https://gitlab.com/libeigen/eigen/-/issues/2304
-    IF (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 11)    
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-maybe-uninitialized")
-    ENDIF()
     IF (PROFILE_COVERAGE)
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -fprofile-arcs -ftest-coverage")
         # Bug in gcc 10: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=95353

--- a/tket/src/Graphs/GraphColouring.cpp
+++ b/tket/src/Graphs/GraphColouring.cpp
@@ -15,6 +15,7 @@
 #include "GraphColouring.hpp"
 
 #include <algorithm>
+#include <limits>
 #include <set>
 #include <sstream>
 #include <stdexcept>

--- a/tket/src/TokenSwapping/TableLookup/FilteredSwapSequences.cpp
+++ b/tket/src/TokenSwapping/TableLookup/FilteredSwapSequences.cpp
@@ -15,7 +15,7 @@
 #include "TokenSwapping/FilteredSwapSequences.hpp"
 
 #include <algorithm>
-
+#include <limits>
 #include "TokenSwapping/GeneralFunctions.hpp"
 #include "TokenSwapping/SwapSequenceTable.hpp"
 #include "Utils/Assert.hpp"

--- a/tket/src/TokenSwapping/TableLookup/FilteredSwapSequences.cpp
+++ b/tket/src/TokenSwapping/TableLookup/FilteredSwapSequences.cpp
@@ -16,6 +16,7 @@
 
 #include <algorithm>
 #include <limits>
+
 #include "TokenSwapping/GeneralFunctions.hpp"
 #include "TokenSwapping/SwapSequenceTable.hpp"
 #include "Utils/Assert.hpp"

--- a/tket/src/Utils/include/Utils/EigenConfig.hpp
+++ b/tket/src/Utils/include/Utils/EigenConfig.hpp
@@ -21,13 +21,16 @@
 
 #include "Utils/Json.hpp"
 
-#if defined(__clang__)
+#if !defined(_MSC_VER)
 #pragma GCC diagnostic push
 
+#if defined(__clang__)
 #if __has_warning("-Wdeprecated-copy")
 #pragma GCC diagnostic ignored "-Wdeprecated-copy"
 #endif
-
+#elif __GNUC__ >= 11
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
 #endif
 
 #include <Eigen/Dense>
@@ -35,7 +38,7 @@
 #include <unsupported/Eigen/KroneckerProduct>
 #include <unsupported/Eigen/MatrixFunctions>
 
-#if defined(__clang__)
+#if !defined(_MSC_VER)
 #pragma GCC diagnostic pop
 #endif
 


### PR DESCRIPTION
Changes:

(1) Since `tket` is compiled with `-Wall -Werror`, it will fail to compile Eigen due to this [bug](https://gitlab.com/libeigen/eigen/-/issues/2304). Hence, adding `-Wno-maybe-uninitialized` when gcc 11+ is used.

(2) gcc-11 only has changes in its [header dependency](https://gcc.gnu.org/gcc-11/porting_to.html). In particular, `<limits>` (for `std::numeric_limits`) is used less widely and needs to be included explicitly.

Tested by: compiling `tket` following the [instructions](https://github.com/CQCL/tket#how-to-build-tket-and-pytket).
