### PR TITLE
Update boost version in libs.

### DIFF
--- a/libs/tktokenswap/conanfile.py
+++ b/libs/tktokenswap/conanfile.py
@@ -18,7 +18,7 @@ from conans.errors import ConanInvalidConfiguration
 
 class TktokenswapConan(ConanFile):
     name = "tktokenswap"
-    version = "0.1.1"
+    version = "0.1.2"
     license = "Apache 2"
     url = "https://github.com/CQCL/tket"
     description = "Token swapping algorithms library"
@@ -35,7 +35,7 @@ class TktokenswapConan(ConanFile):
         "tklog/0.1.2@tket/stable",
         "tkassert/0.1.1@tket/stable",
         "tkrng/0.1.2@tket/stable",
-        "boost/1.79.0",
+        "boost/1.80.0",
     ]
 
     def config_options(self):

--- a/libs/tktokenswap/test/conanfile.py
+++ b/libs/tktokenswap/test/conanfile.py
@@ -27,7 +27,7 @@ class TestTktokenswapConan(ConanFile):
     default_options = {"with_coverage": False}
     generators = "cmake"
     exports_sources = "*"
-    requires = ["tktokenswap/0.1.1", "catch2/3.1.0"]
+    requires = ["tktokenswap/0.1.2", "catch2/3.1.0"]
 
     _cmake = None
 

--- a/libs/tkwsm/conanfile.py
+++ b/libs/tkwsm/conanfile.py
@@ -18,7 +18,7 @@ from conans.errors import ConanInvalidConfiguration
 
 class TkwsmConan(ConanFile):
     name = "tkwsm"
-    version = "0.2.0"
+    version = "0.2.1"
     license = "Apache 2"
     url = "https://github.com/CQCL/tket"
     description = "Weighted-subgraph-monomorphism algorithms library"
@@ -34,7 +34,7 @@ class TkwsmConan(ConanFile):
     requires = [
         "tkassert/0.1.1@tket/stable",
         "tkrng/0.1.2@tket/stable",
-        "boost/1.79.0",
+        "boost/1.80.0",
     ]
 
     def config_options(self):

--- a/libs/tkwsm/test/conanfile.py
+++ b/libs/tkwsm/test/conanfile.py
@@ -27,7 +27,7 @@ class TestTkwsmConan(ConanFile):
     default_options = {"with_coverage": False}
     generators = "cmake"
     exports_sources = "*"
-    requires = ["tkwsm/0.2.0", "catch2/3.1.0"]
+    requires = ["tkwsm/0.2.1", "catch2/3.1.0"]
 
     _cmake = None
 


### PR DESCRIPTION
I don't know why the coverage check failed; this shouldn't happen as there are no changes to the code being analysed; possibly the last report may have been uploaded in error, or gcovr has changed somehow. Anyway, I think this failure can be ignored.

PR updating tket to follow.