### PR TITLE
add binder functions to simplify setting and copying registers

### DIFF
--- a/pytket/binders/circuit/classical.cpp
+++ b/pytket/binders/circuit/classical.cpp
@@ -19,6 +19,7 @@
 #include "Circuit/Conditional.hpp"
 #include "Ops/ClassicalOps.hpp"
 #include "Ops/OpJsonFactory.hpp"
+#include "UnitRegister.hpp"
 #include "Utils/Json.hpp"
 #include "binder_json.hpp"
 
@@ -112,7 +113,7 @@ void init_classical(py::module& m) {
       m, "RangePredicateOp",
       "A predicate defined by a range of values in binary encoding.")
       .def(
-          py::init<unsigned, uint32_t, uint32_t>(),
+          py::init<unsigned, _tket_uint_t, _tket_uint_t>(),
           "Construct from a bit width, an upper bound and a lower bound.",
           py::arg("width"), py::arg("upper"), py::arg("lower"))
       .def_property_readonly(

--- a/pytket/binders/circuit/unitid.cpp
+++ b/pytket/binders/circuit/unitid.cpp
@@ -71,7 +71,7 @@ void declare_register(py::module &m, const std::string &typestr) {
       });
 }
 void init_unitid(py::module &m) {
-  m.attr("_TEMP_REG_SIZE") = 32;
+  m.attr("_TEMP_REG_SIZE") = _TKET_REG_WIDTH;
   m.attr("_TEMP_BIT_NAME") = "tk_SCRATCH_BIT";
   m.attr("_TEMP_BIT_REG_BASE") = "tk_SCRATCH_BITREG";
   m.attr("_DEBUG_ONE_REG_PREFIX") = py::str(c_debug_one_prefix());

--- a/pytket/binders/include/UnitRegister.hpp
+++ b/pytket/binders/include/UnitRegister.hpp
@@ -17,6 +17,14 @@
 #include "Utils/UnitID.hpp"
 
 namespace tket {
+/*
+Bit registers which can be interpreted as unsigned integers follow the
+conventions defined here:
+registers are up to _TKET_REG_WIDTH wide in bits and are interpreted as
+equivalent to the C++ type _tket_uint_t
+*/
+#define _TKET_REG_WIDTH 32
+typedef uint32_t _tket_uint_t;
 
 template <typename T>
 class UnitRegister {

--- a/pytket/pytket/circuit/decompose_classical.py
+++ b/pytket/pytket/circuit/decompose_classical.py
@@ -195,9 +195,7 @@ def _gen_walk(
             reg = copy.copy(var)
             reg.size = bit_width
             add_method(reg)
-            # map int to bools via litle endian encoding
-            bools = int_to_bools(val, len(reg))
-            newcirc.add_c_setbits(bools, list(reg), **kwargs)
+            newcirc.add_c_setreg(val, reg, **kwargs)
 
     # convert an expression to gates on the circuit
     # and return the variable holding the result

--- a/pytket/pytket/qasm/qasm.py
+++ b/pytket/pytket/qasm/qasm.py
@@ -989,7 +989,10 @@ def circuit_to_qasm_io(
 
         if optype == OpType.ClassicalExpBox:
             out_args = args[op.get_n_i() :]
-            if out_args == list(cregs[out_args[0].reg_name]):
+            if (
+                out_args
+                == list(cregs[out_args[0].reg_name])[: op.get_n_io() + op.get_n_o()]
+            ):
                 stream_out.write(f"{out_args[0].reg_name} = {str(op.get_exp())};\n")
             elif len(out_args) == 1:
                 stream_out.write(f"{out_args[0]} = {str(op.get_exp())};\n")

--- a/pytket/tests/classical_test.py
+++ b/pytket/tests/classical_test.py
@@ -19,8 +19,7 @@ import json
 from pathlib import Path
 
 from jsonschema import validate  # type: ignore
-from hypothesis import given, reproduce_failure, settings, strategies
-from hypothesis.core import encode_failure
+from hypothesis import given, settings, strategies
 from hypothesis.strategies import SearchStrategy
 
 from pytket import wasm
@@ -111,8 +110,12 @@ def test_c_ops() -> None:
     c.add_c_and_to_registers(c0, c1, c2)
     c.add_c_xor_to_registers(c2, c1, c2)
     c.add_c_not_to_registers(c1, c2)
+
+    c.add_c_setreg(3, c0)
+    c.add_c_copyreg(c1, c0)
+
     cmds = c.get_commands()
-    assert len(cmds) == 19
+    assert len(cmds) == 21
     assert len([cmd for cmd in cmds if cmd.op.get_name() == "AND"]) == 2
     rp_cmds = [cmd for cmd in cmds if cmd.op.type == OpType.RangePredicate]
     assert len(rp_cmds) == 2
@@ -124,6 +127,8 @@ def test_c_ops() -> None:
         and mb_cmds[0] != mb_cmds[2]
         and mb_cmds[1] != mb_cmds[2]
     )
+    assert str(cmds[6]) == "CopyBits c1[0], c1[1], c1[2], c0[0], c0[1], c0[2];"
+    assert str(cmds[3]) == "SetBits(110) c0[0], c0[1], c0[2];"
 
 
 def test_wasm() -> None:


### PR DESCRIPTION
also contains a second driveby commit fixing a qasm output bug