### PR TITLE
Prevent Architecture from having an edge between the same node

### DIFF
--- a/tket/src/Graphs/include/Graphs/DirectedGraph.hpp
+++ b/tket/src/Graphs/include/Graphs/DirectedGraph.hpp
@@ -90,6 +90,10 @@ class DirectedGraphBase : public AbstractGraph<T> {
       if (!node_exists(node2)) {
         add_node(node2);
       }
+      if (node1 == node2) {
+        throw std::invalid_argument(
+            "An edge can not be added from a node to itself.");
+      }
       add_connection(node1, node2);
     }
   }
@@ -129,6 +133,10 @@ class DirectedGraphBase : public AbstractGraph<T> {
     if (!node_exists(node1) || !node_exists(node2)) {
       throw NodeDoesNotExistError(
           "The nodes passed to DirectedGraph::add_connection must exist");
+    }
+    if (node1 == node2) {
+      throw std::invalid_argument(
+          "A connection can not be added between a node to itself.");
     }
     boost::add_edge(
         to_vertices(node1), to_vertices(node2), WeightedEdge(weight), graph);

--- a/tket/src/Graphs/include/Graphs/DirectedGraph.hpp
+++ b/tket/src/Graphs/include/Graphs/DirectedGraph.hpp
@@ -373,8 +373,8 @@ class DirectedGraphBase : public AbstractGraph<T> {
 };
 
 /**
- * DirectedGraph instances are directed graphs. It is a wrapper around a
- * BGL graph that provides a clean class API, taking care of mapping all BGL
+ * DirectedGraph instances are loop-free directed graphs. It is a wrapper around
+ * a BGL graph that provides a clean class API, taking care of mapping all BGL
  * vertices and edge pointers to nodes, respectively pairs of nodes.
  *
  * The vertices and edges can be given weights of type double if desired, and

--- a/tket/src/Placement/Qubit_Placement.cpp
+++ b/tket/src/Placement/Qubit_Placement.cpp
@@ -166,6 +166,9 @@ QubitGraph generate_interaction_graph(
 
 QubitLineList qubit_lines(const Circuit& circ) {
   const QubitGraph q_graph = generate_interaction_graph(circ);
+  if (q_graph.get_all_edges_vec().size() == 0) {
+    return {};
+  }
   std::set<Qubit> all_qb;
   for (const Qubit& qb : circ.all_qubits()) {
     all_qb.insert(qb);
@@ -194,7 +197,6 @@ QubitLineList qubit_lines(const Circuit& circ) {
   for (const Qubit& qb : circ.all_qubits()) {
     if (all_qb.find(qb) != all_qb.end()) found_lines.push_back({qb});
   }
-  // print_qubitlines(found_lines);
   return found_lines;
 }
 

--- a/tket/tests/Graphs/test_DirectedGraph.cpp
+++ b/tket/tests/Graphs/test_DirectedGraph.cpp
@@ -59,6 +59,14 @@ SCENARIO("Correct creation of DirectedGraph graphs") {
     CHECK(uidgraph.edge_exists(Qubit(2), Qubit(1)));
     CHECK(uidgraph.edge_exists(Qubit(1), Qubit(0)));
   }
+  GIVEN("Construct qubit graph with invalid edges.") {
+    using Conn = DirectedGraph<Qubit>::Connection;
+    std::vector<Conn> edges{{Qubit(0), Qubit(0)}};
+    CHECK_THROWS(DirectedGraph<Qubit>(edges));
+    edges = {{Qubit(0), Qubit(1)}};
+    DirectedGraph<Qubit> uidgraph(edges);
+    CHECK_THROWS(uidgraph.add_connection(Qubit(0), Qubit(0)));
+  }
   GIVEN("Construct graph using member functions") {
     std::vector<Node> uids = {Node(4), Node(1), Node(0), Node(1231)};
     DirectedGraph<Node> uidgraph;

--- a/tket/tests/Placement/test_Placement.cpp
+++ b/tket/tests/Placement/test_Placement.cpp
@@ -614,6 +614,18 @@ SCENARIO(
     }
     REQUIRE(test_m.at(all_qs[3]) == uid0);
   }
+  GIVEN("A circuit with no two-qubit gates.") {
+    Circuit test_circ(4);
+    test_circ.add_op<unsigned>(OpType::T, {0});
+    test_circ.add_op<unsigned>(OpType::X, {1});
+    test_circ.add_op<unsigned>(OpType::H, {2});
+    test_circ.add_op<unsigned>(OpType::S, {3});
+    const qubit_mapping_t test_m = test_p.get_placement_map(test_circ);
+    REQUIRE(test_m.at(Qubit(0)) == Node("unplaced", 0));
+    REQUIRE(test_m.at(Qubit(1)) == Node("unplaced", 1));
+    REQUIRE(test_m.at(Qubit(2)) == Node("unplaced", 2));
+    REQUIRE(test_m.at(Qubit(3)) == Node("unplaced", 3));
+  }
 }
 
 SCENARIO(


### PR DESCRIPTION
Currently it's possible to have an Architecture with an edge between a node to itself.
This is not something methods are designed to deal with or that we expect a realistic quantum device to need to represent.
This PR adds checks when edges are added to a Architecture and throws an error if the initialisation wants to do this.

Additionally`qubit_lines` has been updated to return an empty list if the circuit has no edges in its interaction graph.