### PR TITLE
[bugfix] Fix serialization of `BackendInfo` with `RingArch` and `FullyConnected` architectures.

### DIFF
--- a/pytket/binders/architecture.cpp
+++ b/pytket/binders/architecture.cpp
@@ -153,6 +153,9 @@ PYBIND11_MODULE(architecture, m) {
           "The constructor for a RingArchitecture with some undirected "
           "connectivity between qubits.\n\n:param number of qubits",
           py::arg("nodes"))
+      .def(
+          "__deepcopy__",
+          [](const RingArch &arc, py::dict = py::dict()) { return arc; })
       .def("__repr__", [](const RingArch &arc) {
         return "<tket::RingArch, nodes=" + std::to_string(arc.n_nodes()) + ">";
       });
@@ -166,6 +169,9 @@ PYBIND11_MODULE(architecture, m) {
           "Construct a fully-connected architecture."
           "\n\n:param n: number of qubits",
           py::arg("n"))
+      .def(
+          "__deepcopy__",
+          [](const FullyConnected &arc, py::dict = py::dict()) { return arc; })
       .def(
           "__repr__",
           [](const FullyConnected &arc) {

--- a/pytket/docs/changelog.rst
+++ b/pytket/docs/changelog.rst
@@ -11,6 +11,11 @@ Minor new features:
 * New ``to_graphviz_str`` method for ``ZXDiagram`` to generate a source string
   that can be rendered by the ``graphviz`` package.
 
+Fixes:
+
+* Fix serialization of `BackendInfo` for `RingArch` and `FullyConnected`
+  architectures.
+
 1.2.2 (May 2022)
 ----------------
 

--- a/pytket/tests/backendinfo_test.py
+++ b/pytket/tests/backendinfo_test.py
@@ -174,4 +174,4 @@ if __name__ == "__main__":
     test_misc()
     test_serialization()
     test_fullyconnected()
-    test_gate_errors_options
+    test_gate_errors_options()

--- a/pytket/tests/backendinfo_test.py
+++ b/pytket/tests/backendinfo_test.py
@@ -161,6 +161,10 @@ def test_fullyconnected() -> None:
     assert bi.n_nodes == 10
     assert type(bi.architecture) == FullyConnected
 
+    # https://github.com/CQCL/tket/issues/390
+    d = bi.to_dict()
+    assert BackendInfo.from_dict(d) == bi
+
 
 if __name__ == "__main__":
     test_nodes()

--- a/pytket/tests/backendinfo_test.py
+++ b/pytket/tests/backendinfo_test.py
@@ -23,7 +23,7 @@ from hypothesis import given
 import pytest  # type: ignore
 
 from pytket.backends.backendinfo import BackendInfo, fully_connected_backendinfo
-from pytket.architecture import SquareGrid, FullyConnected  # type: ignore
+from pytket.architecture import SquareGrid, RingArch, FullyConnected  # type: ignore
 from pytket.circuit import OpType, Node  # type: ignore
 
 import strategies as st  # type: ignore
@@ -105,12 +105,29 @@ def test_misc() -> None:
         bi.add_misc(key, otherval)
 
 
-def test_serialization() -> None:
+def test_serialization_squaregrid() -> None:
     bi = BackendInfo(
         "name",
         "device_name",
         "version",
         SquareGrid(3, 4),
+        {OpType.CX, OpType.Rx},
+        True,
+        True,
+        True,
+    )
+    bi_dict = bi.to_dict()
+    bi2 = BackendInfo.from_dict(bi_dict)
+
+    assert bi == bi2
+
+
+def test_serialization_ringarch() -> None:
+    bi = BackendInfo(
+        "name",
+        "device_name",
+        "version",
+        RingArch(3),
         {OpType.CX, OpType.Rx},
         True,
         True,
@@ -172,6 +189,7 @@ if __name__ == "__main__":
     test_default_no_reset()
     test_default_no_midcircuit_meas()
     test_misc()
-    test_serialization()
+    test_serialization_squaregrid()
+    test_serialization_ringarch()
     test_fullyconnected()
     test_gate_errors_options()


### PR DESCRIPTION
Fixes #390 .