### PR TITLE
Improvements to workflow and README

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -255,7 +255,7 @@ jobs:
       run: conan remote add tket-libs https://quantinuumsw.jfrog.io/artifactory/api/conan/tket1-libs --force
     - name: Build tket
       if: needs.check_changes.outputs.tket_changed == 'true'
-      run: conan create --profile=tket recipes/tket tket/stable --build=missing
+      run: conan create --profile=tket recipes/tket tket/stable --build=missing --build=tket
     - name: Build and run tket tests
       if: needs.check_changes.outputs.tket_changed == 'true' || needs.check_changes.outputs.tket_tests_changed == 'true'
       run: conan create --profile=tket recipes/tket-tests
@@ -355,11 +355,9 @@ jobs:
       run: conan profile update options.tket-tests:full=True tket
     - name: add remote
       run: conan remote add tket-libs https://quantinuumsw.jfrog.io/artifactory/api/conan/tket1-libs --force
-    - name: Remove tket package from local cache
-      run: conan remove -f 'tket/*'
     - name: Build tket
       if: needs.check_changes.outputs.tket_changed == 'true'
-      run: conan create --profile=tket recipes/tket tket/stable --build=missing
+      run: conan create --profile=tket recipes/tket tket/stable --build=missing --build=tket
     - name: Build and run tket tests
       if: needs.check_changes.outputs.tket_changed == 'true' || needs.check_changes.outputs.tket_tests_changed == 'true'
       run: conan create --profile=tket recipes/tket-tests

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -116,6 +116,7 @@ jobs:
       if: github.event_name == 'pull_request'
       run: ./.github/workflows/check-tket-reqs  ${{ needs.check_changes.outputs.tket_ver }}
     - name: Install runtime test requirements
+      if: needs.check_changes.outputs.tket_changed == 'true' || needs.check_changes.outputs.tket_tests_changed == 'true'
       run: |
         sudo apt-get install texlive texlive-latex-extra latexmk
         mkdir -p ~/texmf/tex/latex

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,7 +69,7 @@ jobs:
         conan profile update options.tklog:shared=True tket
         conan profile update options.tket:shared=True tket
         conan remote add tket-libs https://quantinuumsw.jfrog.io/artifactory/api/conan/tket1-libs --force
-        conan create --profile=tket recipes/tket tket/stable --build=missing
+        conan create --profile=tket recipes/tket tket/stable --build=missing --build=tket
     - name: Install pybind11
       run: conan create --profile=tket recipes/pybind11
     - name: Build wheel (3.8)
@@ -112,7 +112,7 @@ jobs:
         conan profile update options.tklog:shared=True tket
         conan profile update options.tket:shared=True tket
         conan remote add tket-libs https://quantinuumsw.jfrog.io/artifactory/api/conan/tket1-libs --force
-        conan create --profile=tket recipes/tket tket/stable --build=missing
+        conan create --profile=tket recipes/tket tket/stable --build=missing --build=tket
         conan create --profile=tket recipes/pybind11
         .github/workflows/build_macos_m1_wheel
         pyenv shell tket-3.9

--- a/README.md
+++ b/README.md
@@ -266,8 +266,9 @@ First create a `build` folder in the project root. Then proceed as follows.
 4. To export to `conan` cache (necessary to build pytket):
 
    ```shell
-   conan export-pkg recipes/tket -f --build-folder=build --source-folder=tket/src
+   conan export-pkg recipes/tket tket/${VERSION}@tket/stable -f --build-folder=build --source-folder=tket/src
    ```
+   where `${VERSION}` is the tket library version, e.g. `1.0.3`.
 
 ## Test coverage
 


### PR DESCRIPTION
Forcing build of tket when `--build=missing` is used on MacOS prevents use of cached version. I think this could make a difference in cases where PRs get updated.