### PR TITLE
[feature] Improve ThreeQubitConversion

### DIFF
--- a/tket/src/Circuit/CircUtils.cpp
+++ b/tket/src/Circuit/CircUtils.cpp
@@ -146,10 +146,6 @@ Circuit two_qubit_canonical(const Eigen::Matrix4cd &U, OpType target_2qb_gate) {
         "Non-unitary matrix passed to two_qubit_canonical");
   }
 
-  if (!std::set<OpType>{OpType::CX, OpType::TK2}.contains(target_2qb_gate)) {
-    throw std::invalid_argument("Target_2qb_gate must be CX or TK2");
-  }
-
   auto [K1, A, K2] = get_information_content(U);
 
   K1 /= pow(K1.determinant(), 0.25);
@@ -169,10 +165,15 @@ Circuit two_qubit_canonical(const Eigen::Matrix4cd &U, OpType target_2qb_gate) {
   result.add_op<unsigned>(
       OpType::TK1, {angles_q1.begin(), angles_q1.end() - 1}, {1});
 
-  if (target_2qb_gate == OpType::CX) {
-    result.append(CircPool::TK2_using_CX(a, b, c));
-  } else {
-    result.append(CircPool::TK2_using_normalised_TK2(a, b, c));
+  switch (target_2qb_gate) {
+    case OpType::TK2:
+      result.append(CircPool::TK2_using_normalised_TK2(a, b, c));
+      break;
+    case OpType::CX:
+      result.append(CircPool::TK2_using_CX(a, b, c));
+      break;
+    default:
+      throw std::invalid_argument("target_2qb_gate must be CX or TK2.");
   }
 
   angles_q0 = tk1_angles_from_unitary(K1a);

--- a/tket/src/Circuit/ThreeQubitConversion.cpp
+++ b/tket/src/Circuit/ThreeQubitConversion.cpp
@@ -106,9 +106,15 @@ static const std::vector<Eigen::Matrix4cd> &get_conj_unitaries() {
     c3.add_op<unsigned>(OpType::CX, {0, 1});
     Circuit c4(2);
     c4.add_op<unsigned>(OpType::CX, {1, 0});
-    return {
-        get_matrix_from_2qb_circ(c1), get_matrix_from_2qb_circ(c2),
-        get_matrix_from_2qb_circ(c3), get_matrix_from_2qb_circ(c4)};
+    Circuit c5(2);
+    c5.add_op<unsigned>(OpType::CX, {0, 1});
+    c5.add_op<unsigned>(OpType::CX, {1, 0});
+    Circuit c6(2);
+    c6.add_op<unsigned>(OpType::CX, {1, 0});
+    c6.add_op<unsigned>(OpType::CX, {0, 1});
+    return {get_matrix_from_2qb_circ(c1), get_matrix_from_2qb_circ(c2),
+            get_matrix_from_2qb_circ(c3), get_matrix_from_2qb_circ(c4),
+            get_matrix_from_2qb_circ(c5), get_matrix_from_2qb_circ(c6)};
   };
 
   static const std::vector<Eigen::Matrix4cd> vec = make_conj_unitaries();
@@ -148,8 +154,8 @@ static std::pair<Circuit, Complex> two_qubit_plex(
 
   // We try conjugating the L and R circuits to see if we can reduce CX count.
   std::optional<Circuit> best_circ;
-  Complex best_z0;
-  unsigned best_n_cx;
+  Complex best_z0 = 0;
+  unsigned best_n_cx = 0;
   for (const Eigen::Matrix4cd &u_conj : get_conj_unitaries()) {
     // 4. Decompose R into a 2-CX circuit followed by a diagonal.
     auto u_conj_adj = u_conj.adjoint();

--- a/tket/src/Circuit/ThreeQubitConversion.cpp
+++ b/tket/src/Circuit/ThreeQubitConversion.cpp
@@ -153,8 +153,8 @@ static std::pair<Circuit, Complex> two_qubit_plex(
 
   // We try conjugating the L and R circuits to see if we can reduce CX count.
   std::optional<Circuit> best_circ;
-  Complex best_z0;
-  unsigned best_n_cx;
+  std::optional<Complex> best_z0;
+  std::optional<unsigned> best_n_cx;
   for (const Eigen::Matrix4cd &u_conj : get_conj_unitaries()) {
     // 4. Decompose R into a 2-CX circuit followed by a diagonal.
     auto u_conj_adj = u_conj.adjoint();
@@ -187,7 +187,7 @@ static std::pair<Circuit, Complex> two_qubit_plex(
     }
   }
   TKET_ASSERT(best_circ);
-  return {*best_circ, best_z0};
+  return {*best_circ, *best_z0};
 }
 
 // Return a 3-qubit circuit which implements the unitary

--- a/tket/src/Circuit/ThreeQubitConversion.cpp
+++ b/tket/src/Circuit/ThreeQubitConversion.cpp
@@ -17,7 +17,6 @@
 #include <array>
 #include <cmath>
 #include <complex>
-#include <limits>
 #include <optional>
 #include <stdexcept>
 #include <tkassert/Assert.hpp>
@@ -154,8 +153,8 @@ static std::pair<Circuit, Complex> two_qubit_plex(
 
   // We try conjugating the L and R circuits to see if we can reduce CX count.
   std::optional<Circuit> best_circ;
-  Complex best_z0 = 1.;
-  unsigned best_n_cx = UINT_MAX;
+  Complex best_z0;
+  unsigned best_n_cx;
   for (const Eigen::Matrix4cd &u_conj : get_conj_unitaries()) {
     // 4. Decompose R into a 2-CX circuit followed by a diagonal.
     auto u_conj_adj = u_conj.adjoint();

--- a/tket/src/Circuit/include/Circuit/CircUtils.hpp
+++ b/tket/src/Circuit/include/Circuit/CircUtils.hpp
@@ -71,10 +71,10 @@ Eigen::Matrix4cd get_matrix_from_2qb_circ(const Circuit& circ);
  * @param target_2qb_gate whether to decompose to TK2 or CX (default: TK2)
  *
  * @pre \p U is in \ref BasisOrder::ilo
- * @post circuit consists of one TK2 and single-qubit gates, or of up to 3 CX
- * and single-qubit gates.
+ * @post Circuit consists of one normalised TK2 and single-qubit gates, or of
+ * up to 3 CX and single-qubit gates.
  *
- * @return circuit implementing U exactly.
+ * @return circuit implementing U exactly
  */
 Circuit two_qubit_canonical(
     const Eigen::Matrix4cd& U, OpType target_2qb_gate = OpType::TK2);

--- a/tket/src/Circuit/include/Circuit/CircUtils.hpp
+++ b/tket/src/Circuit/include/Circuit/CircUtils.hpp
@@ -63,17 +63,21 @@ Eigen::Matrix4cd get_matrix_from_2qb_circ(const Circuit& circ);
 /**
  * Convert a 4x4 unitary matrix optimally to a corresponding circuit
  *
- * This will express `U` using a single TK2 gate. See `decompose_TK2` to
- * decompose this gate further into other primitives.
+ * This will express `U` using CX gates or a single TK2 gate.
+ * See also `decompose_TK2` to decompose the TK2 gate further into other
+ * primitives.
  *
  * @param U unitary matrix
+ * @param target_2qb_gate whether to decompose to TK2 or CX (default: TK2)
  *
  * @pre \p U is in \ref BasisOrder::ilo
- * @post circuit consists of one TK2 and single-qubit gates
+ * @post circuit consists of one TK2 and single-qubit gates, or of up to 3 CX
+ * and single-qubit gates.
  *
- * @return circuit implementing U with minimal error
+ * @return circuit implementing U exactly.
  */
-Circuit two_qubit_canonical(const Eigen::Matrix4cd& U);
+Circuit two_qubit_canonical(
+    const Eigen::Matrix4cd& U, OpType target_2qb_gate = OpType::TK2);
 
 /**
  * Decompose a unitary matrix into a 2-CX circuit following a diagonal operator.

--- a/tket/src/Transformations/BasicOptimisation.cpp
+++ b/tket/src/Transformations/BasicOptimisation.cpp
@@ -282,7 +282,6 @@ static bool replace_two_qubit_interaction(
   decompose_multi_qubits_TK2().apply(replacement);
   Eigen::Matrix4cd mat = get_matrix_from_2qb_circ(replacement);
   replacement = two_qubit_canonical(mat);
-  normalise_TK2().apply(replacement);
   TwoQbFidelities fid;
   fid.CX_fidelity = cx_fidelity;
   if (target != OpType::TK2) {


### PR DESCRIPTION
Small changes that can save a CX or two in some cases when using `three_qubit_squash`.

This only applies when the decomposition targets CX gates. I think this could be generalised to work on TK2 gates, and in a wider scope. I will write some notes down and might present it once on a Friday.