### PR TITLE
Extend reg comparison

### DIFF
--- a/pytket/docs/circuit_class.rst
+++ b/pytket/docs/circuit_class.rst
@@ -11,7 +11,7 @@ the end of the circuit. Where ``kwargs`` are indicated in these methods, the
 following keyword arguments are supported:
 
 - ``opgroup`` (:py:class:`str`): name of the associated operation group, if any
-- ``condition`` (:py:class:`Bit`, :py:class:`BitLogicExp` or :py:class:`RegPredicate`): classical condition for applying operation
+- ``condition`` (:py:class:`Bit`, :py:class:`BitLogicExp` or :py:class:`Predicate`): classical condition for applying operation
 - ``condition_bits`` (list of :py:class:`Bit`): classical bits on which to condition operation
 - ``condition_value`` (:py:class:`int`): required value of condition bits (little-endian), defaulting to all-1s if not specified
 

--- a/pytket/docs/circuit_class.rst
+++ b/pytket/docs/circuit_class.rst
@@ -11,7 +11,7 @@ the end of the circuit. Where ``kwargs`` are indicated in these methods, the
 following keyword arguments are supported:
 
 - ``opgroup`` (:py:class:`str`): name of the associated operation group, if any
-- ``condition`` (:py:class:`Bit`, :py:class:`BitLogicExp` or :py:class:`ConstPredicate`): classical condition for applying operation
+- ``condition`` (:py:class:`Bit`, :py:class:`BitLogicExp` or :py:class:`RegPredicate`): classical condition for applying operation
 - ``condition_bits`` (list of :py:class:`Bit`): classical bits on which to condition operation
 - ``condition_value`` (:py:class:`int`): required value of condition bits (little-endian), defaulting to all-1s if not specified
 

--- a/pytket/pytket/circuit/add_condition.py
+++ b/pytket/pytket/circuit/add_condition.py
@@ -46,7 +46,7 @@ def _add_condition(
     elif isinstance(condition, Predicate):
         pred_exp, pred_val = condition.args
         # Predicate constructor should ensure arg order
-        if isinstance(pred_val, Constant):
+        if not isinstance(pred_val, Constant):
             raise NotImplementedError
     elif isinstance(condition, BitLogicExp):
         pred_val = 1

--- a/pytket/pytket/circuit/add_condition.py
+++ b/pytket/pytket/circuit/add_condition.py
@@ -52,7 +52,8 @@ def _add_condition(
         # Predicate constructor should ensure arg order
         if not isinstance(pred_val, Constant):
             raise NonConstError(
-                "Condition expressions must be of type `Predicate` with a constant second operand."
+                "Condition expressions must be of type `Predicate`\
+                with a constant second operand."
             )
     elif isinstance(condition, BitLogicExp):
         pred_val = 1

--- a/pytket/pytket/circuit/add_condition.py
+++ b/pytket/pytket/circuit/add_condition.py
@@ -52,8 +52,7 @@ def _add_condition(
         pred_exp = condition
     else:
         raise ValueError(
-            f"Condition {condition} must be of type Bit, "
-            "BitLogicExp or RegPredicate"
+            f"Condition {condition} must be of type Bit, " "BitLogicExp or RegPredicate"
         )
 
     next_index = (

--- a/pytket/pytket/circuit/add_condition.py
+++ b/pytket/pytket/circuit/add_condition.py
@@ -35,6 +35,10 @@ from pytket.circuit.logic_exp import (
 )
 
 
+class NonConstError(Exception):
+    """A custom exception class for non constant predicate argument."""
+
+
 def _add_condition(
     circ: Circuit, condition: Union[Predicate, Bit, BitLogicExp]
 ) -> Tuple[Bit, bool]:
@@ -47,7 +51,9 @@ def _add_condition(
         pred_exp, pred_val = condition.args
         # Predicate constructor should ensure arg order
         if not isinstance(pred_val, Constant):
-            raise NotImplementedError
+            raise NonConstError(
+                "Condition expressions must be of type `Predicate` with a constant second operand."
+            )
     elif isinstance(condition, BitLogicExp):
         pred_val = 1
         pred_exp = condition

--- a/pytket/pytket/circuit/add_condition.py
+++ b/pytket/pytket/circuit/add_condition.py
@@ -24,7 +24,7 @@ from pytket._tket.circuit import (  # type: ignore
 from pytket.circuit.logic_exp import (
     BitLogicExp,
     Constant,
-    Predicate,
+    RegPredicate,
     RegEq,
     RegNeq,
     RegGeq,
@@ -40,19 +40,19 @@ class NonConstError(Exception):
 
 
 def _add_condition(
-    circ: Circuit, condition: Union[Predicate, Bit, BitLogicExp]
+    circ: Circuit, condition: Union[RegPredicate, Bit, BitLogicExp]
 ) -> Tuple[Bit, bool]:
     """Add a condition expression to a circuit using classical expression boxes,
     rangepredicates and conditionals. Return predicate bit and value of said bit.
     """
     if isinstance(condition, Bit):
         return condition, True
-    elif isinstance(condition, Predicate):
+    elif isinstance(condition, RegPredicate):
         pred_exp, pred_val = condition.args
-        # Predicate constructor should ensure arg order
+        # RegPredicate constructor should ensure arg order
         if not isinstance(pred_val, Constant):
             raise NonConstError(
-                "Condition expressions must be of type `Predicate`\
+                "Condition expressions must be of type `RegPredicate`\
                 with a constant second operand."
             )
     elif isinstance(condition, BitLogicExp):
@@ -60,7 +60,7 @@ def _add_condition(
         pred_exp = condition
     else:
         raise ValueError(
-            f"Condition {condition} must be of type Bit, " "BitLogicExp or Predicate"
+            f"Condition {condition} must be of type Bit, " "BitLogicExp or RegPredicate"
         )
 
     next_index = (

--- a/pytket/pytket/circuit/add_condition.py
+++ b/pytket/pytket/circuit/add_condition.py
@@ -46,7 +46,7 @@ def _add_condition(
     elif isinstance(condition, Predicate):
         pred_exp, pred_val = condition.args
         # Predicate constructor should ensure arg order
-        if assert isinstance(pred_val, Constant):
+        if isinstance(pred_val, Constant):
             raise NotImplementedError
     elif isinstance(condition, BitLogicExp):
         pred_val = 1

--- a/pytket/pytket/circuit/add_condition.py
+++ b/pytket/pytket/circuit/add_condition.py
@@ -24,7 +24,7 @@ from pytket._tket.circuit import (  # type: ignore
 from pytket.circuit.logic_exp import (
     BitLogicExp,
     Constant,
-    RegPredicate,
+    Predicate,
     RegEq,
     RegNeq,
     RegGeq,
@@ -36,23 +36,23 @@ from pytket.circuit.logic_exp import (
 
 
 def _add_condition(
-    circ: Circuit, condition: Union[RegPredicate, Bit, BitLogicExp]
+    circ: Circuit, condition: Union[Predicate, Bit, BitLogicExp]
 ) -> Tuple[Bit, bool]:
     """Add a condition expression to a circuit using classical expression boxes,
     rangepredicates and conditionals. Return predicate bit and value of said bit.
     """
     if isinstance(condition, Bit):
         return condition, True
-    elif isinstance(condition, RegPredicate):
+    elif isinstance(condition, Predicate):
         pred_exp, pred_val = condition.args
-        # RegPredicate constructor should ensure arg order
+        # Predicate constructor should ensure arg order
         assert isinstance(pred_val, Constant)
     elif isinstance(condition, BitLogicExp):
         pred_val = 1
         pred_exp = condition
     else:
         raise ValueError(
-            f"Condition {condition} must be of type Bit, " "BitLogicExp or RegPredicate"
+            f"Condition {condition} must be of type Bit, " "BitLogicExp or Predicate"
         )
 
     next_index = (

--- a/pytket/pytket/circuit/add_condition.py
+++ b/pytket/pytket/circuit/add_condition.py
@@ -46,7 +46,8 @@ def _add_condition(
     elif isinstance(condition, Predicate):
         pred_exp, pred_val = condition.args
         # Predicate constructor should ensure arg order
-        assert isinstance(pred_val, Constant)
+        if assert isinstance(pred_val, Constant):
+            raise NotImplementedError
     elif isinstance(condition, BitLogicExp):
         pred_val = 1
         pred_exp = condition

--- a/pytket/pytket/circuit/add_condition.py
+++ b/pytket/pytket/circuit/add_condition.py
@@ -24,7 +24,7 @@ from pytket._tket.circuit import (  # type: ignore
 from pytket.circuit.logic_exp import (
     BitLogicExp,
     Constant,
-    RegPredicate,
+    PredicateExp,
     RegEq,
     RegNeq,
     RegGeq,
@@ -40,19 +40,19 @@ class NonConstError(Exception):
 
 
 def _add_condition(
-    circ: Circuit, condition: Union[RegPredicate, Bit, BitLogicExp]
+    circ: Circuit, condition: Union[PredicateExp, Bit, BitLogicExp]
 ) -> Tuple[Bit, bool]:
     """Add a condition expression to a circuit using classical expression boxes,
     rangepredicates and conditionals. Return predicate bit and value of said bit.
     """
     if isinstance(condition, Bit):
         return condition, True
-    elif isinstance(condition, RegPredicate):
+    elif isinstance(condition, PredicateExp):
         pred_exp, pred_val = condition.args
-        # RegPredicate constructor should ensure arg order
+        # PredicateExp constructor should ensure arg order
         if not isinstance(pred_val, Constant):
             raise NonConstError(
-                "Condition expressions must be of type `RegPredicate`\
+                "Condition expressions must be of type `PredicateExp`\
                 with a constant second operand."
             )
     elif isinstance(condition, BitLogicExp):
@@ -60,7 +60,7 @@ def _add_condition(
         pred_exp = condition
     else:
         raise ValueError(
-            f"Condition {condition} must be of type Bit, " "BitLogicExp or RegPredicate"
+            f"Condition {condition} must be of type Bit, " "BitLogicExp or PredicateExp"
         )
 
     next_index = (

--- a/pytket/pytket/circuit/add_condition.py
+++ b/pytket/pytket/circuit/add_condition.py
@@ -24,7 +24,7 @@ from pytket._tket.circuit import (  # type: ignore
 from pytket.circuit.logic_exp import (
     BitLogicExp,
     Constant,
-    ConstPredicate,
+    RegPredicate,
     RegEq,
     RegNeq,
     RegGeq,
@@ -36,16 +36,16 @@ from pytket.circuit.logic_exp import (
 
 
 def _add_condition(
-    circ: Circuit, condition: Union[ConstPredicate, Bit, BitLogicExp]
+    circ: Circuit, condition: Union[RegPredicate, Bit, BitLogicExp]
 ) -> Tuple[Bit, bool]:
     """Add a condition expression to a circuit using classical expression boxes,
     rangepredicates and conditionals. Return predicate bit and value of said bit.
     """
     if isinstance(condition, Bit):
         return condition, True
-    elif isinstance(condition, ConstPredicate):
+    elif isinstance(condition, RegPredicate):
         pred_exp, pred_val = condition.args
-        # ConstPredicate constructor should ensure arg order
+        # RegPredicate constructor should ensure arg order
         assert isinstance(pred_val, Constant)
     elif isinstance(condition, BitLogicExp):
         pred_val = 1
@@ -53,7 +53,7 @@ def _add_condition(
     else:
         raise ValueError(
             f"Condition {condition} must be of type Bit, "
-            "BitLogicExp or ConstPredicate"
+            "BitLogicExp or RegPredicate"
         )
 
     next_index = (

--- a/pytket/pytket/circuit/decompose_classical.py
+++ b/pytket/pytket/circuit/decompose_classical.py
@@ -292,7 +292,7 @@ def _decompose_expressions(circ: Circuit) -> Tuple[Circuit, bool]:
             op = op.op
             optype = op.type
 
-        if optype == OpType.RangeRegPredicate:
+        if optype == OpType.RangePredicate:
             target = args[-1]
             newcirc.add_bit(target, reject_dups=False)
             temp_reg = temp_reg_in_args(args)

--- a/pytket/pytket/circuit/decompose_classical.py
+++ b/pytket/pytket/circuit/decompose_classical.py
@@ -292,7 +292,7 @@ def _decompose_expressions(circ: Circuit) -> Tuple[Circuit, bool]:
             op = op.op
             optype = op.type
 
-        if optype == OpType.RangePredicate:
+        if optype == OpType.RangeRegPredicate:
             target = args[-1]
             newcirc.add_bit(target, reject_dups=False)
             temp_reg = temp_reg_in_args(args)

--- a/pytket/pytket/circuit/logic_exp.py
+++ b/pytket/pytket/circuit/logic_exp.py
@@ -350,20 +350,20 @@ class RegRsh(BinaryOp, RegLogicExp):
     op = RegWiseOp.RSH
 
 
-class Predicate(BinaryOp):
+class RegPredicate(BinaryOp):
     """
     A binary predicate where the arguments are either
     Bits, BitRegisters, or Constants.
     """
 
 
-class Eq(Predicate):
+class Eq(RegPredicate):
     @staticmethod
     def _const_eval(args: List[Constant]) -> Constant:
         return args[0] == args[1]
 
 
-class Neq(Predicate):
+class Neq(RegPredicate):
     @staticmethod
     def _const_eval(args: List[Constant]) -> Constant:
         return 1 - Eq._const_eval(args)
@@ -385,7 +385,7 @@ class RegNeq(Neq, RegLogicExp):
     op = RegWiseOp.NEQ
 
 
-class RegLt(Predicate, RegLogicExp):
+class RegLt(RegPredicate, RegLogicExp):
     op = RegWiseOp.LT
 
     @staticmethod
@@ -393,7 +393,7 @@ class RegLt(Predicate, RegLogicExp):
         return args[0] < args[1]
 
 
-class RegGt(Predicate, RegLogicExp):
+class RegGt(RegPredicate, RegLogicExp):
     op = RegWiseOp.GT
 
     @staticmethod
@@ -401,7 +401,7 @@ class RegGt(Predicate, RegLogicExp):
         return args[0] > args[1]
 
 
-class RegLeq(Predicate, RegLogicExp):
+class RegLeq(RegPredicate, RegLogicExp):
     op = RegWiseOp.LEQ
 
     @staticmethod
@@ -409,7 +409,7 @@ class RegLeq(Predicate, RegLogicExp):
         return args[0] <= args[1]
 
 
-class RegGeq(Predicate, RegLogicExp):
+class RegGeq(RegPredicate, RegLogicExp):
     op = RegWiseOp.GEQ
 
     @staticmethod
@@ -420,11 +420,11 @@ class RegGeq(Predicate, RegLogicExp):
 # utility to define register comparison methods
 def gen_regpredicate(
     op: Ops,
-) -> Callable[[Union[RegLogicExp, BitRegister], Constant], Predicate]:
+) -> Callable[[Union[RegLogicExp, BitRegister], Constant], RegPredicate]:
     def const_predicate(
         register: Union[RegLogicExp, BitRegister], value: Constant
-    ) -> Predicate:
-        return cast(Type[Predicate], LogicExp.factory(op))(register, value)
+    ) -> RegPredicate:
+        return cast(Type[RegPredicate], LogicExp.factory(op))(register, value)
 
     return const_predicate
 
@@ -450,11 +450,11 @@ reg_geq.__doc__ = """Function to express a BitRegister greater than or equal to
     ``reg_geq(r, 5)``"""
 
 
-def if_bit(bit: Union[Bit, BitLogicExp]) -> Predicate:
+def if_bit(bit: Union[Bit, BitLogicExp]) -> RegPredicate:
     """Equivalent of ``if bit:``."""
     return BitEq(bit, 1)
 
 
-def if_not_bit(bit: Union[Bit, BitLogicExp]) -> Predicate:
+def if_not_bit(bit: Union[Bit, BitLogicExp]) -> RegPredicate:
     """Equivalent of ``if not bit:``."""
     return BitEq(bit, 0)

--- a/pytket/pytket/circuit/logic_exp.py
+++ b/pytket/pytket/circuit/logic_exp.py
@@ -353,10 +353,15 @@ class RegRsh(BinaryOp, RegLogicExp):
 class RegPredicate(BinaryOp):
     """A binary predicate where the arguments are either registers or constants."""
 
-    def __init__(self, lhs: Union[LogicExp, Variable, Constant], rhs: Union[LogicExp, Variable, Constant]) -> None:
+    def __init__(
+        self,
+        lhs: Union[LogicExp, Variable, Constant],
+        rhs: Union[LogicExp, Variable, Constant],
+    ) -> None:
         super().__init__(lhs, rhs)
         assert isinstance(lhs, (LogicExp, Bit, BitRegister, Constant))
         assert isinstance(rhs, (LogicExp, Bit, BitRegister, Constant))
+
 
 class Eq(RegPredicate):
     @staticmethod

--- a/pytket/pytket/circuit/logic_exp.py
+++ b/pytket/pytket/circuit/logic_exp.py
@@ -351,7 +351,10 @@ class RegRsh(BinaryOp, RegLogicExp):
 
 
 class Predicate(BinaryOp):
-    """A binary predicate where the arguments are either Bits, BitRegisters, or Constants."""
+    """
+    A binary predicate where the arguments are either
+    Bits, BitRegisters, or Constants.
+    """
 
 
 class Eq(Predicate):

--- a/pytket/pytket/circuit/logic_exp.py
+++ b/pytket/pytket/circuit/logic_exp.py
@@ -351,16 +351,8 @@ class RegRsh(BinaryOp, RegLogicExp):
 
 
 class Predicate(BinaryOp):
-    """A binary predicate where the arguments are either Bits, BitRegisters, or constants."""
-
-    def __init__(
-        self,
-        lhs: Union[LogicExp, Variable, Constant],
-        rhs: Union[LogicExp, Variable, Constant],
-    ) -> None:
-        super().__init__(lhs, rhs)
-        assert isinstance(lhs, (LogicExp, Bit, BitRegister, Constant))
-        assert isinstance(rhs, (LogicExp, Bit, BitRegister, Constant))
+    """A binary predicate where the arguments are either Bits, BitRegisters, or Constants."""
+    ...
 
 
 class Eq(RegPredicate):

--- a/pytket/pytket/circuit/logic_exp.py
+++ b/pytket/pytket/circuit/logic_exp.py
@@ -350,20 +350,20 @@ class RegRsh(BinaryOp, RegLogicExp):
     op = RegWiseOp.RSH
 
 
-class RegPredicate(BinaryOp):
+class PredicateExp(BinaryOp):
     """
     A binary predicate where the arguments are either
     Bits, BitRegisters, or Constants.
     """
 
 
-class Eq(RegPredicate):
+class Eq(PredicateExp):
     @staticmethod
     def _const_eval(args: List[Constant]) -> Constant:
         return args[0] == args[1]
 
 
-class Neq(RegPredicate):
+class Neq(PredicateExp):
     @staticmethod
     def _const_eval(args: List[Constant]) -> Constant:
         return 1 - Eq._const_eval(args)
@@ -385,7 +385,7 @@ class RegNeq(Neq, RegLogicExp):
     op = RegWiseOp.NEQ
 
 
-class RegLt(RegPredicate, RegLogicExp):
+class RegLt(PredicateExp, RegLogicExp):
     op = RegWiseOp.LT
 
     @staticmethod
@@ -393,7 +393,7 @@ class RegLt(RegPredicate, RegLogicExp):
         return args[0] < args[1]
 
 
-class RegGt(RegPredicate, RegLogicExp):
+class RegGt(PredicateExp, RegLogicExp):
     op = RegWiseOp.GT
 
     @staticmethod
@@ -401,7 +401,7 @@ class RegGt(RegPredicate, RegLogicExp):
         return args[0] > args[1]
 
 
-class RegLeq(RegPredicate, RegLogicExp):
+class RegLeq(PredicateExp, RegLogicExp):
     op = RegWiseOp.LEQ
 
     @staticmethod
@@ -409,7 +409,7 @@ class RegLeq(RegPredicate, RegLogicExp):
         return args[0] <= args[1]
 
 
-class RegGeq(RegPredicate, RegLogicExp):
+class RegGeq(PredicateExp, RegLogicExp):
     op = RegWiseOp.GEQ
 
     @staticmethod
@@ -420,11 +420,11 @@ class RegGeq(RegPredicate, RegLogicExp):
 # utility to define register comparison methods
 def gen_regpredicate(
     op: Ops,
-) -> Callable[[Union[RegLogicExp, BitRegister], Constant], RegPredicate]:
+) -> Callable[[Union[RegLogicExp, BitRegister], Constant], PredicateExp]:
     def const_predicate(
         register: Union[RegLogicExp, BitRegister], value: Constant
-    ) -> RegPredicate:
-        return cast(Type[RegPredicate], LogicExp.factory(op))(register, value)
+    ) -> PredicateExp:
+        return cast(Type[PredicateExp], LogicExp.factory(op))(register, value)
 
     return const_predicate
 
@@ -450,11 +450,11 @@ reg_geq.__doc__ = """Function to express a BitRegister greater than or equal to
     ``reg_geq(r, 5)``"""
 
 
-def if_bit(bit: Union[Bit, BitLogicExp]) -> RegPredicate:
+def if_bit(bit: Union[Bit, BitLogicExp]) -> PredicateExp:
     """Equivalent of ``if bit:``."""
     return BitEq(bit, 1)
 
 
-def if_not_bit(bit: Union[Bit, BitLogicExp]) -> RegPredicate:
+def if_not_bit(bit: Union[Bit, BitLogicExp]) -> PredicateExp:
     """Equivalent of ``if not bit:``."""
     return BitEq(bit, 0)

--- a/pytket/pytket/circuit/logic_exp.py
+++ b/pytket/pytket/circuit/logic_exp.py
@@ -352,7 +352,6 @@ class RegRsh(BinaryOp, RegLogicExp):
 
 class Predicate(BinaryOp):
     """A binary predicate where the arguments are either Bits, BitRegisters, or Constants."""
-    ...
 
 
 class Eq(RegPredicate):

--- a/pytket/pytket/circuit/logic_exp.py
+++ b/pytket/pytket/circuit/logic_exp.py
@@ -350,7 +350,7 @@ class RegRsh(BinaryOp, RegLogicExp):
     op = RegWiseOp.RSH
 
 
-class RegPredicate(BinaryOp):
+class Predicate(BinaryOp):
     """A binary predicate where the arguments are either registers or constants."""
 
     def __init__(

--- a/pytket/pytket/circuit/logic_exp.py
+++ b/pytket/pytket/circuit/logic_exp.py
@@ -458,3 +458,7 @@ def if_bit(bit: Union[Bit, BitLogicExp]) -> PredicateExp:
 def if_not_bit(bit: Union[Bit, BitLogicExp]) -> PredicateExp:
     """Equivalent of ``if not bit:``."""
     return BitEq(bit, 0)
+
+
+#  ConstPredicate is deprecated in favour of PredicateExp
+ConstPredicate = PredicateExp

--- a/pytket/pytket/circuit/logic_exp.py
+++ b/pytket/pytket/circuit/logic_exp.py
@@ -350,22 +350,21 @@ class RegRsh(BinaryOp, RegLogicExp):
     op = RegWiseOp.RSH
 
 
-class ConstPredicate(BinaryOp):
-    """A binary predicate where at least one of the arguments is constant."""
+class RegPredicate(BinaryOp):
+    """A binary predicate where the arguments are either registers or constants."""
 
-    def __init__(self, exp: Union[LogicExp, Variable], const: Constant) -> None:
-        super().__init__(exp, const)
-        assert isinstance(exp, (LogicExp, Bit, BitRegister))
-        assert isinstance(const, Constant)
+    def __init__(self, lhs: Union[LogicExp, Variable, Constant], rhs: Union[LogicExp, Variable, Constant]) -> None:
+        super().__init__(lhs, rhs)
+        assert isinstance(lhs, (LogicExp, Bit, BitRegister, Constant))
+        assert isinstance(rhs, (LogicExp, Bit, BitRegister, Constant))
 
-
-class Eq(ConstPredicate):
+class Eq(RegPredicate):
     @staticmethod
     def _const_eval(args: List[Constant]) -> Constant:
         return args[0] == args[1]
 
 
-class Neq(ConstPredicate):
+class Neq(RegPredicate):
     @staticmethod
     def _const_eval(args: List[Constant]) -> Constant:
         return 1 - Eq._const_eval(args)
@@ -387,7 +386,7 @@ class RegNeq(Neq, RegLogicExp):
     op = RegWiseOp.NEQ
 
 
-class RegLt(ConstPredicate, RegLogicExp):
+class RegLt(RegPredicate, RegLogicExp):
     op = RegWiseOp.LT
 
     @staticmethod
@@ -395,7 +394,7 @@ class RegLt(ConstPredicate, RegLogicExp):
         return args[0] < args[1]
 
 
-class RegGt(ConstPredicate, RegLogicExp):
+class RegGt(RegPredicate, RegLogicExp):
     op = RegWiseOp.GT
 
     @staticmethod
@@ -403,7 +402,7 @@ class RegGt(ConstPredicate, RegLogicExp):
         return args[0] > args[1]
 
 
-class RegLeq(ConstPredicate, RegLogicExp):
+class RegLeq(RegPredicate, RegLogicExp):
     op = RegWiseOp.LEQ
 
     @staticmethod
@@ -411,7 +410,7 @@ class RegLeq(ConstPredicate, RegLogicExp):
         return args[0] <= args[1]
 
 
-class RegGeq(ConstPredicate, RegLogicExp):
+class RegGeq(RegPredicate, RegLogicExp):
     op = RegWiseOp.GEQ
 
     @staticmethod
@@ -420,43 +419,43 @@ class RegGeq(ConstPredicate, RegLogicExp):
 
 
 # utility to define register comparison methods
-def gen_const_regpredicate(
+def gen_regpredicate(
     op: Ops,
-) -> Callable[[Union[RegLogicExp, BitRegister], Constant], ConstPredicate]:
+) -> Callable[[Union[RegLogicExp, BitRegister], Constant], RegPredicate]:
     def const_predicate(
         register: Union[RegLogicExp, BitRegister], value: Constant
-    ) -> ConstPredicate:
-        return cast(Type[ConstPredicate], LogicExp.factory(op))(register, value)
+    ) -> RegPredicate:
+        return cast(Type[RegPredicate], LogicExp.factory(op))(register, value)
 
     return const_predicate
 
 
-reg_eq = gen_const_regpredicate(RegWiseOp.EQ)
+reg_eq = gen_regpredicate(RegWiseOp.EQ)
 reg_eq.__doc__ = """Function to express a BitRegister equality predicate, i.e.
     for a register ``r``, ``(r == 5)`` is expressed as ``reg_eq(r, 5)``"""
-reg_neq = gen_const_regpredicate(RegWiseOp.NEQ)
+reg_neq = gen_regpredicate(RegWiseOp.NEQ)
 reg_neq.__doc__ = """Function to express a BitRegister inequality predicate, i.e.
     for a register ``r``, ``(r != 5)`` is expressed as ``reg_neq(r, 5)``"""
-reg_lt = gen_const_regpredicate(RegWiseOp.LT)
+reg_lt = gen_regpredicate(RegWiseOp.LT)
 reg_lt.__doc__ = """Function to express a BitRegister less than predicate, i.e.
     for a register ``r``, ``(r < 5)`` is expressed as ``reg_lt(r, 5)``"""
-reg_gt = gen_const_regpredicate(RegWiseOp.GT)
+reg_gt = gen_regpredicate(RegWiseOp.GT)
 reg_gt.__doc__ = """Function to express a BitRegister greater than predicate, i.e.
     for a register ``r``, ``(r > 5)`` is expressed as ``reg_gt(r, 5)``"""
-reg_leq = gen_const_regpredicate(RegWiseOp.LEQ)
+reg_leq = gen_regpredicate(RegWiseOp.LEQ)
 reg_leq.__doc__ = """Function to express a BitRegister less than or equal to predicate,
     i.e. for a register ``r``, ``(r <= 5)`` is expressed as ``reg_leq(r, 5)``"""
-reg_geq = gen_const_regpredicate(RegWiseOp.GEQ)
+reg_geq = gen_regpredicate(RegWiseOp.GEQ)
 reg_geq.__doc__ = """Function to express a BitRegister greater than or equal to
     predicate, i.e. for a register ``r``, ``(r >= 5)`` is expressed as
     ``reg_geq(r, 5)``"""
 
 
-def if_bit(bit: Union[Bit, BitLogicExp]) -> ConstPredicate:
+def if_bit(bit: Union[Bit, BitLogicExp]) -> RegPredicate:
     """Equivalent of ``if bit:``."""
     return BitEq(bit, 1)
 
 
-def if_not_bit(bit: Union[Bit, BitLogicExp]) -> ConstPredicate:
+def if_not_bit(bit: Union[Bit, BitLogicExp]) -> RegPredicate:
     """Equivalent of ``if not bit:``."""
     return BitEq(bit, 0)

--- a/pytket/pytket/circuit/logic_exp.py
+++ b/pytket/pytket/circuit/logic_exp.py
@@ -354,13 +354,13 @@ class Predicate(BinaryOp):
     """A binary predicate where the arguments are either Bits, BitRegisters, or Constants."""
 
 
-class Eq(RegPredicate):
+class Eq(Predicate):
     @staticmethod
     def _const_eval(args: List[Constant]) -> Constant:
         return args[0] == args[1]
 
 
-class Neq(RegPredicate):
+class Neq(Predicate):
     @staticmethod
     def _const_eval(args: List[Constant]) -> Constant:
         return 1 - Eq._const_eval(args)
@@ -382,7 +382,7 @@ class RegNeq(Neq, RegLogicExp):
     op = RegWiseOp.NEQ
 
 
-class RegLt(RegPredicate, RegLogicExp):
+class RegLt(Predicate, RegLogicExp):
     op = RegWiseOp.LT
 
     @staticmethod
@@ -390,7 +390,7 @@ class RegLt(RegPredicate, RegLogicExp):
         return args[0] < args[1]
 
 
-class RegGt(RegPredicate, RegLogicExp):
+class RegGt(Predicate, RegLogicExp):
     op = RegWiseOp.GT
 
     @staticmethod
@@ -398,7 +398,7 @@ class RegGt(RegPredicate, RegLogicExp):
         return args[0] > args[1]
 
 
-class RegLeq(RegPredicate, RegLogicExp):
+class RegLeq(Predicate, RegLogicExp):
     op = RegWiseOp.LEQ
 
     @staticmethod
@@ -406,7 +406,7 @@ class RegLeq(RegPredicate, RegLogicExp):
         return args[0] <= args[1]
 
 
-class RegGeq(RegPredicate, RegLogicExp):
+class RegGeq(Predicate, RegLogicExp):
     op = RegWiseOp.GEQ
 
     @staticmethod
@@ -417,11 +417,11 @@ class RegGeq(RegPredicate, RegLogicExp):
 # utility to define register comparison methods
 def gen_regpredicate(
     op: Ops,
-) -> Callable[[Union[RegLogicExp, BitRegister], Constant], RegPredicate]:
+) -> Callable[[Union[RegLogicExp, BitRegister], Constant], Predicate]:
     def const_predicate(
         register: Union[RegLogicExp, BitRegister], value: Constant
-    ) -> RegPredicate:
-        return cast(Type[RegPredicate], LogicExp.factory(op))(register, value)
+    ) -> Predicate:
+        return cast(Type[Predicate], LogicExp.factory(op))(register, value)
 
     return const_predicate
 
@@ -447,11 +447,11 @@ reg_geq.__doc__ = """Function to express a BitRegister greater than or equal to
     ``reg_geq(r, 5)``"""
 
 
-def if_bit(bit: Union[Bit, BitLogicExp]) -> RegPredicate:
+def if_bit(bit: Union[Bit, BitLogicExp]) -> Predicate:
     """Equivalent of ``if bit:``."""
     return BitEq(bit, 1)
 
 
-def if_not_bit(bit: Union[Bit, BitLogicExp]) -> RegPredicate:
+def if_not_bit(bit: Union[Bit, BitLogicExp]) -> Predicate:
     """Equivalent of ``if not bit:``."""
     return BitEq(bit, 0)

--- a/pytket/pytket/circuit/logic_exp.py
+++ b/pytket/pytket/circuit/logic_exp.py
@@ -351,7 +351,7 @@ class RegRsh(BinaryOp, RegLogicExp):
 
 
 class Predicate(BinaryOp):
-    """A binary predicate where the arguments are either registers or constants."""
+    """A binary predicate where the arguments are either Bits, BitRegisters, or constants."""
 
     def __init__(
         self,

--- a/pytket/pytket/qasm/qasm.py
+++ b/pytket/pytket/qasm/qasm.py
@@ -59,7 +59,7 @@ from pytket.circuit.decompose_classical import int_to_bools
 from pytket.circuit.logic_exp import (
     BitLogicExp,
     BitWiseOp,
-    Predicate,
+    PredicateExp,
     LogicExp,
     RegEq,
     RegLogicExp,
@@ -455,7 +455,7 @@ class CircuitTransformer(Transformer):
     def neg(self, tree: List[Union[Token, LogicExp]]) -> RegNeg:
         return RegNeg(self._get_logic_args(tree)[0][0])
 
-    def cond(self, tree: List[Token]) -> Predicate:
+    def cond(self, tree: List[Token]) -> PredicateExp:
         if tree[1].type == "IARG":
             arg = Bit(*_extract_reg(tree[1]))
         else:
@@ -463,7 +463,7 @@ class CircuitTransformer(Transformer):
 
         op_enum = BitWiseOp if isinstance(arg, Bit) else RegWiseOp
         comp = cast(
-            Type[Predicate],
+            Type[PredicateExp],
             LogicExp.factory(
                 cast(
                     Union[BitWiseOp, RegWiseOp],
@@ -474,7 +474,7 @@ class CircuitTransformer(Transformer):
         return comp(arg, int(tree[3].value))
 
     def ifc(self, tree: Sequence) -> Iterable[CommandDict]:
-        condition = cast(Predicate, tree[0])
+        condition = cast(PredicateExp, tree[0])
 
         var, val = condition.args
         condition_bits = []

--- a/pytket/pytket/qasm/qasm.py
+++ b/pytket/pytket/qasm/qasm.py
@@ -59,7 +59,7 @@ from pytket.circuit.decompose_classical import int_to_bools
 from pytket.circuit.logic_exp import (
     BitLogicExp,
     BitWiseOp,
-    ConstPredicate,
+    RegPredicate,
     LogicExp,
     RegEq,
     RegLogicExp,
@@ -455,7 +455,7 @@ class CircuitTransformer(Transformer):
     def neg(self, tree: List[Union[Token, LogicExp]]) -> RegNeg:
         return RegNeg(self._get_logic_args(tree)[0][0])
 
-    def cond(self, tree: List[Token]) -> ConstPredicate:
+    def cond(self, tree: List[Token]) -> RegPredicate:
         if tree[1].type == "IARG":
             arg = Bit(*_extract_reg(tree[1]))
         else:
@@ -463,7 +463,7 @@ class CircuitTransformer(Transformer):
 
         op_enum = BitWiseOp if isinstance(arg, Bit) else RegWiseOp
         comp = cast(
-            Type[ConstPredicate],
+            Type[RegPredicate],
             LogicExp.factory(
                 cast(
                     Union[BitWiseOp, RegWiseOp],
@@ -474,7 +474,7 @@ class CircuitTransformer(Transformer):
         return comp(arg, int(tree[3].value))
 
     def ifc(self, tree: Sequence) -> Iterable[CommandDict]:
-        condition = cast(ConstPredicate, tree[0])
+        condition = cast(RegPredicate, tree[0])
 
         var, val = condition.args
         condition_bits = []

--- a/pytket/pytket/qasm/qasm.py
+++ b/pytket/pytket/qasm/qasm.py
@@ -59,7 +59,7 @@ from pytket.circuit.decompose_classical import int_to_bools
 from pytket.circuit.logic_exp import (
     BitLogicExp,
     BitWiseOp,
-    RegPredicate,
+    Predicate,
     LogicExp,
     RegEq,
     RegLogicExp,
@@ -455,7 +455,7 @@ class CircuitTransformer(Transformer):
     def neg(self, tree: List[Union[Token, LogicExp]]) -> RegNeg:
         return RegNeg(self._get_logic_args(tree)[0][0])
 
-    def cond(self, tree: List[Token]) -> RegPredicate:
+    def cond(self, tree: List[Token]) -> Predicate:
         if tree[1].type == "IARG":
             arg = Bit(*_extract_reg(tree[1]))
         else:
@@ -463,7 +463,7 @@ class CircuitTransformer(Transformer):
 
         op_enum = BitWiseOp if isinstance(arg, Bit) else RegWiseOp
         comp = cast(
-            Type[RegPredicate],
+            Type[Predicate],
             LogicExp.factory(
                 cast(
                     Union[BitWiseOp, RegWiseOp],
@@ -474,7 +474,7 @@ class CircuitTransformer(Transformer):
         return comp(arg, int(tree[3].value))
 
     def ifc(self, tree: Sequence) -> Iterable[CommandDict]:
-        condition = cast(RegPredicate, tree[0])
+        condition = cast(Predicate, tree[0])
 
         var, val = condition.args
         condition_bits = []

--- a/pytket/tests/classical_test.py
+++ b/pytket/tests/classical_test.py
@@ -46,7 +46,7 @@ from pytket.circuit.logic_exp import (
     BinaryOp,
     BitLogicExp,
     BitWiseOp,
-    RegPredicate,
+    Predicate,
     LogicExp,
     RegEq,
     RegGeq,
@@ -251,7 +251,7 @@ def primitive_bit_logic_exps(
     exp_type = LogicExp.factory(op)
     args: List[Bit] = [draw(bits)]
     if issubclass(exp_type, BinaryOp):
-        if issubclass(exp_type, RegPredicate):
+        if issubclass(exp_type, Predicate):
             const_compare = draw(binary_digits)
             args.append(const_compare)
         else:
@@ -442,8 +442,8 @@ def bit_const_predicates(
     draw: Callable,
     operators: SearchStrategy[Callable] = strategies.sampled_from([if_bit, if_not_bit]),
     exp: SearchStrategy[BitLogicExp] = composite_bit_logic_exps(),
-) -> RegPredicate:
-    return cast(RegPredicate, draw(operators)(draw(exp)))
+) -> Predicate:
+    return cast(Predicate, draw(operators)(draw(exp)))
 
 
 @strategies.composite
@@ -454,14 +454,14 @@ def reg_const_predicates(
         [reg_eq, reg_neq, reg_lt, reg_gt, reg_leq, reg_geq]
     ),
     constants: SearchStrategy[int] = uint32,
-) -> RegPredicate:
-    return cast(RegPredicate, draw(operators)(draw(exp), draw(constants)))
+) -> Predicate:
+    return cast(Predicate, draw(operators)(draw(exp), draw(constants)))
 
 
 @given(condition=strategies.one_of(bit_const_predicates(), reg_const_predicates()))
 @settings(print_blob=True, deadline=None)
-def test_regpredicate(condition: RegPredicate) -> None:
-    assert isinstance(condition, RegPredicate)
+def test_regpredicate(condition: Predicate) -> None:
+    assert isinstance(condition, Predicate)
     # test serialization round trip here
     # as condition should be the most nested structure
     assert LogicExp.from_dict(condition.to_dict()) == condition

--- a/pytket/tests/classical_test.py
+++ b/pytket/tests/classical_test.py
@@ -46,7 +46,7 @@ from pytket.circuit.logic_exp import (
     BinaryOp,
     BitLogicExp,
     BitWiseOp,
-    Predicate,
+    PredicateExp,
     LogicExp,
     RegEq,
     RegGeq,
@@ -251,7 +251,7 @@ def primitive_bit_logic_exps(
     exp_type = LogicExp.factory(op)
     args: List[Bit] = [draw(bits)]
     if issubclass(exp_type, BinaryOp):
-        if issubclass(exp_type, Predicate):
+        if issubclass(exp_type, PredicateExp):
             const_compare = draw(binary_digits)
             args.append(const_compare)
         else:
@@ -442,8 +442,8 @@ def bit_const_predicates(
     draw: Callable,
     operators: SearchStrategy[Callable] = strategies.sampled_from([if_bit, if_not_bit]),
     exp: SearchStrategy[BitLogicExp] = composite_bit_logic_exps(),
-) -> Predicate:
-    return cast(Predicate, draw(operators)(draw(exp)))
+) -> PredicateExp:
+    return cast(PredicateExp, draw(operators)(draw(exp)))
 
 
 @strategies.composite
@@ -454,14 +454,14 @@ def reg_const_predicates(
         [reg_eq, reg_neq, reg_lt, reg_gt, reg_leq, reg_geq]
     ),
     constants: SearchStrategy[int] = uint32,
-) -> Predicate:
-    return cast(Predicate, draw(operators)(draw(exp), draw(constants)))
+) -> PredicateExp:
+    return cast(PredicateExp, draw(operators)(draw(exp), draw(constants)))
 
 
 @given(condition=strategies.one_of(bit_const_predicates(), reg_const_predicates()))
 @settings(print_blob=True, deadline=None)
-def test_regpredicate(condition: Predicate) -> None:
-    assert isinstance(condition, Predicate)
+def test_regpredicate(condition: PredicateExp) -> None:
+    assert isinstance(condition, PredicateExp)
     # test serialization round trip here
     # as condition should be the most nested structure
     assert LogicExp.from_dict(condition.to_dict()) == condition

--- a/pytket/tests/classical_test.py
+++ b/pytket/tests/classical_test.py
@@ -46,7 +46,7 @@ from pytket.circuit.logic_exp import (
     BinaryOp,
     BitLogicExp,
     BitWiseOp,
-    ConstPredicate,
+    RegPredicate,
     LogicExp,
     RegEq,
     RegGeq,
@@ -251,7 +251,7 @@ def primitive_bit_logic_exps(
     exp_type = LogicExp.factory(op)
     args: List[Bit] = [draw(bits)]
     if issubclass(exp_type, BinaryOp):
-        if issubclass(exp_type, ConstPredicate):
+        if issubclass(exp_type, RegPredicate):
             const_compare = draw(binary_digits)
             args.append(const_compare)
         else:
@@ -442,8 +442,8 @@ def bit_const_predicates(
     draw: Callable,
     operators: SearchStrategy[Callable] = strategies.sampled_from([if_bit, if_not_bit]),
     exp: SearchStrategy[BitLogicExp] = composite_bit_logic_exps(),
-) -> ConstPredicate:
-    return cast(ConstPredicate, draw(operators)(draw(exp)))
+) -> RegPredicate:
+    return cast(RegPredicate, draw(operators)(draw(exp)))
 
 
 @strategies.composite
@@ -454,14 +454,14 @@ def reg_const_predicates(
         [reg_eq, reg_neq, reg_lt, reg_gt, reg_leq, reg_geq]
     ),
     constants: SearchStrategy[int] = uint32,
-) -> ConstPredicate:
-    return cast(ConstPredicate, draw(operators)(draw(exp), draw(constants)))
+) -> RegPredicate:
+    return cast(RegPredicate, draw(operators)(draw(exp), draw(constants)))
 
 
 @given(condition=strategies.one_of(bit_const_predicates(), reg_const_predicates()))
 @settings(print_blob=True, deadline=None)
-def test_const_predicate(condition: ConstPredicate) -> None:
-    assert isinstance(condition, ConstPredicate)
+def test_regpredicate(condition: RegPredicate) -> None:
+    assert isinstance(condition, RegPredicate)
     # test serialization round trip here
     # as condition should be the most nested structure
     assert LogicExp.from_dict(condition.to_dict()) == condition


### PR DESCRIPTION
This PR addresses the extension of the previous `ConstPredicate` to a more general `RegPredicate` where the operands can be either logic expressions, bits, bitregisters or constants.