### PR TITLE
Revert changes to `commute_through_multis()` to handle conditionals

### DIFF
--- a/pytket/conanfile.txt
+++ b/pytket/conanfile.txt
@@ -1,5 +1,5 @@
 [requires]
-tket/1.0.2@tket/stable
+tket/1.0.3@tket/stable
 tklog/0.1.2@tket/stable
 pybind11/2.10.0
 nlohmann_json/3.10.5

--- a/recipes/tket-proptests/conanfile.py
+++ b/recipes/tket-proptests/conanfile.py
@@ -28,7 +28,7 @@ class TketProptestsConan(ConanFile):
     generators = "cmake"
     exports_sources = "../../tket/proptests/*"
     requires = (
-        "tket/1.0.2@tket/stable",
+        "tket/1.0.3@tket/stable",
         "rapidcheck/cci.20220514",
     )
 

--- a/recipes/tket-tests/conanfile.py
+++ b/recipes/tket-tests/conanfile.py
@@ -34,7 +34,7 @@ class TketTestsConan(ConanFile):
     default_options = {"with_coverage": False, "full": False, "long": False}
     generators = "cmake"
     exports_sources = "../../tket/tests/*"
-    requires = ("tket/1.0.2@tket/stable", "catch2/3.1.0")
+    requires = ("tket/1.0.3@tket/stable", "catch2/3.1.0")
 
     _cmake = None
 

--- a/recipes/tket/conanfile.py
+++ b/recipes/tket/conanfile.py
@@ -20,7 +20,7 @@ import shutil
 
 class TketConan(ConanFile):
     name = "tket"
-    version = "1.0.2"
+    version = "1.0.3"
     license = "CQC Proprietary"
     homepage = "https://github.com/CQCL/tket"
     url = "https://github.com/conan-io/conan-center-index"

--- a/tket/src/Transformations/BasicOptimisation.cpp
+++ b/tket/src/Transformations/BasicOptimisation.cpp
@@ -194,17 +194,6 @@ Transform commute_through_multis() {
   return Transform(commute_singles_to_front);
 }
 
-// whether source and target commute
-static bool ends_commute(const Circuit &circ, const Edge &e) {
-  const std::pair<port_t, port_t> ports = circ.get_ports(e);
-  const Vertex source = circ.source(e);
-  const Vertex target = circ.target(e);
-
-  auto colour = circ.commuting_basis(target, PortType::Target, ports.second);
-  return circ.commutes_with_basis(
-      source, colour, PortType::Source, ports.first);
-}
-
 // moves single qubit operations past multiqubit operations they commute with,
 // towards front of circuit (hardcoded)
 static bool commute_singles_to_front(Circuit &circ) {
@@ -217,33 +206,33 @@ static bool commute_singles_to_front(Circuit &circ) {
     while (!is_initial_q_type(circ.get_OpType_from_Vertex(current_v))) {
       const Op_ptr curr_op = circ.get_Op_ptr_from_Vertex(current_v);
       // if current vertex is a multiqubit gate
-      if (circ.n_in_edges_of_type(current_v, EdgeType::Quantum) > 1) {
-        while (circ.n_in_edges_of_type(prev_v, EdgeType::Quantum) == 1 &&
-               ends_commute(circ, current_e)) {
-          // subsequent op on qubit path is a single qubit gate
-          // and commutes with current multi qubit gate
-          success = true;
-          EdgeVec rewire_edges;
-          op_signature_t edge_types;
-          for (const Edge &e : circ.get_in_edges(prev_v)) {
-            EdgeType type = circ.get_edgetype(e);
-            Edge boundary_edge;
-            if (type == EdgeType::Quantum) {
-              boundary_edge = circ.get_last_edge(current_v, current_e);
-            } else {
-              // There should not be any Classical edges for conditional ops
-              TKET_ASSERT(type == EdgeType::Boolean);
-              boundary_edge = circ.get_linear_edge(e);
-            }
-            rewire_edges.push_back(boundary_edge);
-            edge_types.push_back(type);
+      if (circ.n_in_edges_of_type(current_v, EdgeType::Quantum) > 1 &&
+          curr_op->get_desc().is_gate()) {
+        // need gate check to access commuting_basis
+        const std::pair<port_t, port_t> ports = circ.get_ports(current_e);
+      check_prev_commutes:
+        const Op_ptr prev_op = circ.get_Op_ptr_from_Vertex(prev_v);
+        // if previous vertex is single qubit gate
+        if (prev_op->get_desc().is_gate() &&
+            circ.n_in_edges_of_type(prev_v, EdgeType::Quantum) == 1) {
+          const std::optional<Pauli> prev_colour =
+              circ.commuting_basis(prev_v, PortType::Target, ports.second);
+
+          if (circ.commutes_with_basis(
+                  current_v, prev_colour, PortType::Source, ports.first)) {
+            // subsequent op on qubit path is a single qubit gate
+            // and commutes with current multi qubit gate
+            success = true;
+            circ.remove_vertex(
+                prev_v, Circuit::GraphRewiring::Yes,
+                Circuit::VertexDeletion::No);
+            Edge rewire_edge = circ.get_nth_in_edge(current_v, ports.first);
+            circ.rewire(prev_v, {rewire_edge}, {EdgeType::Quantum});
+            current_e = circ.get_nth_out_edge(current_v, ports.first);
+            prev_v = circ.target(current_e);
+            // check if new previous gate can be commuted through too
+            goto check_prev_commutes;
           }
-          const port_t backup_port = circ.get_source_port(current_e);
-          circ.remove_vertex(
-              prev_v, Circuit::GraphRewiring::Yes, Circuit::VertexDeletion::No);
-          circ.rewire(prev_v, rewire_edges, edge_types);
-          current_e = circ.get_nth_out_edge(current_v, backup_port);
-          prev_v = circ.target(current_e);
         }
       }
       // move to next vertex (towards input)

--- a/tket/tests/test_Synthesis.cpp
+++ b/tket/tests/test_Synthesis.cpp
@@ -162,48 +162,6 @@ SCENARIO("Check commutation through multiqubit ops") {
       }
     }
   }
-  GIVEN("A circuit with classical control") {
-    Circuit circ(2, 1);
-    circ.add_op<unsigned>(OpType::CX, {0, 1});
-    circ.add_conditional_gate<unsigned>(OpType::Rz, {0.142}, {0}, {0}, 1);
-
-    circ.add_barrier({0, 1});
-
-    circ.add_conditional_gate<unsigned>(OpType::CX, {}, {1, 0}, {0}, 0);
-    circ.add_conditional_gate<unsigned>(OpType::CX, {}, {1, 0}, {0}, 1);
-    circ.add_conditional_gate<unsigned>(OpType::X, {}, {0}, {0}, 1);
-    circ.add_op<unsigned>(OpType::X, {0});
-
-    REQUIRE(Transforms::commute_through_multis().apply(circ));
-
-    Circuit solution(2, 1);
-    solution.add_conditional_gate<unsigned>(OpType::Rz, {0.142}, {0}, {0}, 1);
-    solution.add_op<unsigned>(OpType::CX, {0, 1});
-
-    solution.add_barrier({0, 1});
-
-    solution.add_conditional_gate<unsigned>(OpType::X, {}, {0}, {0}, 1);
-    solution.add_op<unsigned>(OpType::X, {0});
-    solution.add_conditional_gate<unsigned>(OpType::CX, {}, {1, 0}, {0}, 0);
-    solution.add_conditional_gate<unsigned>(OpType::CX, {}, {1, 0}, {0}, 1);
-
-    REQUIRE(circ == solution);
-  }
-  GIVEN("A bridge") {
-    Circuit circ(3);
-    circ.add_op<unsigned>(OpType::BRIDGE, {1, 2, 0});
-    REQUIRE_FALSE(Transforms::commute_through_multis().apply(circ));
-  }
-  GIVEN("A circuit with a conditional measure") {
-    Circuit circ(2, 3);
-    circ.add_op<unsigned>(OpType::CX, {0, 1});
-    circ.add_conditional_gate<unsigned>(OpType::Measure, {}, {0, 0}, {1}, 1);
-    circ.add_conditional_gate<unsigned>(OpType::Measure, {}, {1, 0}, {2}, 1);
-    Circuit orig = circ;
-
-    REQUIRE(!Transforms::commute_through_multis().apply(circ));
-    REQUIRE(orig == circ);
-  }
 }
 
 SCENARIO(


### PR DESCRIPTION
Fixes #514 .

This is the quick fix. Of course it would be better to find the cause and fix it (so that `commute_through_multis()` can work with conditionals), but given the need for a hotfix release I propose doing this first and then coming back to it.