### PR TITLE
Circuit HTML - Remove blank lines in template.

### DIFF
--- a/pytket/pytket/circuit/display/circuit.html
+++ b/pytket/pytket/circuit/display/circuit.html
@@ -5,7 +5,6 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-
     <script type="application/javascript" src="https://cdn.jsdelivr.net/npm/vue@3"></script>
     <script type="application/javascript" src="https://unpkg.com/pytket-circuit-renderer@0.2/dist/pytket-circuit-renderer.umd.js"></script>
     <link rel="stylesheet" href="https://unpkg.com/pytket-circuit-renderer@0.2/dist/pytket-circuit-renderer.css">
@@ -17,18 +16,14 @@
         </div>
         <circuit-display-container :circuit-element-str="'#circuit-json-to-display'"></circuit-display-container>
     </div>
-
     <script type="application/javascript">
         const { createApp } = Vue;
         const circuitDisplayContainer = window["pytket-circuit-renderer"].default;
-
         // Init variables to be shared between circuit display instances
         if (typeof window.pytketCircuitDisplays === "undefined") {
             window.pytketCircuitDisplays = {};
         }
-
         const uid = "{{ uid }}";
-
         // Create the root Vue component
         window.pytketCircuitDisplays[uid] = createApp({
             delimiters: ['[[#', '#]]'],


### PR DESCRIPTION
When exporting jupyter notebooks as markdown, Jupyter (or pandoc presumably) preserves blank lines in the html it exports which isn't valid in a markdown file. I could try and write a fix on the jupyter repo or write a custom html parser but this is the easiest solution for now. This will help when embedding the circuit renderer on webpages when using a markdown export.