### PR TITLE
[test] Use --decisions flag for gcovr while generating tket coverage report

### DIFF
--- a/.github/workflows/compare-coverage
+++ b/.github/workflows/compare-coverage
@@ -24,8 +24,8 @@
 # functions: 100.0% (10 out of 10)
 # branches: 46.4% (23147 out of 49885)
 #
-# Returns status 0 if `file1` is at least as good as `file` on the "lines" score,
-# otherwise returns status 1.
+# Returns status 0 if `file1` is at least as good as `file` on the "lines" score
+# and the "functions" score, otherwise returns status 1.
 
 import sys
 
@@ -62,10 +62,13 @@ def compare(summary, summary1):
     # control.
     # TODO: Maybe use the `--decisions` flag (available in gcovr 5.1) to mitigate this
     # issue, but this seems to throw an error.
-    # TODO: Take account of function coverage
     if lpercent1 < lpercent:
         print("Percentage line coverage has decreased.")
         exit(1)
+    if fpercent1 < fpercent:
+        print("Percentage function coverage has decreased.")
+        exit(1)
+
 
 
 if __name__ == "__main__":

--- a/.github/workflows/compare-coverage
+++ b/.github/workflows/compare-coverage
@@ -58,15 +58,14 @@ def compare(summary, summary1):
     lpercent, fpercent, bpercent = get_percentages(summary)
     lpercent1, fpercent1, bpercent1 = get_percentages(summary1)
 
-    # Ignore branch coverage since it includes compiler-generated branches beyond our
-    # control.
-    # TODO: Maybe use the `--decisions` flag (available in gcovr 5.1) to mitigate this
-    # issue, but this seems to throw an error.
     if lpercent1 < lpercent:
         print("Percentage line coverage has decreased.")
         exit(1)
     if fpercent1 < fpercent:
         print("Percentage function coverage has decreased.")
+        exit(1)
+    if bpercent1 < bpercent:
+        print("Percentage branch coverage has decreased.")
         exit(1)
 
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -30,6 +30,7 @@ jobs:
         filters: |
           tket:
             - 'tket/**'
+            - '.github/workflows/coverage.yml'
 
   generate_coverage:
     name: Generate coverage report
@@ -104,7 +105,7 @@ jobs:
     - name: Build coverage report
       run: |
         mkdir test-coverage
-        gcovr --print-summary --html --html-details -r ./tket/src/ --exclude-lines-by-pattern '.*\bTKET_ASSERT\(.*\);' --object-directory ${PWD}/build/tket/ -o test-coverage/index.html > test-coverage/summary.txt
+        gcovr --print-summary --html --html-details -r ./tket/src/ --exclude-lines-by-pattern '.*\bTKET_ASSERT\(.*\);' --object-directory ${PWD}/build/tket/ -o test-coverage/index.html --decisions -v > test-coverage/summary.txt
     - name: Upload artefact
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -112,11 +112,11 @@ jobs:
     - name: Build publishable coverage report
       run: |
         mkdir test-coverage
-        gcovr --print-summary --html --html-details -r ./tket/src/ --exclude-lines-by-pattern '.*\bTKET_ASSERT\(.*\);' --object-directory ${PWD}/build/tket/ -o test-coverage/index.html > test-coverage/summary.txt
+        gcovr --print-summary --html --html-details -r ./tket/src/ --exclude-lines-by-pattern '.*\bTKET_ASSERT\(.*\);' --object-directory ${PWD}/build/tket/ -o test-coverage/index.html --gcov-executable gcov-10 > test-coverage/summary.txt
         cat test-coverage/summary.txt
     - name: Build coverage report
       run: |
-        gcovr --print-summary --html --html-details -r ./tket/src/ --exclude-lines-by-pattern '.*\bTKET_ASSERT\(.*\);' --object-directory ${PWD}/build/tket/ -o test-coverage/index.html --decisions --gcov-executable gcov-10 > test-coverage/summary-decisions.txt
+        gcovr --print-summary -r ./tket/src/ --exclude-lines-by-pattern '.*\bTKET_ASSERT\(.*\);' --object-directory ${PWD}/build/tket/ --decisions --gcov-executable gcov-10 > test-coverage/summary-decisions.txt
         cat test-coverage/summary-decisions.txt
     - name: Upload artefact
       uses: actions/upload-artifact@v3

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -45,7 +45,13 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: '0'
+        persist-credentials: false
     - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
+    - name: checkout gcovr repo
+      uses: actions/checkout@v2
+      with:
+        repository: gcovr/gcovr.git
+        token: ${{ secrets.GITHUB_TOKEN }}
     - name: Get current time
       uses: srfrnk/current-time@v1.1.0
       id: current_time
@@ -101,11 +107,11 @@ jobs:
       working-directory: ./build/tket-tests/package/bin
       run: ./test_tket "[long],~[long]"
     - name: Install gcovr
-      run: pip install gcovr~=5.1
+      run: pip install -e gcovr/
     - name: Build coverage report
       run: |
         mkdir test-coverage
-        gcovr --print-summary --html --html-details -r ./tket/src/ --exclude-lines-by-pattern '.*\bTKET_ASSERT\(.*\);' --object-directory ${PWD}/build/tket/ -o test-coverage/index.html --decisions -v > test-coverage/summary.txt
+        gcovr --print-summary --html --html-details -r ./tket/src/ --exclude-lines-by-pattern '.*\bTKET_ASSERT\(.*\);' --object-directory ${PWD}/build/tket/ -o test-coverage/index.html --decisions -v --gcov-executable gcov-10 > test-coverage/summary.txt
     - name: Upload artefact
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -103,15 +103,11 @@ jobs:
       run: ./test_tket "[long],~[long]"
     - name: Install gcovr
       run: pip install gcovr~=5.2
-    - name: Build publishable coverage report
-      run: |
-        mkdir test-coverage
-        gcovr --print-summary --html --html-details -r ./tket/src/ --exclude-lines-by-pattern '.*\bTKET_ASSERT\(.*\);' --object-directory ${PWD}/build/tket/ -o test-coverage/index.html > test-coverage/summary.txt
-        cat test-coverage/summary.txt
     - name: Build coverage report
       run: |
-        gcovr --print-summary -r ./tket/src/ --exclude-lines-by-pattern '.*\bTKET_ASSERT\(.*\);' --object-directory ${PWD}/build/tket/ --decisions > test-coverage/summary-decisions.txt
-        cat test-coverage/summary-decisions.txt
+        mkdir test-coverage
+        gcovr --print-summary --html --html-details -r ./tket/src/ --exclude-lines-by-pattern '.*\bTKET_ASSERT\(.*\);' --object-directory ${PWD}/build/tket/ -o test-coverage/index.html --decisions > test-coverage/summary.txt
+        cat test-coverage/summary.txt
     - name: Upload artefact
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -47,12 +47,6 @@ jobs:
         fetch-depth: '0'
         persist-credentials: false
     - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
-    - name: checkout gcovr repo
-      uses: actions/checkout@v2
-      with:
-        repository: gcovr/gcovr
-        token: ${{ secrets.GH_PAT }}
-        path: gcovr
     - name: Get current time
       uses: srfrnk/current-time@v1.1.0
       id: current_time
@@ -108,7 +102,7 @@ jobs:
       working-directory: ./build/tket-tests/package/bin
       run: ./test_tket "[long],~[long]"
     - name: Install gcovr
-      run: pip install -e gcovr/
+      run: pip install gcovr~=5.2
     - name: Build publishable coverage report
       run: |
         mkdir test-coverage

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -112,11 +112,11 @@ jobs:
     - name: Build publishable coverage report
       run: |
         mkdir test-coverage
-        gcovr --print-summary --html --html-details -r ./tket/src/ --exclude-lines-by-pattern '.*\bTKET_ASSERT\(.*\);' --object-directory ${PWD}/build/tket/ -o test-coverage/index.html --gcov-executable gcov-10 > test-coverage/summary.txt
+        gcovr --print-summary --html --html-details -r ./tket/src/ --exclude-lines-by-pattern '.*\bTKET_ASSERT\(.*\);' --object-directory ${PWD}/build/tket/ -o test-coverage/index.html > test-coverage/summary.txt
         cat test-coverage/summary.txt
     - name: Build coverage report
       run: |
-        gcovr --print-summary -r ./tket/src/ --exclude-lines-by-pattern '.*\bTKET_ASSERT\(.*\);' --object-directory ${PWD}/build/tket/ --decisions --gcov-executable gcov-10 > test-coverage/summary-decisions.txt
+        gcovr --print-summary -r ./tket/src/ --exclude-lines-by-pattern '.*\bTKET_ASSERT\(.*\);' --object-directory ${PWD}/build/tket/ --decisions > test-coverage/summary-decisions.txt
         cat test-coverage/summary-decisions.txt
     - name: Upload artefact
       uses: actions/upload-artifact@v3

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -45,7 +45,6 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: '0'
-        persist-credentials: false
     - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
     - name: Get current time
       uses: srfrnk/current-time@v1.1.0

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -116,7 +116,6 @@ jobs:
         cat test-coverage/summary.txt
     - name: Build coverage report
       run: |
-        mkdir test-coverage
         gcovr --print-summary --html --html-details -r ./tket/src/ --exclude-lines-by-pattern '.*\bTKET_ASSERT\(.*\);' --object-directory ${PWD}/build/tket/ -o test-coverage/index.html --decisions --gcov-executable gcov-10 > test-coverage/summary-decisions.txt
         cat test-coverage/summary-decisions.txt
     - name: Upload artefact

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -50,8 +50,9 @@ jobs:
     - name: checkout gcovr repo
       uses: actions/checkout@v2
       with:
-        repository: gcovr/gcovr.git
-        token: ${{ secrets.GITHUB_TOKEN }}
+        repository: gcovr/gcovr
+        token: ${{ secrets.GH_PAT }}
+        path: gcovr
     - name: Get current time
       uses: srfrnk/current-time@v1.1.0
       id: current_time

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -109,10 +109,16 @@ jobs:
       run: ./test_tket "[long],~[long]"
     - name: Install gcovr
       run: pip install -e gcovr/
+    - name: Build publishable coverage report
+      run: |
+        mkdir test-coverage
+        gcovr --print-summary --html --html-details -r ./tket/src/ --exclude-lines-by-pattern '.*\bTKET_ASSERT\(.*\);' --object-directory ${PWD}/build/tket/ -o test-coverage/index.html > test-coverage/summary.txt
+        cat test-coverage/summary.txt
     - name: Build coverage report
       run: |
         mkdir test-coverage
-        gcovr --print-summary --html --html-details -r ./tket/src/ --exclude-lines-by-pattern '.*\bTKET_ASSERT\(.*\);' --object-directory ${PWD}/build/tket/ -o test-coverage/index.html --decisions -v --gcov-executable gcov-10 > test-coverage/summary.txt
+        gcovr --print-summary --html --html-details -r ./tket/src/ --exclude-lines-by-pattern '.*\bTKET_ASSERT\(.*\);' --object-directory ${PWD}/build/tket/ -o test-coverage/index.html --decisions --gcov-executable gcov-10 > test-coverage/summary-decisions.txt
+        cat test-coverage/summary-decisions.txt
     - name: Upload artefact
       uses: actions/upload-artifact@v3
       with:


### PR DESCRIPTION
The latest release of [gcovr](https://github.com/gcovr/gcovr/releases/tag/5.2) fixes the issue observed when using the `--decisions` flag in the tket code base. Also, it seems the line coverage is now correctly calculated. This PR then enables the use of the `--decisions` flag with `gcovr` for creating the coverage report, and the check done in `compare-coverage` against the branches score reported.