### PR TITLE
Run `normalise_TK2()` before `decompose_TK2()`.

### DIFF
--- a/pytket/docs/changelog.rst
+++ b/pytket/docs/changelog.rst
@@ -11,6 +11,10 @@ Minor new features:
 * Circuit to QASM converters with the "hqslib1" header now fix ZZPhase angles
   to be between -1 and 1 half-turns.
 
+Fixes:
+
+* Ensure TK2 angles are normalised before decomposing TK2 gates in passes.
+
 1.3.0 (June 2022)
 -----------------
 

--- a/tket/src/Transformations/BasicOptimisation.cpp
+++ b/tket/src/Transformations/BasicOptimisation.cpp
@@ -281,7 +281,8 @@ static bool replace_two_qubit_interaction(
   // should output TK2, and decompose to CX (or other gates) later if necessary.
   TwoQbFidelities fid;
   fid.CX_fidelity = cx_fidelity;
-  (decompose_TK2(fid) >> squash_1qb_to_tk1()).apply(replacement);
+  (normalise_TK2() >> decompose_TK2(fid) >> squash_1qb_to_tk1())
+      .apply(replacement);
   const int nb_cx_old = subc.count_gates(OpType::CX);
   const int nb_cx_new = replacement.count_gates(OpType::CX);
   if (nb_cx_new < nb_cx_old) {

--- a/tket/src/Transformations/ThreeQubitSquash.cpp
+++ b/tket/src/Transformations/ThreeQubitSquash.cpp
@@ -24,6 +24,7 @@
 #include <string>
 #include <tkassert/Assert.hpp>
 
+#include "BasicOptimisation.hpp"
 #include "Circuit/CircUtils.hpp"
 #include "Circuit/Circuit.hpp"
 #include "Circuit/DAGDefs.hpp"
@@ -119,6 +120,7 @@ static Circuit candidate_sub(const Circuit &circ) {
     // TODO: for now we decompose all the way to CX. In the future, it's worth
     // considering keeping TK2, and decomposing to CX (or other gates) later
     // when necessary.
+    normalise_TK2().apply(repl);
     decompose_TK2().apply(repl);
     clifford_simp(false).apply(repl);
     return repl;

--- a/tket/src/Transformations/include/Transformations/Decomposition.hpp
+++ b/tket/src/Transformations/include/Transformations/Decomposition.hpp
@@ -124,6 +124,9 @@ struct TwoQbFidelities {
  * decompositions for arbitrary symbolic parameters, so consider substituting
  * for concrete values if possible.
  *
+ * All TK2 angles must be normalised to the Weyl chamber. This can be achieved
+ * using the \ref normalise_TK2 transform.
+ *
  * @param fid The two-qubit gate fidelities (optional).
  * @return Transform
  */


### PR DESCRIPTION
Fixes #418 .