### PR TITLE
Require "changes".

### DIFF
--- a/.github/workflows/test_libs.yml
+++ b/.github/workflows/test_libs.yml
@@ -170,7 +170,7 @@ jobs:
         fi
   publish_coverage:
     name: Publish coverage
-    needs: generate_coverage
+    needs: [changes, generate_coverage]
     if: ${{ github.event_name == 'push' && needs.changes.outputs.libs != '[]' && needs.changes.outputs.libs != '' }}
     strategy:
       matrix:


### PR DESCRIPTION
This fixes one problem but not the main issues, which I am stil trying tol debug.

What I can't understand is why the build-and-test workflows are succeeding here but not on push to develop. My only idea at the moment is that we are being throttled by the artifactory for exceeding our usage limits...

Let's see if it happens again when this is merged?