### PR TITLE
Upload tket conan packages

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -432,6 +432,20 @@ jobs:
       run: conan profile update options.tket-tests:full=True tket
     - name: add remote
       run: conan remote add tket-libs https://quantinuumsw.jfrog.io/artifactory/api/conan/tket1-libs
+    - name: normalize line endings in conanfile and src directory
+      if: needs.check_changes.outputs.tket_package_exists == 'false'
+      # This is necessary to ensure consistent revisions across platforms.
+      # Conan's revision hash is composed of hashes of all the exported files,
+      # so we must normalize the line endings in these.
+      run: |
+        $conanfile ='recipes/tket/conanfile.py'
+        $normalized_file = [IO.File]::ReadAllText($conanfile) -replace "`r`n", "`n"
+        [IO.File]::WriteAllText($conanfile, $normalized_file)
+        $src_files = Get-ChildItem "tket/src" -File -Recurse
+        foreach ($f in $src_files) {
+          $normalized_file = [IO.File]::ReadAllText($f) -replace "`r`n", "`n"
+          [IO.File]::WriteAllText($f, $normalized_file)
+        }
     - name: Build tket
       if: needs.check_changes.outputs.tket_changed == 'true'
       run: conan create --profile=tket recipes/tket tket/stable

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -354,6 +354,8 @@ jobs:
       run: conan profile update options.tket-tests:full=True tket
     - name: add remote
       run: conan remote add tket-libs https://quantinuumsw.jfrog.io/artifactory/api/conan/tket1-libs --force
+    - name: Remove tket package from local cache
+      run: conan remove -f 'tket/*'
     - name: Build tket
       if: needs.check_changes.outputs.tket_changed == 'true'
       run: conan create --profile=tket recipes/tket tket/stable --build=missing

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -66,7 +66,7 @@ jobs:
     - name: Install ninja and ccache
       run: sudo apt-get install ninja-build ccache
     - name: Build tket
-      run: ${CONAN_CMD} create --profile=tket recipes/tket
+      run: ${CONAN_CMD} create --profile=tket recipes/tket tket/stable
     - name: Install runtime test requirements
       run: |
         sudo apt-get install texlive texlive-latex-extra latexmk
@@ -197,7 +197,7 @@ jobs:
     - name: add remote
       run: conan remote add tket-libs https://quantinuumsw.jfrog.io/artifactory/api/conan/tket1-libs --force
     - name: Build tket
-      run: conan create --profile=tket recipes/tket --build=missing
+      run: conan create --profile=tket recipes/tket tket/stable --build=missing
     - name: Build and run tket tests
       run: conan create --profile=tket recipes/tket-tests
     - name: Build and run tket proptests
@@ -290,7 +290,7 @@ jobs:
     - name: add remote
       run: conan remote add tket-libs https://quantinuumsw.jfrog.io/artifactory/api/conan/tket1-libs --force
     - name: Build tket
-      run: conan create --profile=tket recipes/tket --build=missing
+      run: conan create --profile=tket recipes/tket tket/stable --build=missing
     - name: Build and run tket tests
       run: conan create --profile=tket recipes/tket-tests
     - name: Build and run tket proptests
@@ -400,7 +400,7 @@ jobs:
         key: ${{ runner.os }}-tket-tket-${{ steps.hash_tket_source.outputs.tket_hash }}-19
     - name: Build tket
       if: steps.cache-tket.outputs.cache-hit != 'true'
-      run: conan create --profile=tket recipes/tket
+      run: conan create --profile=tket recipes/tket tket/stable
     - name: Build and run tket tests
       run: conan create --profile=tket recipes/tket-tests
     - name: Build and run tket proptests

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -17,10 +17,54 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  check_changes:
+    name: Check tket library version
+    runs-on: ubuntu-22.04
+    outputs:
+      tket_changed: ${{ steps.filter.outputs.tket }}
+      tket_tests_changed: ${{ steps.filter.outputs.tket_tests }}
+      tket_proptests_changed: ${{ steps.filter.outputs.tket_proptests }}
+      pytket_changed: ${{ steps.filter.outputs.pytket }}
+      tket_ver: ${{ steps.tket_ver.outputs.tket_ver }}
+      tket_package_exists: ${{ steps.tket_package_exists.outputs.tket_package_exists }}
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v3
+      with:
+        python-version: '3.10'
+    - uses: dorny/paths-filter@v2
+      id: filter
+      with:
+        base: ${{ github.ref }}
+        filters: |
+          tket:
+            - '{tket/src/**,recipes/tket/conanfile.py}'
+          tket_tests:
+            - '{tket/tests/**,recipes/tket-tests/conanfile.py}'
+          tket_proptests:
+            - '{tket/proptests/**,recipes/tket-proptests/conanfile.py}'
+          pytket:
+            - 'pytket/**'
+    - name: parse version from conanfile
+      id: tket_ver
+      run: |
+        pip install conan
+        tket_ver=$(conan inspect --raw version recipes/tket/conanfile.py)
+        echo "::set-output name=tket_ver::${tket_ver}"
+    - name: See if version exists on remote
+      id: tket_package_exists
+      run: |
+        conan remote add tket-libs https://quantinuumsw.jfrog.io/artifactory/api/conan/tket1-libs
+        tket_package_exists=`conan search -r tket-libs "tket/${{ steps.tket_ver.outputs.tket_ver }}@tket/stable" > /dev/null 2>&1 && echo true || echo false`
+        echo "::set-output name=tket_package_exists::${tket_package_exists}"
+    - name: Check tket version bump
+      run: |
+        if [ ${{ steps.filter.outputs.tket == 'true' }} && ${{ steps.test_package_exists.outputs.tket_package_exists == 'true' }} ] ; then exit 1 ; fi
 
   linux:
     name: Build and test (Linux)
     runs-on: ubuntu-22.04
+    needs: check_changes
     env:
       CONAN_REVISIONS_ENABLED: 1
       PYTKET_SKIP_REGISTRATION: "true"
@@ -67,6 +111,9 @@ jobs:
       run: sudo apt-get install ninja-build ccache
     - name: Build tket
       run: ${CONAN_CMD} create --profile=tket recipes/tket tket/stable
+    - name: check that version is consistent
+      if: github.event_name == 'pull_request'
+      run: ./.github/workflows/check-tket-reqs  ${{ needs.check_changes.outputs.tket_ver }}
     - name: Install runtime test requirements
       run: |
         sudo apt-get install texlive texlive-latex-extra latexmk

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -188,6 +188,11 @@ jobs:
       with:
         name: pytket_test_coverage
         path: pytket/tests/htmlcov
+    - name: Upload package
+      if: github.event_name == 'push' && github.ref == 'refs/heads/develop' && needs.check_changes.outputs.tket_changed == 'true'
+      run: |
+        conan user -p ${{ secrets.JFROG_ARTIFACTORY_TOKEN_2 }} -r tket-libs ${{ secrets.JFROG_ARTIFACTORY_USER_2 }}
+        conan upload tket/${{ needs.check_changes.outputs.tket_ver }}@tket/stable --all -r=tket-libs
 
 
   macos:
@@ -314,6 +319,11 @@ jobs:
         cd pytket/tests
         pip install -r requirements.txt
         pytest --ignore=simulator/ --doctest-modules
+    - name: Upload package
+      if: github.event_name == 'push' && github.ref == 'refs/heads/develop' && needs.check_changes.outputs.tket_changed == 'true'
+      run: |
+        conan user -p ${{ secrets.JFROG_ARTIFACTORY_TOKEN_2 }} -r tket-libs ${{ secrets.JFROG_ARTIFACTORY_USER_2 }}
+        conan upload tket/${{ needs.check_changes.outputs.tket_ver }}@tket/stable --all -r=tket-libs
 
   macos-m1:
     name: Build and test (MacOS M1)
@@ -406,6 +416,12 @@ jobs:
         cd pytket/tests
         pip install -r requirements.txt
         pytest --ignore=simulator/ --doctest-modules
+    - name: Upload package
+      if: github.event_name == 'push' && github.ref == 'refs/heads/develop' && needs.check_changes.outputs.tket_changed == 'true'
+      run: |
+        conan user -p ${{ secrets.JFROG_ARTIFACTORY_TOKEN_2 }} -r tket-libs ${{ secrets.JFROG_ARTIFACTORY_USER_2 }}
+        conan upload tket/${{ needs.check_changes.outputs.tket_ver }}@tket/stable --all -r=tket-libs
+        conan user -c
 
   windows:
     name: Build and test (Windows)
@@ -496,6 +512,11 @@ jobs:
         cd tests
         pip install -r requirements.txt
         pytest --ignore=simulator/ --doctest-modules
+    - name: Upload package
+      if: github.event_name == 'push' && github.ref == 'refs/heads/develop' && needs.check_changes.outputs.tket_changed == 'true'
+      run: |
+        conan user -p ${{ secrets.JFROG_ARTIFACTORY_TOKEN_2 }} -r tket-libs ${{ secrets.JFROG_ARTIFACTORY_USER_2 }}
+        conan upload tket/${{ needs.check_changes.outputs.tket_ver }}@tket/stable --all -r=tket-libs
 
   publish_pytket_coverage:
     name: Publish pytket coverage

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -359,25 +359,6 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: '0'
-    - name: Hash tket source
-      id: hash_tket_source
-      run: |
-        Function Get-FolderHash
-        {
-            param ($folder)
-            $files = dir $folder -Recurse |? { -not $_.psiscontainer }
-            $allBytes = new-object System.Collections.Generic.List[byte]
-            foreach ($file in $files)
-            {
-                $allBytes.AddRange([System.IO.File]::ReadAllBytes($file.FullName))
-                $allBytes.AddRange([System.Text.Encoding]::UTF8.GetBytes($file.Name))
-            }
-            $hasher = [System.Security.Cryptography.MD5]::Create()
-            $ret = [string]::Join("",$($hasher.ComputeHash($allBytes.ToArray()) | %{"{0:x2}" -f $_}))
-            return $ret
-        }
-        $tket_hash = Get-FolderHash tket
-        echo "::set-output name=tket_hash::${tket_hash}"
     - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
     - name: Install conan
       run: |
@@ -392,14 +373,7 @@ jobs:
       run: conan profile update options.tket-tests:full=True tket
     - name: add remote
       run: conan remote add tket-libs https://quantinuumsw.jfrog.io/artifactory/api/conan/tket1-libs
-    - name: Cache tket build
-      id: cache-tket
-      uses: actions/cache@v3
-      with:
-        path: C:\Users\runneradmin\.conan\data\tket
-        key: ${{ runner.os }}-tket-tket-${{ steps.hash_tket_source.outputs.tket_hash }}-19
     - name: Build tket
-      if: steps.cache-tket.outputs.cache-hit != 'true'
       run: conan create --profile=tket recipes/tket tket/stable
     - name: Build and run tket tests
       run: conan create --profile=tket recipes/tket-tests

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -110,6 +110,7 @@ jobs:
     - name: Install ninja and ccache
       run: sudo apt-get install ninja-build ccache
     - name: Build tket
+      if: needs.check_changes.outputs.tket_changed == 'true'
       run: ${CONAN_CMD} create --profile=tket recipes/tket tket/stable
     - name: check that version is consistent
       if: github.event_name == 'pull_request'
@@ -190,6 +191,7 @@ jobs:
   macos:
     name: Build and test (MacOS)
     runs-on: macos-11
+    needs: check_changes
     env:
       CONAN_REVISIONS_ENABLED: 1
       PYTKET_SKIP_REGISTRATION: "true"
@@ -244,6 +246,7 @@ jobs:
     - name: add remote
       run: conan remote add tket-libs https://quantinuumsw.jfrog.io/artifactory/api/conan/tket1-libs --force
     - name: Build tket
+      if: needs.check_changes.outputs.tket_changed == 'true'
       run: conan create --profile=tket recipes/tket tket/stable --build=missing
     - name: Build and run tket tests
       run: conan create --profile=tket recipes/tket-tests
@@ -311,6 +314,7 @@ jobs:
   macos-m1:
     name: Build and test (MacOS M1)
     runs-on: [self-hosted, macos, M1]
+    needs: check_changes
     if: github.event_name == 'push' || github.event_name == 'schedule' || github.event.pull_request.head.repo.full_name == github.repository
     defaults:
       run:
@@ -337,6 +341,7 @@ jobs:
     - name: add remote
       run: conan remote add tket-libs https://quantinuumsw.jfrog.io/artifactory/api/conan/tket1-libs --force
     - name: Build tket
+      if: needs.check_changes.outputs.tket_changed == 'true'
       run: conan create --profile=tket recipes/tket tket/stable --build=missing
     - name: Build and run tket tests
       run: conan create --profile=tket recipes/tket-tests
@@ -399,6 +404,7 @@ jobs:
   windows:
     name: Build and test (Windows)
     runs-on: windows-2019
+    needs: check_changes
     env:
       CONAN_REVISIONS_ENABLED: 1
       PYTKET_SKIP_REGISTRATION: "true"
@@ -421,6 +427,7 @@ jobs:
     - name: add remote
       run: conan remote add tket-libs https://quantinuumsw.jfrog.io/artifactory/api/conan/tket1-libs
     - name: Build tket
+      if: needs.check_changes.outputs.tket_changed == 'true'
       run: conan create --profile=tket recipes/tket tket/stable
     - name: Build and run tket tests
       run: conan create --profile=tket recipes/tket-tests

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -121,8 +121,10 @@ jobs:
         mkdir -p ~/texmf/tex/latex
         wget http://mirrors.ctan.org/graphics/pgf/contrib/quantikz/tikzlibraryquantikz.code.tex -P ~/texmf/tex/latex
     - name: Build and run tket tests
+      if: needs.check_changes.outputs.tket_changed == 'true' || needs.check_changes.outputs.tket_tests_changed == 'true'
       run: ${CONAN_CMD} create --profile=tket recipes/tket-tests
     - name: Build and run tket proptests
+      if: needs.check_changes.outputs.tket_changed == 'true' || needs.check_changes.outputs.tket_proptests_changed == 'true'
       run: ${CONAN_CMD} create --profile=tket recipes/tket-proptests
     - name: Install pybind11
       run: ${CONAN_CMD} create --profile=tket recipes/pybind11
@@ -249,8 +251,10 @@ jobs:
       if: needs.check_changes.outputs.tket_changed == 'true'
       run: conan create --profile=tket recipes/tket tket/stable --build=missing
     - name: Build and run tket tests
+      if: needs.check_changes.outputs.tket_changed == 'true' || needs.check_changes.outputs.tket_tests_changed == 'true'
       run: conan create --profile=tket recipes/tket-tests
     - name: Build and run tket proptests
+      if: needs.check_changes.outputs.tket_changed == 'true' || needs.check_changes.outputs.tket_proptests_changed == 'true'
       run: |
         conan install --profile=tket rapidcheck/cci.20210702@ --build=missing
         conan create --profile=tket recipes/tket-proptests
@@ -344,8 +348,10 @@ jobs:
       if: needs.check_changes.outputs.tket_changed == 'true'
       run: conan create --profile=tket recipes/tket tket/stable --build=missing
     - name: Build and run tket tests
+      if: needs.check_changes.outputs.tket_changed == 'true' || needs.check_changes.outputs.tket_tests_changed == 'true'
       run: conan create --profile=tket recipes/tket-tests
     - name: Build and run tket proptests
+      if: needs.check_changes.outputs.tket_changed == 'true' || needs.check_changes.outputs.tket_proptests_changed == 'true'
       run: conan create --profile=tket recipes/tket-proptests
     - name: Install pybind11
       run: conan create --profile=tket recipes/pybind11
@@ -430,8 +436,10 @@ jobs:
       if: needs.check_changes.outputs.tket_changed == 'true'
       run: conan create --profile=tket recipes/tket tket/stable
     - name: Build and run tket tests
+      if: needs.check_changes.outputs.tket_changed == 'true' || needs.check_changes.outputs.tket_tests_changed == 'true'
       run: conan create --profile=tket recipes/tket-tests
     - name: Build and run tket proptests
+      if: needs.check_changes.outputs.tket_changed == 'true' || needs.check_changes.outputs.tket_proptests_changed == 'true'
       run: conan create --profile=tket recipes/tket-proptests
     - name: Install pybind11
       run: conan create --profile=tket recipes/pybind11

--- a/.github/workflows/build_libs.yml
+++ b/.github/workflows/build_libs.yml
@@ -127,6 +127,8 @@ jobs:
     - name: upload package
       if: github.event_name == 'push'
       run: conan upload ${{ matrix.lib }}/${LIB_VER}@tket/stable --all -r=tket-libs
+    - name: unauthenticate
+      run: conan user -c
   manylinux:
     name: build library (manylinux)
     needs: changes

--- a/.github/workflows/check-tket-reqs
+++ b/.github/workflows/check-tket-reqs
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+
+# Check that the expected tket version requirement is present for:
+# - tket-tests
+# - tket-proptests
+# - pytket
+# Usage: check-tket-reqs <version>
+# E.g.: check-tket-reqs 1.0.2
+
+import json
+import os
+import subprocess
+import sys
+
+version = sys.argv[1]
+
+jsondump = "conaninfo.json"
+for path in [
+    os.path.join(".", "recipes", "tket-tests", "conanfile.py"),
+    os.path.join(".", "recipes", "tket-proptests", "conanfile.py"),
+    os.path.join(".", "pytket", "conanfile.txt"),
+]:
+    subprocess.run(["conan", "info", "--path", "--json", jsondump, path])
+    with open(jsondump) as f:
+        info = json.load(f)
+    os.remove(jsondump)
+    assert any(
+        comp["reference"].startswith("conanfile")
+        and f"tket/{version}@tket/stable" in comp["requires"]
+        for comp in info
+    )

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -75,10 +75,10 @@ jobs:
         sudo apt-get install ninja-build ccache
     - name: Build tket
       run: |
-        ${CONAN_CMD} install recipes/tket --install-folder=build/tket --profile=tket -o tket:profile_coverage=True
+        ${CONAN_CMD} install recipes/tket tket/stable --install-folder=build/tket --profile=tket -o tket:profile_coverage=True
         ${CONAN_CMD} build recipes/tket --configure --build-folder=build/tket --source-folder=tket/src
         ${CONAN_CMD} build recipes/tket --build --build-folder=build/tket
-        ${CONAN_CMD} export-pkg recipes/tket -f --build-folder=build/tket --source-folder=tket/src
+        ${CONAN_CMD} export-pkg recipes/tket tket/stable -f --build-folder=build/tket --source-folder=tket/src
     - name: Build tket tests
       run: |
         ${CONAN_CMD} install recipes/tket-tests --install-folder=build/tket-tests --profile=tket -o tket-tests:with_coverage=True

--- a/.github/workflows/linuxbuildwheel
+++ b/.github/workflows/linuxbuildwheel
@@ -30,7 +30,7 @@ ${CONAN_CMD} profile new tket --detect
 ${CONAN_CMD} profile update options.tklog:shared=True tket
 ${CONAN_CMD} profile update options.tket:shared=True tket
 ${CONAN_CMD} remote add tket-libs https://quantinuumsw.jfrog.io/artifactory/api/conan/tket1-libs --force
-${CONAN_CMD} create --profile=tket --test-folder=None recipes/tket
+${CONAN_CMD} create --profile=tket --test-folder=None recipes/tket tket/stable
 ${CONAN_CMD} create --profile=tket --test-folder=None recipes/pybind11
 
 cd /tket/pytket

--- a/.github/workflows/linuxbuildwheel
+++ b/.github/workflows/linuxbuildwheel
@@ -47,5 +47,5 @@ do
     export PYVER=`${PYEX} -c 'import sys; print(".".join(map(str, sys.version_info[:3])))'`
     ${PYEX} -m pip install -U pip build
     ${PYEX} -m build --outdir "tmpwheel_${PYVER}"
-    auditwheel repair "tmpwheel_${PYVER}/pytket-"*".whl" -w "audited/${PYVER}/"
+    LD_LIBRARY_PATH=./pytket/_tket auditwheel repair "tmpwheel_${PYVER}/pytket-"*".whl" -w "audited/${PYVER}/"
 done

--- a/.github/workflows/publish_tket_package.yml
+++ b/.github/workflows/publish_tket_package.yml
@@ -96,3 +96,5 @@ jobs:
         echo "LIB_VER=${lib_ver}" >> $GITHUB_ENV
     - name: upload package
       run: conan upload tket/${{ env.LIB_VER }}@tket/stable --all -r=tket-libs
+    - name: unauthenticate
+      run: conan user -c

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -133,25 +133,6 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: '0'
-    - name: Hash tket source
-      id: hash_tket_source
-      run: |
-        Function Get-FolderHash
-        {
-            param ($folder)
-            $files = dir $folder -Recurse |? { -not $_.psiscontainer }
-            $allBytes = new-object System.Collections.Generic.List[byte]
-            foreach ($file in $files)
-            {
-                $allBytes.AddRange([System.IO.File]::ReadAllBytes($file.FullName))
-                $allBytes.AddRange([System.Text.Encoding]::UTF8.GetBytes($file.Name))
-            }
-            $hasher = [System.Security.Cryptography.MD5]::Create()
-            $ret = [string]::Join("",$($hasher.ComputeHash($allBytes.ToArray()) | %{"{0:x2}" -f $_}))
-            return $ret
-        }
-        $tket_hash = Get-FolderHash tket
-        echo "::set-output name=tket_hash::${tket_hash}"
     - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
     - name: Install conan
       run: |
@@ -163,14 +144,7 @@ jobs:
         echo "CONAN_CMD=${conan_cmd}" >> $GITHUB_ENV
     - name: add remote
       run: conan remote add tket-libs https://quantinuumsw.jfrog.io/artifactory/api/conan/tket1-libs
-    - name: Cache tket build
-      id: cache-tket
-      uses: actions/cache@v3
-      with:
-        path: C:\Users\runneradmin\.conan\data\tket
-        key: ${{ runner.os }}-tket-tket-${{ steps.hash_tket_source.outputs.tket_hash }}-13
     - name: Build tket
-      if: steps.cache-tket.outputs.cache-hit != 'true'
       run: conan create --profile=tket recipes/tket tket/stable
     - name: Install pybind11
       run: conan create --profile=tket recipes/pybind11

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,7 +69,7 @@ jobs:
         conan profile update options.tklog:shared=True tket
         conan profile update options.tket:shared=True tket
         conan remote add tket-libs https://quantinuumsw.jfrog.io/artifactory/api/conan/tket1-libs --force
-        conan create --profile=tket recipes/tket --build=missing
+        conan create --profile=tket recipes/tket tket/stable --build=missing
     - name: Install pybind11
       run: conan create --profile=tket recipes/pybind11
     - name: Build wheel (3.8)
@@ -112,7 +112,7 @@ jobs:
         conan profile update options.tklog:shared=True tket
         conan profile update options.tket:shared=True tket
         conan remote add tket-libs https://quantinuumsw.jfrog.io/artifactory/api/conan/tket1-libs --force
-        conan create --profile=tket recipes/tket --build=missing
+        conan create --profile=tket recipes/tket tket/stable --build=missing
         conan create --profile=tket recipes/pybind11
         .github/workflows/build_macos_m1_wheel
         pyenv shell tket-3.9
@@ -171,7 +171,7 @@ jobs:
         key: ${{ runner.os }}-tket-tket-${{ steps.hash_tket_source.outputs.tket_hash }}-13
     - name: Build tket
       if: steps.cache-tket.outputs.cache-hit != 'true'
-      run: conan create --profile=tket recipes/tket
+      run: conan create --profile=tket recipes/tket tket/stable
     - name: Install pybind11
       run: conan create --profile=tket recipes/pybind11
     - name: Set up Python 3.8

--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -65,10 +65,10 @@ jobs:
       run: sudo apt-get install ninja-build ccache
     - name: build tket
       run: |
-        conan install recipes/tket --install-folder=build/tket --profile=tket
+        conan install recipes/tket tket/stable --install-folder=build/tket --profile=tket
         conan build recipes/tket --configure --build-folder=build/tket --source-folder=tket/src
         conan build recipes/tket --build --build-folder=build/tket
-        conan export-pkg recipes/tket -f --build-folder=build/tket --source-folder=tket/src
+        conan export-pkg recipes/tket tket/stable -f --build-folder=build/tket --source-folder=tket/src
     - name: build tket tests
       run: |
         conan install recipes/tket-tests --install-folder=build/tket-tests --profile=tket

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,3 +69,7 @@ If you make any changes in `thet/src`, you should bump the version number of
 `requires` field in `recipes/tket-test/conanfile.py`,
 `recipes/tket-proptests/conanfile.py` and `pytket/conanfile.txt` so that they
 match the new version. (This is checked on the CI for all PRs to `develop`.)
+Follow the "sematic versioning" convention: any backwards-incompatible changes
+to the C++ API require a major version bump; new API features that maintain
+backwards compatibility require a minor version bump; internal improvements and
+bugfixes require a patch version bump.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,3 +61,11 @@ mypy --config-file=mypy.ini -p pytket -p tests
 We use [pylint](https://pypi.org/project/pylint/) on the CI to check compliance
 with a set of style requirements (listed in `pytket/.pylintrc`). You should run
 `pylint` over any changed files before submitting a PR, to catch any issues.
+
+## Version numbers
+
+If you make any changes in `thet/src`, you should bump the version number of
+`tket` in `recipes/tket/conanfile.py`, and also the `tket` versions in the
+`requires` field in `recipes/tket-test/conanfile.py`,
+`recipes/tket-proptests/conanfile.py` and `pytket/conanfile.txt` so that they
+match the new version. (This is checked on the CI for all PRs to `develop`.)

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ conan create --profile=tket recipes/pybind11
 
 where the first line serves to remove any version already installed.
 
-### TKET libraries
+### TKET libraries and conan packages
 
 Some TKET functionality has been separated out into self-contained libraries,
 as a way to modularize and reduce average build times. These are in
@@ -163,6 +163,9 @@ If you make a change to one of these libraries, please increase the version
 number and make a PR with that change only: the component will then be tested on
 the CI, and on merge to `develop` the new version will be uploaded. Then it will
 be possible to update conan requirements to use the new version.
+
+A new version of TKET is uploaded to our conan repo with each push to `develop`
+that changes the core library. This process is managed by CI workflows.
 
 ### Building tket
 

--- a/README.md
+++ b/README.md
@@ -165,7 +165,10 @@ the CI, and on merge to `develop` the new version will be uploaded. Then it will
 be possible to update conan requirements to use the new version.
 
 A new version of TKET is uploaded to our conan repo with each push to `develop`
-that changes the core library. This process is managed by CI workflows.
+that changes the core library. This process is managed by CI workflows. If you
+are making changes only to TKET tests or pytket, you do not need to build TKET
+locally: the right version should be downloaded automatically from the conan
+repo.
 
 ### Building tket
 

--- a/pytket/CMakeLists.txt
+++ b/pytket/CMakeLists.txt
@@ -43,6 +43,12 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-redundant-move")
 endif()
 
+if (UNIX)
+    # Allow binder libraries to load other shared libraries from same directory.
+    set(CMAKE_BUILD_WITH_INSTALL_RPATH TRUE)
+    set(CMAKE_INSTALL_RPATH "\${ORIGIN}")
+endif()
+
 pybind11_add_module(circuit
     binders/circuit/main.cpp
     binders/circuit/unitid.cpp

--- a/pytket/conanfile.txt
+++ b/pytket/conanfile.txt
@@ -1,5 +1,5 @@
 [requires]
-tket/1.0.1
+tket/1.0.2@tket/stable
 tklog/0.1.2@tket/stable
 pybind11/2.10.0
 nlohmann_json/3.10.5

--- a/recipes/tket-proptests/conanfile.py
+++ b/recipes/tket-proptests/conanfile.py
@@ -28,7 +28,7 @@ class TketProptestsConan(ConanFile):
     generators = "cmake"
     exports_sources = "../../tket/proptests/*"
     requires = (
-        "tket/1.0.1",
+        "tket/1.0.2@tket/stable",
         "rapidcheck/cci.20220514",
     )
 

--- a/recipes/tket-tests/conanfile.py
+++ b/recipes/tket-tests/conanfile.py
@@ -34,7 +34,7 @@ class TketTestsConan(ConanFile):
     default_options = {"with_coverage": False, "full": False, "long": False}
     generators = "cmake"
     exports_sources = "../../tket/tests/*"
-    requires = ("tket/1.0.1", "catch2/3.1.0")
+    requires = ("tket/1.0.2@tket/stable", "catch2/3.1.0")
 
     _cmake = None
 

--- a/recipes/tket/conanfile.py
+++ b/recipes/tket/conanfile.py
@@ -20,7 +20,7 @@ import shutil
 
 class TketConan(ConanFile):
     name = "tket"
-    version = "1.0.1"
+    version = "1.0.2"
     license = "CQC Proprietary"
     homepage = "https://github.com/CQCL/tket"
     url = "https://github.com/conan-io/conan-center-index"

--- a/recipes/tket/conanfile.py
+++ b/recipes/tket/conanfile.py
@@ -36,7 +36,7 @@ class TketConan(ConanFile):
     exports_sources = ["../../tket/src/*", "!*/build/*"]
     requires = (
         # tk* libraries may come from remote:
-        # https://tket.jfrog.io/artifactory/api/conan/tket-conan
+        # https://quantinuumsw.jfrog.io/artifactory/api/conan/tket1-libs
         "boost/1.79.0",
         "symengine/0.9.0",
         "eigen/3.4.0",

--- a/tket/src/CMakeLists.txt
+++ b/tket/src/CMakeLists.txt
@@ -55,6 +55,9 @@ ELSEIF(APPLE)
     # set correct install_name
     set(CMAKE_INSTALL_NAME_DIR "@loader_path")
     set(CMAKE_BUILD_WITH_INSTALL_NAME_DIR ON)
+ELSEIF(UNIX)
+    set(CMAKE_BUILD_WITH_INSTALL_RPATH TRUE)
+    set(CMAKE_INSTALL_RPATH "\${ORIGIN}")
 ENDIF()
 
 # if you add new modules here make sure that it is added at the right position


### PR DESCRIPTION
This is a second attempt at #487 , which was reverted because on Linux pytket was not working when the tket package was downloaded from the repo insetad of being built locally. The reason was that the shared libraries contained hard-coded rpath information pointing to paths that were correct when they were built but are no longer correct at runtime.

The solution is to:

- move the tket libraries alongside the binder libraries in Linux builds of pytket, as we were already doing for MacOS and Windows;
- explicitly set the rpath to `${ORIGIN}` on Linux, which ensures that libraries look in the local directory for other libraries that they need to load.