### PR TITLE
Use native ARM64 runner

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -241,12 +241,9 @@ jobs:
 
   macos-m1:
     name: Build and test (MacOS M1)
-    runs-on: [self-hosted, macos, M1]
+    runs-on: ['self-hosted', 'macOS', 'ARM64']
     needs: check_changes
     if: github.event_name == 'push' || github.event_name == 'schedule' || github.event.pull_request.head.repo.full_name == github.repository
-    defaults:
-      run:
-        shell: "/usr/bin/arch -arch arm64e /bin/bash {0}"
     env:
       CONAN_REVISIONS_ENABLED: 1
       PYTKET_SKIP_REGISTRATION: "true"

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -281,7 +281,7 @@ jobs:
       run: |
         eval "$(pyenv init -)"
         pyenv shell tket-3.8
-        OPENBLAS="$(brew --prefix openblas)" pip install -U scipy
+        PKG_CONFIG_PATH="$(brew --prefix openblas)"/lib/pkgconfig pip install -U scipy
         cd pytket
         pip uninstall -y pytket
         pip install -e . -v
@@ -298,7 +298,7 @@ jobs:
       run: |
         eval "$(pyenv init -)"
         pyenv shell tket-3.9
-        OPENBLAS="$(brew --prefix openblas)" pip install -U scipy
+        PKG_CONFIG_PATH="$(brew --prefix openblas)"/lib/pkgconfig pip install -U scipy
         cd pytket
         pip uninstall -y pytket
         pip install -e . -v
@@ -315,7 +315,7 @@ jobs:
       run: |
         eval "$(pyenv init -)"
         pyenv shell tket-3.10
-        OPENBLAS="$(brew --prefix openblas)" pip install -U scipy
+        PKG_CONFIG_PATH="$(brew --prefix openblas)"/lib/pkgconfig pip install -U scipy
         cd pytket
         pip uninstall -y pytket
         pip install -e . -v

--- a/.github/workflows/build_libs.yml
+++ b/.github/workflows/build_libs.yml
@@ -97,7 +97,7 @@ jobs:
     name: build library (macos-m1)
     needs: changes
     if: ${{ needs.changes.outputs.libs != '[]' && needs.changes.outputs.libs != '' }}
-    runs-on: [self-hosted, macos, M1]
+    runs-on: ['self-hosted', 'macOS', 'ARM64']
     strategy:
       matrix:
         lib: ${{ fromJson(needs.changes.outputs.libs) }}

--- a/.github/workflows/publish_tket_package.yml
+++ b/.github/workflows/publish_tket_package.yml
@@ -75,7 +75,7 @@ jobs:
         exclude:
           - build_type: 'Debug'
             shared: 'True'
-    runs-on: [self-hosted, macos, M1]
+    runs-on: ['self-hosted', 'macOS', 'ARM64']
     env:
       CONAN_REVISIONS_ENABLED: 1
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -270,6 +270,7 @@ jobs:
       run: |
         eval "$(pyenv init -)"
         pyenv shell tket-${{ matrix.python-version }}
+        PKG_CONFIG_PATH="$(brew --prefix openblas)"/lib/pkgconfig pip install -U scipy
         pip uninstall -y pytket
         pip install $GITHUB_WORKSPACE/wheelhouse/${{ matrix.python-version }}.*/pytket-*.whl
     - name: Run tests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,12 +93,9 @@ jobs:
 
   build_macos_M1_wheels:
     name: Build macos (M1) wheels
-    runs-on: [self-hosted, macos, M1]
+    runs-on: ['self-hosted', 'macOS', 'ARM64']
     env:
       CONAN_REVISIONS_ENABLED: 1
-    defaults:
-      run:
-        shell: "/usr/bin/arch -arch arm64e /bin/bash {0}"
     steps:
     - uses: actions/checkout@v3
       with:
@@ -253,10 +250,7 @@ jobs:
   test_macos_M1_wheels:
     name: Test macos (M1) wheels
     needs: build_macos_M1_wheels
-    runs-on: [self-hosted, macos, M1]
-    defaults:
-      run:
-        shell: "/usr/bin/arch -arch arm64e /bin/bash {0}"
+    runs-on: ['self-hosted', 'macOS', 'ARM64']
     env:
       PRIVATE_PYPI_PASS: ${{ secrets.PRIVATE_PYPI_PASS }}
       PYTKET_SKIP_REGISTRATION: "true"

--- a/.github/workflows/test_libs.yml
+++ b/.github/workflows/test_libs.yml
@@ -72,7 +72,7 @@ jobs:
     name: test library (macos-m1)
     needs: changes
     if: ${{ needs.changes.outputs.libs != '[]' && needs.changes.outputs.libs != '' }}
-    runs-on: [self-hosted, macos, M1]
+    runs-on: ['self-hosted', 'macOS', 'ARM64']
     strategy:
       matrix:
         lib: ${{ fromJson(needs.changes.outputs.libs) }}

--- a/.github/workflows/test_libs_all.yml
+++ b/.github/workflows/test_libs_all.yml
@@ -41,7 +41,7 @@ jobs:
       run: ./test-${{ matrix.lib }}
   macos-m1:
     name: test library (macos-m1)
-    runs-on: [self-hosted, macos, M1]
+    runs-on: ['self-hosted', 'macOS', 'ARM64']
     strategy:
       matrix:
         lib: ['tklog', 'tkassert', 'tkrng', 'tktokenswap', 'tkwsm']


### PR DESCRIPTION
I installed the ARM64 runner on our CI Mac Mini and added it to the repo. This updates our workflows to use it.

https://github.blog/changelog/2022-08-09-github-actions-self-hosted-runners-now-support-apple-m1-hardware/