### PR TITLE
Add workflow to upload tket package to conan

### DIFF
--- a/.github/workflows/publish_tket_package.yml
+++ b/.github/workflows/publish_tket_package.yml
@@ -70,8 +70,8 @@ jobs:
       run: |
         $${{ matrix.lib }}_ver = conan inspect --raw version recipes/tket/conanfile.py
         echo "LIB_VER=${${{ matrix.lib }}_ver}" >> $env:GITHUB_ENV
-    - name: upload package (dry run)
-      run: conan upload tket/${{ env.LIB_VER }}@tket/stable --all -r=tket-conan --skip-upload
+    - name: upload package
+      run: conan upload tket/${{ env.LIB_VER }}@tket/stable --all -r=tket-conan
 
   macos_m1:
     name: build and publish tket (MacOS M1)
@@ -101,5 +101,5 @@ jobs:
       run: |
         lib_ver=$(conan inspect --raw version recipes/tket/conanfile.py)
         echo "LIB_VER=${lib_ver}" >> $GITHUB_ENV
-    - name: upload package (dry run)
-      run: conan upload tket/${{ env.LIB_VER }}@tket/stable --all -r=tket-conan --skip-upload
+    - name: upload package
+      run: conan upload tket/${{ env.LIB_VER }}@tket/stable --all -r=tket-conan

--- a/.github/workflows/publish_tket_package.yml
+++ b/.github/workflows/publish_tket_package.yml
@@ -1,0 +1,98 @@
+name: Publish tket package
+
+on:
+  push:
+    branches:
+      - 'package/**'
+
+jobs:
+  build_and_publish:
+    name: build and publish tket
+    strategy:
+      matrix:
+        os: ['ubuntu-20.04', 'macos-11', 'windows-2019']
+        build_type: ['Release', 'Debug']
+        shared: ['True', 'False']
+    runs-on: ${{ matrix.os }}
+    env:
+      CONAN_REVISIONS_ENABLED: 1
+    steps:
+    - uses: actions/checkout@v3
+    - name: normalize line endings in conanfile and src directory
+      if: matrix.os == 'windows-2019'
+      # This is necessary to ensure consistent revisions across platforms.
+      # Conan's revision hash is composed of hashes all the exported files, so
+      # we must normalize the line endings in these.
+      run: |
+        $conanfile ='recipes/tket/conanfile.py'
+        $normalized_file = [IO.File]::ReadAllText($conanfile) -replace "`r`n", "`n"
+        [IO.File]::WriteAllText($conanfile, $normalized_file)
+        $src_files = Get-ChildItem "tket/src" -File -Recurse
+        foreach ($f in $src_files) {
+          $normalized_file = [IO.File]::ReadAllText($f) -replace "`r`n", "`n"
+          [IO.File]::WriteAllText($f, $normalized_file)
+        }
+    - name: set compiler
+      if: matrix.os == 'ubuntu-20.04'
+      run: |
+        sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 100
+        sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 100
+        sudo update-alternatives --set gcc /usr/bin/gcc-10
+        sudo update-alternatives --set g++ /usr/bin/g++-10
+    - name: Set up Python 3.9
+      uses: actions/setup-python@v3
+      with:
+        python-version: '3.9'
+    - name: install conan
+      run: pip install conan
+    - name: create profile
+      run: conan profile new tket --detect
+    - name: set libcxx
+      if: matrix.os == 'ubuntu-20.04'
+      run: conan profile update settings.compiler.libcxx=libstdc++11 tket
+    - name: add remote
+      run: conan remote add tket-conan https://tket.jfrog.io/artifactory/api/conan/tket-conan
+    - name: build tket
+      run: conan create --profile=tket -s build_type=${{ matrix.build_type }} -o tket:shared=${{ matrix.shared }} recipes/tket tket/stable --build=missing
+    - name: authenticate to repository
+      run: conan user -p ${{ secrets.JFROG_ARTIFACTORY_TOKEN_1 }} -r tket-conan ${{ secrets.JFROG_ARTIFACTORY_USER_1 }}
+    - name: get version
+      if: matrix.os != 'windows-2019'
+      run: |
+        lib_ver=$(conan inspect --raw version recipes/tket/conanfile.py)
+        echo "LIB_VER=${lib_ver}" >> $GITHUB_ENV
+    - name: get version
+      if: matrix.os == 'windows-2019'
+      run: |
+        $${{ matrix.lib }}_ver = conan inspect --raw version recipes/tket/conanfile.py
+        echo "LIB_VER=${${{ matrix.lib }}_ver}" >> $env:GITHUB_ENV
+    - name: upload package (dry run)
+      run: conan upload tket/${{ env.LIB_VER }}@tket/stable --all -r=tket-conan --skip-upload
+
+  macos_m1:
+    name: build and publish tket (MacOS M1)
+    strategy:
+      matrix:
+        build_type: ['Release', 'Debug']
+        shared: ['True', 'False']
+    runs-on: [self-hosted, macos, M1]
+    env:
+      CONAN_REVISIONS_ENABLED: 1
+    steps:
+    - uses: actions/checkout@v3
+    - name: install conan
+      run: pip install conan
+    - name: create profile
+      run: conan profile new tket --detect --force
+    - name: add remote
+      run: conan remote add tket-conan https://tket.jfrog.io/artifactory/api/conan/tket-conan --force
+    - name: build tket
+      run: conan create --profile=tket -s build_type=${{ matrix.build_type }} -o tket:shared=${{ matrix.shared }} recipes/tket tket/stable --build=missing
+    - name: authenticate to repository
+      run: conan user -p ${{ secrets.JFROG_ARTIFACTORY_TOKEN_1 }} -r tket-conan ${{ secrets.JFROG_ARTIFACTORY_USER_1 }}
+    - name: get version
+      run: |
+        lib_ver=$(conan inspect --raw version recipes/tket/conanfile.py)
+        echo "LIB_VER=${lib_ver}" >> $GITHUB_ENV
+    - name: upload package (dry run)
+      run: conan upload tket/${{ env.LIB_VER }}@tket/stable --all -r=tket-conan --skip-upload

--- a/.github/workflows/publish_tket_package.yml
+++ b/.github/workflows/publish_tket_package.yml
@@ -13,6 +13,10 @@ jobs:
         os: ['ubuntu-20.04', 'macos-11', 'windows-2019']
         build_type: ['Release', 'Debug']
         shared: ['True', 'False']
+        exclude:
+          - os: 'macos-11'
+            build_type: 'Debug'
+            shared: 'True'
     runs-on: ${{ matrix.os }}
     env:
       CONAN_REVISIONS_ENABLED: 1
@@ -75,6 +79,9 @@ jobs:
       matrix:
         build_type: ['Release', 'Debug']
         shared: ['True', 'False']
+        exclude:
+          - build_type: 'Debug'
+            shared: 'True'
     runs-on: [self-hosted, macos, M1]
     env:
       CONAN_REVISIONS_ENABLED: 1

--- a/recipes/tket/conanfile.py
+++ b/recipes/tket/conanfile.py
@@ -103,6 +103,7 @@ class TketConan(ConanFile):
         self.copy("*.lib", dst="lib", keep_path=False)
         self.copy("*.so", dst="lib", keep_path=False)
         self.copy("*.dylib", dst="lib", keep_path=False)
+        self.copy("*.a", dst="lib", keep_path=False)
 
     def package_info(self):
         self.cpp_info.libs = [f"tket-{comp}" for comp in self.comps]

--- a/recipes/tket/conanfile.py
+++ b/recipes/tket/conanfile.py
@@ -48,9 +48,9 @@ class TketConan(ConanFile):
         "tkwsm/0.1.0@tket/stable",
     )
 
+    # List of components in a topological sort according to dependencies:
     comps = [
         "Utils",
-        "ZX",
         "OpType",
         "Clifford",
         "Ops",
@@ -62,12 +62,13 @@ class TketConan(ConanFile):
         "Simulation",
         "Diagonalisation",
         "Characterisation",
+        "ZX",
         "Converters",
-        "Mapping",
         "Placement",
+        "ArchAwareSynth",
+        "Mapping",
         "MeasurementSetup",
         "Transformations",
-        "ArchAwareSynth",
         "Predicates",
     ]
 
@@ -106,4 +107,7 @@ class TketConan(ConanFile):
         self.copy("*.a", dst="lib", keep_path=False)
 
     def package_info(self):
-        self.cpp_info.libs = [f"tket-{comp}" for comp in self.comps]
+        # These must be ordered "top to bottom", so that when building statically
+        # unresolved symbols in libraries earlier in the list get resolved by later
+        # libraries.
+        self.cpp_info.libs = [f"tket-{comp}" for comp in reversed(self.comps)]


### PR DESCRIPTION
Workflow is triggered by a push to a branch called package/something.

Versions are built and uploaded for Linux, MacOS x86_64, MacOS arm64 and Windows; Release/Debug; static/shared. Exception: no package for MacOS (either architecture)/Debug/shared, because this causes an assertion failure in symengine when running the test program.

To see available configurations:
```shell
conan search tket/1.0.1@tket/stable -r tket-conan
```

The packages are being uploaded now: https://github.com/CQCL/tket/actions/runs/2589117597


