### PR TITLE
Update test suite to catch2 3.0.1

### DIFF
--- a/recipes/tket-proptests/conanfile.py
+++ b/recipes/tket-proptests/conanfile.py
@@ -29,7 +29,7 @@ class TketProptestsConan(ConanFile):
     exports_sources = "../../tket/proptests/*"
     requires = (
         "tket/1.0.1",
-        "rapidcheck/cci.20210702",
+        "rapidcheck/cci.20220514",
     )
 
     def build(self):

--- a/recipes/tket-tests/conanfile.py
+++ b/recipes/tket-tests/conanfile.py
@@ -34,7 +34,7 @@ class TketTestsConan(ConanFile):
     default_options = {"with_coverage": False, "full": False, "long": False}
     generators = "cmake"
     exports_sources = "../../tket/tests/*"
-    requires = ("tket/1.0.1", "catch2/2.13.9")
+    requires = ("tket/1.0.1", "catch2/3.0.1")
 
     _cmake = None
 

--- a/tket/tests/CMakeLists.txt
+++ b/tket/tests/CMakeLists.txt
@@ -67,4 +67,4 @@ target_link_libraries(test_tket PRIVATE
     tket-ZX)
 
 target_link_libraries(test_tket PRIVATE
-    ${CONAN_LIBS_FMT} ${CONAN_LIBS_SPDLOG} ${CONAN_LIBS_SYMENGINE})
+    ${CONAN_LIBS_FMT} ${CONAN_LIBS_SPDLOG} ${CONAN_LIBS_SYMENGINE} ${CONAN_LIBS_CATCH2})

--- a/tket/tests/Circuit/test_Boxes.cpp
+++ b/tket/tests/Circuit/test_Boxes.cpp
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
 
 #include "../testutil.hpp"
 #include "Circuit/CircUtils.hpp"
@@ -21,6 +22,8 @@
 #include "Eigen/src/Core/Matrix.h"
 #include "Gate/SymTable.hpp"
 #include "Simulation/CircuitSimulator.hpp"
+
+using Catch::Matchers::StartsWith;
 
 namespace tket {
 namespace test_Boxes {
@@ -876,7 +879,7 @@ SCENARIO("Checking box names", "[boxes]") {
     // Of course, 0.4444 is NOT exactly represented by a double,
     // so it might print something like 0.4443999... or 0.4440000...1.
     // This test will still pass even if so.
-    CHECK_THAT(g.get_name(), Catch::Matchers::StartsWith(prefix + "(0.444"));
+    CHECK_THAT(g.get_name(), StartsWith(prefix + "(0.444"));
   }
   GIVEN("CustomGate with 3 parameters") {
     Circuit setup(1);

--- a/tket/tests/Circuit/test_Circ.cpp
+++ b/tket/tests/Circuit/test_Circ.cpp
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #include <boost/graph/graph_traits.hpp>
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 #include <memory>
 #include <sstream>
 #include <unsupported/Eigen/MatrixFunctions>

--- a/tket/tests/Circuit/test_Symbolic.cpp
+++ b/tket/tests/Circuit/test_Symbolic.cpp
@@ -17,7 +17,7 @@
 #include <Transformations/CliffordOptimisation.hpp>
 #include <Transformations/OptimisationPass.hpp>
 #include <Transformations/Transform.hpp>
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 #include <vector>
 
 #include "OpType/OpType.hpp"

--- a/tket/tests/Circuit/test_ThreeQubitConversion.cpp
+++ b/tket/tests/Circuit/test_ThreeQubitConversion.cpp
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #include <array>
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 #include <cmath>
 
 #include "../Simulation/ComparisonFunctions.hpp"

--- a/tket/tests/Gate/GatesData.cpp
+++ b/tket/tests/Gate/GatesData.cpp
@@ -14,7 +14,7 @@
 
 #include "GatesData.hpp"
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 namespace tket {
 namespace internal {

--- a/tket/tests/Gate/test_GateUnitaryMatrix.cpp
+++ b/tket/tests/Gate/test_GateUnitaryMatrix.cpp
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
 #include <map>
 #include <set>
 #include <sstream>
@@ -29,7 +30,7 @@
 #include "Simulation/CircuitSimulator.hpp"
 #include "Utils/MatrixAnalysis.hpp"
 
-using Catch::Matchers::Contains;
+using Catch::Matchers::ContainsSubstring;
 
 namespace tket {
 namespace test_GateUnitaryMatrix {
@@ -345,10 +346,10 @@ SCENARIO("Invalid numbers of arguments cause exceptions") {
             } catch (const GateUnitaryMatrixError& e) {
               CHECK(e.cause == GateUnitaryMatrixError::Cause::INPUT_ERROR);
               if (type != OpType::CnX && type != OpType::CnRy) {
-                CHECK_THAT(e.what(), Contains(name));
+                CHECK_THAT(e.what(), ContainsSubstring(name));
               }
-              CHECK_THAT(e.what(), Contains(std::to_string(number_of_qubits)));
-              CHECK_THAT(e.what(), Contains(std::to_string(parameters.size())));
+              CHECK_THAT(e.what(), ContainsSubstring(std::to_string(number_of_qubits)));
+              CHECK_THAT(e.what(), ContainsSubstring(std::to_string(parameters.size())));
               did_throw = true;
             }
             CHECK(expect_throw == did_throw);
@@ -390,7 +391,7 @@ SCENARIO("Non-unitary op types cause not implemented exceptions") {
       CHECK(false);
     } catch (const GateUnitaryMatrixError& e) {
       CHECK(e.cause == GateUnitaryMatrixError::Cause::GATE_NOT_IMPLEMENTED);
-      CHECK_THAT(e.what(), Contains(name));
+      CHECK_THAT(e.what(), ContainsSubstring(name));
     }
   }
 }

--- a/tket/tests/Gate/test_GateUnitaryMatrix.cpp
+++ b/tket/tests/Gate/test_GateUnitaryMatrix.cpp
@@ -348,8 +348,12 @@ SCENARIO("Invalid numbers of arguments cause exceptions") {
               if (type != OpType::CnX && type != OpType::CnRy) {
                 CHECK_THAT(e.what(), ContainsSubstring(name));
               }
-              CHECK_THAT(e.what(), ContainsSubstring(std::to_string(number_of_qubits)));
-              CHECK_THAT(e.what(), ContainsSubstring(std::to_string(parameters.size())));
+              CHECK_THAT(
+                  e.what(),
+                  ContainsSubstring(std::to_string(number_of_qubits)));
+              CHECK_THAT(
+                  e.what(),
+                  ContainsSubstring(std::to_string(parameters.size())));
               did_throw = true;
             }
             CHECK(expect_throw == did_throw);

--- a/tket/tests/Graphs/EdgeSequenceColouringParameters.cpp
+++ b/tket/tests/Graphs/EdgeSequenceColouringParameters.cpp
@@ -14,7 +14,7 @@
 
 #include "EdgeSequenceColouringParameters.hpp"
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 #include "EdgeSequence.hpp"
 #include "GraphTestingRoutines.hpp"

--- a/tket/tests/Graphs/GraphTestingRoutines.cpp
+++ b/tket/tests/Graphs/GraphTestingRoutines.cpp
@@ -14,7 +14,7 @@
 
 #include "GraphTestingRoutines.hpp"
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 #include <set>
 #include <sstream>
 #include <stdexcept>

--- a/tket/tests/Graphs/RandomGraphGeneration.cpp
+++ b/tket/tests/Graphs/RandomGraphGeneration.cpp
@@ -15,7 +15,7 @@
 #include "RandomGraphGeneration.hpp"
 
 #include <algorithm>
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 #include "EdgeSequence.hpp"
 #include "Graphs/AdjacencyData.hpp"

--- a/tket/tests/Graphs/RandomPlanarGraphs.cpp
+++ b/tket/tests/Graphs/RandomPlanarGraphs.cpp
@@ -14,7 +14,7 @@
 
 #include "RandomPlanarGraphs.hpp"
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 #include "Utils/RNG.hpp"
 

--- a/tket/tests/Graphs/test_ArticulationPoints.cpp
+++ b/tket/tests/Graphs/test_ArticulationPoints.cpp
@@ -14,7 +14,7 @@
 
 #include <algorithm>
 #include <boost/graph/adjacency_list.hpp>
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 #include <iostream>
 #include <vector>
 

--- a/tket/tests/Graphs/test_DirectedGraph.cpp
+++ b/tket/tests/Graphs/test_DirectedGraph.cpp
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #include <boost/graph/adjacency_list.hpp>
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 #include <iostream>
 #include <vector>
 

--- a/tket/tests/Graphs/test_GraphColouring.cpp
+++ b/tket/tests/Graphs/test_GraphColouring.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 #include "EdgeSequence.hpp"
 #include "EdgeSequenceColouringParameters.hpp"

--- a/tket/tests/Graphs/test_GraphFindComponents.cpp
+++ b/tket/tests/Graphs/test_GraphFindComponents.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 #include <set>
 
 #include "Graphs/AdjacencyData.hpp"

--- a/tket/tests/Graphs/test_GraphFindMaxClique.cpp
+++ b/tket/tests/Graphs/test_GraphFindMaxClique.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 #include <set>
 
 #include "Graphs/AdjacencyData.hpp"

--- a/tket/tests/Graphs/test_GraphUtils.cpp
+++ b/tket/tests/Graphs/test_GraphUtils.cpp
@@ -16,7 +16,7 @@
 #include <algorithm>
 #include <boost/graph/adjacency_list.hpp>
 #include <boost/range/iterator_range_core.hpp>
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 #include <map>
 #include <set>
 #include <string>

--- a/tket/tests/Graphs/test_TreeSearch.cpp
+++ b/tket/tests/Graphs/test_TreeSearch.cpp
@@ -15,7 +15,7 @@
 #include <boost/graph/adjacency_list.hpp>
 #include <boost/property_map/property_map.hpp>
 #include <boost/range/iterator_range_core.hpp>
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 #include <map>
 #include <vector>
 

--- a/tket/tests/OpType/test_OpTypeFunctions.cpp
+++ b/tket/tests/OpType/test_OpTypeFunctions.cpp
@@ -1,4 +1,4 @@
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 #include "Gate/GatePtr.hpp"
 #include "OpType/OpTypeFunctions.hpp"

--- a/tket/tests/Ops/test_ClassicalOps.cpp
+++ b/tket/tests/Ops/test_ClassicalOps.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 #include "../testutil.hpp"
 #include "Circuit/Circuit.hpp"

--- a/tket/tests/Ops/test_Expression.cpp
+++ b/tket/tests/Ops/test_Expression.cpp
@@ -14,7 +14,7 @@
 
 #include <symengine/eval.h>
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 #include "../testutil.hpp"
 #include "Utils/Expression.hpp"

--- a/tket/tests/Ops/test_Ops.cpp
+++ b/tket/tests/Ops/test_Ops.cpp
@@ -14,7 +14,7 @@
 
 #include <symengine/eval.h>
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 #include <optional>
 #include <unsupported/Eigen/MatrixFunctions>
 

--- a/tket/tests/Passes/test_SynthesiseTK.cpp
+++ b/tket/tests/Passes/test_SynthesiseTK.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 #include "../testutil.hpp"
 #include "Circuit/Circuit.hpp"

--- a/tket/tests/Placement/test_NeighbourPlacements.cpp
+++ b/tket/tests/Placement/test_NeighbourPlacements.cpp
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #include <Placement/NeighbourPlacements.hpp>
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 #include <random>
 #include <utility>
 

--- a/tket/tests/Placement/test_Placement.cpp
+++ b/tket/tests/Placement/test_Placement.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 #include <random>
 
 #include "../testutil.hpp"

--- a/tket/tests/Simulation/test_CircuitSimulator.cpp
+++ b/tket/tests/Simulation/test_CircuitSimulator.cpp
@@ -15,7 +15,9 @@
 // This file is specifically for testing of tket-sim functions
 // (which, of course, are used in other tests for correctness).
 #include <array>
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
+#include <catch2/catch_approx.hpp>
 
 #include "../Gate/GatesData.hpp"
 #include "../testutil.hpp"
@@ -31,7 +33,8 @@
 
 namespace tket {
 namespace test_CircuitSimulator {
-using Catch::Matchers::Contains;
+using Catch::Matchers::ContainsSubstring;
+using Catch::Approx;
 
 SCENARIO("Simple circuits produce the correct statevectors") {
   GIVEN("A 1 qubit circ with X-gate") {
@@ -508,7 +511,7 @@ SCENARIO("compare_statevectors_or_unitaries gives expected errors") {
         INFO("matrices compared equivalent: " << equivalent);
         CHECK(false);
       } catch (const std::exception& e) {
-        CHECK_THAT(e.what(), Contains(message));
+        CHECK_THAT(e.what(), ContainsSubstring(message));
       }
     }
   };

--- a/tket/tests/Simulation/test_CircuitSimulator.cpp
+++ b/tket/tests/Simulation/test_CircuitSimulator.cpp
@@ -15,9 +15,9 @@
 // This file is specifically for testing of tket-sim functions
 // (which, of course, are used in other tests for correctness).
 #include <array>
+#include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_string.hpp>
-#include <catch2/catch_approx.hpp>
 
 #include "../Gate/GatesData.hpp"
 #include "../testutil.hpp"
@@ -33,8 +33,8 @@
 
 namespace tket {
 namespace test_CircuitSimulator {
-using Catch::Matchers::ContainsSubstring;
 using Catch::Approx;
+using Catch::Matchers::ContainsSubstring;
 
 SCENARIO("Simple circuits produce the correct statevectors") {
   GIVEN("A 1 qubit circ with X-gate") {

--- a/tket/tests/Simulation/test_PauliExpBoxUnitaryCalculator.cpp
+++ b/tket/tests/Simulation/test_PauliExpBoxUnitaryCalculator.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 #include <stack>
 
 #include "Circuit/Boxes.hpp"

--- a/tket/tests/TokenSwapping/Data/FixedCompleteSolutions.cpp
+++ b/tket/tests/TokenSwapping/Data/FixedCompleteSolutions.cpp
@@ -14,7 +14,7 @@
 
 #include "FixedCompleteSolutions.hpp"
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 namespace tket {
 namespace tsa_internal {

--- a/tket/tests/TokenSwapping/TSAUtils/test_SwapFunctions.cpp
+++ b/tket/tests/TokenSwapping/TSAUtils/test_SwapFunctions.cpp
@@ -12,11 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
 
 #include "TokenSwapping/SwapFunctions.hpp"
 
-using Catch::Matchers::Contains;
+using Catch::Matchers::ContainsSubstring;
 
 using std::vector;
 
@@ -34,7 +35,7 @@ SCENARIO("Get swaps, with exceptions") {
         CHECK(swap.second == std::max(ii, jj));
       } catch (const std::exception& e) {
         CHECK(ii == jj);
-        CHECK_THAT(std::string(e.what()), Contains("equal vertices"));
+        CHECK_THAT(std::string(e.what()), ContainsSubstring("equal vertices"));
       }
     }
   }

--- a/tket/tests/TokenSwapping/TableLookup/PermutationTestUtils.cpp
+++ b/tket/tests/TokenSwapping/TableLookup/PermutationTestUtils.cpp
@@ -14,7 +14,7 @@
 
 #include "PermutationTestUtils.hpp"
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 #include <vector>
 
 namespace tket {

--- a/tket/tests/TokenSwapping/TableLookup/SwapSequenceReductionTester.cpp
+++ b/tket/tests/TokenSwapping/TableLookup/SwapSequenceReductionTester.cpp
@@ -14,7 +14,7 @@
 
 #include "SwapSequenceReductionTester.hpp"
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 #include "NeighboursFromEdges.hpp"
 #include "TokenSwapping/SwapListSegmentOptimiser.hpp"

--- a/tket/tests/TokenSwapping/TableLookup/test_CanonicalRelabelling.cpp
+++ b/tket/tests/TokenSwapping/TableLookup/test_CanonicalRelabelling.cpp
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #include <algorithm>
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 #include <numeric>
 #include <set>
 

--- a/tket/tests/TokenSwapping/TableLookup/test_ExactMappingLookup.cpp
+++ b/tket/tests/TokenSwapping/TableLookup/test_ExactMappingLookup.cpp
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #include <algorithm>
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 #include "../TestUtils/DebugFunctions.hpp"
 #include "TokenSwapping/ExactMappingLookup.hpp"

--- a/tket/tests/TokenSwapping/TableLookup/test_FilteredSwapSequences.cpp
+++ b/tket/tests/TokenSwapping/TableLookup/test_FilteredSwapSequences.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 #include <limits>
 #include <map>
 

--- a/tket/tests/TokenSwapping/TableLookup/test_SwapSequenceReductions.cpp
+++ b/tket/tests/TokenSwapping/TableLookup/test_SwapSequenceReductions.cpp
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #include <algorithm>
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 #include "../Data/FixedCompleteSolutions.hpp"
 #include "../Data/FixedSwapSequences.hpp"

--- a/tket/tests/TokenSwapping/TableLookup/test_SwapSequenceTable.cpp
+++ b/tket/tests/TokenSwapping/TableLookup/test_SwapSequenceTable.cpp
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #include <algorithm>
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 #include <numeric>
 
 #include "PermutationTestUtils.hpp"

--- a/tket/tests/TokenSwapping/TestUtils/ArchitectureEdgesReimplementation.cpp
+++ b/tket/tests/TokenSwapping/TestUtils/ArchitectureEdgesReimplementation.cpp
@@ -14,7 +14,7 @@
 
 #include "ArchitectureEdgesReimplementation.hpp"
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 namespace tket {
 namespace tsa_internal {

--- a/tket/tests/TokenSwapping/TestUtils/BestTsaTester.cpp
+++ b/tket/tests/TokenSwapping/TestUtils/BestTsaTester.cpp
@@ -14,7 +14,7 @@
 
 #include "BestTsaTester.hpp"
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 #include "Architecture/BestTsaWithArch.hpp"
 #include "TokenSwapping/VertexMappingFunctions.hpp"

--- a/tket/tests/TokenSwapping/TestUtils/DecodedProblemData.cpp
+++ b/tket/tests/TokenSwapping/TestUtils/DecodedProblemData.cpp
@@ -14,7 +14,7 @@
 
 #include "DecodedProblemData.hpp"
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 #include "TokenSwapping/GeneralFunctions.hpp"
 #include "TokenSwapping/VertexSwapResult.hpp"

--- a/tket/tests/TokenSwapping/TestUtils/FullTsaTesting.cpp
+++ b/tket/tests/TokenSwapping/TestUtils/FullTsaTesting.cpp
@@ -14,7 +14,7 @@
 
 #include "FullTsaTesting.hpp"
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 #include "Architecture/ArchitectureMapping.hpp"
 #include "Architecture/DistancesFromArchitecture.hpp"

--- a/tket/tests/TokenSwapping/TestUtils/PartialTsaTesting.cpp
+++ b/tket/tests/TokenSwapping/TestUtils/PartialTsaTesting.cpp
@@ -14,7 +14,7 @@
 
 #include "PartialTsaTesting.hpp"
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 #include "Architecture/DistancesFromArchitecture.hpp"
 #include "Architecture/NeighboursFromArchitecture.hpp"

--- a/tket/tests/TokenSwapping/TestUtils/ProblemGeneration.cpp
+++ b/tket/tests/TokenSwapping/TestUtils/ProblemGeneration.cpp
@@ -14,7 +14,7 @@
 
 #include "ProblemGeneration.hpp"
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 #include "GetRandomSet.hpp"
 #include "TokenSwapping/GeneralFunctions.hpp"

--- a/tket/tests/TokenSwapping/TestUtils/TestStatsStructs.cpp
+++ b/tket/tests/TokenSwapping/TestUtils/TestStatsStructs.cpp
@@ -15,7 +15,7 @@
 #include "TestStatsStructs.hpp"
 
 #include <algorithm>
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 #include <sstream>
 
 namespace tket {

--- a/tket/tests/TokenSwapping/TestUtils/test_DebugFunctions.cpp
+++ b/tket/tests/TokenSwapping/TestUtils/test_DebugFunctions.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 #include "DebugFunctions.hpp"
 

--- a/tket/tests/TokenSwapping/test_ArchitectureMappingEndToEnd.cpp
+++ b/tket/tests/TokenSwapping/test_ArchitectureMappingEndToEnd.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 #include <sstream>
 
 #include "Architecture/ArchitectureMapping.hpp"

--- a/tket/tests/TokenSwapping/test_BestTsaFixedSwapSequences.cpp
+++ b/tket/tests/TokenSwapping/test_BestTsaFixedSwapSequences.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 #include "Data/FixedCompleteSolutions.hpp"
 #include "Data/FixedSwapSequences.hpp"

--- a/tket/tests/TokenSwapping/test_DistancesFromArchitecture.cpp
+++ b/tket/tests/TokenSwapping/test_DistancesFromArchitecture.cpp
@@ -12,13 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
 #include <sstream>
 #include <stdexcept>
 
 #include "Architecture/DistancesFromArchitecture.hpp"
 
-using Catch::Matchers::Contains;
+using Catch::Matchers::ContainsSubstring;
 using std::vector;
 
 namespace tket {
@@ -58,7 +59,7 @@ SCENARIO("Architecture with disconnected graph") {
         CHECK(v1 + v2 != 9);
         summary << "INF;";
         const std::string message = e.what();
-        CHECK_THAT(message, Contains("are not connected"));
+        CHECK_THAT(message, ContainsSubstring("are not connected"));
       }
     }
   }

--- a/tket/tests/TokenSwapping/test_FullTsa.cpp
+++ b/tket/tests/TokenSwapping/test_FullTsa.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 #include "TestUtils/ArchitectureEdgesReimplementation.hpp"
 #include "TestUtils/FullTsaTesting.hpp"

--- a/tket/tests/TokenSwapping/test_RiverFlowPathFinder.cpp
+++ b/tket/tests/TokenSwapping/test_RiverFlowPathFinder.cpp
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #include <array>
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 #include "Architecture/ArchitectureMapping.hpp"
 #include "Architecture/DistancesFromArchitecture.hpp"

--- a/tket/tests/TokenSwapping/test_SwapList.cpp
+++ b/tket/tests/TokenSwapping/test_SwapList.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 #include <sstream>
 #include <string>
 

--- a/tket/tests/TokenSwapping/test_SwapListOptimiser.cpp
+++ b/tket/tests/TokenSwapping/test_SwapListOptimiser.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 #include <functional>
 #include <set>
 #include <sstream>

--- a/tket/tests/TokenSwapping/test_SwapsFromQubitMapping.cpp
+++ b/tket/tests/TokenSwapping/test_SwapsFromQubitMapping.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 #include <sstream>
 
 #include "Architecture/BestTsaWithArch.hpp"

--- a/tket/tests/TokenSwapping/test_VariousPartialTsa.cpp
+++ b/tket/tests/TokenSwapping/test_VariousPartialTsa.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 #include "TestUtils/ArchitectureEdgesReimplementation.hpp"
 #include "TestUtils/DebugFunctions.hpp"

--- a/tket/tests/TokenSwapping/test_VectorListHybrid.cpp
+++ b/tket/tests/TokenSwapping/test_VectorListHybrid.cpp
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #include <algorithm>
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 #include <sstream>
 
 #include "TokenSwapping/VectorListHybrid.hpp"

--- a/tket/tests/TokenSwapping/test_VectorListHybridSkeleton.cpp
+++ b/tket/tests/TokenSwapping/test_VectorListHybridSkeleton.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 #include <list>
 #include <optional>
 #include <set>

--- a/tket/tests/Utils/test_CosSinDecomposition.cpp
+++ b/tket/tests/Utils/test_CosSinDecomposition.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 #include <cstdlib>
 
 #include "../testutil.hpp"

--- a/tket/tests/Utils/test_HelperFunctions.cpp
+++ b/tket/tests/Utils/test_HelperFunctions.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 #include "Utils/HelperFunctions.hpp"
 

--- a/tket/tests/Utils/test_Logging.cpp
+++ b/tket/tests/Utils/test_Logging.cpp
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #include <Utils/TketLog.hpp>
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 #include <sstream>
 #include <string>
 

--- a/tket/tests/Utils/test_MatrixAnalysis.cpp
+++ b/tket/tests/Utils/test_MatrixAnalysis.cpp
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #include <algorithm>
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 #include <vector>
 
 #include "Utils/MatrixAnalysis.hpp"

--- a/tket/tests/Utils/test_RNG.cpp
+++ b/tket/tests/Utils/test_RNG.cpp
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #include <array>
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 #include <numeric>
 #include <set>
 #include <sstream>

--- a/tket/tests/ZX/test_Flow.cpp
+++ b/tket/tests/ZX/test_Flow.cpp
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers.hpp>
 
 #include "ZX/Flow.hpp"
 

--- a/tket/tests/ZX/test_ZXAxioms.cpp
+++ b/tket/tests/ZX/test_ZXAxioms.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 #include "ZX/Rewrite.hpp"
 

--- a/tket/tests/ZX/test_ZXConverters.cpp
+++ b/tket/tests/ZX/test_ZXConverters.cpp
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #include <boost/graph/adjacency_list.hpp>
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 #include "../testutil.hpp"
 #include "Converters/Converters.hpp"

--- a/tket/tests/ZX/test_ZXDiagram.cpp
+++ b/tket/tests/ZX/test_ZXDiagram.cpp
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers.hpp>
 #include <fstream>
 
 #include "ZX/ZXDiagram.hpp"

--- a/tket/tests/ZX/test_ZXExtraction.cpp
+++ b/tket/tests/ZX/test_ZXExtraction.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 #include "Converters/Converters.hpp"
 #include "ZX/Flow.hpp"

--- a/tket/tests/ZX/test_ZXRebase.cpp
+++ b/tket/tests/ZX/test_ZXRebase.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 #include "ZX/Rewrite.hpp"
 #include "ZX/ZXDiagram.hpp"

--- a/tket/tests/ZX/test_ZXSimp.cpp
+++ b/tket/tests/ZX/test_ZXSimp.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 #include "ZX/Rewrite.hpp"
 

--- a/tket/tests/test_AASRoute.cpp
+++ b/tket/tests/test_AASRoute.cpp
@@ -1,5 +1,5 @@
 #include <algorithm>
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 #include "Circuit/Circuit.hpp"
 #include "Mapping/AASLabelling.hpp"

--- a/tket/tests/test_ArchitectureAwareSynthesis.cpp
+++ b/tket/tests/test_ArchitectureAwareSynthesis.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 #include "Architecture/Architecture.hpp"
 #include "Predicates/CompilerPass.hpp"

--- a/tket/tests/test_Architectures.cpp
+++ b/tket/tests/test_Architectures.cpp
@@ -14,7 +14,7 @@
 
 #include <algorithm>
 #include <boost/graph/adjacency_list.hpp>
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 #include <cmath>
 #include <iostream>
 #include <vector>

--- a/tket/tests/test_Assertion.cpp
+++ b/tket/tests/test_Assertion.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 #include "Circuit/AssertionSynthesis.hpp"
 #include "Circuit/Circuit.hpp"

--- a/tket/tests/test_BoxDecompRoutingMethod.cpp
+++ b/tket/tests/test_BoxDecompRoutingMethod.cpp
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 #include "Mapping/BoxDecomposition.hpp"
 #include "Mapping/LexiRoute.hpp"

--- a/tket/tests/test_CliffTableau.cpp
+++ b/tket/tests/test_CliffTableau.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 #include "Clifford/CliffTableau.hpp"
 #include "Converters/Converters.hpp"

--- a/tket/tests/test_Clifford.cpp
+++ b/tket/tests/test_Clifford.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 #include <set>
 
 #include "Circuit/CircUtils.hpp"

--- a/tket/tests/test_Combinators.cpp
+++ b/tket/tests/test_Combinators.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 #include "CircuitsForTesting.hpp"
 #include "Predicates/PassGenerators.hpp"

--- a/tket/tests/test_CompilerPass.cpp
+++ b/tket/tests/test_CompilerPass.cpp
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #include <algorithm>
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 #include "Circuit/CircPool.hpp"
 #include "Circuit/Circuit.hpp"

--- a/tket/tests/test_ContextOpt.cpp
+++ b/tket/tests/test_ContextOpt.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 #include "Circuit/Circuit.hpp"
 #include "Predicates/CompilationUnit.hpp"

--- a/tket/tests/test_ControlDecomp.cpp
+++ b/tket/tests/test_ControlDecomp.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 #include <numeric>
 
 #include "Circuit/CircPool.hpp"

--- a/tket/tests/test_DeviceCharacterisation.cpp
+++ b/tket/tests/test_DeviceCharacterisation.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 #include "Characterisation/DeviceCharacterisation.hpp"
 #include "OpType/OpDesc.hpp"

--- a/tket/tests/test_FrameRandomisation.cpp
+++ b/tket/tests/test_FrameRandomisation.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 #include "Characterisation/FrameRandomisation.hpp"
 #include "Transformations/Rebase.hpp"

--- a/tket/tests/test_GlobalisePhasedX.cpp
+++ b/tket/tests/test_GlobalisePhasedX.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 #include "Circuit/Circuit.hpp"
 #include "Simulation/CircuitSimulator.hpp"

--- a/tket/tests/test_LexiRoute.cpp
+++ b/tket/tests/test_LexiRoute.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 #include <fstream>
 
 #include "Mapping/LexiLabelling.hpp"

--- a/tket/tests/test_LexicographicalComparison.cpp
+++ b/tket/tests/test_LexicographicalComparison.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 #include <cstdlib>
 #include <fstream>
 #include <iostream>

--- a/tket/tests/test_MappingFrontier.cpp
+++ b/tket/tests/test_MappingFrontier.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 #include <cstdlib>
 #include <fstream>
 #include <iostream>

--- a/tket/tests/test_MappingManager.cpp
+++ b/tket/tests/test_MappingManager.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 #include <cstdlib>
 #include <fstream>
 #include <iostream>

--- a/tket/tests/test_MappingVerification.cpp
+++ b/tket/tests/test_MappingVerification.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 #include "Mapping/LexiRoute.hpp"
 #include "Mapping/MappingManager.hpp"

--- a/tket/tests/test_MeasurementReduction.cpp
+++ b/tket/tests/test_MeasurementReduction.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 #include "MeasurementSetup/MeasurementReduction.hpp"
 

--- a/tket/tests/test_MeasurementSetup.cpp
+++ b/tket/tests/test_MeasurementSetup.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 #include "MeasurementSetup/MeasurementSetup.hpp"
 #include "testutil.hpp"

--- a/tket/tests/test_MultiGateReorder.cpp
+++ b/tket/tests/test_MultiGateReorder.cpp
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 #include "Mapping/LexiRoute.hpp"
 #include "Mapping/MappingManager.hpp"

--- a/tket/tests/test_Partition.cpp
+++ b/tket/tests/test_Partition.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 #include "Diagonalisation/PauliPartition.hpp"
 #include "testutil.hpp"

--- a/tket/tests/test_Path.cpp
+++ b/tket/tests/test_Path.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 #include "ArchAwareSynth/Path.hpp"
 

--- a/tket/tests/test_PauliGraph.cpp
+++ b/tket/tests/test_PauliGraph.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 #include "Circuit/Boxes.hpp"
 #include "CircuitsForTesting.hpp"

--- a/tket/tests/test_PauliString.cpp
+++ b/tket/tests/test_PauliString.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 #include <iostream>
 
 #include "CircuitsForTesting.hpp"

--- a/tket/tests/test_PhaseGadget.cpp
+++ b/tket/tests/test_PhaseGadget.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 #include <utility>
 
 #include "Circuit/CircUtils.hpp"

--- a/tket/tests/test_PhasePolynomials.cpp
+++ b/tket/tests/test_PhasePolynomials.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 #include "Circuit/Boxes.hpp"
 #include "Circuit/CircUtils.hpp"

--- a/tket/tests/test_PhasedXFrontier.cpp
+++ b/tket/tests/test_PhasedXFrontier.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 #include <optional>
 
 #include "Circuit/Circuit.hpp"

--- a/tket/tests/test_Predicates.cpp
+++ b/tket/tests/test_Predicates.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 #include <memory>
 
 #include "Circuit/Boxes.hpp"

--- a/tket/tests/test_Rebase.cpp
+++ b/tket/tests/test_Rebase.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 #include <numeric>
 
 #include "Circuit/Boxes.hpp"

--- a/tket/tests/test_RoutingMethod.cpp
+++ b/tket/tests/test_RoutingMethod.cpp
@@ -1,4 +1,4 @@
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 #include <cstdlib>
 #include <fstream>
 #include <iostream>

--- a/tket/tests/test_RoutingPasses.cpp
+++ b/tket/tests/test_RoutingPasses.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 #include <numeric>
 #include <optional>
 

--- a/tket/tests/test_SteinerForest.cpp
+++ b/tket/tests/test_SteinerForest.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 #include "ArchAwareSynth/SteinerForest.hpp"
 #include "testutil.hpp"

--- a/tket/tests/test_SteinerTree.cpp
+++ b/tket/tests/test_SteinerTree.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 #include "ArchAwareSynth/SteinerTree.hpp"
 

--- a/tket/tests/test_Synthesis.cpp
+++ b/tket/tests/test_Synthesis.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 #include <numeric>
 #include <optional>
 

--- a/tket/tests/test_TwoQubitCanonical.cpp
+++ b/tket/tests/test_TwoQubitCanonical.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 #include "Circuit/CircUtils.hpp"
 #include "Circuit/Command.hpp"

--- a/tket/tests/test_UnitaryTableau.cpp
+++ b/tket/tests/test_UnitaryTableau.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 #include <sstream>
 
 #include "Clifford/UnitaryTableau.hpp"

--- a/tket/tests/test_json.cpp
+++ b/tket/tests/test_json.cpp
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #include <boost/range/join.hpp>
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 #include <iostream>
 
 #include "Architecture/Architecture.hpp"

--- a/tket/tests/test_wasm.cpp
+++ b/tket/tests/test_wasm.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 #include "Circuit/CircUtils.hpp"
 #include "Circuit/Circuit.hpp"

--- a/tket/tests/tests_main.cpp
+++ b/tket/tests/tests_main.cpp
@@ -14,4 +14,4 @@
 
 #define CATCH_CONFIG_MAIN  // This tells Catch to provide a main() - only do
                            // this in one cpp file
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>

--- a/tket/tests/testutil.cpp
+++ b/tket/tests/testutil.cpp
@@ -14,7 +14,7 @@
 
 #include "testutil.hpp"
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 #include "Circuit/Circuit.hpp"
 #include "Simulation/CircuitSimulator.hpp"


### PR DESCRIPTION
Version 3 of catch2 is no longer header-only, so we link against the static library.

Instead of including `catch.hpp`, just include `catch_test_macros.hpp` and any other headers needed.

Also update the version of rapidcheck used for the proptests.