### PR TITLE
[bugfix] FullPeephole in TK2 mode squashes correctly

### DIFF
--- a/pytket/binders/passes.cpp
+++ b/pytket/binders/passes.cpp
@@ -461,7 +461,8 @@ PYBIND11_MODULE(passes, m) {
       "FullPeepholeOptimise", &FullPeepholeOptimise,
       "Performs peephole optimisation including resynthesis of 2- and 3-qubit "
       "gate sequences, and converts to a circuit containing only the given "
-      "2-qubit gate (which may be CX or TK2) and TK1 gates."
+      "2-qubit gate (which may be CX or TK2) and TK1 gates.\n\n"
+      "The `allow_swaps` parameter has no effect when the target gate is TK2."
       "\n\n:param allow_swaps: whether to allow implicit wire swaps",
       py::arg("allow_swaps") = true, py::arg("target_2qb_gate") = OpType::CX);
   m.def("RebaseTket", &RebaseTket, "Converts all gates to CX and TK1.");

--- a/pytket/docs/changelog.rst
+++ b/pytket/docs/changelog.rst
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+x.y.z (unreleased)
+------------------
+
+Fixes:
+
+* Squash two-qubit circuits properly in ``FullPeepholeOptimise`` for parameter
+  `target_2qb_gate=OpType.TK2`.
+
 1.5.0 (August 2022)
 -------------------
 

--- a/tket/src/Predicates/include/Predicates/PassGenerators.hpp
+++ b/tket/src/Predicates/include/Predicates/PassGenerators.hpp
@@ -211,6 +211,8 @@ PassPtr ThreeQubitSquash(bool allow_swaps = true);
  * sequences, and converts to a circuit containing a given 2-qubit gate and TK1
  * gates.
  *
+ * The allow_swaps parameter has no effect when the target gate is TK2.
+ *
  * @param target_2qb_gate target 2-qubit gate (CX or TK2)
  * @param allow_swaps whether to allow introduction of implicit swaps
  */

--- a/tket/src/Transformations/OptimisationPass.cpp
+++ b/tket/src/Transformations/OptimisationPass.cpp
@@ -53,7 +53,8 @@ Transform full_peephole_optimise(bool allow_swaps, OpType target_2qb_gate) {
           synthesise_tk() >> two_qubit_squash(OpType::TK2) >>
           clifford_simp(false) >> two_qubit_squash(OpType::TK2) >>
           synthesise_tk() >> three_qubit_squash(OpType::TK2) >>
-          clifford_simp(allow_swaps) >> synthesise_tk());
+          clifford_simp(false) >> two_qubit_squash(OpType::TK2) >>
+          synthesise_tk());
     default:
       throw std::invalid_argument("Invalid target 2-qubit gate");
   }

--- a/tket/src/Transformations/include/Transformations/OptimisationPass.hpp
+++ b/tket/src/Transformations/include/Transformations/OptimisationPass.hpp
@@ -35,6 +35,8 @@ Transform peephole_optimise_2q();
 /**
  * Peephole optimisation including resynthesis of three-qubit gate sequences.
  *
+ * The allow_swaps parameter has no effect when the target gate is TK2.
+ *
  * @param allow_swaps whether to allow introduction of implicit wire swaps
  * @param target_2qb_gate target 2-qubut gate (CX or TK2)
  *

--- a/tket/tests/test_CompilerPass.cpp
+++ b/tket/tests/test_CompilerPass.cpp
@@ -770,6 +770,18 @@ SCENARIO("PeepholeOptimise2Q and FullPeepholeOptimise") {
     REQUIRE(FullPeepholeOptimise()->apply(cu));
     REQUIRE(test_unitary_comparison(circ, cu.get_circ_ref()));
   }
+  GIVEN("A circuit targetting TK2.") {
+    Circuit circ(2);
+    circ.add_op<unsigned>(OpType::CX, {0, 1});
+    circ.add_op<unsigned>(OpType::Rz, 0.2, {1});
+    circ.add_op<unsigned>(OpType::CX, {0, 1});
+    CompilationUnit cu(circ);
+    REQUIRE(FullPeepholeOptimise(true, OpType::TK2)->apply(cu));
+
+    circ = cu.get_circ_ref();
+
+    REQUIRE(circ.count_gates(OpType::TK2) == 1);
+  }
 }
 
 SCENARIO("FullPeepholeOptimise with various options") {


### PR DESCRIPTION
An extra `two_qubit_squash` pass is necessary after `clifford_simp` when targetting TK2.

Also, implicit swaps are never required when targetting TK2 because any such swap can be swallowed into an existing TK2. Implicit swaps would be added in further down the compilation when TK2s are further decomposed into hardware primitives.