### PR TITLE
Improvements to `phase_poly_synthesis()`

### DIFF
--- a/tket/src/ArchAwareSynth/Path.cpp
+++ b/tket/src/ArchAwareSynth/Path.cpp
@@ -169,7 +169,11 @@ std::vector<Node> find_hampath(const Architecture &arch, long timeout) {
       undirected_pattern, undirected_target, 1, timeout);
 
   /* Architecture has no hampath, sad. */
-  if (all_maps.empty()) return {};
+  if (all_maps.empty()) {
+    throw NoHamiltonPath(
+        "[AAS]: no Hamilton path found in the given architecture, CNOT "
+        "synthesis stopped. Please try an alternative CNotSynthType.");
+  }
 
   /* Left: line, Right: input architecture. */
   const qubit_bimap_t &qmap = all_maps[0];

--- a/tket/src/ArchAwareSynth/SteinerForest.cpp
+++ b/tket/src/ArchAwareSynth/SteinerForest.cpp
@@ -14,6 +14,7 @@
 
 #include "SteinerForest.hpp"
 
+#include <algorithm>
 #include <vector>
 
 #include "Architecture/Architecture.hpp"
@@ -395,7 +396,11 @@ class PhasePolySynthesizer {
 
   Circuit get_result_using_hampath() {
     std::vector<Node> hampath = find_hampath(arch);  // using default timeout
-    return get_result_from_hampath(hampath);
+    Circuit c0 = get_result_from_hampath(hampath);
+    // Sometimes the reversed path gives a better circuit. Try both!
+    std::reverse(hampath.begin(), hampath.end());
+    Circuit c1 = get_result_from_hampath(hampath);
+    return (c0.depth() < c1.depth()) ? c0 : c1;
   }
 
   Circuit get_result_standard() {

--- a/tket/src/ArchAwareSynth/SteinerForest.cpp
+++ b/tket/src/ArchAwareSynth/SteinerForest.cpp
@@ -353,7 +353,10 @@ Circuit phase_poly_synthesis(
 
   PhasePolyBox placed_ppb(circuit_ppb_place);
 
-  std::vector<Node> hampath = find_hampath(arch);  // using default timeout
+  std::vector<Node> hampath;
+  if (cnottype == CNotSynthType::HamPath) {
+    hampath = find_hampath(arch);  // using default timeout
+  }
 
   // create maps from qubits/node to int
   std::map<UnitID, UnitID> forward_contiguous_uids_q;
@@ -364,12 +367,6 @@ Circuit phase_poly_synthesis(
   // calculate iteration order
   std::vector<Node> node_order;
   IterationOrder iter_order(arch);
-
-  if ((hampath.empty()) && (cnottype == CNotSynthType::HamPath)) {
-    throw NoHamiltonPath(
-        "[AAS]: no Hamilton path found in the given architecture, CNOT "
-        "synthesis stopped. Please try an alternative CNotSynthType.");
-  }
 
   if ((cnottype == CNotSynthType::Rec) || (cnottype == CNotSynthType::SWAP)) {
     node_order = iter_order.get_iterationorder();

--- a/tket/src/ArchAwareSynth/SteinerForest.cpp
+++ b/tket/src/ArchAwareSynth/SteinerForest.cpp
@@ -14,6 +14,11 @@
 
 #include "SteinerForest.hpp"
 
+#include <vector>
+
+#include "Architecture/Architecture.hpp"
+#include "SteinerTree.hpp"
+
 namespace tket {
 namespace aas {
 
@@ -315,16 +320,8 @@ Circuit phase_poly_synthesis_int(
   return forest.synth_circuit >> cnot_circ.dagger();
 }
 
-Circuit phase_poly_synthesis(
-    const Architecture &arch, const PhasePolyBox &phasepolybox,
-    unsigned lookahead, CNotSynthType cnottype) {
-  // the aas code is implemented under the assumption that all qubits in the
-  // circuit are named from 0 to n. The same assumption was made for the nodes
-  // of the architecture. To make sure that this condition is fulfilled the
-  // qubits in the circuit and the architecture are renamed. The new names are
-  // reverted at the end of the aas procedure. The qubits and the nodes have
-  // the same name in the input.
-
+static PhasePolyBox make_placed_ppb(
+    const Architecture &arch, const PhasePolyBox &phasepolybox) {
   Circuit circuit_ppb_place(*phasepolybox.to_circuit());
 
   const std::string register_name = "surplus";
@@ -351,18 +348,31 @@ Circuit phase_poly_synthesis(
 
   circuit_ppb_place.rename_units(qubit_to_nodes_place);
 
-  PhasePolyBox placed_ppb(circuit_ppb_place);
+  return PhasePolyBox(circuit_ppb_place);
+}
 
-  // create maps from qubits/node to int
-  std::map<UnitID, UnitID> forward_contiguous_uids_q;
-  std::map<UnitID, UnitID> backward_contiguous_uids_n;
-  // extra map with node type needed for the creation of the architecture
-  std::map<UnitID, Node> unitid_to_int_nodes;
+class PhasePolySynthesizer {
+ public:
+  PhasePolySynthesizer(
+      const Architecture &arch, const PhasePolyBox &phasepolybox,
+      unsigned lookahead, CNotSynthType cnottype)
+      : arch(arch),
+        placed_ppb(make_placed_ppb(arch, phasepolybox)),
+        lookahead(lookahead),
+        cnottype(cnottype) {}
 
-  std::vector<Architecture::Connection> new_con;
+  Circuit get_result() {
+    return (cnottype == CNotSynthType::HamPath) ? get_result_using_hampath()
+                                                : get_result_standard();
+  }
 
-  if (cnottype == CNotSynthType::HamPath) {
-    std::vector<Node> hampath = find_hampath(arch);  // using default timeout
+ private:
+  Circuit get_result_from_hampath(const std::vector<Node> &hampath) {
+    // maps from qubits/node to int
+    std::map<UnitID, UnitID> forward_contiguous_uids_q;
+    std::map<UnitID, UnitID> backward_contiguous_uids_n;
+    // extra map with node type needed for the creation of the architecture
+    std::map<UnitID, Node> unitid_to_int_nodes;
     for (unsigned i = 0; i < hampath.size(); i++) {
       UnitID qu_no = UnitID(hampath[i]);
       Qubit q = Qubit(i);
@@ -372,15 +382,31 @@ Circuit phase_poly_synthesis(
       backward_contiguous_uids_n.insert({qu_no, n});
     }
     // define new arcitecture
+    std::vector<Architecture::Connection> new_con;
     for (auto pair : arch.get_all_edges_vec()) {
       new_con.push_back(
           {unitid_to_int_nodes[UnitID(pair.first)],
            unitid_to_int_nodes[UnitID(pair.second)]});
     }
-  } else {
+    Architecture con_arch(new_con);
+    return make_result_from_con_arch(
+        con_arch, forward_contiguous_uids_q, backward_contiguous_uids_n);
+  }
+
+  Circuit get_result_using_hampath() {
+    std::vector<Node> hampath = find_hampath(arch);  // using default timeout
+    return get_result_from_hampath(hampath);
+  }
+
+  Circuit get_result_standard() {
     // calculate iteration order
     IterationOrder iter_order(arch);
     std::vector<Node> node_order = iter_order.get_iterationorder();
+    // maps from qubits/node to int
+    std::map<UnitID, UnitID> forward_contiguous_uids_q;
+    std::map<UnitID, UnitID> backward_contiguous_uids_n;
+    // extra map with node type needed for the creation of the architecture
+    std::map<UnitID, Node> unitid_to_int_nodes;
     for (unsigned i = 0; i < node_order.size(); i++) {
       // convert node to superclass type of qubit/node
       UnitID qu_no = UnitID(node_order[i]);
@@ -391,29 +417,48 @@ Circuit phase_poly_synthesis(
       unitid_to_int_nodes.insert({qu_no, n});
     }
     // define new arcitecture: include only the tree edges
+    std::vector<Architecture::Connection> new_con;
     for (auto pair : iter_order.get_edgelist()) {
       new_con.push_back(
           {unitid_to_int_nodes[UnitID(pair.first)],
            unitid_to_int_nodes[UnitID(pair.second)]});
     }
+    Architecture con_arch(new_con);
+    return make_result_from_con_arch(
+        con_arch, forward_contiguous_uids_q, backward_contiguous_uids_n);
   }
 
-  Architecture con_arch = Architecture(new_con);
+  Circuit make_result_from_con_arch(
+      const Architecture &con_arch,
+      const std::map<UnitID, UnitID> &forward_contiguous_uids_q,
+      const std::map<UnitID, UnitID> &backward_contiguous_uids_n) {
+    // define new phase poly box
+    Circuit circuit_ppb(*placed_ppb.to_circuit());
+    // the aas code is implemented under the assumption that all qubits in the
+    // circuit are named from 0 to n. The same assumption was made for the nodes
+    // of the architecture. To make sure that this condition is fulfilled the
+    // qubits in the circuit and the architecture are renamed. The new names are
+    // reverted at the end of the aas procedure. The qubits and the nodes have
+    // the same name in the input.
+    circuit_ppb.rename_units(backward_contiguous_uids_n);
+    PhasePolyBox new_ppb(circuit_ppb);
+    Circuit result =
+        phase_poly_synthesis_int(con_arch, new_ppb, lookahead, cnottype);
+    result.rename_units(forward_contiguous_uids_q);
+    return result;
+  }
 
-  // define new phase poly box
-  Circuit circuit_ppb(*placed_ppb.to_circuit());
+  Architecture arch;
+  PhasePolyBox placed_ppb;
+  unsigned lookahead;
+  CNotSynthType cnottype;
+};
 
-  circuit_ppb.rename_units(backward_contiguous_uids_n);
-
-  PhasePolyBox new_ppb(circuit_ppb);
-
-  Circuit result =
-      phase_poly_synthesis_int(con_arch, new_ppb, lookahead, cnottype);
-
-  // revert rename of the result
-  result.rename_units(forward_contiguous_uids_q);
-
-  return result;
+Circuit phase_poly_synthesis(
+    const Architecture &arch, const PhasePolyBox &phasepolybox,
+    unsigned lookahead, CNotSynthType cnottype) {
+  PhasePolySynthesizer pps(arch, phasepolybox, lookahead, cnottype);
+  return pps.get_result();
 }
 
 }  // namespace aas

--- a/tket/src/ArchAwareSynth/include/ArchAwareSynth/Path.hpp
+++ b/tket/src/ArchAwareSynth/include/ArchAwareSynth/Path.hpp
@@ -23,6 +23,12 @@ namespace aas {
 typedef Eigen::Matrix<unsigned, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>
     MatrixXu;
 
+class NoHamiltonPath : public std::logic_error {
+ public:
+  explicit NoHamiltonPath(const std::string &message)
+      : std::logic_error(message) {}
+};
+
 /**
  *  Holds distances & paths between nodes -- can optionally remove edges to form
  * a tree.
@@ -124,13 +130,13 @@ class IterationOrder {
 };
 
 /**
- * Find a Hamiltonian path in the architecture. Returns {} if no
- * Hamiltonian path is found within timeout. Timeout is in ms.
+ * Find a Hamiltonian path in the architecture. Timeout is in ms.
  *
  * @param arch architecture where the path is searched
  * @param timeout give the timeout for the search of the hamiltonpath,
  *                  default value is 10000
  * @return ordered vector of nodes in the path
+ * @throws NoHamiltonPath if no Hamiltonian path is found within timeout
  */
 std::vector<Node> find_hampath(const Architecture &arch, long timeout = 10000);
 

--- a/tket/src/ArchAwareSynth/include/ArchAwareSynth/Path.hpp
+++ b/tket/src/ArchAwareSynth/include/ArchAwareSynth/Path.hpp
@@ -132,6 +132,10 @@ class IterationOrder {
 /**
  * Find a Hamiltonian path in the architecture. Timeout is in ms.
  *
+ * The architecture is always treated as undirected, i.e. the path may traverse
+ * a connection in either direction even if only one direction is specified in
+ * the architecture.
+ *
  * @param arch architecture where the path is searched
  * @param timeout give the timeout for the search of the hamiltonpath,
  *                  default value is 10000

--- a/tket/src/ArchAwareSynth/include/ArchAwareSynth/SteinerForest.hpp
+++ b/tket/src/ArchAwareSynth/include/ArchAwareSynth/SteinerForest.hpp
@@ -29,12 +29,6 @@ typedef std::vector<CostedTrees> TrialCostedTrees;
 typedef std::list<unsigned> ParityList;
 typedef std::pair<unsigned, OperationList> CostedOperations;
 
-class NoHamiltonPath : public std::logic_error {
- public:
-  explicit NoHamiltonPath(const std::string &message)
-      : std::logic_error(message) {}
-};
-
 /**
  * Represents a series of sequential operations on an architecture,
  * each of which are represented by Steiner trees. The prototypical

--- a/tket/tests/test_Path.cpp
+++ b/tket/tests/test_Path.cpp
@@ -779,8 +779,7 @@ SCENARIO("Check Hamiltonian path construction is correct") {
   GIVEN("3 edge star Architecture") {
     Architecture arch(
         {{Node(0), Node(1)}, {Node(1), Node(2)}, {Node(1), Node(3)}});
-    std::vector<Node> ham = aas::find_hampath(arch);
-    REQUIRE(ham.empty());
+    REQUIRE_THROWS_AS(aas::find_hampath(arch), aas::NoHamiltonPath);
   }
   GIVEN("5 edge cycle Architecture") {
     Architecture arch(
@@ -798,8 +797,7 @@ SCENARIO("Check Hamiltonian path construction is correct") {
          {Node(0), Node(3)},
          {Node(0), Node(4)},
          {Node(0), Node(5)}});
-    std::vector<Node> ham = aas::find_hampath(arch);
-    REQUIRE(ham.empty());
+    REQUIRE_THROWS_AS(aas::find_hampath(arch), aas::NoHamiltonPath);
   }
   GIVEN("8 edge line Architecture") {
     Architecture arch(


### PR DESCRIPTION
- Refactor `phase_poly_synthesis()` so that it makes use of a helper class.
- Don't call `find_hampath()` unless we need to.
- When we do need to find a Hamiltonian path, construct two circuits from it, one with the path reversed, and select the circuit of lower depth.

Fixes #412 .