### PR TITLE
Catch tket exceptions

### DIFF
--- a/pytket/binders/circuit/main.cpp
+++ b/pytket/binders/circuit/main.cpp
@@ -19,6 +19,7 @@
 #include <sstream>
 
 #include "Circuit/Command.hpp"
+#include "Circuit/Circuit.hpp"
 #include "Gate/Gate.hpp"
 #include "Gate/OpPtrFunctions.hpp"
 #include "Gate/SymTable.hpp"
@@ -44,6 +45,12 @@ void init_library(py::module &m);
 
 PYBIND11_MODULE(circuit, m) {
   init_unitid(m);
+  py::register_exception<CircuitInequality>(m, "CircuitInequality");
+  py::register_exception<CircuitInvalidity>(m, "CircuitInvalidity");
+  py::register_exception<Unsupported>(m, "Unsupported");
+  py::register_exception<MissingVertex>(m, "MissingVertex");
+  py::register_exception<MissingEdge>(m, "MissingEdge");
+  py::register_exception<SimpleOnly>(m, "SimpleOnly");
   py::class_<Op, std::shared_ptr<Op>>(
       m, "Op", "Encapsulates operation information")
       .def_static(

--- a/pytket/tests/circuit_test.py
+++ b/pytket/tests/circuit_test.py
@@ -19,6 +19,12 @@ import pickle
 
 from pytket.circuit import (  # type: ignore
     Circuit,
+    CircuitInequality,
+    CircuitInvalidity,
+    Unsupported,
+    MissingVertex,
+    MissingEdge,
+    SimpleOnly,
     Op,
     OpType,
     Command,
@@ -61,6 +67,16 @@ curr_file_path = Path(__file__).resolve().parent
 
 with open(curr_file_path.parent.parent / "schemas/circuit_v1.json", "r") as f:
     schema = json.load(f)
+
+
+def test_exceptions() -> None:
+    c = Circuit(2)
+    with pytest.raises(CircuitInvalidity):
+        c.add_gate(OpType.Barrier, [0,1])
+    # with pytest.raises(Unsupported):
+    #     c2 = Circuit()
+    #     c2.add_c_register("q", 2)
+    #     c.append(c2)
 
 
 def test_op_free_symbols() -> None:


### PR DESCRIPTION
This PR adds functionality to catch `tket` exceptions in a more meaningful way in `pytket`.

Currently, exceptions in `tket` are `std::exception` that `pybind11` translates into `RuntimeError`. 
There is a larger spectrum of errors defined in individual modules. For instance [here](https://github.com/CQCL/tket/blob/df1b966350e151d31b2f66a4503db0dade75379a/tket/src/Circuit/include/Circuit/Circuit.hpp#L188) in the `Circuit` module. 