### PR TITLE
Add option to `Transforms.ThreeQubitSquash` to target TK2 gates

### DIFF
--- a/pytket/binders/transform.cpp
+++ b/pytket/binders/transform.cpp
@@ -327,8 +327,9 @@ PYBIND11_MODULE(transform, m) {
           py::arg("cx_fidelity") = 1.)
       .def_static(
           "ThreeQubitSquash", &Transforms::three_qubit_squash,
-          "Squash three-qubit subcircuits into subcircuits having fewer CX "
-          "gates, when possible.")
+          "Squash three-qubit subcircuits into subcircuits having fewer "
+          "2-qubit gates of the target type (default CX), when possible.",
+          py::arg("target_2q_gate") = OpType::CX)
       .def_static(
           "CommuteSQThroughSWAP",
           [](const avg_node_errors_t &avg_node_errors) {

--- a/pytket/binders/transform.cpp
+++ b/pytket/binders/transform.cpp
@@ -339,7 +339,8 @@ PYBIND11_MODULE(transform, m) {
       .def_static(
           "ThreeQubitSquash", &Transforms::three_qubit_squash,
           "Squash three-qubit subcircuits into subcircuits having fewer "
-          "2-qubit gates of the target type (default CX), when possible.",
+          "2-qubit gates of the target type, when possible. The supported "
+          "target types are CX (default) and TK2.",
           py::arg("target_2qb_gate") = OpType::CX)
       .def_static(
           "CommuteSQThroughSWAP",

--- a/pytket/binders/transform.cpp
+++ b/pytket/binders/transform.cpp
@@ -340,7 +340,7 @@ PYBIND11_MODULE(transform, m) {
           "ThreeQubitSquash", &Transforms::three_qubit_squash,
           "Squash three-qubit subcircuits into subcircuits having fewer "
           "2-qubit gates of the target type (default CX), when possible.",
-          py::arg("target_2q_gate") = OpType::CX)
+          py::arg("target_2qb_gate") = OpType::CX)
       .def_static(
           "CommuteSQThroughSWAP",
           [](const avg_node_errors_t &avg_node_errors) {

--- a/pytket/docs/changelog.rst
+++ b/pytket/docs/changelog.rst
@@ -1,7 +1,17 @@
 Changelog
 =========
 
-1.4.0 (July 2022)
+x.y.z (unreleased)
+------------------
+
+Minor new features:
+
+* ``Transform.ThreeQubitSquash()`` can now use TK2 gates as an alternative to CX
+  gates.
+* ``Unitary3qBox.get_circuit()`` decomposes the circuit using (at most 15) TK2
+  gates.
+
+1.4.1 (July 2022)
 -----------------
 
 Minor new features:

--- a/pytket/tests/backendinfo_test.py
+++ b/pytket/tests/backendinfo_test.py
@@ -165,6 +165,7 @@ def test_to_json() -> None:
 
 
 @given(st.backendinfo())
+@settings(deadline=None)
 def test_backendinfo_serialization(backinfo: BackendInfo) -> None:
     serializable = backinfo.to_dict()
     assert BackendInfo.from_dict(serializable) == backinfo

--- a/pytket/tests/backendinfo_test.py
+++ b/pytket/tests/backendinfo_test.py
@@ -19,7 +19,7 @@ than a dataclass
 
 from json import dumps, loads
 
-from hypothesis import given
+from hypothesis import given, settings
 import pytest  # type: ignore
 
 from pytket.backends.backendinfo import BackendInfo, fully_connected_backendinfo

--- a/pytket/tests/transform_test.py
+++ b/pytket/tests/transform_test.py
@@ -211,6 +211,15 @@ def test_three_qubit_squash() -> None:
     assert c.n_gates_of_type(OpType.CX) <= 14
 
 
+def test_three_qubit_squash_tk() -> None:
+    c = Circuit(3)
+    for i in range(50):
+        c.Rz(0.125, i % 3)
+        c.add_gate(OpType.TK2, [0.1, 0.2, 0.3], [(i + 2) % 3, (i + 1) % 3])
+    assert Transform.ThreeQubitSquash(OpType.TK2).apply(c)
+    assert c.n_gates_of_type(OpType.TK2) <= 15
+
+
 def test_basic_rebases() -> None:
     c = get_test_circuit()
     Transform.RebaseToTket().apply(c)

--- a/tket/src/Circuit/Boxes.cpp
+++ b/tket/src/Circuit/Boxes.cpp
@@ -183,7 +183,7 @@ Op_ptr Unitary3qBox::transpose() const {
 }
 
 void Unitary3qBox::generate_circuit() const {
-  circ_ = std::make_shared<Circuit>(three_qubit_synthesis(m_));
+  circ_ = std::make_shared<Circuit>(three_qubit_tk_synthesis(m_));
 }
 
 ExpBox::ExpBox(const Eigen::Matrix4cd &A, double t, BasisOrder basis)

--- a/tket/src/Circuit/include/Circuit/ThreeQubitConversion.hpp
+++ b/tket/src/Circuit/include/Circuit/ThreeQubitConversion.hpp
@@ -32,6 +32,18 @@ namespace tket {
 Circuit three_qubit_synthesis(const Eigen::MatrixXcd &U);
 
 /**
+ * Synthesise a 3-qubit circuit from an arbitrary 8x8 unitary.
+ *
+ * The returned circuit consists of TK2 and 1-qubit gates only. It contains a
+ * maximum of 15 TK2 gates.
+ *
+ * @param U unitary matrix in \ref BasisOrder::ilo
+ *
+ * @return circuit implementing the unitary
+ */
+Circuit three_qubit_tk_synthesis(const Eigen::MatrixXcd &U);
+
+/**
  * Convert a 3-qubit circuit to its corresponding unitary matrix.
  *
  * @param c pure quantum circuit with 3 qubits

--- a/tket/src/Circuit/include/Circuit/ThreeQubitConversion.hpp
+++ b/tket/src/Circuit/include/Circuit/ThreeQubitConversion.hpp
@@ -48,7 +48,7 @@ Circuit three_qubit_tk_synthesis(const Eigen::MatrixXcd &U);
  *
  * @param c pure quantum circuit with 3 qubits
  *
- * @pre \p c is composed of CX and single-qubit gates only
+ * @pre \p c is composed of 1- and 2-qubit gates only
  * @pre \p c has no symbolic parameters
  *
  * @return 8x8 unitary matrix in \ref BasisOrder::ilo

--- a/tket/src/Transformations/ThreeQubitSquash.cpp
+++ b/tket/src/Transformations/ThreeQubitSquash.cpp
@@ -119,15 +119,16 @@ static Circuit candidate_sub(const Circuit &circ, OpType target_2qb_gate) {
     return repl;
   } else {
     TKET_ASSERT(n_qb == 3);
+    Eigen::MatrixXcd U = get_3q_unitary(circ);
     if (target_2qb_gate == OpType::CX) {
-      Circuit repl = three_qubit_synthesis(get_3q_unitary(circ));
+      Circuit repl = three_qubit_synthesis(U);
       normalise_TK2().apply(repl);
       decompose_TK2().apply(repl);
       clifford_simp(false).apply(repl);
       return repl;
     } else {
       TKET_ASSERT(target_2qb_gate == OpType::TK2);
-      Circuit repl = three_qubit_tk_synthesis(get_3q_unitary(circ));
+      Circuit repl = three_qubit_tk_synthesis(U);
       squash_1qb_to_tk1().apply(repl);
       return repl;
     }

--- a/tket/src/Transformations/ThreeQubitSquash.cpp
+++ b/tket/src/Transformations/ThreeQubitSquash.cpp
@@ -108,22 +108,28 @@ class QInteraction {
 typedef std::unique_ptr<QInteraction> iptr;
 
 // Candidate substitution for a 2- or 3-qubit circuit.
-static Circuit candidate_sub(const Circuit &circ) {
+static Circuit candidate_sub(const Circuit &circ, OpType target_2q_gate) {
   unsigned n_qb = circ.n_qubits();
   if (n_qb == 2) {
     Circuit repl = two_qubit_canonical(get_matrix_from_2qb_circ(circ));
-    clifford_simp(false).apply(repl);
+    if (target_2q_gate == OpType::CX) {
+      clifford_simp(false).apply(repl);
+    }
     return repl;
   } else {
     TKET_ASSERT(n_qb == 3);
-    Circuit repl = three_qubit_synthesis(get_3q_unitary(circ));
-    // TODO: for now we decompose all the way to CX. In the future, it's worth
-    // considering keeping TK2, and decomposing to CX (or other gates) later
-    // when necessary.
-    normalise_TK2().apply(repl);
-    decompose_TK2().apply(repl);
-    clifford_simp(false).apply(repl);
-    return repl;
+    if (target_2q_gate == OpType::CX) {
+      Circuit repl = three_qubit_synthesis(get_3q_unitary(circ));
+      normalise_TK2().apply(repl);
+      decompose_TK2().apply(repl);
+      clifford_simp(false).apply(repl);
+      return repl;
+    } else {
+      TKET_ASSERT(target_2q_gate == OpType::TK2);
+      Circuit repl = three_qubit_tk_synthesis(get_3q_unitary(circ));
+      squash_1qb_to_tk1().apply(repl);
+      return repl;
+    }
   }
 }
 
@@ -132,8 +138,12 @@ static Circuit candidate_sub(const Circuit &circ) {
 class QISystem {
  public:
   // Construct an empty system.
-  explicit QISystem(Circuit &circ)
-      : circ_(circ), bin_(), interactions_(), idx_(0) {}
+  explicit QISystem(Circuit &circ, OpType target_2q_gate)
+      : circ_(circ),
+        target_2q_gate_(target_2q_gate),
+        bin_(),
+        interactions_(),
+        idx_(0) {}
 
   // Add a new interaction to the system consisting of a single edge, and
   // return its index.
@@ -207,9 +217,9 @@ class QISystem {
       case 3: {
         Subcircuit sub = I->subcircuit();
         Circuit subc = circ_.subcircuit(sub);
-        Circuit replacement = candidate_sub(subc);
-        if (replacement.count_gates(OpType::CX) <
-            subc.count_gates(OpType::CX)) {
+        Circuit replacement = candidate_sub(subc, target_2q_gate_);
+        if (replacement.count_gates(target_2q_gate_) <
+            subc.count_gates(target_2q_gate_)) {
           // 1. Collect data needed later to reconstruct the list of out-edges:
           std::vector<std::pair<Vertex, port_t>> out_vertex_ports;
           for (const Edge &e : outs) {
@@ -294,17 +304,18 @@ class QISystem {
 
  private:
   Circuit &circ_;
+  OpType target_2q_gate_;
   VertexList bin_;
   std::map<int, iptr> interactions_;
   int idx_;
 };
 
-Transform three_qubit_squash() {
-  return Transform([](Circuit &circ) {
+Transform three_qubit_squash(OpType target_2q_gate) {
+  return Transform([target_2q_gate](Circuit &circ) {
     bool changed = false;
 
     // Step through the vertices in topological order.
-    QISystem Is(circ);  // set of "live" interactions
+    QISystem Is(circ, target_2q_gate);  // set of "live" interactions
     for (const Vertex &v : circ.vertices_in_order()) {
       const EdgeVec v_q_ins = circ.get_in_edges_of_type(v, EdgeType::Quantum);
       const EdgeVec v_q_outs = circ.get_out_edges_of_type(v, EdgeType::Quantum);
@@ -343,9 +354,10 @@ Transform three_qubit_squash() {
       }
 
       // The circuit should contain only 1-qubit and CX gates.
-      if ((n_q_ins == 2 && optype != OpType::CX) || (n_q_ins > 2)) {
+      if ((n_q_ins == 2 && optype != target_2q_gate) || (n_q_ins > 2)) {
         throw std::invalid_argument(
-            "Three-qubit squash requires circuits with 1q and CX gates only");
+            "Three-qubit squash requires circuits with 1-qubit and target "
+            "2-qubit gates only");
       }
 
       // Absorb v into existing interactions, closing or merging as necessary.

--- a/tket/src/Transformations/ThreeQubitSquash.cpp
+++ b/tket/src/Transformations/ThreeQubitSquash.cpp
@@ -112,6 +112,7 @@ static Circuit candidate_sub(const Circuit &circ, OpType target_2qb_gate) {
   unsigned n_qb = circ.n_qubits();
   if (n_qb == 2) {
     Circuit repl = two_qubit_canonical(get_matrix_from_2qb_circ(circ));
+    // TODO Remove this once `clifford_simp` supports TK2.
     if (target_2qb_gate == OpType::CX) {
       clifford_simp(false).apply(repl);
     }

--- a/tket/src/Transformations/ThreeQubitSquash.cpp
+++ b/tket/src/Transformations/ThreeQubitSquash.cpp
@@ -125,6 +125,7 @@ static Circuit candidate_sub(const Circuit &circ, OpType target_2qb_gate) {
       normalise_TK2().apply(repl);
       decompose_TK2().apply(repl);
       clifford_simp(false).apply(repl);
+      squash_1qb_to_tk1().apply(repl);
       return repl;
     } else {
       TKET_ASSERT(target_2qb_gate == OpType::TK2);

--- a/tket/src/Transformations/include/Transformations/ThreeQubitSquash.hpp
+++ b/tket/src/Transformations/include/Transformations/ThreeQubitSquash.hpp
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include "OpType/OpType.hpp"
 #include "Transform.hpp"
 
 namespace tket {
@@ -21,15 +22,17 @@ namespace tket {
 namespace Transforms {
 
 /**
- * Squash sequences of 3-qubit instructions into their canonical 20-CX form.
+ * Squash sequences of 3-qubit instructions into a canonical form.
  *
- * The circuit should comprise only CX and single-qubit gates. The transform
- * may perform a combination of 2-qubit (KAK) and 3-qubit decompositions of
- * subcircuits, but only does so if this reduces the CX count.
+ * The circuit should comprise only 1- and 2-qubit gates, with the 2-qubit gates
+ * being either all CX or all TK2; this is also the target gate. The transform
+ * will only squash subcircuits that reduce the count of the relevant 2-qubit
+ * gate.
  *
+ * @param target_2q_gate Target 2-qubit gate (either CX or TK2)
  * @return Transform implementing the squash
  */
-Transform three_qubit_squash();
+Transform three_qubit_squash(OpType target_2q_gate = OpType::CX);
 
 }  // namespace Transforms
 

--- a/tket/src/Transformations/include/Transformations/ThreeQubitSquash.hpp
+++ b/tket/src/Transformations/include/Transformations/ThreeQubitSquash.hpp
@@ -29,10 +29,10 @@ namespace Transforms {
  * will only squash subcircuits that reduce the count of the relevant 2-qubit
  * gate.
  *
- * @param target_2q_gate Target 2-qubit gate (either CX or TK2)
+ * @param target_2qb_gate Target 2-qubit gate (either CX or TK2)
  * @return Transform implementing the squash
  */
-Transform three_qubit_squash(OpType target_2q_gate = OpType::CX);
+Transform three_qubit_squash(OpType target_2qb_gate = OpType::CX);
 
 }  // namespace Transforms
 

--- a/tket/tests/Circuit/test_ThreeQubitConversion.cpp
+++ b/tket/tests/Circuit/test_ThreeQubitConversion.cpp
@@ -247,6 +247,25 @@ SCENARIO("Unitary from circuits") {
     c.add_op<unsigned>(OpType::CX, {2, 1});
     check_3q_unitary(c);
   }
+  GIVEN("Circuit with TK2 gates") {
+    Circuit c(3);
+    c.add_op<unsigned>(OpType::H, {0});
+    c.add_op<unsigned>(OpType::S, {1});
+    c.add_op<unsigned>(OpType::T, {2});
+    c.add_op<unsigned>(OpType::TK2, {0.1, 0.2, 0.3}, {0, 1});
+    c.add_op<unsigned>(OpType::TK2, {0.7, 0.8, 0.9}, {0, 2});
+    c.add_op<unsigned>(OpType::S, {0});
+    c.add_op<unsigned>(OpType::T, {1});
+    c.add_op<unsigned>(OpType::H, {2});
+    c.add_op<unsigned>(OpType::TK2, {0.5, 0.6, 0.7}, {1, 2});
+    c.add_op<unsigned>(OpType::TK2, {0.2, 0.3, 0.4}, {1, 0});
+    c.add_op<unsigned>(OpType::T, {0});
+    c.add_op<unsigned>(OpType::H, {1});
+    c.add_op<unsigned>(OpType::S, {2});
+    c.add_op<unsigned>(OpType::TK2, {0.3, 0.4, 0.5}, {2, 0});
+    c.add_op<unsigned>(OpType::TK2, {0.4, 0.5, 0.6}, {2, 1});
+    check_3q_unitary(c);
+  }
 }
 
 static bool check_3q_squash(const Circuit &c) {

--- a/tket/tests/Circuit/test_ThreeQubitConversion.cpp
+++ b/tket/tests/Circuit/test_ThreeQubitConversion.cpp
@@ -270,16 +270,16 @@ SCENARIO("Unitary from circuits") {
 }
 
 static bool check_3q_squash(
-    const Circuit &c, OpType target_2q_gate = OpType::CX) {
+    const Circuit &c, OpType target_2qb_gate = OpType::CX) {
   OpType other_type = OpType::TK2;
-  if (target_2q_gate == OpType::TK2) {
+  if (target_2qb_gate == OpType::TK2) {
     other_type = OpType::CX;
   }
-  unsigned n_2q = c.count_gates(target_2q_gate);
+  unsigned n_2q = c.count_gates(target_2qb_gate);
   Eigen::MatrixXcd U = tket_sim::get_unitary(c);
   Circuit c1 = c;
-  bool success = Transforms::three_qubit_squash(target_2q_gate).apply(c1);
-  unsigned n_2q1 = c1.count_gates(target_2q_gate);
+  bool success = Transforms::three_qubit_squash(target_2qb_gate).apply(c1);
+  unsigned n_2q1 = c1.count_gates(target_2qb_gate);
   unsigned n_other = c1.count_gates(other_type);
   CHECK(n_other == 0);
   if (success) {

--- a/tket/tests/Circuit/test_ThreeQubitConversion.cpp
+++ b/tket/tests/Circuit/test_ThreeQubitConversion.cpp
@@ -21,6 +21,7 @@
 #include "Circuit/Circuit.hpp"
 #include "Circuit/Command.hpp"
 #include "Circuit/ThreeQubitConversion.hpp"
+#include "OpType/OpType.hpp"
 #include "Simulation/CircuitSimulator.hpp"
 #include "Transformations/Decomposition.hpp"
 #include "Transformations/ThreeQubitSquash.hpp"
@@ -268,14 +269,21 @@ SCENARIO("Unitary from circuits") {
   }
 }
 
-static bool check_3q_squash(const Circuit &c) {
-  unsigned n_cx = c.count_gates(OpType::CX);
+static bool check_3q_squash(
+    const Circuit &c, OpType target_2q_gate = OpType::CX) {
+  OpType other_type = OpType::TK2;
+  if (target_2q_gate == OpType::TK2) {
+    other_type = OpType::CX;
+  }
+  unsigned n_2q = c.count_gates(target_2q_gate);
   Eigen::MatrixXcd U = tket_sim::get_unitary(c);
   Circuit c1 = c;
-  bool success = Transforms::three_qubit_squash().apply(c1);
-  unsigned n_cx1 = c1.count_gates(OpType::CX);
+  bool success = Transforms::three_qubit_squash(target_2q_gate).apply(c1);
+  unsigned n_2q1 = c1.count_gates(target_2q_gate);
+  unsigned n_other = c1.count_gates(other_type);
+  CHECK(n_other == 0);
   if (success) {
-    CHECK(n_cx1 < n_cx);
+    CHECK(n_2q1 < n_2q);
     Eigen::MatrixXcd U1 = tket_sim::get_unitary(c1);
     CHECK(tket_sim::compare_statevectors_or_unitaries(U, U1));
   } else {
@@ -288,26 +296,36 @@ SCENARIO("Three-qubit squash") {
   GIVEN("Empty circuit") {
     Circuit c(2);
     CHECK_FALSE(check_3q_squash(c));
+    CHECK_FALSE(check_3q_squash(c, OpType::TK2));
   }
   GIVEN("1-qubit circuit, 1 gate") {
     Circuit c(1);
     c.add_op<unsigned>(OpType::H, {0});
     CHECK_FALSE(check_3q_squash(c));
+    CHECK_FALSE(check_3q_squash(c, OpType::TK2));
   }
   GIVEN("1-qubit circuit, 2 gates") {
     Circuit c(1);
     c.add_op<unsigned>(OpType::H, {0});
     c.add_op<unsigned>(OpType::Rz, 0.25, {0});
     CHECK_FALSE(check_3q_squash(c));
+    CHECK_FALSE(check_3q_squash(c, OpType::TK2));
   }
-  GIVEN("2-qubit circuit that cannot be squashed") {
+  GIVEN("2-qubit CX circuit that cannot be squashed") {
     Circuit c(2);
     c.add_op<unsigned>(OpType::H, {0});
     c.add_op<unsigned>(OpType::Rz, 0.25, {0});
     c.add_op<unsigned>(OpType::CX, {0, 1});
     CHECK_FALSE(check_3q_squash(c));
   }
-  GIVEN("2-qubit circuit that can be squashed") {
+  GIVEN("2-qubit TK2 circuit that cannot be squashed") {
+    Circuit c(2);
+    c.add_op<unsigned>(OpType::H, {0});
+    c.add_op<unsigned>(OpType::Rz, 0.25, {0});
+    c.add_op<unsigned>(OpType::TK2, {0.1, 0.2, 0.3}, {0, 1});
+    CHECK_FALSE(check_3q_squash(c, OpType::TK2));
+  }
+  GIVEN("2-qubit CX circuit that can be squashed") {
     Circuit c(2);
     c.add_op<unsigned>(OpType::H, {0});
     c.add_op<unsigned>(OpType::Rz, 0.25, {0});
@@ -323,7 +341,17 @@ SCENARIO("Three-qubit squash") {
     c.add_op<unsigned>(OpType::CX, {1, 0});
     CHECK(check_3q_squash(c));
   }
-  GIVEN("3-qubit circuit that cannot be squashed") {
+  GIVEN("2-qubit TK2 circuit that can be squashed") {
+    Circuit c(2);
+    c.add_op<unsigned>(OpType::H, {0});
+    c.add_op<unsigned>(OpType::Rz, 0.25, {0});
+    c.add_op<unsigned>(OpType::TK2, {0.1, 0.2, 0.3}, {0, 1});
+    c.add_op<unsigned>(OpType::H, {1});
+    c.add_op<unsigned>(OpType::Rz, 0.25, {0});
+    c.add_op<unsigned>(OpType::TK2, {0.2, 0.3, 0.4}, {0, 1});
+    CHECK(check_3q_squash(c, OpType::TK2));
+  }
+  GIVEN("3-qubit CX circuit that cannot be squashed") {
     Circuit c(3);
     c.add_op<unsigned>(OpType::H, {0});
     c.add_op<unsigned>(OpType::CX, {0, 1});
@@ -335,7 +363,15 @@ SCENARIO("Three-qubit squash") {
     c.add_op<unsigned>(OpType::CX, {1, 0});
     CHECK_FALSE(check_3q_squash(c));
   }
-  GIVEN("Three-qubit circuit that can be squashed") {
+  GIVEN("3-qubit TK2 circuit that cannot be squashed") {
+    Circuit c(3);
+    c.add_op<unsigned>(OpType::H, {0});
+    c.add_op<unsigned>(OpType::TK2, {0.1, 0.2, 0.3}, {0, 1});
+    c.add_op<unsigned>(OpType::Rz, 0.25, {2});
+    c.add_op<unsigned>(OpType::TK2, {0.2, 0.3, 0.4}, {2, 0});
+    CHECK_FALSE(check_3q_squash(c, OpType::TK2));
+  }
+  GIVEN("Three-qubit CX circuit that can be squashed") {
     Circuit c(3);
     for (unsigned i = 0; i < 21; i++) {
       c.add_op<unsigned>(OpType::H, {i % 3});
@@ -344,7 +380,17 @@ SCENARIO("Three-qubit squash") {
     }
     CHECK(check_3q_squash(c));
   }
-  GIVEN("A complex circuit that can be squashed") {
+  GIVEN("Three-qubit TK2 circuit that can be squashed") {
+    Circuit c(3);
+    for (unsigned i = 0; i < 16; i++) {
+      c.add_op<unsigned>(OpType::H, {i % 3});
+      c.add_op<unsigned>(
+          OpType::TK2, {0.1 * i, 0.2 * i, 0.3 * i}, {i % 3, (i + 1) % 3});
+      c.add_op<unsigned>(OpType::Rz, 0.25, {(i + 1) % 3});
+    }
+    CHECK(check_3q_squash(c, OpType::TK2));
+  }
+  GIVEN("A complex CX circuit that can be squashed") {
     Circuit c2q(2);
     for (unsigned i = 0; i < 4; i++) {
       c2q.add_op<unsigned>(OpType::Rz, 0.25, {i % 2});
@@ -365,7 +411,30 @@ SCENARIO("Three-qubit squash") {
     Transforms::decomp_boxes().apply(c);
     CHECK(check_3q_squash(c));
   }
-  GIVEN("A circuit with measurements") {
+  GIVEN("A complex TK2 circuit that can be squashed") {
+    Circuit c2q(2);
+    for (unsigned i = 0; i < 4; i++) {
+      c2q.add_op<unsigned>(OpType::Rz, 0.25, {i % 2});
+      c2q.add_op<unsigned>(
+          OpType::TK2, {0.1 * i, 0.2 * i, 0.3 * i}, {i % 2, (i + 1) % 2});
+    }
+    CircBox c2qbox(c2q);
+    Circuit c3q(3);
+    for (unsigned i = 0; i < 16; i++) {
+      c3q.add_op<unsigned>(OpType::Rz, 0.25, {i % 3});
+      c3q.add_op<unsigned>(
+          OpType::TK2, {0.1 * i, 0.2 * i, 0.3 * i}, {i % 3, (i + 1) % 3});
+    }
+    CircBox c3qbox(c3q);
+    Circuit c(5);
+    c.add_box(c2qbox, {1, 3});
+    c.add_box(c3qbox, {3, 0, 2});
+    c.add_box(c2qbox, {4, 2});
+    c.add_box(c3qbox, {4, 3, 0});
+    Transforms::decomp_boxes().apply(c);
+    CHECK(check_3q_squash(c, OpType::TK2));
+  }
+  GIVEN("A CX circuit with measurements") {
     Circuit c(3, 3);
     for (unsigned i = 0; i < 22; i++) {
       c.add_op<unsigned>(OpType::H, {i % 3});
@@ -377,6 +446,20 @@ SCENARIO("Three-qubit squash") {
     }
     CHECK(Transforms::three_qubit_squash().apply(c));
     CHECK(c.count_gates(OpType::CX) <= 20);
+  }
+  GIVEN("A TK2 circuit with measurements") {
+    Circuit c(3, 3);
+    for (unsigned i = 0; i < 22; i++) {
+      c.add_op<unsigned>(OpType::H, {i % 3});
+      c.add_op<unsigned>(
+          OpType::TK2, {0.1 * i, 0.2 * i, 0.3 * i}, {i % 3, (i + 1) % 3});
+      c.add_op<unsigned>(OpType::Rz, 0.25, {(i + 1) % 3});
+    }
+    for (unsigned q = 0; q < 3; q++) {
+      c.add_op<unsigned>(OpType::Measure, {q, q});
+    }
+    CHECK(Transforms::three_qubit_squash(OpType::TK2).apply(c));
+    CHECK(c.count_gates(OpType::TK2) <= 16);
   }
   GIVEN("A circuit with classical control") {
     Circuit c(3, 1);
@@ -425,7 +508,7 @@ SCENARIO("Three-qubit squash") {
 }
 
 SCENARIO("Special cases") {
-  GIVEN("A 3-qubit circuit with no interaction between qb 0 and qbs 1,2") {
+  GIVEN("A 3-qubit CX circuit with no interaction between qb 0 and qbs 1,2") {
     Circuit c(3);
     c.add_op<unsigned>(OpType::U3, {0.6, 0.7, 0.8}, {0});
     c.add_op<unsigned>(OpType::Rz, 0.1, {1});
@@ -449,7 +532,31 @@ SCENARIO("Special cases") {
     Eigen::Matrix U1 = tket_sim::get_unitary(c1);
     CHECK(U.isApprox(U1));
   }
-  GIVEN("A 3-qubit circuit with no interaction between qb 1 and qbs 0,2") {
+  GIVEN("A 3-qubit TK2 circuit with no interaction between qb 0 and qbs 1,2") {
+    Circuit c(3);
+    c.add_op<unsigned>(OpType::U3, {0.6, 0.7, 0.8}, {0});
+    c.add_op<unsigned>(OpType::Rz, 0.1, {1});
+    c.add_op<unsigned>(OpType::TK2, {0.1, 0.2, 0.3}, {1, 2});
+    c.add_op<unsigned>(OpType::Rz, 0.2, {2});
+    c.add_op<unsigned>(OpType::TK2, {0.1, 0.2, 0.3}, {2, 1});
+    c.add_op<unsigned>(OpType::Rz, 0.3, {1});
+    c.add_op<unsigned>(OpType::TK2, {0.1, 0.2, 0.3}, {1, 2});
+    c.add_op<unsigned>(OpType::Rz, 0.4, {2});
+    c.add_op<unsigned>(OpType::TK2, {0.1, 0.2, 0.3}, {2, 1});
+    Eigen::MatrixXcd U = tket_sim::get_unitary(c);
+    Circuit c1 = three_qubit_tk_synthesis(U);
+    REQUIRE(c1.count_gates(OpType::TK2) <= 1);
+    for (const Command &com : c1) {
+      qubit_vector_t qbs = com.get_qubits();
+      if (qbs.size() == 2) {
+        CHECK(qbs[0] != Qubit(0));
+        CHECK(qbs[1] != Qubit(0));
+      }
+    }
+    Eigen::Matrix U1 = tket_sim::get_unitary(c1);
+    CHECK(U.isApprox(U1));
+  }
+  GIVEN("A 3-qubit CX circuit with no interaction between qb 1 and qbs 0,2") {
     Circuit c(3);
     c.add_op<unsigned>(OpType::U3, {0.6, 0.7, 0.8}, {1});
     c.add_op<unsigned>(OpType::Rz, 0.1, {0});
@@ -473,7 +580,31 @@ SCENARIO("Special cases") {
     Eigen::Matrix U1 = tket_sim::get_unitary(c1);
     CHECK(U.isApprox(U1));
   }
-  GIVEN("A 3-qubit circuit with no interaction between qb 0 and qbs 1,2") {
+  GIVEN("A 3-qubit TK2 circuit with no interaction between qb 1 and qbs 0,2") {
+    Circuit c(3);
+    c.add_op<unsigned>(OpType::U3, {0.6, 0.7, 0.8}, {1});
+    c.add_op<unsigned>(OpType::Rz, 0.1, {0});
+    c.add_op<unsigned>(OpType::TK2, {0.1, 0.2, 0.3}, {0, 2});
+    c.add_op<unsigned>(OpType::Rz, 0.2, {2});
+    c.add_op<unsigned>(OpType::TK2, {0.1, 0.2, 0.3}, {2, 0});
+    c.add_op<unsigned>(OpType::Rz, 0.3, {0});
+    c.add_op<unsigned>(OpType::TK2, {0.1, 0.2, 0.3}, {0, 2});
+    c.add_op<unsigned>(OpType::Rz, 0.4, {2});
+    c.add_op<unsigned>(OpType::TK2, {0.1, 0.2, 0.3}, {2, 0});
+    Eigen::MatrixXcd U = tket_sim::get_unitary(c);
+    Circuit c1 = three_qubit_tk_synthesis(U);
+    REQUIRE(c1.count_gates(OpType::TK2) <= 1);
+    for (const Command &com : c1) {
+      qubit_vector_t qbs = com.get_qubits();
+      if (qbs.size() == 2) {
+        CHECK(qbs[0] != Qubit(1));
+        CHECK(qbs[1] != Qubit(1));
+      }
+    }
+    Eigen::Matrix U1 = tket_sim::get_unitary(c1);
+    CHECK(U.isApprox(U1));
+  }
+  GIVEN("A 3-qubit CX circuit with no interaction between qb 0 and qbs 1,2") {
     Circuit c(3);
     c.add_op<unsigned>(OpType::U3, {0.6, 0.7, 0.8}, {2});
     c.add_op<unsigned>(OpType::Rz, 0.1, {1});
@@ -487,6 +618,30 @@ SCENARIO("Special cases") {
     Eigen::MatrixXcd U = tket_sim::get_unitary(c);
     Circuit c1 = three_qubit_synthesis(U);
     REQUIRE(c1.count_gates(OpType::CX) <= 3);
+    for (const Command &com : c1) {
+      qubit_vector_t qbs = com.get_qubits();
+      if (qbs.size() == 2) {
+        CHECK(qbs[0] != Qubit(2));
+        CHECK(qbs[1] != Qubit(2));
+      }
+    }
+    Eigen::Matrix U1 = tket_sim::get_unitary(c1);
+    CHECK(U.isApprox(U1));
+  }
+  GIVEN("A 3-qubit TK2 circuit with no interaction between qb 0 and qbs 1,2") {
+    Circuit c(3);
+    c.add_op<unsigned>(OpType::U3, {0.6, 0.7, 0.8}, {2});
+    c.add_op<unsigned>(OpType::Rz, 0.1, {1});
+    c.add_op<unsigned>(OpType::TK2, {0.1, 0.2, 0.3}, {1, 0});
+    c.add_op<unsigned>(OpType::Rz, 0.2, {0});
+    c.add_op<unsigned>(OpType::TK2, {0.1, 0.2, 0.3}, {0, 1});
+    c.add_op<unsigned>(OpType::Rz, 0.3, {1});
+    c.add_op<unsigned>(OpType::TK2, {0.1, 0.2, 0.3}, {1, 0});
+    c.add_op<unsigned>(OpType::Rz, 0.4, {0});
+    c.add_op<unsigned>(OpType::TK2, {0.1, 0.2, 0.3}, {0, 1});
+    Eigen::MatrixXcd U = tket_sim::get_unitary(c);
+    Circuit c1 = three_qubit_tk_synthesis(U);
+    REQUIRE(c1.count_gates(OpType::TK2) <= 1);
     for (const Command &com : c1) {
       qubit_vector_t qbs = com.get_qubits();
       if (qbs.size() == 2) {

--- a/tket/tests/Circuit/test_ThreeQubitConversion.cpp
+++ b/tket/tests/Circuit/test_ThreeQubitConversion.cpp
@@ -50,8 +50,22 @@ static void check_three_qubit_synthesis(const Eigen::MatrixXcd &U) {
   CHECK(n_cx <= 20);
   Eigen::MatrixXcd U1 = tket_sim::get_unitary(c);
   CHECK(tket_sim::compare_statevectors_or_unitaries(U, U1));
-  Eigen::MatrixXcd U2 = get_3q_unitary(c);
-  CHECK(tket_sim::compare_statevectors_or_unitaries(U, U2));
+}
+
+static void check_three_qubit_tk_synthesis(const Eigen::MatrixXcd &U) {
+  Circuit c = three_qubit_tk_synthesis(U);
+  unsigned n_tk2 = 0;
+  for (const Command &cmd : c) {
+    OpType optype = cmd.get_op_ptr()->get_type();
+    if (optype == OpType::TK2) {
+      n_tk2++;
+    } else {
+      CHECK(cmd.get_args().size() == 1);
+    }
+  }
+  CHECK(n_tk2 <= 15);
+  Eigen::MatrixXcd U1 = tket_sim::get_unitary(c);
+  CHECK(tket_sim::compare_statevectors_or_unitaries(U, U1));
 }
 
 SCENARIO("Three-qubit circuits") {
@@ -123,6 +137,7 @@ SCENARIO("Three-qubit circuits") {
     U(7, 6) = {0.32103151296141164, 0.21632916190339818};
     U(7, 7) = {-0.04551679980729478, 0.12225020102655798};
     check_three_qubit_synthesis(U);
+    check_three_qubit_tk_synthesis(U);
   }
   GIVEN("Round trip from a small circuit") {
     Circuit c(3);
@@ -132,6 +147,7 @@ SCENARIO("Three-qubit circuits") {
     c.add_op<unsigned>(OpType::CX, {1, 2});
     auto u = tket_sim::get_unitary(c);
     check_three_qubit_synthesis(u);
+    check_three_qubit_tk_synthesis(u);
   }
   GIVEN("Round trip from a larger circuit") {
     Circuit c(3);
@@ -197,6 +213,7 @@ SCENARIO("Three-qubit circuits") {
     c.add_op<unsigned>(OpType::CX, {0, 2});
     auto u = tket_sim::get_unitary(c);
     check_three_qubit_synthesis(u);
+    check_three_qubit_tk_synthesis(u);
   }
 }
 


### PR DESCRIPTION
The existing `three_qubit_synthesis()` method decomposes a unitary into at most 20 CX gates. I have added an analogous `three_qubit_tk_synthesis()` method that decomposes a unitary into at most 15 TK2 gates. (It may be possible to do better than this, but I don't know how. I simply took the existing steps based on the cosine--sine decomposition and modified them. I had hoped that it might be possible to use fewer gates in the `two_qubit_diag_adjoint_plex_tk()` and `two_qubit_modified_cossin_circ_tk()` subroutines, but numerical experiments suggest not.)

Decompose `Unitary3qBox` using this method.

Add an option to the `three_qubit_squash` transform (and its Python wrapper) to target TK2 instead of CX.