### PR TITLE
Minor clean-up

### DIFF
--- a/recipes/tket/conanfile.py
+++ b/recipes/tket/conanfile.py
@@ -50,7 +50,6 @@ class TketConan(ConanFile):
     comps = [
         "WeightSubgrMono",
         "Utils",
-        "PlacementWithWSM",
         "ZX",
         "OpType",
         "Clifford",
@@ -62,7 +61,6 @@ class TketConan(ConanFile):
         "Architecture",
         "Simulation",
         "Diagonalisation",
-        "Program",
         "Characterisation",
         "Converters",
         "Mapping",

--- a/recipes/tket/test_package/CMakeLists.txt
+++ b/recipes/tket/test_package/CMakeLists.txt
@@ -32,11 +32,4 @@ include_directories(${CONAN_INCLUDE_DIRS_TKET})
 
 add_executable(test test.cpp)
 
-target_link_libraries(test PRIVATE
-    tket-Circuit
-    tket-Gate
-    tket-OpType
-    tket-Transformations
-    tket-Utils)
-
-target_link_libraries(test PRIVATE ${CONAN_LIBS_SYMENGINE} tklog tkassert)
+target_link_libraries(test PRIVATE ${CONAN_LIBS})


### PR DESCRIPTION
* Remove obsolete components from tket conanfile.
* Make the test program link to everything: this saves having to edit the dependency list whenever one wants to change the program, e.g. for debugging an issue.