### PR TITLE
Switch to quantinuum conan repo

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -64,7 +64,7 @@ jobs:
       if: github.event_name == 'schedule'
       run: ${CONAN_CMD} profile update options.tket-tests:full=True tket
     - name: add remote
-      run: ${CONAN_CMD} remote add tket-conan https://tket.jfrog.io/artifactory/api/conan/tket-conan
+      run: ${CONAN_CMD} remote add tket-libs https://quantinuumsw.jfrog.io/artifactory/api/conan/tket1-libs
     - name: Install ninja and ccache
       run: sudo apt-get install ninja-build ccache
     - name: Build tket
@@ -197,7 +197,7 @@ jobs:
       if: github.event_name == 'schedule'
       run: conan profile update options.tket-tests:full=True tket
     - name: add remote
-      run: conan remote add tket-conan https://tket.jfrog.io/artifactory/api/conan/tket-conan --force
+      run: conan remote add tket-libs https://quantinuumsw.jfrog.io/artifactory/api/conan/tket1-libs --force
     - name: Build tket
       run: conan create --profile=tket recipes/tket --build=missing
     - name: Build and run tket tests
@@ -290,7 +290,7 @@ jobs:
       if: github.event_name == 'schedule'
       run: conan profile update options.tket-tests:full=True tket
     - name: add remote
-      run: conan remote add tket-conan https://tket.jfrog.io/artifactory/api/conan/tket-conan --force
+      run: conan remote add tket-libs https://quantinuumsw.jfrog.io/artifactory/api/conan/tket1-libs --force
     - name: Build tket
       run: conan create --profile=tket recipes/tket --build=missing
     - name: Build and run tket tests
@@ -393,7 +393,7 @@ jobs:
       if: github.event_name == 'schedule'
       run: conan profile update options.tket-tests:full=True tket
     - name: add remote
-      run: conan remote add tket-conan https://tket.jfrog.io/artifactory/api/conan/tket-conan
+      run: conan remote add tket-libs https://quantinuumsw.jfrog.io/artifactory/api/conan/tket1-libs
     - name: Cache tket build
       id: cache-tket
       uses: actions/cache@v3

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -399,7 +399,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: C:\Users\runneradmin\.conan\data\tket
-        key: ${{ runner.os }}-tket-tket-${{ steps.hash_tket_source.outputs.tket_hash }}-17
+        key: ${{ runner.os }}-tket-tket-${{ steps.hash_tket_source.outputs.tket_hash }}-18
     - name: Build tket
       if: steps.cache-tket.outputs.cache-hit != 'true'
       run: conan create --profile=tket recipes/tket

--- a/.github/workflows/build_libs.yml
+++ b/.github/workflows/build_libs.yml
@@ -79,11 +79,11 @@ jobs:
       if: matrix.os == 'ubuntu-20.04'
       run: conan profile update settings.compiler.libcxx=libstdc++11 tket
     - name: add remote
-      run: conan remote add tket-conan https://tket.jfrog.io/artifactory/api/conan/tket-conan
+      run: conan remote add tket-libs https://quantinuumsw.jfrog.io/artifactory/api/conan/tket1-libs
     - name: build ${{ matrix.lib }}
       run: conan create --profile=tket -s build_type=${{ matrix.build_type }} -o ${{ matrix.lib }}:shared=${{ matrix.shared }} libs/${{ matrix.lib }} tket/stable --build=missing
     - name: authenticate to repository
-      run: conan user -p ${{ secrets.JFROG_ARTIFACTORY_TOKEN_1 }} -r tket-conan ${{ secrets.JFROG_ARTIFACTORY_USER_1 }}
+      run: conan user -p ${{ secrets.JFROG_ARTIFACTORY_TOKEN_2 }} -r tket-libs ${{ secrets.JFROG_ARTIFACTORY_USER_2 }}
     - name: get version
       if: matrix.os != 'windows-2019'
       run: |
@@ -96,10 +96,10 @@ jobs:
         echo "LIB_VER=${${{ matrix.lib }}_ver}" >> $env:GITHUB_ENV
     - name: upload package (dry run)
       if: github.event_name == 'pull_request'
-      run: conan upload ${{ matrix.lib }}/${{ env.LIB_VER }}@tket/stable --all -r=tket-conan --skip-upload
+      run: conan upload ${{ matrix.lib }}/${{ env.LIB_VER }}@tket/stable --all -r=tket-libs --skip-upload
     - name: upload package
       if: github.event_name == 'push'
-      run: conan upload ${{ matrix.lib }}/${{ env.LIB_VER }}@tket/stable --all -r=tket-conan
+      run: conan upload ${{ matrix.lib }}/${{ env.LIB_VER }}@tket/stable --all -r=tket-libs
   macos-m1:
     name: build library (macos-m1)
     needs: changes
@@ -119,21 +119,21 @@ jobs:
     - name: create profile
       run: conan profile new tket --detect --force
     - name: add remote
-      run: conan remote add tket-conan https://tket.jfrog.io/artifactory/api/conan/tket-conan --force
+      run: conan remote add tket-libs https://quantinuumsw.jfrog.io/artifactory/api/conan/tket1-libs --force
     - name: build ${{ matrix.lib }}
       run: conan create --profile=tket -s build_type=${{ matrix.build_type }} -o ${{ matrix.lib }}:shared=${{ matrix.shared }} libs/${{ matrix.lib }} tket/stable --build=missing
     - name: authenticate to repository
-      run: conan user -p ${{ secrets.JFROG_ARTIFACTORY_TOKEN_1 }} -r tket-conan ${{ secrets.JFROG_ARTIFACTORY_USER_1 }}
+      run: conan user -p ${{ secrets.JFROG_ARTIFACTORY_TOKEN_2 }} -r tket-libs ${{ secrets.JFROG_ARTIFACTORY_USER_2 }}
     - name: get version
       run: |
         lib_ver=$(conan inspect --raw version libs/${{ matrix.lib }}/conanfile.py)
         echo "LIB_VER=${lib_ver}" >> $GITHUB_ENV
     - name: upload package (dry run)
       if: github.event_name == 'pull_request'
-      run: conan upload ${{ matrix.lib }}/${LIB_VER}@tket/stable --all -r=tket-conan --skip-upload
+      run: conan upload ${{ matrix.lib }}/${LIB_VER}@tket/stable --all -r=tket-libs --skip-upload
     - name: upload package
       if: github.event_name == 'push'
-      run: conan upload ${{ matrix.lib }}/${LIB_VER}@tket/stable --all -r=tket-conan
+      run: conan upload ${{ matrix.lib }}/${LIB_VER}@tket/stable --all -r=tket-libs
   manylinux:
     name: build library (manylinux)
     needs: changes
@@ -160,7 +160,7 @@ jobs:
         cat <<EOF > env-vars
         TKLIB=${{ matrix.lib }}
         UPLOAD_PACKAGE=${UPLOAD_PACKAGE}
-        JFROG_ARTIFACTORY_TOKEN_1=${{ secrets.JFROG_ARTIFACTORY_TOKEN_1 }}
-        JFROG_ARTIFACTORY_USER_1=${{ secrets.JFROG_ARTIFACTORY_USER_1 }}
+        JFROG_ARTIFACTORY_TOKEN_2=${{ secrets.JFROG_ARTIFACTORY_TOKEN_2 }}
+        JFROG_ARTIFACTORY_USER_2=${{ secrets.JFROG_ARTIFACTORY_USER_2 }}
         EOF
         docker exec --env-file env-vars linux_build /bin/bash -c "/linuxbuildlib"

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -69,7 +69,7 @@ jobs:
         ${conan_cmd} profile update settings.build_type=Debug tket
         echo "CONAN_CMD=${conan_cmd}" >> $GITHUB_ENV
     - name: add remote
-      run: ${CONAN_CMD} remote add tket-conan https://tket.jfrog.io/artifactory/api/conan/tket-conan
+      run: ${CONAN_CMD} remote add tket-libs https://quantinuumsw.jfrog.io/artifactory/api/conan/tket1-libs
     - name: Install ninja and ccache
       run: |
         sudo apt-get update

--- a/.github/workflows/linuxbuildlib
+++ b/.github/workflows/linuxbuildlib
@@ -28,9 +28,9 @@ export CONAN_CMD=${PYBIN}/conan
 
 ${CONAN_CMD} profile new tket --detect
 
-${CONAN_CMD} remote add tket-conan https://tket.jfrog.io/artifactory/api/conan/tket-conan
+${CONAN_CMD} remote add tket-libs https://quantinuumsw.jfrog.io/artifactory/api/conan/tket1-libs
 
-${CONAN_CMD} user -p ${JFROG_ARTIFACTORY_TOKEN_1} -r tket-conan ${JFROG_ARTIFACTORY_USER_1}
+${CONAN_CMD} user -p ${JFROG_ARTIFACTORY_TOKEN_2} -r tket-libs ${JFROG_ARTIFACTORY_USER_2}
 
 LIB_VER=$(${CONAN_CMD} inspect --raw version ${TKLIB})
 
@@ -39,7 +39,7 @@ ${CONAN_CMD} create --profile=tket -o ${TKLIB}:shared=True ${TKLIB} tket/stable
 
 if [ ${UPLOAD_PACKAGE} == "YES" ]
 then
-    ${CONAN_CMD} upload ${TKLIB}/${LIB_VER}@tket/stable --all -r=tket-conan
+    ${CONAN_CMD} upload ${TKLIB}/${LIB_VER}@tket/stable --all -r=tket-libs
 else
-    ${CONAN_CMD} upload ${TKLIB}/${LIB_VER}@tket/stable --all -r=tket-conan --skip-upload
+    ${CONAN_CMD} upload ${TKLIB}/${LIB_VER}@tket/stable --all -r=tket-libs --skip-upload
 fi

--- a/.github/workflows/linuxbuildwheel
+++ b/.github/workflows/linuxbuildwheel
@@ -29,7 +29,7 @@ cd /tket
 ${CONAN_CMD} profile new tket --detect
 ${CONAN_CMD} profile update options.tklog:shared=True tket
 ${CONAN_CMD} profile update options.tket:shared=True tket
-${CONAN_CMD} remote add tket-conan https://tket.jfrog.io/artifactory/api/conan/tket-conan --force
+${CONAN_CMD} remote add tket-libs https://quantinuumsw.jfrog.io/artifactory/api/conan/tket1-libs --force
 ${CONAN_CMD} create --profile=tket --test-folder=None recipes/tket
 ${CONAN_CMD} create --profile=tket --test-folder=None recipes/pybind11
 

--- a/.github/workflows/publish_tket_package.yml
+++ b/.github/workflows/publish_tket_package.yml
@@ -55,11 +55,11 @@ jobs:
       if: matrix.os == 'ubuntu-20.04'
       run: conan profile update settings.compiler.libcxx=libstdc++11 tket
     - name: add remote
-      run: conan remote add tket-conan https://tket.jfrog.io/artifactory/api/conan/tket-conan
+      run: conan remote add tket-libs https://quantinuumsw.jfrog.io/artifactory/api/conan/tket1-libs
     - name: build tket
       run: conan create --profile=tket -s build_type=${{ matrix.build_type }} -o tket:shared=${{ matrix.shared }} recipes/tket tket/stable --build=missing
     - name: authenticate to repository
-      run: conan user -p ${{ secrets.JFROG_ARTIFACTORY_TOKEN_1 }} -r tket-conan ${{ secrets.JFROG_ARTIFACTORY_USER_1 }}
+      run: conan user -p ${{ secrets.JFROG_ARTIFACTORY_TOKEN_2 }} -r tket-libs ${{ secrets.JFROG_ARTIFACTORY_USER_2 }}
     - name: get version
       if: matrix.os != 'windows-2019'
       run: |
@@ -71,7 +71,7 @@ jobs:
         $${{ matrix.lib }}_ver = conan inspect --raw version recipes/tket/conanfile.py
         echo "LIB_VER=${${{ matrix.lib }}_ver}" >> $env:GITHUB_ENV
     - name: upload package
-      run: conan upload tket/${{ env.LIB_VER }}@tket/stable --all -r=tket-conan
+      run: conan upload tket/${{ env.LIB_VER }}@tket/stable --all -r=tket-libs
 
   macos_m1:
     name: build and publish tket (MacOS M1)
@@ -92,14 +92,14 @@ jobs:
     - name: create profile
       run: conan profile new tket --detect --force
     - name: add remote
-      run: conan remote add tket-conan https://tket.jfrog.io/artifactory/api/conan/tket-conan --force
+      run: conan remote add tket-libs https://quantinuumsw.jfrog.io/artifactory/api/conan/tket1-libs --force
     - name: build tket
       run: conan create --profile=tket -s build_type=${{ matrix.build_type }} -o tket:shared=${{ matrix.shared }} recipes/tket tket/stable --build=missing
     - name: authenticate to repository
-      run: conan user -p ${{ secrets.JFROG_ARTIFACTORY_TOKEN_1 }} -r tket-conan ${{ secrets.JFROG_ARTIFACTORY_USER_1 }}
+      run: conan user -p ${{ secrets.JFROG_ARTIFACTORY_TOKEN_2 }} -r tket-libs ${{ secrets.JFROG_ARTIFACTORY_USER_2 }}
     - name: get version
       run: |
         lib_ver=$(conan inspect --raw version recipes/tket/conanfile.py)
         echo "LIB_VER=${lib_ver}" >> $GITHUB_ENV
     - name: upload package
-      run: conan upload tket/${{ env.LIB_VER }}@tket/stable --all -r=tket-conan
+      run: conan upload tket/${{ env.LIB_VER }}@tket/stable --all -r=tket-libs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -168,7 +168,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: C:\Users\runneradmin\.conan\data\tket
-        key: ${{ runner.os }}-tket-tket-${{ steps.hash_tket_source.outputs.tket_hash }}-11
+        key: ${{ runner.os }}-tket-tket-${{ steps.hash_tket_source.outputs.tket_hash }}-12
     - name: Build tket
       if: steps.cache-tket.outputs.cache-hit != 'true'
       run: conan create --profile=tket recipes/tket

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,7 +68,7 @@ jobs:
         conan profile new tket --detect --force
         conan profile update options.tklog:shared=True tket
         conan profile update options.tket:shared=True tket
-        conan remote add tket-conan https://tket.jfrog.io/artifactory/api/conan/tket-conan --force
+        conan remote add tket-libs https://quantinuumsw.jfrog.io/artifactory/api/conan/tket1-libs --force
         conan create --profile=tket recipes/tket --build=missing
     - name: Install pybind11
       run: conan create --profile=tket recipes/pybind11
@@ -111,7 +111,7 @@ jobs:
         conan profile new tket --detect --force
         conan profile update options.tklog:shared=True tket
         conan profile update options.tket:shared=True tket
-        conan remote add tket-conan https://tket.jfrog.io/artifactory/api/conan/tket-conan --force
+        conan remote add tket-libs https://quantinuumsw.jfrog.io/artifactory/api/conan/tket1-libs --force
         conan create --profile=tket recipes/tket --build=missing
         conan create --profile=tket recipes/pybind11
         .github/workflows/build_macos_m1_wheel
@@ -162,7 +162,7 @@ jobs:
         $conan_cmd = (gcm conan).Path
         echo "CONAN_CMD=${conan_cmd}" >> $GITHUB_ENV
     - name: add remote
-      run: conan remote add tket-conan https://tket.jfrog.io/artifactory/api/conan/tket-conan
+      run: conan remote add tket-libs https://quantinuumsw.jfrog.io/artifactory/api/conan/tket1-libs
     - name: Cache tket build
       id: cache-tket
       uses: actions/cache@v3

--- a/.github/workflows/test_libs.yml
+++ b/.github/workflows/test_libs.yml
@@ -63,7 +63,7 @@ jobs:
       if: matrix.os == 'ubuntu-20.04'
       run: conan profile update settings.compiler.libcxx=libstdc++11 tket
     - name: add remote
-      run: conan remote add tket-conan https://tket.jfrog.io/artifactory/api/conan/tket-conan
+      run: conan remote add tket-libs https://quantinuumsw.jfrog.io/artifactory/api/conan/tket1-libs
     - name: build ${{ matrix.lib }}
       run: conan create --profile=tket libs/${{ matrix.lib }} --build=missing
     - name: build ${{ matrix.lib }} tests
@@ -92,7 +92,7 @@ jobs:
     - name: create profile
       run: conan profile new tket --detect --force
     - name: add remote
-      run: conan remote add tket-conan https://tket.jfrog.io/artifactory/api/conan/tket-conan --force
+      run: conan remote add tket-libs https://quantinuumsw.jfrog.io/artifactory/api/conan/tket1-libs --force
     - name: build ${{ matrix.lib }}
       run: conan create --profile=tket libs/${{ matrix.lib }} --build=missing
     - name: build ${{ matrix.lib }} tests
@@ -133,7 +133,7 @@ jobs:
     - name: set libcxx
       run: conan profile update settings.compiler.libcxx=libstdc++11 tket
     - name: add remote
-      run: conan remote add tket-conan https://tket.jfrog.io/artifactory/api/conan/tket-conan
+      run: conan remote add tket-libs https://quantinuumsw.jfrog.io/artifactory/api/conan/tket1-libs
     - name: set Debug in profile
       run: conan profile update settings.build_type=Debug tket
     - name: build ${{ matrix.lib }}

--- a/.github/workflows/test_libs_all.yml
+++ b/.github/workflows/test_libs_all.yml
@@ -34,7 +34,7 @@ jobs:
       if: matrix.os == 'ubuntu-20.04'
       run: conan profile update settings.compiler.libcxx=libstdc++11 tket
     - name: add remote
-      run: conan remote add tket-conan https://tket.jfrog.io/artifactory/api/conan/tket-conan
+      run: conan remote add tket-libs https://quantinuumsw.jfrog.io/artifactory/api/conan/tket1-libs
     - name: build ${{ matrix.lib }}
       run: conan create --profile=tket libs/${{ matrix.lib }} --build=missing
     - name: build ${{ matrix.lib }} tests
@@ -61,7 +61,7 @@ jobs:
     - name: create profile
       run: conan profile new tket --detect --force
     - name: add remote
-      run: conan remote add tket-conan https://tket.jfrog.io/artifactory/api/conan/tket-conan --force
+      run: conan remote add tket-libs https://quantinuumsw.jfrog.io/artifactory/api/conan/tket1-libs --force
     - name: build ${{ matrix.lib }}
       run: conan create --profile=tket libs/${{ matrix.lib }} --build=missing
     - name: build ${{ matrix.lib }} tests

--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -55,7 +55,7 @@ jobs:
       if: github.event_name == 'schedule'
       run: conan profile update options.tket-tests:full=True tket
     - name: add remote
-      run: conan remote add tket-conan https://tket.jfrog.io/artifactory/api/conan/tket-conan
+      run: conan remote add tket-libs https://quantinuumsw.jfrog.io/artifactory/api/conan/tket1-libs
     - name: install tex components
       run: |
         sudo apt install texlive texlive-latex-extra latexmk

--- a/README.md
+++ b/README.md
@@ -82,10 +82,10 @@ recommended in the warning message:
 conan profile update settings.compiler.libcxx=libstdc++11 tket
 ```
 
-Add the `tket.conan` repository to your remotes:
+Add the `tket.libs` repository to your remotes:
 
 ```shell
-conan remote add tket-conan https://tket.jfrog.io/artifactory/api/conan/tket-conan
+conan remote add tket-libs https://quantinuumsw.jfrog.io/artifactory/api/conan/tket1-libs
 ```
 
 Enable revisions:

--- a/libs/README.md
+++ b/libs/README.md
@@ -1,0 +1,13 @@
+# Dependencies
+
+The libraries in this directory have the following dependency graph (where a
+downward line means "is required by"):
+
+        tklog
+          |
+          |
+      tkassert   tkrng
+          |   \ /  |
+          |    X   |
+          |   / \  |
+    tktokenswap tkwsm

--- a/libs/tkassert/conanfile.py
+++ b/libs/tkassert/conanfile.py
@@ -18,7 +18,7 @@ from conans.errors import ConanInvalidConfiguration
 
 class TkassertConan(ConanFile):
     name = "tkassert"
-    version = "0.1.0"
+    version = "0.1.1"
     license = "Apache 2"
     url = "https://github.com/CQCL/tket"
     description = "Assertions"
@@ -31,7 +31,7 @@ class TkassertConan(ConanFile):
     default_options = {"shared": False, "fPIC": True, "profile_coverage": False}
     generators = "cmake"
     exports_sources = "src/*"
-    requires = ["tklog/0.1.1@tket/stable"]
+    requires = ["tklog/0.1.2@tket/stable"]
 
     def config_options(self):
         if self.settings.os == "Windows":

--- a/libs/tkassert/test/conanfile.py
+++ b/libs/tkassert/test/conanfile.py
@@ -18,7 +18,7 @@ import platform
 
 class TestTkassertConan(ConanFile):
     name = "test-tkassert"
-    version = "0.1.0"
+    version = "0.1.1"
     license = "Apache 2"
     url = "https://github.com/CQCL/tket"
     description = "Unit tests for tkassert"
@@ -27,7 +27,7 @@ class TestTkassertConan(ConanFile):
     default_options = {"with_coverage": False}
     generators = "cmake"
     exports_sources = "*"
-    requires = ["tkassert/0.1.0", "catch2/3.1.0"]
+    requires = ["tkassert/0.1.1", "catch2/3.1.0"]
 
     _cmake = None
 

--- a/libs/tklog/conanfile.py
+++ b/libs/tklog/conanfile.py
@@ -18,7 +18,7 @@ from conans.errors import ConanInvalidConfiguration
 
 class TklogConan(ConanFile):
     name = "tklog"
-    version = "0.1.1"
+    version = "0.1.2"
     license = "Apache 2"
     url = "https://github.com/CQCL/tket"
     description = "Simple logging library"

--- a/libs/tklog/test/conanfile.py
+++ b/libs/tklog/test/conanfile.py
@@ -18,7 +18,7 @@ import platform
 
 class TestTklogConan(ConanFile):
     name = "test-tklog"
-    version = "0.1.0"
+    version = "0.1.1"
     license = "Apache 2"
     url = "https://github.com/CQCL/tket"
     description = "Unit tests for tklog"
@@ -27,7 +27,7 @@ class TestTklogConan(ConanFile):
     default_options = {"with_coverage": False}
     generators = "cmake"
     exports_sources = "*"
-    requires = ["tklog/0.1.1", "catch2/3.1.0"]
+    requires = ["tklog/0.1.2", "catch2/3.1.0"]
 
     _cmake = None
 

--- a/libs/tkrng/conanfile.py
+++ b/libs/tkrng/conanfile.py
@@ -18,7 +18,7 @@ from conans.errors import ConanInvalidConfiguration
 
 class TkrngConan(ConanFile):
     name = "tkrng"
-    version = "0.1.1"
+    version = "0.1.2"
     license = "Apache 2"
     url = "https://github.com/CQCL/tket"
     description = "Deterministic cross-platform PRNG"

--- a/libs/tkrng/test/conanfile.py
+++ b/libs/tkrng/test/conanfile.py
@@ -18,7 +18,7 @@ import platform
 
 class TestTkrngConan(ConanFile):
     name = "test-tkrng"
-    version = "0.1.0"
+    version = "0.1.1"
     license = "Apache 2"
     url = "https://github.com/CQCL/tket"
     description = "Unit tests for tkrng"
@@ -27,7 +27,7 @@ class TestTkrngConan(ConanFile):
     default_options = {"with_coverage": False}
     generators = "cmake"
     exports_sources = "*"
-    requires = ["tkrng/0.1.1", "catch2/3.1.0"]
+    requires = ["tkrng/0.1.2", "catch2/3.1.0"]
 
     _cmake = None
 

--- a/libs/tktokenswap/conanfile.py
+++ b/libs/tktokenswap/conanfile.py
@@ -18,7 +18,7 @@ from conans.errors import ConanInvalidConfiguration
 
 class TktokenswapConan(ConanFile):
     name = "tktokenswap"
-    version = "0.1.0"
+    version = "0.1.1"
     license = "Apache 2"
     url = "https://github.com/CQCL/tket"
     description = "Token swapping algorithms library"
@@ -32,9 +32,9 @@ class TktokenswapConan(ConanFile):
     generators = "cmake"
     exports_sources = "src/*"
     requires = [
-        "tklog/0.1.1@tket/stable",
-        "tkassert/0.1.0@tket/stable",
-        "tkrng/0.1.1@tket/stable",
+        "tklog/0.1.2@tket/stable",
+        "tkassert/0.1.1@tket/stable",
+        "tkrng/0.1.2@tket/stable",
         "boost/1.79.0",
     ]
 

--- a/libs/tktokenswap/test/conanfile.py
+++ b/libs/tktokenswap/test/conanfile.py
@@ -18,7 +18,7 @@ import platform
 
 class TestTktokenswapConan(ConanFile):
     name = "test-tktokenswap"
-    version = "0.1.0"
+    version = "0.1.1"
     license = "Apache 2"
     url = "https://github.com/CQCL/tket"
     description = "Unit tests for tktokenswap"
@@ -27,7 +27,7 @@ class TestTktokenswapConan(ConanFile):
     default_options = {"with_coverage": False}
     generators = "cmake"
     exports_sources = "*"
-    requires = ["tktokenswap/0.1.0", "catch2/3.1.0"]
+    requires = ["tktokenswap/0.1.1", "catch2/3.1.0"]
 
     _cmake = None
 

--- a/libs/tkwsm/conanfile.py
+++ b/libs/tkwsm/conanfile.py
@@ -18,7 +18,7 @@ from conans.errors import ConanInvalidConfiguration
 
 class TkwsmConan(ConanFile):
     name = "tkwsm"
-    version = "0.1.0"
+    version = "0.1.1"
     license = "Apache 2"
     url = "https://github.com/CQCL/tket"
     description = "Weighted-subgraph-monomorphism algorithms library"
@@ -32,8 +32,8 @@ class TkwsmConan(ConanFile):
     generators = "cmake"
     exports_sources = "src/*"
     requires = [
-        "tkassert/0.1.0@tket/stable",
-        "tkrng/0.1.1@tket/stable",
+        "tkassert/0.1.1@tket/stable",
+        "tkrng/0.1.2@tket/stable",
     ]
 
     def config_options(self):

--- a/libs/tkwsm/test/SolvingProblems/test_RandomGraphs.cpp
+++ b/libs/tkwsm/test/SolvingProblems/test_RandomGraphs.cpp
@@ -376,11 +376,11 @@ SCENARIO(
     entry = -1;
   }
   TestParameters params;
-  params.timeout = 30000;
+  params.timeout = 60000;
   params.total_number_of_edges = 3250;
   params.total_number_of_vertices = 334;
 
-  params.expected_max_total_time_ms = 30000;
+  params.expected_max_total_time_ms = 60000;
   params.expected_min_total_time_ms = 1000;
   const auto result = tester.test_all_against_all(params);
   CHECK(result.success_count == 2);

--- a/libs/tkwsm/test/conanfile.py
+++ b/libs/tkwsm/test/conanfile.py
@@ -18,7 +18,7 @@ import platform
 
 class TestTkwsmConan(ConanFile):
     name = "test-tkwsm"
-    version = "0.1.0"
+    version = "0.1.1"
     license = "Apache 2"
     url = "https://github.com/CQCL/tket"
     description = "Unit tests for tkwsm"
@@ -27,7 +27,7 @@ class TestTkwsmConan(ConanFile):
     default_options = {"with_coverage": False}
     generators = "cmake"
     exports_sources = "*"
-    requires = ["tkwsm/0.1.0", "catch2/3.1.0"]
+    requires = ["tkwsm/0.1.1", "catch2/3.1.0"]
 
     _cmake = None
 

--- a/pytket/conanfile.txt
+++ b/pytket/conanfile.txt
@@ -1,6 +1,6 @@
 [requires]
 tket/1.0.1
-tklog/0.1.1@tket/stable
+tklog/0.1.2@tket/stable
 pybind11/2.9.2
 nlohmann_json/3.10.5
 pybind11_json/0.2.12

--- a/recipes/tket/conanfile.py
+++ b/recipes/tket/conanfile.py
@@ -41,11 +41,11 @@ class TketConan(ConanFile):
         "symengine/0.9.0",
         "eigen/3.4.0",
         "nlohmann_json/3.10.5",
-        "tklog/0.1.1@tket/stable",
-        "tkassert/0.1.0@tket/stable",
-        "tkrng/0.1.1@tket/stable",
-        "tktokenswap/0.1.0@tket/stable",
-        "tkwsm/0.1.0@tket/stable",
+        "tklog/0.1.2@tket/stable",
+        "tkassert/0.1.1@tket/stable",
+        "tkrng/0.1.2@tket/stable",
+        "tktokenswap/0.1.1@tket/stable",
+        "tkwsm/0.1.1@tket/stable",
     )
 
     # List of components in a topological sort according to dependencies:


### PR DESCRIPTION
Requires a small change to your conan configuration to build, as described in the README.

I have uploaded new versions of all the libraries in `libs` to the new repo, increasing the version numbers so that there can be no ambiguity if both repos are registered as remotes (though I'd recommend removing the old remote from config).