### PR TITLE
Ensure conditional gates are rebased in synthesis passes

### DIFF
--- a/tket/src/Transformations/OptimisationPass.cpp
+++ b/tket/src/Transformations/OptimisationPass.cpp
@@ -67,7 +67,7 @@ Transform synthesise_tk() {
   Transform small_part = remove_redundancies() >> rep >> squash_1qb_to_tk1();
   Transform repeat_synth = repeat_with_metric(
       small_part, [](const Circuit &circ) { return circ.n_vertices(); });
-  return synth >> repeat_synth;
+  return synth >> repeat_synth >> rebase_TK() >> remove_redundancies();
 }
 
 Transform synthesise_tket() {
@@ -128,10 +128,10 @@ Transform synthesise_HQS() {
         remove_redundancies() >> commute_through_multis() >> reduce_XZ_chains();
     Transform hqs_loop = remove_redundancies() >> commute_and_combine_HQS2() >>
                          reduce_XZ_chains();
-    Transform main_seq = decompose_multi_qubits_CX() >> clifford_simp() >>
-                         decompose_ZX() >> repeat(single_loop) >>
-                         decompose_CX_to_HQS2() >> repeat(hqs_loop) >>
-                         decompose_ZX_to_HQS1();
+    Transform main_seq =
+        decompose_multi_qubits_CX() >> clifford_simp() >> decompose_ZX() >>
+        repeat(single_loop) >> decompose_CX_to_HQS2() >> repeat(hqs_loop) >>
+        decompose_ZX_to_HQS1() >> rebase_HQS() >> remove_redundancies();
     return main_seq.apply(circ);
   });
 }
@@ -139,30 +139,32 @@ Transform synthesise_HQS() {
 // TODO: Make the XXPhase gates combine
 Transform synthesise_UMD() {
   return Transform([](Circuit &circ) {
-    bool success = (synthesise_tket() >> decompose_ZX() >>
-                    decompose_MolmerSorensen() >> squash_1qb_to_tk1())
-                       .apply(circ);
-    VertexList bin;
-    BGL_FORALL_VERTICES(v, circ.dag, DAG) {
-      const Op_ptr op_ptr = circ.get_Op_ptr_from_Vertex(v);
-      OpType type = op_ptr->get_type();
-      if (type == OpType::TK1) {
-        std::vector<Expr> tk1_angles = as_gate_ptr(op_ptr)->get_tk1_angles();
-        Circuit in_circ = CircPool::tk1_to_PhasedXRz(
-            tk1_angles[0], tk1_angles[1], tk1_angles[2]);
-        remove_redundancies().apply(in_circ);
-        Subcircuit sub = {
-            {circ.get_in_edges(v)}, {circ.get_all_out_edges(v)}, {v}};
-        bin.push_back(v);
-        circ.substitute(in_circ, sub, Circuit::VertexDeletion::No);
-        circ.add_phase(tk1_angles[3]);
-        success = true;
-      }
-    }
-    circ.remove_vertices(
-        bin, Circuit::GraphRewiring::No, Circuit::VertexDeletion::Yes);
-    return success;
-  });
+           bool success = (synthesise_tket() >> decompose_ZX() >>
+                           decompose_MolmerSorensen() >> squash_1qb_to_tk1())
+                              .apply(circ);
+           VertexList bin;
+           BGL_FORALL_VERTICES(v, circ.dag, DAG) {
+             const Op_ptr op_ptr = circ.get_Op_ptr_from_Vertex(v);
+             OpType type = op_ptr->get_type();
+             if (type == OpType::TK1) {
+               std::vector<Expr> tk1_angles =
+                   as_gate_ptr(op_ptr)->get_tk1_angles();
+               Circuit in_circ = CircPool::tk1_to_PhasedXRz(
+                   tk1_angles[0], tk1_angles[1], tk1_angles[2]);
+               remove_redundancies().apply(in_circ);
+               Subcircuit sub = {
+                   {circ.get_in_edges(v)}, {circ.get_all_out_edges(v)}, {v}};
+               bin.push_back(v);
+               circ.substitute(in_circ, sub, Circuit::VertexDeletion::No);
+               circ.add_phase(tk1_angles[3]);
+               success = true;
+             }
+           }
+           circ.remove_vertices(
+               bin, Circuit::GraphRewiring::No, Circuit::VertexDeletion::Yes);
+           return success;
+         }) >>
+         rebase_UMD() >> remove_redundancies();
 }
 
 }  // namespace Transforms

--- a/tket/src/Transformations/OptimisationPass.cpp
+++ b/tket/src/Transformations/OptimisationPass.cpp
@@ -78,7 +78,7 @@ Transform synthesise_tket() {
   Transform small_part = remove_redundancies() >> rep >> squash_1qb_to_tk1();
   Transform repeat_synth = repeat_with_metric(
       small_part, [](const Circuit &circ) { return circ.n_vertices(); });
-  return synth >> repeat_synth;
+  return synth >> repeat_synth >> rebase_tket() >> remove_redundancies();
 }
 
 static Transform CXs_from_phase_gadgets(CXConfigType cx_config) {

--- a/tket/src/Transformations/Rebase.cpp
+++ b/tket/src/Transformations/Rebase.cpp
@@ -18,6 +18,7 @@
 #include "Circuit/CircPool.hpp"
 #include "Circuit/CircUtils.hpp"
 #include "Gate/GatePtr.hpp"
+#include "OpType/OpType.hpp"
 #include "Replacement.hpp"
 #include "Transform.hpp"
 #include "Utils/TketLog.hpp"
@@ -154,6 +155,30 @@ Transform rebase_OQC() {
   return rebase_factory(
       {OpType::ECR, OpType::Rz, OpType::SX}, CircPool::CX_using_ECR(),
       CircPool::tk1_to_rzsx);
+}
+
+// Multiqs: ZZMax
+// Singleqs: Rz, PhasedX
+Transform rebase_HQS() {
+  return rebase_factory(
+      {OpType::ZZMax, OpType::Rz, OpType::PhasedX}, CircPool::CX_using_ZZMax(),
+      CircPool::tk1_to_PhasedXRz);
+}
+
+// Multiqs: TK2
+// Singleqs: TK1
+Transform rebase_TK() {
+  return rebase_factory(
+      {OpType::TK2, OpType::TK1}, CircPool::CX_using_TK2(),
+      CircPool::tk1_to_tk1);
+}
+
+// Multiqs: XXPhase
+// Singleqs: Rz, PhasedX
+Transform rebase_UMD() {
+  return rebase_factory(
+      {OpType::XXPhase, OpType::Rz, OpType::PhasedX},
+      CircPool::CX_using_XXPhase_0(), CircPool::tk1_to_PhasedXRz);
 }
 
 }  // namespace Transforms

--- a/tket/src/Transformations/include/Transformations/Rebase.hpp
+++ b/tket/src/Transformations/include/Transformations/Rebase.hpp
@@ -58,6 +58,18 @@ Transform rebase_UFR();
 // Singleqs: Rz, SX
 Transform rebase_OQC();
 
+// Multiqs: ZZMax
+// Singleqs: Rz, PhasedX
+Transform rebase_HQS();
+
+// Multiqs: TK2
+// Singleqs: TK1
+Transform rebase_TK();
+
+// Multiqs: XXPhase
+// Singleqs: Rz, PhasedX
+Transform rebase_UMD();
+
 }  // namespace Transforms
 
 }  // namespace tket


### PR DESCRIPTION
Fixes #394 .

Simply append a rebase and redundancy-removal to the end of the passes in question. (Rebases do handle conditionals correctly.)

As well as the `GateSetPredicate`, the `MaxTwoQubitGates` postcondition was also failing. I've added tests to ensure all postconditions are satisfied for circuits containing conditional gates and three-qubit gates.