### PR TITLE
Switch to windows-2022.

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -66,7 +66,7 @@ jobs:
     needs: check_changes
     strategy:
       matrix:
-        os: ['ubuntu-22.04', 'macos-11', 'windows-2019']
+        os: ['ubuntu-22.04', 'macos-11', 'windows-2022']
     runs-on: ${{ matrix.os }}
     env:
       CONAN_REVISIONS_ENABLED: 1
@@ -122,7 +122,7 @@ jobs:
     - name: add remote
       run: conan remote add tket-libs https://quantinuumsw.jfrog.io/artifactory/api/conan/tket1-libs --force
     - name: normalize line endings in conanfile and src directory
-      if: matrix.os == 'windows-2019' && needs.check_changes.outputs.tket_package_exists == 'false'
+      if: matrix.os == 'windows-2022' && needs.check_changes.outputs.tket_package_exists == 'false'
       # This is necessary to ensure consistent revisions across platforms.
       # Conan's revision hash is composed of hashes of all the exported files,
       # so we must normalize the line endings in these.

--- a/.github/workflows/build_libs.yml
+++ b/.github/workflows/build_libs.yml
@@ -37,7 +37,7 @@ jobs:
     if: ${{ needs.changes.outputs.libs != '[]' && needs.changes.outputs.libs != '' }}
     strategy:
       matrix:
-        os: ['ubuntu-22.04', 'macos-11', 'windows-2019']
+        os: ['ubuntu-22.04', 'macos-11', 'windows-2022']
         lib: ${{ fromJson(needs.changes.outputs.libs) }}
         build_type: ['Release', 'Debug']
         shared: ['True', 'False']
@@ -47,7 +47,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: normalize line endings in conanfile and src directory
-      if: matrix.os == 'windows-2019'
+      if: matrix.os == 'windows-2022'
       # This is necessary to ensure consistent revisions across platforms.
       # Conan's revision hash is composed of hashes all the exported files, so
       # we must normalize the line endings in these.
@@ -78,12 +78,12 @@ jobs:
     - name: authenticate to repository
       run: conan user -p ${{ secrets.JFROG_ARTIFACTORY_TOKEN_2 }} -r tket-libs ${{ secrets.JFROG_ARTIFACTORY_USER_2 }}
     - name: get version
-      if: matrix.os != 'windows-2019'
+      if: matrix.os != 'windows-2022'
       run: |
         lib_ver=$(conan inspect --raw version libs/${{ matrix.lib }}/conanfile.py)
         echo "LIB_VER=${lib_ver}" >> $GITHUB_ENV
     - name: get version
-      if: matrix.os == 'windows-2019'
+      if: matrix.os == 'windows-2022'
       run: |
         $${{ matrix.lib }}_ver = conan inspect --raw version libs/${{ matrix.lib }}/conanfile.py
         echo "LIB_VER=${${{ matrix.lib }}_ver}" >> $env:GITHUB_ENV

--- a/.github/workflows/publish_tket_package.yml
+++ b/.github/workflows/publish_tket_package.yml
@@ -10,7 +10,7 @@ jobs:
     name: build and publish tket
     strategy:
       matrix:
-        os: ['ubuntu-22.04', 'macos-11', 'windows-2019']
+        os: ['ubuntu-22.04', 'macos-11', 'windows-2022']
         build_type: ['Release', 'Debug']
         shared: ['True', 'False']
         exclude:
@@ -23,7 +23,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: normalize line endings in conanfile and src directory
-      if: matrix.os == 'windows-2019'
+      if: matrix.os == 'windows-2022'
       # This is necessary to ensure consistent revisions across platforms.
       # Conan's revision hash is composed of hashes all the exported files, so
       # we must normalize the line endings in these.
@@ -54,12 +54,12 @@ jobs:
     - name: authenticate to repository
       run: conan user -p ${{ secrets.JFROG_ARTIFACTORY_TOKEN_2 }} -r tket-libs ${{ secrets.JFROG_ARTIFACTORY_USER_2 }}
     - name: get version
-      if: matrix.os != 'windows-2019'
+      if: matrix.os != 'windows-2022'
       run: |
         lib_ver=$(conan inspect --raw version recipes/tket/conanfile.py)
         echo "LIB_VER=${lib_ver}" >> $GITHUB_ENV
     - name: get version
-      if: matrix.os == 'windows-2019'
+      if: matrix.os == 'windows-2022'
       run: |
         $${{ matrix.lib }}_ver = conan inspect --raw version recipes/tket/conanfile.py
         echo "LIB_VER=${${{ matrix.lib }}_ver}" >> $env:GITHUB_ENV

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,7 +123,7 @@ jobs:
 
   build_Windows_wheels:
     name: Build Windows wheels
-    runs-on: windows-2019
+    runs-on: windows-2022
     env:
       CONAN_REVISIONS_ENABLED: 1
     steps:
@@ -284,7 +284,7 @@ jobs:
   test_Windows_wheels:
     name: Test Windows wheels
     needs: build_Windows_wheels
-    runs-on: windows-2019
+    runs-on: windows-2022
     env:
       PYTKET_SKIP_REGISTRATION: "true"
     strategy:

--- a/.github/workflows/test_libs.yml
+++ b/.github/workflows/test_libs.yml
@@ -37,7 +37,7 @@ jobs:
     if: ${{ needs.changes.outputs.libs != '[]' && needs.changes.outputs.libs != '' }}
     strategy:
       matrix:
-        os: ['ubuntu-22.04', 'macos-11', 'windows-2019']
+        os: ['ubuntu-22.04', 'macos-11', 'windows-2022']
         lib: ${{ fromJson(needs.changes.outputs.libs) }}
     runs-on: ${{ matrix.os }}
     env:

--- a/.github/workflows/test_libs_all.yml
+++ b/.github/workflows/test_libs_all.yml
@@ -8,7 +8,7 @@ jobs:
     name: test library
     strategy:
       matrix:
-        os: ['ubuntu-22.04', 'macos-11', 'windows-2019']
+        os: ['ubuntu-22.04', 'macos-11', 'windows-2022']
         lib: ['tklog', 'tkassert', 'tkrng', 'tktokenswap', 'tkwsm']
     runs-on: ${{ matrix.os }}
     env:


### PR DESCRIPTION
Will update names of "required" checks after merging.
Note that I have already built and uploaded windows-2022 versions of the libraries and tket itself to the artifactory:

- https://github.com/CQCL/tket/actions/runs/3067139661
- https://github.com/CQCL/tket/actions/runs/3067799640

I have also uploaded suitable versions of boost and its dependencies, and catch2, so that those don't have to be built each time. (They are not in the conan-center yet.)