### PR TITLE
Add basic ToffoliBox synthesis

### DIFF
--- a/pytket/binders/circuit/Circuit/add_op.cpp
+++ b/pytket/binders/circuit/Circuit/add_op.cpp
@@ -252,6 +252,18 @@ void init_circuit_add_op(py::class_<Circuit, std::shared_ptr<Circuit>> &c) {
           "\n:return: the new :py:class:`Circuit`",
           py::arg("pauliexpbox"), py::arg("qubits"))
       .def(
+          "add_toffolibox",
+          [](Circuit *circ, const ToffoliBox &box,
+             const std::vector<unsigned> &qubits, const py::kwargs &kwargs) {
+            return add_box_method<unsigned>(
+                circ, std::make_shared<ToffoliBox>(box), qubits, kwargs);
+          },
+          "Append a :py:class:`ToffoliBox` to the "
+          "circuit.\n\n:param toffolibox: The box to append\n:param "
+          "qubits: Indices of the qubits to append the box to"
+          "\n:return: the new :py:class:`Circuit`",
+          py::arg("toffolibox"), py::arg("qubits"))
+      .def(
           "add_qcontrolbox",
           [](Circuit *circ, const QControlBox &box,
              const std::vector<unsigned> &args, const py::kwargs &kwargs) {

--- a/pytket/binders/circuit/boxes.cpp
+++ b/pytket/binders/circuit/boxes.cpp
@@ -128,6 +128,18 @@ void init_boxes(py::module &m) {
       .def(
           "get_phase", &PauliExpBox::get_phase,
           ":return: the corresponding phase parameter");
+  py::class_<ToffoliBox, std::shared_ptr<ToffoliBox>, Op>(
+      m, "ToffoliBox",
+      "An operation that constructs a circuit to implement the specified "
+      "permutation of classical basis states.")
+      .def(
+          py::init<std::map<std::vector<bool>, std::vector<bool>> &>(),
+          "Construct from the cycle of basis states described by the "
+          "permutation provided.",
+          py::arg("permutation"))
+      .def(
+          "get_circuit", [](ToffoliBox &tbox) { return *tbox.to_circuit(); },
+          ":return: the :py:class:`Circuit` described by the box");
   py::class_<QControlBox, std::shared_ptr<QControlBox>, Op>(
       m, "QControlBox",
       "A user-defined controlled operation specified by an "

--- a/pytket/binders/circuit/main.cpp
+++ b/pytket/binders/circuit/main.cpp
@@ -324,6 +324,9 @@ PYBIND11_MODULE(circuit, m) {
           "QControlBox", OpType::QControlBox,
           "An arbitrary n-controlled operation")
       .value(
+          "ToffoliBox", OpType::ToffoliBox,
+          "A permutation of classical basis states")
+      .value(
           "CustomGate", OpType::CustomGate,
           ":math:`(\\alpha, \\beta, \\ldots) \\mapsto` A user-defined "
           "operation, based on a :py:class:`Circuit` :math:`C` with "

--- a/pytket/tests/circuit_test.py
+++ b/pytket/tests/circuit_test.py
@@ -405,15 +405,12 @@ def test_boxes() -> None:
     assert all(box == box for box in boxes)
     assert all(isinstance(box, Op) for box in boxes)
 
-    permutation = {(0,0): (1,1), (1,1): (0,0)}
+    permutation = {(0, 0): (1, 1), (1, 1): (0, 0)}
     tb = ToffoliBox(permutation)
     assert tb.type == OpType.ToffoliBox
     unitary = tb.get_circuit().get_unitary()
     comparison = np.asarray([[0, 0, 0, 1], [0, 1, 0, 0], [0, 0, 1, 0], [1, 0, 0, 0]])
     assert np.allclose(unitary, comparison)
-
-
-
 
 
 def test_u1q_stability() -> None:

--- a/pytket/tests/circuit_test.py
+++ b/pytket/tests/circuit_test.py
@@ -31,6 +31,7 @@ from pytket.circuit import (  # type: ignore
     PauliExpBox,
     QControlBox,
     PhasePolyBox,
+    ToffoliBox,
     CustomGateDef,
     CustomGate,
     Qubit,
@@ -403,6 +404,16 @@ def test_boxes() -> None:
     boxes = (cbox, mbox, u2qbox, u3qbox, ebox, pbox, qcbox)
     assert all(box == box for box in boxes)
     assert all(isinstance(box, Op) for box in boxes)
+
+    permutation = {(0,0): (1,1), (1,1): (0,0)}
+    tb = ToffoliBox(permutation)
+    assert tb.type == OpType.ToffoliBox
+    unitary = tb.get_circuit().get_unitary()
+    comparison = np.asarray([[0, 0, 0, 1], [0, 1, 0, 0], [0, 0, 1, 0], [1, 0, 0, 0]])
+    assert np.allclose(unitary, comparison)
+
+
+
 
 
 def test_u1q_stability() -> None:

--- a/tket/src/Circuit/Boxes.cpp
+++ b/tket/src/Circuit/Boxes.cpp
@@ -733,29 +733,33 @@ ToffoliBox::cycle_transposition_t merge_cycles(
       // try adding cycle it to back of cycle jt
       // TODO: instead of trying one then the other, try both and pick ones with
       // best hamming distance to indivdual middles
+      auto jt_rbegin = jt->rbegin();
+      auto it_begin = it->begin();
       std::pair<std::vector<bool>, std::vector<bool>> output =
           merge_transpositions(
-              jt->rbegin()->last, jt->rbegin()->middle, it->begin()->first,
-              it->begin()->middle);
+              jt_rbegin->last, jt_rbegin->middle, it_begin->first,
+              it_begin->middle);
       // => cycle it can be added to back of cycle jt with cancellations
-      if (output.first != jt->rbegin()->last) {
-        jt->rbegin()->last = output.first;
-        it->begin()->first = output.second;
+      if (output.first != jt_rbegin->last) {
+        jt_rbegin->last = output.first;
+        it_begin->first = output.second;
         // combine cycle transpositions
         jt->insert(jt->end(), it->begin(), it->end());
         // n.b. jt after it, so it now == jt != cycle_transpositions.end()
         // but we increment jt immediately after
         it = cycle_transpositions.erase(it);
       } else {
+        auto jt_begin = jt->begin();
+        auto it_rbegin = it->rbegin();
         // try adding cycle jt to back of cycle it
         output = merge_transpositions(
-            it->rbegin()->last, it->rbegin()->middle, jt->begin()->first,
-            jt->begin()->middle);
+            it_rbegin->last, it_rbegin->middle, jt_begin->first,
+            jt_begin->middle);
         // => cycle jt can be added to back of cycle it with
         // cancellations
-        if (output.first != it->rbegin()->last) {
-          it->rbegin()->last = output.first;
-          jt->begin()->first = output.second;
+        if (output.first != it_rbegin->last) {
+          it_rbegin->last = output.first;
+          jt_begin->first = output.second;
           // combine cycle transpositions
           // such new information is held in jt
           jt->insert(jt->begin(), it->rbegin(), it->rend());

--- a/tket/src/Circuit/Boxes.cpp
+++ b/tket/src/Circuit/Boxes.cpp
@@ -494,46 +494,92 @@ op_signature_t StabiliserAssertionBox::get_signature() const {
   return qubs;
 }
 
-std::vector<transposition_t> ToffoliBox::cycle_to_transposition(
-    const cycle_t &cycle) {
-  // TODO: naively just do 0th entry with each other entry
-  // can this be improved?
-  auto it = cycle.begin();
-  std::vector<bool> first = *it;
-  ++it;
-  std::vector<transposition_t> transpositions;
-  while (it != cycle.end()) {
-    transpositions.push_back({first, *it});
-    ++it;
-  }
-  return transpositions;
+unsigned get_hamming_distance(const vector<bool> &a, const vector<bool> &b) {
+  std::vector<bool> diff = a ^ b;
+  return std::accumulate(diff.begin(), diff.end(), 0);
 }
 
-std::vector<transposition_t> ToffoliBox::get_transpositions() {
-  std::vector<transposition_t> transpositions;
+std::vector<ToffoliBox::transposition_t> ToffoliBox::cycle_to_transposition(
+    const cycle_t &cycle) const {
+  // use summation of the hamming distance to decide between two basic options
+  // std::cout << "Cycle: " << std::endl;
+  // for (auto x : cycle) {
+  //   for (auto b : x) {
+  //     std::cout << b;
+  //   }
+  //   std::cout << std::endl;
+  // }
+
+  // iterate through cycle_t object pairwise and produce two cheap
+  // transpositions options
+  cycle_t::const_iterator it = cycle.begin();
+  std::vector<bool> first = *it;
+  ++it;
+  cycle_t::const_iterator jt = cycle.begin();
+  // also cost transposition options as they are produced
+  unsigned accumulated_hamming_distance0, accumulated_hamming_distance1;
+  std::vector<ToffoliBox::transposition_t> transpositions0, transpositions1;
+  while (it != cycle.end()) {
+    transpositions0.push_back({first, *it});
+    transpositions1.push_back({*jt, *it});
+
+    accumulated_hamming_distance0 += get_hamming_distance(first, *it);
+    accumulated_hamming_distance1 += get_hamming_distance(*jt, *it);
+
+    ++it;
+    ++jt;
+  }
+  if (accumulated_hamming_distance0 > accumulated_hamming_distance1) {
+    return transpositions1;
+  }
+  return transpositions0;
+}
+
+std::set<std::vector<ToffoliBox::transposition_t>>
+ToffoliBox::get_transpositions() const {
+  std::set<std::vector<ToffoliBox::transposition_t>> transpositions;
   for (const cycle_t &cycle : this->cycles_) {
-    transposition_t transposition = this->cycle_to_transposition(cycle);
-    transpositions.reserve(transpositions.size() + cycle.size() - 1);
-    transpositions.insert(
-        transpositions.end(), transposition.begin(), transposition.end());
+    transpositions.insert(this->cycle_to_transposition);
   }
   return transpositions;
 }
 
 // TODO: check every vector is the same size
 ToffoliBox::ToffoliBox(
-    std::map<std::vector<bool>, std::vector<bool>> &_permutation) {
+    std::map<std::vector<bool>, std::vector<bool>> &_permutation)
+    : Box(OpType::ToffoliBox) {
   // Convert passed permutation to cycles
   while (!_permutation.empty()) {
-    auto it = _permutation.first();
+    auto it = _permutation.begin();
+    // std::cout << "{";
+    // for(auto b : it->first){
+    //   std::cout << b << " ";
+    // }
+    // std::cout << "}" << std::endl;
     cycle_t cycle = {it->first};
+    it = _permutation.find(it->second);
     while (it->first != cycle[0]) {
-      cycle.push_back(it->second);
+      // std::cout << "While Loop" << std::endl;
+      // std::cout << "{";
+      // for(auto b : it->first){
+      //   std::cout << b << " ";
+      // }
+      // std::cout << "}" << std::endl;
+      cycle.push_back(it->first);
       it = _permutation.find(it->second);
       if (it == _permutation.end()) {
-        throw std::invalid_argument("Permutation is not complete.")
+        throw std::invalid_argument("Permutation is not complete.");
       }
     }
+    // std::cout << "Produced Cycle!" << std::endl;
+    // for(auto x : cycle){
+    //   std::cout << "{";
+    //   for(auto b : x){
+    //     std::cout << b << " ";
+    //   }
+    //   std::cout << "}" << std::endl;
+    // }
+    // std::cout << cycle.size() << std::endl;
     if (cycle.size() > 1) {
       this->cycles_.push_back(cycle);
     }
@@ -544,34 +590,354 @@ ToffoliBox::ToffoliBox(
   }
 }
 
-void ToffoliBox::add_bitstring_circuit(
-    const std::vector<bool> &bitstring, const unsigned &target) {
+Circuit ToffoliBox::get_bitstring_circuit(
+    const std::vector<bool> &bitstring, const unsigned &target) const {
   // flip qubits that need to be state 0
+  unsigned n_qubits = bitstring.size();
   Circuit x_circuit(n_qubits);
   std::vector<unsigned> controls;
-  for (unsigned i = 0; i < bitstring; i++) {
-    if (!bitstring[i] && i != target) {
-      x_circuit.add_op<unsigned>(OpType::X, {i});
+  for (unsigned i = 0; i < n_qubits; i++) {
+    if (i != target) {
+      if (!bitstring[i]) {
+        x_circuit.add_op<unsigned>(OpType::X, {i});
+      }
       controls.push_back(i);
     }
   }
-  this->circuit_.add_circuit(x_circuit);
-  this->circuit_.add_op<unsigned>(OpType::CnX, controls + target);
-  this->circuit_.add_circuit(x_circuit);
+  controls.push_back(target);
+  TKET_ASSERT(controls.size() == n_qubits);
+
+  Circuit return_circuit(n_qubits);
+  return_circuit.append(x_circuit);
+  return_circuit.add_op<unsigned>(OpType::CnX, controls);
+  return_circuit.append(x_circuit);
+  return return_circuit;
+}
+
+gray_code_t ToffoliBox::order_cycle_graycodes(
+    const std::set<std::vector<
+        std::tuple<std::vector<bool>, std::vector<bool>, gray_code_t>>>
+        &transposition_gray_codes) const {
+  // First note that the transpositions have been produced to attempt to reduce
+  // hamming distance in cycle Gray code have then been found for each
+  // transposition Two rules:
+  // 1) for two sequential bitstrings b0 and b1 with
+  // target indices i0 and i1 can optionally do b0[i0] = !b0[i0] and b0[i1] =
+  // !b0[i1]
+  // 2) cycles can be ordered s.t. the last transposition_t in a vector
+  // matches the first in the next, meaning they can be cancelled out
+
+  // Reduction is done with these two rules in mind by first looking at all
+  // graycodes for a single cycle and attempt to switch graycode entries to
+  // reduce overlap at merge points, and then ordering cycles s.t. graycode
+  // entries can cancel (with swapping if needed)
+
+  // first order cycles so as to encourage cancellation
+  std::vector<std::tuple<std::vector<bool>, std::vector<bool>, gray_code_t>>
+      sequenced_graycodes;
+  for (const std::vector<
+           std::tuple<std::vector<bool>, std::vector<bool>, gray_code_t>>
+           &cycle : transposition_gray_codes) {
+    // a cycle can start with one of two bitstrings + replacement target and end
+    // with one of two bitstrings + replacement target
+    std::set<std::pair<std::vector<bool, unsigned>>> initial_options;
+    // first find these
+    auto it = cycle.begin();
+    gray_code_t gray_code_front = std::get<2>(*it);
+    TKET_ASSERT(!gray_code_front.empty());
+    // if transpositions had hamming distance 1 then only one option
+    initial_options.insert(gray_code_front[0]);
+    if (gray_code_front.size() > 1) {
+      std::pair<std::vector<bool>, unsigned> first = gray_code_front[0];
+      unsigned second_target = gray_code_front[1].second;
+      first[second_target] = !first[second_target];
+      first[first.second] = !first[first.second];
+      initial_options.insert(first);
+    }
+
+    // repeat for final options
+    std::set<std::pair<std::vector<bool, unsigned>>> final_options;
+    it = cycle.rbegin();
+    gray_code_t gray_code_back = std::get<2>(*it);
+    TKET_ASSERT(!gray_code_back.empty());
+    final_options.insert(gray_code_back[0]);
+    if (gray_code_back.size() > 1) {
+      std::pair<std::vector<bool>, unsigned> first = gray_code_back[0];
+      unsigned second_target = gray_code_back[1].second;
+      first[second_target] = !first[second_target];
+      first[first.second] = !first[first.second];
+      final_options.insert(first);
+    }
+  }
+}
+
+std::set<std::pair<std::vector<bool, unsigned>>> gen_gray_code_step(
+    const std::vector<bool> &a, const std::vector<bool> &b) {
+  if (a.size() != b.size()) {
+    throw std::invalid_argument("Bitstrings must have identical length.");
+  }
+  std::set < std::pair<std::vector<bool, unsigned>> output;
+  for (unsigned i = 0; i < a.size(); i++) {
+    if (a[i] != b[i]) {
+      std::vector<bool> entry = a;
+      entry[i] = !entry[i];
+      output.insert({entry, i});
+    }
+  }
+  return output;
+}
+
+// attempting to merge b to back of a
+std::pair<std::vector<bool>, std::vector<bool>> merge_transpositions(
+    const std::vector<bool> &a_last, const std::vector<bool> &a_middle,
+    const std::vector<bool> &b_first, const std::vector<bool> &b_middle) {
+  //
+  std::set<std::pair<std::vector<bool, unsigned>>> transposition_a_graycodes =
+      gen_gray_code_step(a_last, b_middle);
+  std::set<std::pair<std::vector<bool, unsigned>>> transposition_b_graycodes =
+      gen_gray_code_step(b_first, a_middle);
+
+  std::set<std::pair<std::vector<bool, unsigned>>> intersection;
+  std::set_intersection(
+      transposition_a_graycodes.begin(), transposition_a_graycodes.end(),
+      transposition_b_graycodes.begin(), transposition_b_graycodes.end(),
+      std::back_inserter(intersection));
+
+  if (!intersections.empty()) {
+    while (true) {
+      std::set<std::pair<std::vector<bool, unsigned>>> new_intersections = {};
+      for (const std::pair<std::vector<bool, unsigned>> &step : intersection) {
+        // number of returned steps is empty if the target has already been
+        // reached all instances of transposition_a_graycodes or
+        // transposition_b_graycodes will be empty if one is
+        transposition_a_graycodes = gen_gray_code_step(step.first, a_middle);
+        transposition_b_graycodes = gen_gray_code_step(step.first, b_middle);
+        std::set_intersection(
+            transposition_a_graycodes.begin(), transposition_a_graycodes.end(),
+            transposition_b_graycodes.begin(), transposition_b_graycodes.end(),
+            std::back_inserter(new_intersections));
+      }
+      if (new_intersections.empty()) {
+        break;
+      }
+      intersections = new_intersections;
+    }
+    // if matches, just get first in intersection
+    std::pair<std::vector<bool, unsigned>> match = *intersection.begin();
+    return {match, match};
+  } else {
+    return {a_last, b_first};
+  }
+}
+
+cycle_transposition_t ToffoliBox::merge_cycles(
+    std::set<cycle_transposition_t> &cycle_transpositions) const {
+  // For comparison, use bool from construction to choose how cycle is made
+
+  // First note that the transpositions have been produced to attempt to reduce
+  // hamming distance in cycle.
+  // There are multiple gray code possible between transpositions.
+  // A transposition is defined as a {first, middle, last} struct
+
+  // Taking each transposition in the a cycle pairwise, produce an option of
+  // first step of gray code based on a last->middle of the first entry in the
+  // pair, and first->middle of the second entry in the pair for all that match,
+  // produce a new option of match->middle of the first and match->middle of the
+  // second repeat until there is one match left (or take one of the "equal"
+  // matches) set the first transposition to {first, middle, match}, set the
+  // second transposition to {match, middle, last}
+  for (const cycle_transposition_t &cycle : cycle_transpositions) {
+    auto it = cycle.begin();
+    auto jt = it;
+    ++jt;
+    while (jt != cycle.end()) {
+      std::pair<std::vector<bool>, std::vector<bool>> update =
+          merge_transpositions(it->last, it->middle, jt->first, jt->middle);
+      it->last = update.first;
+      jt->first = update.second;
+      ++it;
+      ++jt;
+    }
+  }
+
+  // Next repeat this process with the whole cycles.
+  // A cycle is defined by the {first, middle} of its first transposition and
+  // then {middle, last} of its final transposition Go through permutations (can
+  // be capped) of ordered pairs pt0, pt1 of cycles. Generate range of first
+  // step of gray code for pt0 last->middle and pt1 first->middle If any match,
+  // produce options as before, repeat until best chosen set pt0 last
+  // transposition last to match, set pt1 first transposition to match combine
+  // into new cycle, repeat from top
+
+  auto it = cycle_transpositions.begin();
+  while (it != cycle_transpositions.end()) {
+    // it and jt are cycle_transposition_t objects
+    auto jt = it;
+
+    while (jt != cycle_transpositions.end()) {
+      // try adding cycle it to back of cycle jt
+      // TODO: instead of trying one then the other, try both and pick ones with
+      // best hamming distance to indivdual middles
+      std::pair<std::vector<bool>, std::vector<bool>> output =
+          merge_transpositions(jt->last, jt->middle, it->first, it->middle);
+      if (output.first != jt->last) {
+        jt->last = pair.first;
+        it->first = pair.second;
+        // combine cycle transpositions
+        jt->insert(jt->end(), it->begin(), it->end());
+        // n.b. jt after it, so it now == jt != cycle_transpositions.end()
+        // but we increment jt immediately after
+        it = cycle_transpositions.erase(it);
+      } else {
+        // try adding cycle jt to back of cycle it
+        output =
+            merge_transpositions(it->last, it->middle, jt->first, jt->middle);
+        if (output.first != it->last) {
+          it->last = pair.first;
+          jt->first = pair.second;
+          // combine cycle transpositions
+          // such new information is held in jt
+          jt->insert(jt->begin(), it->rbegin(), it->rend());
+          // n.b. jt after it, so now it == jt != cycle_transpositions.end()
+          // but we increment jt immediately after
+          it = cycle_transpositions.erase(it);
+        }
+      }
+      ++jt;
+    }
+    ++it;
+  }
+
+  // std::set<std::pair<std::vector<bool, unsigned>>>
+  // transposition_a_graycodes = gen_gray_code_step(it->first, it->middle);
+  // std::set<std::pair<std::vector<bool, unsigned>>>
+  //     transposition_b_graycodes = gen_gray_code_step(jt->last, jt->middle);
+
+  // std::set<std::pair<std::vector<bool, unsigned>>> intersection;
+  // std::set_intersection(
+  //     transposition_a_graycodes.begin(), transposition_a_graycodes.end(),
+  //     transposition_b_graycodes.begin(), transposition_b_graycodes.end(),
+  //     std::back_inserter(intersection));
+
+  // if (!intersections.empty()) {
+  //   // find best gray code match
+  //   while (true) {
+  //     std::set<std::pair<std::vector<bool, unsigned>>> new_intersections =
+  //         {};
+  //     for (const std::pair<std::vector<bool, unsigned>> &step :
+  //          intersection) {
+  //       // number of returned steps is empty if the target has already been
+  //       // reached all instances of transposition_a_graycodes or
+  //       // transposition_b_graycodes will be empty if one is
+  //       transposition_a_graycodes =
+  //           gen_gray_code_step(step.first, it->middle);
+  //       transposition_b_graycodes =
+  //           gen_gray_code_step(step.first, jt->middle);
+  //       std::set_intersection(
+  //           transposition_a_graycodes.begin(),
+  //           transposition_a_graycodes.end(),
+  //           transposition_b_graycodes.begin(),
+  //           transposition_b_graycodes.end(),
+  //           std::back_inserter(new_intersections));
+  //     }
+  //     if (new_intersections.empty()) {
+  //       break;
+  //     }
+  //     intersections = new_intersections;
+  //   }
+  //   // if matches, just get first in intersection
+  //   std::pair<std::vector<bool, unsigned>> match =
+  //       *intersection.begin() it->first = match;
+  //   jt->last = match;
+  //   // combine cycle transpositions
+  //   jt->insert(jt->end(), it->begin(), it->end());
+  //   // n.b. jt after it, so it now == jt != cycle_transpositions.end()
+  //   // but we increment jt immediately after
+  //   it = cycle_transpositions.erase(it);
+  //     } else {
+  //       // try with back
+  //       transposition_a_graycodes = gen_gray_code_step(it->last, it->middle);
+  //       transposition_b_graycodes = gen_gray_code_step(jt->first,
+  //       jt->middle); intersection.clear(); std::set_intersection(
+  //           transposition_a_graycodes.begin(),
+  //           transposition_a_graycodes.end(),
+  //           transposition_b_graycodes.begin(),
+  //           transposition_b_graycodes.end(),
+  //           std::back_inserter(intersection));
+  //       if (!intersections.empty()) {
+  //         while (true) {
+  //           std::set <
+  //               std::pair<std::vector<bool, unsigned>> new_intersections =
+  //               {};
+  //           for (const std::pair < std::vector < bool,
+  //                unsigned >>> &step : intersection) {
+  //             // number of returned steps is empty if the target has already
+  //             // been reached all instances of transposition_a_graycodes or
+  //             // transposition_b_graycodes will be empty if one is
+  //             transposition_a_graycodes =
+  //                 gen_gray_code_step(step.first, it->middle);
+  //             transposition_b_graycodes =
+  //                 gen_gray_code_step(step.first, jt->middle);
+  //             std::set_intersection(
+  //                 transposition_a_graycodes.begin(),
+  //                 transposition_a_graycodes.end(),
+  //                 transposition_b_graycodes.begin(),
+  //                 transposition_b_graycodes.end(),
+  //                 std::back_inserter(new_intersections));
+  //           }
+  //           if (new_intersections.empty()) {
+  //             break;
+  //           }
+  //           intersections = new_intersections;
+  //         }
+
+  //         // if matches, just get first in intersection
+  //         std::pair<std::vector<bool, unsigned>> match =
+  //             *intersection.begin() it->last = match;
+  //         jt->first = match;
+  //         // combine cycle transpositions
+  //         // such new information is held in jt
+  //         jt->insert(jt->begin(), it->rbegin(), it->rend());
+  //         // n.b. jt after it, so now it == jt != cycle_transpositions.end()
+  //         // but we increment jt immediately after
+  //         it = cycle_transpositions.erase(it);
+  //       }
+  //     }
+  //     ++jt;
+  //   }
+  //   ++it;
+  // }
 }
 
 void ToffoliBox::generate_circuit() const {
   // This decomposition is as described on page 191, section 4.5.2 "Single qubit
   // and CNOT gates are universal" of Nielsen & Chuang
-  std::vector<transposition_t> transpositions = this->get_transpositions();
-  if (!transpositions.empty()) {
-    size_t n_qubits = transpositions[0].first.size();
-    this->circuit_ = Circuit(n_qubits);
-    for (const transposition_t &transposition : transpositions) {
+  std::set<std::vector<ToffoliBox::transposition_t>> cycle_transpositions =
+      this->get_transpositions();
+
+  std::vector<ToffoliBox::transposition_t> ordered_transpositions =
+      this->reorder_transpositions(cycle_transpositions);
+
+  std::cout << "Generate circuit, post get_transpositions:" << std::endl;
+  std::cout << "n of sets of transpositions: " << transpositions.size()
+            << std::endl;
+  if (transpositions.empty()) {
+    this->circ_ = std::make_shared<Circuit>();
+    return;
+  }
+  std::set<std::vector<gray_code_t>> all_cycle_gray_codes;
+  for (const std::vector<ToffoliBox::transposition_t>
+           &single_cycle_transpositions : transpositions) {
+    TKET_ASSERT(single_cycle_transpositions.size() > 0);
+    size_t n_qubits = single_cycle_transpositions.begin()->first.size();
+    std::vector<gray_code_t> single_cycle_gray_codes;
+    // each transposition is converted into a gray code
+    for (const ToffoliBox::transposition_t &transposition :
+         single_cycle_transpositions) {
       TKET_ASSERT(transposition.first.size() == n_qubits);
       TKET_ASSERT(transposition.second.size() == n_qubits);
       // find a sequence of bitstrings one flip away from eachother
-      std::vector<std::pair<std::vector<bool>, unsigned>> bitstrings;
+      gray_code_t bitstrings;
       std::vector<bool> last_bitstring = transposition.first;
       for (unsigned i = 0; i < transposition.first.size(); i++) {
         // if different, update last bitstring with entry
@@ -580,22 +946,96 @@ void ToffoliBox::generate_circuit() const {
           bitstrings.push_back({last_bitstring, i});
         }
       }
-      std::vector<std::vector<bool>>::const_iterator it = bitstrings.begin();
-      while (it != bitstrings.end()) {
-        this->add_bitstring_circuit(it->first, it->second);
-        ++it;
+
+      gray_code_t gray_code = {{bitstrings[0]}, bitstrings};
+      // => first bitstring has alternative, which could lead to later
+      // optimisations
+      if (bitstrings.size() > 1) {
+        std::pair<std::vector<bool>, unsigned> first = bitstrings[0];
+        unsigned second_target = bitstrings[1].second;
+        first[second_target] = !first[second_target];
+        first[first.second] = !first[first.second];
+        gray_code.first.insert(first);
       }
-      // as one past end & don't want to undo gate
-      std::advance(it, -2);
-      // uncompute basis flips
-      while (it != bitstrings.begin()) {
-        this->add_bitstring_circuit(it->first, it->second);
-        --it;
-      }
+
+      single_cycle_gray_codes.push_back(gray_code);
     }
-  } else {
-    this->circuit_ = Circuit();
+    all_cycle_gray_codes.push_back(single_cycle_gray_codes);
   }
+
+  gray_code_t concatenated_gray_codes =
+      this->order_cycle_graycodes(all_cycle_gray_codes);
+
+  TKET_ASSERT(!concatenated_gray_codes.empty());
+  this->circuit_ =
+      std::make_shared<Circuit>(concatenated_gray_codes[0].first.size());
+  for (const std::pair<std::vector<bool>, unsigned> &bitstring :
+       concatenated_gray_codes) {
+    this->circ_->append(
+        this->get_bitstring_circuit(bitstring.first, bitstring.second));
+  }
+
+  // std::vector<std::vector<std::pair<std::vector<bool>, unsigned>>>
+  // reordered_bitstrings =  this->reorder_bitstrings(all_bitstrings); for(const
+  // std::vector<std::pair<std::vector<bool>, unsigned>>& bitstrings :
+  // reordered_bitstrings){
+  // }
+  // if (!transpositions.empty()) {
+  //   size_t n_qubits = transpositions.begin()->first.size();
+  //   this->circ_ = std::make_shared<Circuit>(n_qubits);
+  //   for (const ToffoliBox::transposition_t &transposition : transpositions) {
+  //     TKET_ASSERT(transposition.first.size() == n_qubits);
+  //     TKET_ASSERT(transposition.second.size() == n_qubits);
+  //     std::cout << "Transposition to convert: " << std::endl;
+  //     for(auto b : transposition.first){
+  //       std::cout << b;
+  //     }
+  //     std::cout << " | ";
+  //     for(auto b : transposition.second){
+  //       std::cout << b;
+  //     }
+  //     std::cout << std::endl;
+  //     // find a sequence of bitstrings one flip away from eachother
+  //     std::vector<std::pair<std::vector<bool>, unsigned>> bitstrings;
+  //     std::vector<bool> last_bitstring = transposition.first;
+  //     for (unsigned i = 0; i < transposition.first.size(); i++) {
+  //       // if different, update last bitstring with entry
+  //       if (transposition.first[i] != transposition.second[i]) {
+  //         last_bitstring[i] = !last_bitstring[i];
+  //         bitstrings.push_back({last_bitstring, i});
+  //       }
+  //     }
+  //     std::cout << "Bitstrings produced: " << std::endl;
+  //     for(auto bs : bitstrings){
+  //       for(auto bo : bs.first){
+  //         std::cout << bo;
+  //       }
+  //       std::cout << " | " << bs.second << std::endl;
+  //     }
+  //     std::vector<std::pair<std::vector<bool>, unsigned>>::const_iterator it
+  //     =
+  //         bitstrings.begin();
+  //     while (it != bitstrings.end()) {
+  //       this->circ_->append(this->get_bitstring_circuit(it->first,
+  //       it->second));
+  //       ++it;
+  //     }
+  //     // as one past end & don't want to undo gate
+  //     std::vector<
+  //         std::pair<std::vector<bool>, unsigned>>::const_reverse_iterator jt
+  //         = bitstrings.rbegin();
+  //     std::advance(jt, 1);
+  //     // uncompute basis flips
+  //     while (jt != bitstrings.rend()) {
+  //       this->circ_->append(this->get_bitstring_circuit(jt->first,
+  //       jt->second));
+  //       ++jt;
+  //     }
+  //   }
+  //   std::cout << "Finished making circuit! " << std::endl;
+  // } else {
+  //   this->circ_ = std::make_shared<Circuit>();
+  // }
 }
 
 nlohmann::json core_box_json(const Box &box) {

--- a/tket/src/Circuit/Boxes.cpp
+++ b/tket/src/Circuit/Boxes.cpp
@@ -772,177 +772,39 @@ void ToffoliBox::generate_circuit() const {
     return;
   }
 
-  // Now we have ordered transpositions, produced front->middle and middle->back gray codes for each
-  // transposition and add to circuit
+  // Now we have ordered transpositions, produced front->middle and middle->back
+  // gray codes for each transposition and add to circuit
   unsigned n_qubits = ordered_transpositions[0].first.size();
   this->circ = std::make_shared<Circuit>(n_qubits);
-  for(const transposition_t& transposition : ordered_transpositions){
+  for (const transposition_t &transposition : ordered_transpositions) {
     TKET_ASSERT(transposition.first.size() == n_qubits);
     TKET_ASSERT(transposition.middle.size() == n_qubits);
     TKET_ASSERT(transposition.last.size() == n_qubits);
     // get bitstrings for first -> middle
-    std::vector<std::pair<bool>, unsigned>> all_gray_code_entries;
+    std::vector < std::pair<bool>, unsigned >> all_gray_code_entries;
     std::vector<bool> bitstring = transposition.first;
-    for(unsigned i=0; i<transposition.first.size(); i++){
-      if(transposition.first[i] != transposition.middle[i]){
+    for (unsigned i = 0; i < transposition.first.size(); i++) {
+      if (transposition.first[i] != transposition.middle[i]) {
         bitstring[i] = !bitstring[i];
         all_gray_code_entries.push_back({bitstring, i});
-        // this->circuit_->append(this->get_bitstring_circuit(bitstring, i));
       }
     }
     // get bitstrings for middle -> last;
     bitstring = transposition.middle;
-    for(unsigned i=0; i<transposition.middle.size(); i++){
-      if(transposition.middle[i] != transposition.last[i]){
+    for (unsigned i = 0; i < transposition.middle.size(); i++) {
+      if (transposition.middle[i] != transposition.last[i]) {
         bitstring[i] = !bitstring[i];
         all_gray_code_entries.push_back({bitstring, i});
-        // this->circuit_->append(this->get_bitstring_circuit(bitstring, i));
       }
     }
     // don't want to add transformation for reaching final, so pop_back
-    
-
-
-  }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-  std::set<std::vector<gray_code_t>> all_cycle_gray_codes;
-  for (const ToffoliBox::cycle_transposition_t &single_cycle_transpositions :
-       transpositions) {
-    TKET_ASSERT(single_cycle_transpositions.size() > 0);
-    size_t n_qubits = single_cycle_transpositions.begin()->first.size();
-    std::vector<gray_code_t> single_cycle_gray_codes;
-    // each transposition is converted into a gray code
-    for (const ToffoliBox::transposition_t &transposition :
-         single_cycle_transpositions) {
-      TKET_ASSERT(transposition.first.size() == n_qubits);
-      TKET_ASSERT(transposition.second.size() == n_qubits);
-      // for first to middle, find graycode sequence and add
-      std::vector<bool> bitstring = transposition.first;
-      for (unsigned i = 0; i < transposition.first.size(); i++) {
-        // if different, update last bitstring with entry
-        if (transposition.first[i] != transposition.middle[i]) {
-          bitstring[i] = !bitstring[i];
-          this->circuit_->append(this->get_bitstring_circuit(bitstring, i));
-        }
-      }
-      // for middle to last, don't want circuit producing last bitstring, so produce an option as a target
-      std::vector<bool> target = get_single_
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-      gray_code_t gray_code = {{bitstrings[0]}, bitstrings};
-      // => first bitstring has alternative, which could lead to later
-      // optimisations
-      if (bitstrings.size() > 1) {
-        std::pair<std::vector<bool>, unsigned> first = bitstrings[0];
-        unsigned second_target = bitstrings[1].second;
-        first[second_target] = !first[second_target];
-        first[first.second] = !first[first.second];
-        gray_code.first.insert(first);
-      }
-
-      single_cycle_gray_codes.push_back(gray_code);
+    all_gray_code_entries.pop_back();
+    for (const std::pair<std::vector<bool>, unsigned> &entry :
+         all_gray_code_entries) {
+      this->circuit_->append(
+          this->get_bitstring_circuit(entry.first, entry.second));
     }
-    all_cycle_gray_codes.push_back(single_cycle_gray_codes);
   }
-
-  gray_code_t concatenated_gray_codes =
-      this->order_cycle_graycodes(all_cycle_gray_codes);
-
-  TKET_ASSERT(!concatenated_gray_codes.empty());
-  this->circuit_ =
-      std::make_shared<Circuit>(concatenated_gray_codes[0].first.size());
-  for (const std::pair<std::vector<bool>, unsigned> &bitstring :
-       concatenated_gray_codes) {
-    this->circ_->append(
-        this->get_bitstring_circuit(bitstring.first, bitstring.second));
-  }
-
-  // std::vector<std::vector<std::pair<std::vector<bool>, unsigned>>>
-  // reordered_bitstrings =  this->reorder_bitstrings(all_bitstrings); for(const
-  // std::vector<std::pair<std::vector<bool>, unsigned>>& bitstrings :
-  // reordered_bitstrings){
-  // }
-  // if (!transpositions.empty()) {
-  //   size_t n_qubits = transpositions.begin()->first.size();
-  //   this->circ_ = std::make_shared<Circuit>(n_qubits);
-  //   for (const ToffoliBox::transposition_t &transposition : transpositions) {
-  //     TKET_ASSERT(transposition.first.size() == n_qubits);
-  //     TKET_ASSERT(transposition.second.size() == n_qubits);
-  //     std::cout << "Transposition to convert: " << std::endl;
-  //     for(auto b : transposition.first){
-  //       std::cout << b;
-  //     }
-  //     std::cout << " | ";
-  //     for(auto b : transposition.second){
-  //       std::cout << b;
-  //     }
-  //     std::cout << std::endl;
-  //     // find a sequence of bitstrings one flip away from eachother
-  //     std::vector<std::pair<std::vector<bool>, unsigned>> bitstrings;
-  //     std::vector<bool> last_bitstring = transposition.first;
-  //     for (unsigned i = 0; i < transposition.first.size(); i++) {
-  //       // if different, update last bitstring with entry
-  //       if (transposition.first[i] != transposition.second[i]) {
-  //         last_bitstring[i] = !last_bitstring[i];
-  //         bitstrings.push_back({last_bitstring, i});
-  //       }
-  //     }
-  //     std::cout << "Bitstrings produced: " << std::endl;
-  //     for(auto bs : bitstrings){
-  //       for(auto bo : bs.first){
-  //         std::cout << bo;
-  //       }
-  //       std::cout << " | " << bs.second << std::endl;
-  //     }
-  //     std::vector<std::pair<std::vector<bool>, unsigned>>::const_iterator it
-  //     =
-  //         bitstrings.begin();
-  //     while (it != bitstrings.end()) {
-  //       this->circ_->append(this->get_bitstring_circuit(it->first,
-  //       it->second));
-  //       ++it;
-  //     }
-  //     // as one past end & don't want to undo gate
-  //     std::vector<
-  //         std::pair<std::vector<bool>, unsigned>>::const_reverse_iterator jt
-  //         = bitstrings.rbegin();
-  //     std::advance(jt, 1);
-  //     // uncompute basis flips
-  //     while (jt != bitstrings.rend()) {
-  //       this->circ_->append(this->get_bitstring_circuit(jt->first,
-  //       jt->second));
-  //       ++jt;
-  //     }
-  //   }
-  //   std::cout << "Finished making circuit! " << std::endl;
-  // } else {
-  //   this->circ_ = std::make_shared<Circuit>();
-  // }
 }
 
 nlohmann::json core_box_json(const Box &box) {

--- a/tket/src/Circuit/include/Circuit/Boxes.hpp
+++ b/tket/src/Circuit/include/Circuit/Boxes.hpp
@@ -749,7 +749,7 @@ class ToffoliBox : public Box {
   std::vector<transposition_t> cycle_to_transposition(
       const cycle_permutation_t &cycle) const;
 
-  std::set<cycle_transposition_t> get_transpositions() const;
+  std::deque<cycle_transposition_t> get_transpositions() const;
 
   Circuit get_bitstring_circuit(
       const std::vector<bool> &bitstring, const unsigned &target) const;

--- a/tket/src/Circuit/include/Circuit/Boxes.hpp
+++ b/tket/src/Circuit/include/Circuit/Boxes.hpp
@@ -720,6 +720,8 @@ class ToffoliBox : public Box {
 
   typedef std::vector<transposition_t> cycle_transposition_t;
 
+  typedef std::vector<std::pair<std::vector<bool>, unsigned>> gray_code_t;
+
   /**
    * Construct from a map between input and output basis states.
    * Map entries should produce a cycle, i.e. if A maps to B but B
@@ -733,7 +735,8 @@ class ToffoliBox : public Box {
    *
    */
   explicit ToffoliBox(
-      std::map<std::vector<bool>, std::vector<bool>> &_permutation);
+      std::map<std::vector<bool>, std::vector<bool>> &_permutation,
+      bool reorder = true);
 
   Op_ptr symbol_substitution(
       const SymEngine::map_basic_basic &) const override {
@@ -755,6 +758,8 @@ class ToffoliBox : public Box {
       const std::vector<bool> &bitstring, const unsigned &target) const;
 
   std::set<cycle_permutation_t> cycles_;
+
+  bool reorder_;
 };
 
 }  // namespace tket

--- a/tket/src/Circuit/include/Circuit/Boxes.hpp
+++ b/tket/src/Circuit/include/Circuit/Boxes.hpp
@@ -708,4 +708,37 @@ class StabiliserAssertionBox : public Box {
   mutable std::vector<bool> expected_readouts_;
 };
 
+class ToffoliBox : public Box {
+ public:
+  typedef std::vector<std::vector<bool>> cycle_t;
+  typedef std::pair<std::vector<bool>, std::vector<bool>> transposition_t;
+  /**
+   * Construct from a map between input and output basis states.
+   * Map entries should produce a cycle, i.e. if A maps to B but B
+   * B has no entry then it will throw an invalid_argument error.
+   * Any basis state not in a permutation cycle will be assumed to
+   * take the identity.
+   * If each basis state is not the same size will throw an
+   * invalid_argument error.
+   *
+   * @param permutation map between basis states
+   *
+   */
+  explicit ToffoliBox(
+      const std::map<std::vector<bool>, std::vector<bool>> &_permutation);
+
+ protected:
+  void generate_circuit() const override;
+
+ private:
+  std::vector<transposition_t> cycle_to_transposition(const cycle_t &cycle);
+
+  std::vector<transposition_t> get_transpositions();
+
+  void add_bitstring_circuit(
+      const std::vector<bool> &bitstring, const unsigned &target);
+
+  std::vector<cycle_t> cycles_;
+}
+
 }  // namespace tket

--- a/tket/src/Circuit/include/Circuit/Boxes.hpp
+++ b/tket/src/Circuit/include/Circuit/Boxes.hpp
@@ -710,8 +710,26 @@ class StabiliserAssertionBox : public Box {
 
 class ToffoliBox : public Box {
  public:
-  typedef std::vector<std::vector<bool>> cycle_t;
-  typedef std::pair<std::vector<bool>, std::vector<bool>> transposition_t;
+  typedef std::vector<std::vector<bool>> cycle_permutation_t;
+
+  struct transposition_t {
+    std::vector<bool> first;
+    std::vector<bool> middle;
+    std::vector<bool> last;
+  }
+
+  typedef std::vector<transposition_t>
+      cycle_transposition_t;
+
+  // typedef std::pair<std::vector<bool>, std::vector<bool>> transposition_t;
+
+  // typedef gray_code_t std::vector<std::pair<std::vector<bool>, unsigned>>;
+
+  // struct gray_code_t {
+  //   std::set<std::pair<std::vector<bool>, unsigned>> first;
+  //   std::vector<std::pair<std::vector<bool>, unsigned>> bitstrings;
+  // };
+
   /**
    * Construct from a map between input and output basis states.
    * Map entries should produce a cycle, i.e. if A maps to B but B
@@ -725,20 +743,28 @@ class ToffoliBox : public Box {
    *
    */
   explicit ToffoliBox(
-      const std::map<std::vector<bool>, std::vector<bool>> &_permutation);
+      std::map<std::vector<bool>, std::vector<bool>> &_permutation);
+
+  Op_ptr symbol_substitution(
+      const SymEngine::map_basic_basic &) const override {
+    return Op_ptr();
+  }
+
+  SymSet free_symbols() const override { return {}; }
 
  protected:
   void generate_circuit() const override;
 
  private:
-  std::vector<transposition_t> cycle_to_transposition(const cycle_t &cycle);
+  std::vector<transposition_t> cycle_to_transposition(
+      const cycle_t &cycle) const;
 
-  std::vector<transposition_t> get_transpositions();
+  std::vector<transposition_t> get_transpositions() const;
 
-  void add_bitstring_circuit(
-      const std::vector<bool> &bitstring, const unsigned &target);
+  Circuit get_bitstring_circuit(
+      const std::vector<bool> &bitstring, const unsigned &target) const;
 
   std::vector<cycle_t> cycles_;
-}
+};
 
 }  // namespace tket

--- a/tket/src/Circuit/include/Circuit/Boxes.hpp
+++ b/tket/src/Circuit/include/Circuit/Boxes.hpp
@@ -735,8 +735,7 @@ class ToffoliBox : public Box {
    *
    */
   explicit ToffoliBox(
-      std::map<std::vector<bool>, std::vector<bool>> &_permutation,
-      bool reorder = true);
+      std::map<std::vector<bool>, std::vector<bool>> &_permutation);
 
   Op_ptr symbol_substitution(
       const SymEngine::map_basic_basic &) const override {
@@ -758,8 +757,6 @@ class ToffoliBox : public Box {
       const std::vector<bool> &bitstring, const unsigned &target) const;
 
   std::set<cycle_permutation_t> cycles_;
-
-  bool reorder_;
 };
 
 }  // namespace tket

--- a/tket/src/Circuit/include/Circuit/Boxes.hpp
+++ b/tket/src/Circuit/include/Circuit/Boxes.hpp
@@ -716,19 +716,9 @@ class ToffoliBox : public Box {
     std::vector<bool> first;
     std::vector<bool> middle;
     std::vector<bool> last;
-  }
+  };
 
-  typedef std::vector<transposition_t>
-      cycle_transposition_t;
-
-  // typedef std::pair<std::vector<bool>, std::vector<bool>> transposition_t;
-
-  // typedef gray_code_t std::vector<std::pair<std::vector<bool>, unsigned>>;
-
-  // struct gray_code_t {
-  //   std::set<std::pair<std::vector<bool>, unsigned>> first;
-  //   std::vector<std::pair<std::vector<bool>, unsigned>> bitstrings;
-  // };
+  typedef std::vector<transposition_t> cycle_transposition_t;
 
   /**
    * Construct from a map between input and output basis states.
@@ -757,14 +747,14 @@ class ToffoliBox : public Box {
 
  private:
   std::vector<transposition_t> cycle_to_transposition(
-      const cycle_t &cycle) const;
+      const cycle_permutation_t &cycle) const;
 
-  std::vector<transposition_t> get_transpositions() const;
+  std::set<cycle_transposition_t> get_transpositions() const;
 
   Circuit get_bitstring_circuit(
       const std::vector<bool> &bitstring, const unsigned &target) const;
 
-  std::vector<cycle_t> cycles_;
+  std::set<cycle_permutation_t> cycles_;
 };
 
 }  // namespace tket

--- a/tket/src/OpType/OpTypeFunctions.cpp
+++ b/tket/src/OpType/OpTypeFunctions.cpp
@@ -169,7 +169,8 @@ bool is_box_type(OpType optype) {
       OpType::ClassicalExpBox,
       OpType::ProjectorAssertionBox,
       OpType::StabiliserAssertionBox,
-      OpType::UnitaryTableauBox};
+      OpType::UnitaryTableauBox,
+      OpType::ToffoliBox};
   return find_in_set(optype, boxes);
 }
 

--- a/tket/src/OpType/OpTypeInfo.cpp
+++ b/tket/src/OpType/OpTypeInfo.cpp
@@ -124,6 +124,7 @@ const std::map<OpType, OpTypeInfo>& optypeinfo() {
        {"ProjectorAssertionBox", "ProjectorAssertionBox", {}, std::nullopt}},
       {OpType::StabiliserAssertionBox,
        {"StabiliserAssertionBox", "StabiliserAssertionBox", {}, std::nullopt}},
+      {OpType::ToffoliBox, {"ToffoliBox", "ToffoliBox", {}, std::nullopt}},
       {OpType::ClassicalTransform,
        {"ClassicalTransform", "ClassicalTransform", {}, std::nullopt}},
       {OpType::WASM, {"WASM", "WASM", {}, std::nullopt}},

--- a/tket/src/OpType/include/OpType/OpType.hpp
+++ b/tket/src/OpType/include/OpType/OpType.hpp
@@ -611,6 +611,11 @@ enum class OpType {
   StabiliserAssertionBox,
 
   /**
+   * See \ref ToffoliBox
+   */
+  ToffoliBox,
+
+  /**
    * See \ref UnitaryTableauBox
    */
   UnitaryTableauBox

--- a/tket/tests/Circuit/test_Boxes.cpp
+++ b/tket/tests/Circuit/test_Boxes.cpp
@@ -989,6 +989,86 @@ SCENARIO("Checking equality", "[boxes]") {
   }
 }
 
+SCENARIO("ToffoliBox", "[boxes]") {
+  std::cout << "\n\nToffoliBox tests!" << std::endl;
+  GIVEN("No permutation.") {
+    std::map<std::vector<bool>, std::vector<bool>> permutation = {};
+    ToffoliBox tb(permutation);
+    std::vector<Command> tb_circuit_commands = tb.to_circuit()->get_commands();
+    REQUIRE(tb_circuit_commands.size() == 0);
+  }
+  GIVEN("Single qubit basis state permutation") {
+    std::map<std::vector<bool>, std::vector<bool>> permutation;
+    permutation[{0}] = {1};
+    permutation[{1}] = {0};
+    ToffoliBox tb(permutation);
+    std::vector<Command> tb_circuit_commands = tb.to_circuit()->get_commands();
+    REQUIRE(tb_circuit_commands.size() == 1);
+    Command com = tb_circuit_commands[0];
+    REQUIRE(com.get_qubits().size() == 1);
+    REQUIRE(com.get_op_ptr()->get_type() == OpType::X);
+  }
+  GIVEN("Two qubit basis state permutation, one two states cycle") {
+    std::map<std::vector<bool>, std::vector<bool>> permutation;
+    permutation[{0, 0}] = {1, 1};
+    permutation[{1, 1}] = {0, 0};
+    ToffoliBox tb(permutation);
+
+    Circuit comparison_circuit(2);
+    comparison_circuit.add_op<unsigned>(OpType::X, {1});
+    comparison_circuit.add_op<unsigned>(OpType::CnX, {1, 0});
+    comparison_circuit.add_op<unsigned>(OpType::X, {1});
+    comparison_circuit.add_op<unsigned>(OpType::CnX, {0, 1});
+    comparison_circuit.add_op<unsigned>(OpType::X, {1});
+    comparison_circuit.add_op<unsigned>(OpType::CnX, {1, 0});
+    comparison_circuit.add_op<unsigned>(OpType::X, {1});
+    REQUIRE(*tb.to_circuit() == comparison_circuit);
+  }
+  GIVEN("Two qubit basis state permutation, two two states cycle") {
+    std::map<std::vector<bool>, std::vector<bool>> permutation;
+    permutation[{0, 0}] = {1, 1};
+    permutation[{1, 1}] = {0, 0};
+    permutation[{0, 1}] = {1, 0};
+    permutation[{1, 0}] = {0, 1};
+    ToffoliBox tb(permutation);
+
+    Circuit comparison_circuit(2);
+    comparison_circuit.add_op<unsigned>(OpType::X, {1});
+    comparison_circuit.add_op<unsigned>(OpType::CnX, {1, 0});
+    comparison_circuit.add_op<unsigned>(OpType::X, {1});
+    comparison_circuit.add_op<unsigned>(OpType::CnX, {0, 1});
+    comparison_circuit.add_op<unsigned>(OpType::X, {1});
+    comparison_circuit.add_op<unsigned>(OpType::CnX, {1, 0});
+    comparison_circuit.add_op<unsigned>(OpType::X, {1});
+    comparison_circuit.add_op<unsigned>(OpType::CnX, {1, 0});
+    comparison_circuit.add_op<unsigned>(OpType::CnX, {0, 1});
+    comparison_circuit.add_op<unsigned>(OpType::CnX, {1, 0});
+    REQUIRE(*tb.to_circuit() == comparison_circuit);
+  }
+  GIVEN("Two qubit basis state permutation, two two states cycle") {
+    std::map<std::vector<bool>, std::vector<bool>> permutation;
+    permutation[{0, 0}] = {1, 1};
+    permutation[{1, 1}] = {0, 1};
+    permutation[{0, 1}] = {1, 0};
+    permutation[{1, 0}] = {0, 0};
+    ToffoliBox tb(permutation);
+    std::cout << *tb.to_circuit() << std::endl;
+
+    // Circuit comparison_circuit(2);
+    // comparison_circuit.add_op<unsigned>(OpType::X, {1});
+    // comparison_circuit.add_op<unsigned>(OpType::CnX, {1,0});
+    // comparison_circuit.add_op<unsigned>(OpType::X, {1});
+    // comparison_circuit.add_op<unsigned>(OpType::CnX, {0,1});
+    // comparison_circuit.add_op<unsigned>(OpType::X, {1});
+    // comparison_circuit.add_op<unsigned>(OpType::CnX, {1,0});
+    // comparison_circuit.add_op<unsigned>(OpType::X, {1});
+    // comparison_circuit.add_op<unsigned>(OpType::CnX, {1,0});
+    // comparison_circuit.add_op<unsigned>(OpType::CnX, {0,1});
+    // comparison_circuit.add_op<unsigned>(OpType::CnX, {1,0});
+    // REQUIRE(*tb.to_circuit() == comparison_circuit);
+  }
+}
+
 SCENARIO("Checking box names", "[boxes]") {
   GIVEN("CustomGate without parameters") {
     Circuit setup(1);

--- a/tket/tests/Circuit/test_Boxes.cpp
+++ b/tket/tests/Circuit/test_Boxes.cpp
@@ -990,7 +990,6 @@ SCENARIO("Checking equality", "[boxes]") {
 }
 
 SCENARIO("ToffoliBox", "[boxes]") {
-  std::cout << "\n\nToffoliBox tests!" << std::endl;
   GIVEN("No permutation.") {
     std::map<std::vector<bool>, std::vector<bool>> permutation = {};
     ToffoliBox tb(permutation);
@@ -998,6 +997,7 @@ SCENARIO("ToffoliBox", "[boxes]") {
     REQUIRE(tb_circuit_commands.size() == 0);
   }
   GIVEN("Single qubit basis state permutation") {
+    std::cout << "\nQBSP" << std::endl;
     std::map<std::vector<bool>, std::vector<bool>> permutation;
     permutation[{0}] = {1};
     permutation[{1}] = {0};
@@ -1013,7 +1013,6 @@ SCENARIO("ToffoliBox", "[boxes]") {
     permutation[{0, 0}] = {1, 1};
     permutation[{1, 1}] = {0, 0};
     ToffoliBox tb(permutation);
-
     Circuit comparison_circuit(2);
     comparison_circuit.add_op<unsigned>(OpType::X, {1});
     comparison_circuit.add_op<unsigned>(OpType::CnX, {1, 0});
@@ -1022,7 +1021,18 @@ SCENARIO("ToffoliBox", "[boxes]") {
     comparison_circuit.add_op<unsigned>(OpType::X, {1});
     comparison_circuit.add_op<unsigned>(OpType::CnX, {1, 0});
     comparison_circuit.add_op<unsigned>(OpType::X, {1});
-    REQUIRE(*tb.to_circuit() == comparison_circuit);
+
+    std::map<std::vector<bool>, std::vector<bool>> permutation2;
+    permutation2[{0, 0}] = {1, 1};
+    permutation2[{1, 1}] = {0, 0};
+    ToffoliBox tb2(permutation2, false);
+
+    const auto optimised_unitary = tket_sim::get_unitary(*tb.to_circuit());
+    const auto nonoptimised_unitary = tket_sim::get_unitary(*tb2.to_circuit());
+    const auto basic_unitary = tket_sim::get_unitary(comparison_circuit);
+
+    CHECK(optimised_unitary.isApprox(basic_unitary));
+    CHECK(nonoptimised_unitary.isApprox(basic_unitary));
   }
   GIVEN("Two qubit basis state permutation, two two states cycle") {
     std::map<std::vector<bool>, std::vector<bool>> permutation;
@@ -1045,27 +1055,64 @@ SCENARIO("ToffoliBox", "[boxes]") {
     comparison_circuit.add_op<unsigned>(OpType::CnX, {1, 0});
     REQUIRE(*tb.to_circuit() == comparison_circuit);
   }
-  GIVEN("Two qubit basis state permutation, two two states cycle") {
+  GIVEN("Two qubit basis state permutation, one four states cycle") {
     std::map<std::vector<bool>, std::vector<bool>> permutation;
     permutation[{0, 0}] = {1, 1};
     permutation[{1, 1}] = {0, 1};
     permutation[{0, 1}] = {1, 0};
     permutation[{1, 0}] = {0, 0};
-    ToffoliBox tb(permutation);
-    std::cout << *tb.to_circuit() << std::endl;
+    ToffoliBox tb1(permutation);
 
-    // Circuit comparison_circuit(2);
-    // comparison_circuit.add_op<unsigned>(OpType::X, {1});
-    // comparison_circuit.add_op<unsigned>(OpType::CnX, {1,0});
-    // comparison_circuit.add_op<unsigned>(OpType::X, {1});
-    // comparison_circuit.add_op<unsigned>(OpType::CnX, {0,1});
-    // comparison_circuit.add_op<unsigned>(OpType::X, {1});
-    // comparison_circuit.add_op<unsigned>(OpType::CnX, {1,0});
-    // comparison_circuit.add_op<unsigned>(OpType::X, {1});
-    // comparison_circuit.add_op<unsigned>(OpType::CnX, {1,0});
-    // comparison_circuit.add_op<unsigned>(OpType::CnX, {0,1});
-    // comparison_circuit.add_op<unsigned>(OpType::CnX, {1,0});
-    // REQUIRE(*tb.to_circuit() == comparison_circuit);
+    permutation = {};
+    permutation[{0, 0}] = {1, 1};
+    permutation[{1, 1}] = {0, 1};
+    permutation[{0, 1}] = {1, 0};
+    permutation[{1, 0}] = {0, 0};
+    ToffoliBox tb2(permutation, false);
+
+    Circuit circ1 = *tb1.to_circuit();
+    Circuit circ2 = *tb2.to_circuit();
+
+    const auto optimised_unitary = tket_sim::get_unitary(circ1);
+    const auto nonoptimised_unitary = tket_sim::get_unitary(circ2);
+    CHECK(nonoptimised_unitary.isApprox(optimised_unitary));
+
+
+
+    Circuit comparison_circuit1(2);
+    comparison_circuit1.add_op<unsigned>(OpType::X, {0});
+    comparison_circuit1.add_op<unsigned>(OpType::CnX, {0, 1});
+    comparison_circuit1.add_op<unsigned>(OpType::X, {0});
+    comparison_circuit1.add_op<unsigned>(OpType::CnX, {1, 0});
+    comparison_circuit1.add_op<unsigned>(OpType::X, {1});
+    comparison_circuit1.add_op<unsigned>(OpType::CnX, {1, 0});
+    comparison_circuit1.add_op<unsigned>(OpType::X, {1});
+    REQUIRE(circ1 == comparison_circuit1);
+  }
+  GIVEN("Four qubit basis state permutation, one large cycle"){
+    std::cout << "\n\n\n\nTEST OF INTEREST" << std::endl;
+    std::map<std::vector<bool>, std::vector<bool>> permutation1, permutation2;
+    permutation1[{0, 0, 0, 0}] = {1, 1, 0, 0};
+    permutation1[{1, 1, 0, 0}] = {1, 1, 0, 1};
+    permutation1[{1, 1, 0, 1}] = {0, 0, 0, 1};
+    permutation1[{0, 0, 0, 1}] = {1, 1, 1, 0};
+    permutation1[{1, 1, 1, 0}] = {0, 0, 1, 1};
+    permutation1[{0, 0, 1, 1}] = {1, 0, 0, 1};
+    permutation1[{1, 0, 0, 1}] = {1, 0, 1, 0};
+    permutation1[{1, 0, 1, 0}] = {0, 0, 0, 0};
+
+    permutation2 = permutation1;
+    ToffoliBox tb1(permutation1);
+    ToffoliBox tb2(permutation2, false);
+
+    Circuit circ1 = *tb1.to_circuit();
+    Circuit circ2 = *tb2.to_circuit();
+
+    const auto optimised_unitary = tket_sim::get_unitary(circ1);
+    const auto nonoptimised_unitary = tket_sim::get_unitary(circ2);
+    CHECK(nonoptimised_unitary.isApprox(optimised_unitary));
+    REQUIRE(circ1.count_gates(OpType::CnX) == 19);
+    REQUIRE(circ2.count_gates(OpType::CnX) == 23);
   }
 }
 

--- a/tket/tests/Circuit/test_Boxes.cpp
+++ b/tket/tests/Circuit/test_Boxes.cpp
@@ -997,7 +997,6 @@ SCENARIO("ToffoliBox", "[boxes]") {
     REQUIRE(tb_circuit_commands.size() == 0);
   }
   GIVEN("Single qubit basis state permutation") {
-    std::cout << "\nQBSP" << std::endl;
     std::map<std::vector<bool>, std::vector<bool>> permutation;
     permutation[{0}] = {1};
     permutation[{1}] = {0};
@@ -1022,17 +1021,10 @@ SCENARIO("ToffoliBox", "[boxes]") {
     comparison_circuit.add_op<unsigned>(OpType::CnX, {1, 0});
     comparison_circuit.add_op<unsigned>(OpType::X, {1});
 
-    std::map<std::vector<bool>, std::vector<bool>> permutation2;
-    permutation2[{0, 0}] = {1, 1};
-    permutation2[{1, 1}] = {0, 0};
-    ToffoliBox tb2(permutation2, false);
-
     const auto optimised_unitary = tket_sim::get_unitary(*tb.to_circuit());
-    const auto nonoptimised_unitary = tket_sim::get_unitary(*tb2.to_circuit());
     const auto basic_unitary = tket_sim::get_unitary(comparison_circuit);
 
     CHECK(optimised_unitary.isApprox(basic_unitary));
-    CHECK(nonoptimised_unitary.isApprox(basic_unitary));
   }
   GIVEN("Two qubit basis state permutation, two two states cycle") {
     std::map<std::vector<bool>, std::vector<bool>> permutation;
@@ -1053,7 +1045,11 @@ SCENARIO("ToffoliBox", "[boxes]") {
     comparison_circuit.add_op<unsigned>(OpType::CnX, {1, 0});
     comparison_circuit.add_op<unsigned>(OpType::CnX, {0, 1});
     comparison_circuit.add_op<unsigned>(OpType::CnX, {1, 0});
-    REQUIRE(*tb.to_circuit() == comparison_circuit);
+
+    const auto optimised_unitary = tket_sim::get_unitary(*tb.to_circuit());
+    const auto basic_unitary = tket_sim::get_unitary(comparison_circuit);
+
+    CHECK(optimised_unitary.isApprox(basic_unitary));
   }
   GIVEN("Two qubit basis state permutation, one four states cycle") {
     std::map<std::vector<bool>, std::vector<bool>> permutation;
@@ -1061,58 +1057,45 @@ SCENARIO("ToffoliBox", "[boxes]") {
     permutation[{1, 1}] = {0, 1};
     permutation[{0, 1}] = {1, 0};
     permutation[{1, 0}] = {0, 0};
-    ToffoliBox tb1(permutation);
+    ToffoliBox tb(permutation);
 
-    permutation = {};
-    permutation[{0, 0}] = {1, 1};
-    permutation[{1, 1}] = {0, 1};
-    permutation[{0, 1}] = {1, 0};
-    permutation[{1, 0}] = {0, 0};
-    ToffoliBox tb2(permutation, false);
+    Circuit circ = *tb.to_circuit();
 
-    Circuit circ1 = *tb1.to_circuit();
-    Circuit circ2 = *tb2.to_circuit();
+    Circuit comparison_circuit(2);
+    comparison_circuit.add_op<unsigned>(OpType::X, {1});
+    comparison_circuit.add_op<unsigned>(OpType::CnX, {1, 0});
+    comparison_circuit.add_op<unsigned>(OpType::X, {1});
+    comparison_circuit.add_op<unsigned>(OpType::CnX, {0, 1});
+    comparison_circuit.add_op<unsigned>(OpType::X, {1});
+    comparison_circuit.add_op<unsigned>(OpType::CnX, {1, 0});
+    comparison_circuit.add_op<unsigned>(OpType::X, {0});
+    comparison_circuit.add_op<unsigned>(OpType::X, {1});
+    comparison_circuit.add_op<unsigned>(OpType::CnX, {0, 1});
+    comparison_circuit.add_op<unsigned>(OpType::X, {0});
+    comparison_circuit.add_op<unsigned>(OpType::X, {1});
+    comparison_circuit.add_op<unsigned>(OpType::CnX, {1, 0});
+    comparison_circuit.add_op<unsigned>(OpType::X, {1});
 
-    const auto optimised_unitary = tket_sim::get_unitary(circ1);
-    const auto nonoptimised_unitary = tket_sim::get_unitary(circ2);
-    CHECK(nonoptimised_unitary.isApprox(optimised_unitary));
+    const auto optimised_unitary = tket_sim::get_unitary(*tb.to_circuit());
+    const auto basic_unitary = tket_sim::get_unitary(comparison_circuit);
 
-
-
-    Circuit comparison_circuit1(2);
-    comparison_circuit1.add_op<unsigned>(OpType::X, {0});
-    comparison_circuit1.add_op<unsigned>(OpType::CnX, {0, 1});
-    comparison_circuit1.add_op<unsigned>(OpType::X, {0});
-    comparison_circuit1.add_op<unsigned>(OpType::CnX, {1, 0});
-    comparison_circuit1.add_op<unsigned>(OpType::X, {1});
-    comparison_circuit1.add_op<unsigned>(OpType::CnX, {1, 0});
-    comparison_circuit1.add_op<unsigned>(OpType::X, {1});
-    REQUIRE(circ1 == comparison_circuit1);
+    CHECK(optimised_unitary.isApprox(basic_unitary));
   }
-  GIVEN("Four qubit basis state permutation, one large cycle"){
-    std::cout << "\n\n\n\nTEST OF INTEREST" << std::endl;
-    std::map<std::vector<bool>, std::vector<bool>> permutation1, permutation2;
-    permutation1[{0, 0, 0, 0}] = {1, 1, 0, 0};
-    permutation1[{1, 1, 0, 0}] = {1, 1, 0, 1};
-    permutation1[{1, 1, 0, 1}] = {0, 0, 0, 1};
-    permutation1[{0, 0, 0, 1}] = {1, 1, 1, 0};
-    permutation1[{1, 1, 1, 0}] = {0, 0, 1, 1};
-    permutation1[{0, 0, 1, 1}] = {1, 0, 0, 1};
-    permutation1[{1, 0, 0, 1}] = {1, 0, 1, 0};
-    permutation1[{1, 0, 1, 0}] = {0, 0, 0, 0};
+  GIVEN("Four qubit basis state permutation, one large cycle") {
+    std::map<std::vector<bool>, std::vector<bool>> permutation;
+    permutation[{0, 0, 0, 0}] = {1, 1, 0, 0};
+    permutation[{1, 1, 0, 0}] = {1, 1, 0, 1};
+    permutation[{1, 1, 0, 1}] = {0, 0, 0, 1};
+    permutation[{0, 0, 0, 1}] = {1, 1, 1, 0};
+    permutation[{1, 1, 1, 0}] = {0, 0, 1, 1};
+    permutation[{0, 0, 1, 1}] = {1, 0, 0, 1};
+    permutation[{1, 0, 0, 1}] = {1, 0, 1, 0};
+    permutation[{1, 0, 1, 0}] = {0, 0, 0, 0};
 
-    permutation2 = permutation1;
-    ToffoliBox tb1(permutation1);
-    ToffoliBox tb2(permutation2, false);
+    ToffoliBox tb(permutation);
 
-    Circuit circ1 = *tb1.to_circuit();
-    Circuit circ2 = *tb2.to_circuit();
-
-    const auto optimised_unitary = tket_sim::get_unitary(circ1);
-    const auto nonoptimised_unitary = tket_sim::get_unitary(circ2);
-    CHECK(nonoptimised_unitary.isApprox(optimised_unitary));
-    REQUIRE(circ1.count_gates(OpType::CnX) == 19);
-    REQUIRE(circ2.count_gates(OpType::CnX) == 23);
+    Circuit circ = *tb.to_circuit();
+    REQUIRE(circ.count_gates(OpType::CnX) == 23);
   }
 }
 


### PR DESCRIPTION
This PR adds a ToffoliBox Op that takes a permutation of basis states as an argument and produces a synthesis circuit for it. This synthesis is based on a method in Nielsen and Chuang with some basic additional optimisation by picking transpositions for a cycle with smaller Hamming distance.