### PR TITLE
Handle python versions in matrix.

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -61,8 +61,8 @@ jobs:
       if: steps.filter.outputs.tket == 'true' && steps.test_package_exists.outputs.tket_package_exists == 'true'
       run: exit 1
 
-  build_test:
-    name: Build and test
+  build_test_tket:
+    name: Build and test (tket)
     needs: check_changes
     strategy:
       matrix:
@@ -153,91 +153,76 @@ jobs:
     - name: Build and run tket proptests
       if: needs.check_changes.outputs.tket_changed == 'true' || needs.check_changes.outputs.tket_proptests_changed == 'true'
       run: conan create --profile=tket recipes/tket-proptests --build=missing --build=tket-proptests
-    - name: Install pybind11
-      run: conan create --profile=tket recipes/pybind11
-    - name: Set up Python 3.8
-      if: github.event_name == 'push'
-      uses: actions/setup-python@v3
-      with:
-        python-version: '3.8'
-    - name: Build pytket (3.8)
-      if: github.event_name == 'push'
-      run: |
-        cd pytket
-        pip install -e . -v
-    - name: Test pytket (3.8) with coverage
-      if: matrix.os == 'ubuntu-22.04' && github.event_name == 'push'
-      run: |
-        cd pytket/tests
-        pip install -r requirements.txt
-        pytest --ignore=simulator/ --doctest-modules --cov=../pytket --cov-branch --cov-report=html --cov-report=xml:htmlcov/cov.xml
-    - name: Test pytket (3.8)
-      if: matrix.os != 'ubuntu-22.04' && github.event_name == 'push'
-      run: |
-        cd pytket/tests
-        pip install -r requirements.txt
-        pytest --ignore=simulator/ --doctest-modules
-    - name: Set up Python 3.9
-      if: github.event_name == 'pull_request'
-      uses: actions/setup-python@v3
-      with:
-        python-version: '3.9'
-    - name: Build pytket (3.9)
-      if: github.event_name == 'pull_request'
-      run: |
-        cd pytket
-        pip install -e . -v
-    - name: Test building docs
-      if: matrix.os == 'ubuntu-22.04' && github.event_name == 'pull_request'
-      timeout-minutes: 20
-      run: |
-        pip install -r pytket/docs/requirements.txt
-        ./.github/workflows/build-docs
-    - name: Test pytket (3.9) with coverage
-      if: matrix.os == 'ubuntu-22.04' && github.event_name == 'pull_request'
-      run: |
-        cd pytket/tests
-        pip install -r requirements.txt
-        pytest --ignore=simulator/ --doctest-modules --cov=../pytket --cov-branch --cov-report=html --cov-report=xml:htmlcov/cov.xml
-    - name: Test pytket (3.9)
-      if: matrix.os != 'ubuntu-22.04' && github.event_name == 'pull_request'
-      run: |
-        cd pytket/tests
-        pip install -r requirements.txt
-        pytest --ignore=simulator/ --doctest-modules
-    - name: Run mypy
-      if: matrix.os == 'macos-11' && github.event_name == 'pull_request'
-      run: |
-        pip install -U mypy
-        cd pytket
-        mypy --config-file=mypy.ini --no-incremental -p pytket -p tests
-    - name: Set up Python 3.10
-      if: github.event_name == 'schedule'
-      uses: actions/setup-python@v3
-      with:
-        python-version: '3.10'
-    - name: Build and test pytket (3.10)
-      if: github.event_name == 'schedule'
-      run: |
-        cd pytket
-        pip install -e . -v
-    - name: Test pytket (3.10)
-      if: github.event_name == 'schedule'
-      run: |
-        cd pytket/tests
-        pip install -r requirements.txt
-        pytest --ignore=simulator/ --doctest-modules
-    - name: Upload pytket coverage artefact
-      if: matrix.os == 'ubuntu-22.04' && (github.event_name == 'pull_request' || github.event_name == 'push')
+    - name: Upload tket conan package
       uses: actions/upload-artifact@v3
       with:
-        name: pytket_test_coverage
-        path: pytket/tests/htmlcov
+        name: tket_conan_${{ matrix.os }}
+        path: ~/.conan/data/tket
     - name: Upload package
       if: github.event_name == 'push' && github.ref == 'refs/heads/develop' && needs.check_changes.outputs.tket_changed == 'true'
       run: |
         conan user -p ${{ secrets.JFROG_ARTIFACTORY_TOKEN_2 }} -r tket-libs ${{ secrets.JFROG_ARTIFACTORY_USER_2 }}
         conan upload tket/${{ needs.check_changes.outputs.tket_ver }}@tket/stable --all -r=tket-libs
+
+  build_test:
+    name: Build and test
+    needs: build_test_tket
+    strategy:
+      matrix:
+        os: ['ubuntu-22.04', 'macos-11', 'windows-2022']
+        pyver: ['3.8', '3.9', '3.10']
+    runs-on: ${{ matrix.os }}
+    env:
+      CONAN_REVISIONS_ENABLED: 1
+    steps:
+    - uses: actions/checkout@v3
+    - name: Install conan
+      uses: turtlebrowser/get-conan@v1.1
+    - name: Download tket conan package
+      uses: actions/download-artifact@v3
+      with:
+        name: tket_conan_${{ matrix.os }}
+        path: ~/.conan/data/tket
+    - name: Install pybind11
+      run: conan create --profile=tket recipes/pybind11
+    - name: Set up Python
+      uses: actions/setup-python@v3
+      with:
+        python-version: ${{ matrix.pyver }}
+    - name: Build pytket
+      run: |
+        cd pytket
+        pip install -e . -v
+    - name: Test pytket with coverage
+      if: matrix.os == 'ubuntu-22.04' && matrix.pyver == '3.8' && github.event_name == 'push'
+      run: |
+        cd pytket/tests
+        pip install -r requirements.txt
+        pytest --ignore=simulator/ --doctest-modules --cov=../pytket --cov-branch --cov-report=html --cov-report=xml:htmlcov/cov.xml
+    - name: Test pytket
+      if: (matrix.os != 'ubuntu-22.04' || matrix.pyver != '3.8') && github.event_name == 'push'
+      run: |
+        cd pytket/tests
+        pip install -r requirements.txt
+        pytest --ignore=simulator/ --doctest-modules
+    - name: Test building docs
+      if: matrix.os == 'ubuntu-22.04' && matrix.pyver == '3.9' && github.event_name == 'pull_request'
+      timeout-minutes: 20
+      run: |
+        pip install -r pytket/docs/requirements.txt
+        ./.github/workflows/build-docs
+    - name: Run mypy
+      if: matrix.os == 'macos-11' && matrix.pyver == '3.9' && github.event_name == 'pull_request'
+      run: |
+        pip install -U mypy
+        cd pytket
+        mypy --config-file=mypy.ini --no-incremental -p pytket -p tests
+    - name: Upload pytket coverage artefact
+      if: matrix.os == 'ubuntu-22.04' && matrix.pyver == '3.8' && (github.event_name == 'pull_request' || github.event_name == 'push')
+      uses: actions/upload-artifact@v3
+      with:
+        name: pytket_test_coverage
+        path: pytket/tests/htmlcov
 
   macos-m1:
     name: Build and test (MacOS M1)

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -114,7 +114,7 @@ jobs:
       if: github.event_name == 'schedule'
       run: conan profile update options.tket-tests:full=True tket
     - name: normalize line endings in conanfile and src directory
-      if: matrix.os == 'windows-2022' && needs.check_changes.outputs.tket_package_exists == 'false'
+      if: matrix.os == 'windows-2022'
       # This is necessary to ensure consistent revisions across platforms.
       # Conan's revision hash is composed of hashes of all the exported files,
       # so we must normalize the line endings in these.

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -339,7 +339,7 @@ jobs:
     name: Publish pytket coverage
     needs: build_test
     concurrency: gh_pages
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/develop'
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -198,7 +198,7 @@ jobs:
         pip install -r requirements.txt
         pytest --ignore=simulator/ --doctest-modules --cov=../pytket --cov-branch --cov-report=html --cov-report=xml:htmlcov/cov.xml
     - name: Test pytket
-      if: (matrix.os != 'ubuntu-22.04' || matrix.pyver != '3.8') && github.event_name == 'push'
+      if: matrix.os != 'ubuntu-22.04' || matrix.pyver != '3.8' || github.event_name != 'push'
       run: |
         cd pytket/tests
         pip install -r requirements.txt

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -107,20 +107,12 @@ jobs:
         cd tket && doxygen
     - name: Install conan
       uses: turtlebrowser/get-conan@v1.1
-    - name: Set up conan profile
-      run: conan profile new tket --detect --force
-    - name: Fix up libcxx in profile
-      if: matrix.os == 'ubuntu-22.04'
-      run: conan profile update settings.compiler.libcxx=libstdc++11 tket
-    - name: Set profile options
-      run: |
-        conan profile update options.tklog:shared=True tket
-        conan profile update options.tket:shared=True tket
+    - name: Set up conan
+      shell: bash
+      run: ./.github/workflows/conan-setup
     - name: set option to run full test suite
       if: github.event_name == 'schedule'
       run: conan profile update options.tket-tests:full=True tket
-    - name: add remote
-      run: conan remote add tket-libs https://quantinuumsw.jfrog.io/artifactory/api/conan/tket1-libs --force
     - name: normalize line endings in conanfile and src directory
       if: matrix.os == 'windows-2022' && needs.check_changes.outputs.tket_package_exists == 'false'
       # This is necessary to ensure consistent revisions across platforms.
@@ -178,6 +170,9 @@ jobs:
     - uses: actions/checkout@v3
     - name: Install conan
       uses: turtlebrowser/get-conan@v1.1
+    - name: Set up conan
+      shell: bash
+      run: ./.github/workflows/conan-setup
     - name: Download tket conan package
       uses: actions/download-artifact@v3
       with:
@@ -238,18 +233,14 @@ jobs:
         fetch-depth: '0'
     - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
     - name: Set up conan
-      id: conan
+      shell: bash
       run: |
-        conan profile new tket --detect --force
-        conan profile update options.tklog:shared=True tket
-        conan profile update options.tket:shared=True tket
+        ./.github/workflows/conan-setup
         export CC=`which conan`
         echo "CONAN_CMD=${CC}" >> $GITHUB_ENV
     - name: set option to run full test suite
       if: github.event_name == 'schedule'
       run: conan profile update options.tket-tests:full=True tket
-    - name: add remote
-      run: conan remote add tket-libs https://quantinuumsw.jfrog.io/artifactory/api/conan/tket1-libs --force
     - name: Build tket
       if: needs.check_changes.outputs.tket_changed == 'true'
       run: conan create --profile=tket recipes/tket tket/stable --build=missing --build=tket

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -192,13 +192,13 @@ jobs:
         cd pytket
         pip install -e . -v
     - name: Test pytket with coverage
-      if: matrix.os == 'ubuntu-22.04' && matrix.pyver == '3.8' && github.event_name == 'push'
+      if: matrix.os == 'ubuntu-22.04' && matrix.pyver == '3.8'
       run: |
         cd pytket/tests
         pip install -r requirements.txt
         pytest --ignore=simulator/ --doctest-modules --cov=../pytket --cov-branch --cov-report=html --cov-report=xml:htmlcov/cov.xml
     - name: Test pytket
-      if: matrix.os != 'ubuntu-22.04' || matrix.pyver != '3.8' || github.event_name != 'push'
+      if: matrix.os != 'ubuntu-22.04' || matrix.pyver != '3.8'
       run: |
         cd pytket/tests
         pip install -r requirements.txt

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -130,6 +130,9 @@ jobs:
     - name: Build tket
       if: needs.check_changes.outputs.tket_changed == 'true'
       run: conan create --profile=tket recipes/tket tket/stable --build=missing --build=tket
+    - name: Install tket
+      if: needs.check_changes.outputs.tket_changed != 'true'
+      run: conan install --profile=tket tket/${{ needs.check_changes.outputs.tket_ver }}@tket/stable
     - name: check that version is consistent
       if: matrix.os == 'ubuntu-22.04' && github.event_name == 'pull_request'
       run: ./.github/workflows/check-tket-reqs  ${{ needs.check_changes.outputs.tket_ver }}

--- a/.github/workflows/conan-setup
+++ b/.github/workflows/conan-setup
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+conan profile new tket --detect --force
+if [ "$(uname -s)" == "Linux" ]; then
+    conan profile update settings.compiler.libcxx=libstdc++11 tket
+fi
+conan profile update options.tklog:shared=True tket
+conan profile update options.tket:shared=True tket
+conan remote add tket-libs https://quantinuumsw.jfrog.io/artifactory/api/conan/tket1-libs --force

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,14 +62,13 @@ jobs:
       uses: actions/setup-python@v3
       with:
         python-version: '3.8'
+    - name: Install conan
+      uses: turtlebrowser/get-conan@v1.1
+    - name: Set up conan
+      shell: bash
+      run: ./.github/workflows/conan-setup
     - name: Build tket C++
-      run: |
-        pip install conan
-        conan profile new tket --detect --force
-        conan profile update options.tklog:shared=True tket
-        conan profile update options.tket:shared=True tket
-        conan remote add tket-libs https://quantinuumsw.jfrog.io/artifactory/api/conan/tket1-libs --force
-        conan create --profile=tket recipes/tket tket/stable --build=missing --build=tket
+      run: conan create --profile=tket recipes/tket tket/stable --build=missing --build=tket
     - name: Install pybind11
       run: conan create --profile=tket recipes/pybind11
     - name: Build wheel (3.8)
@@ -101,14 +100,13 @@ jobs:
       with:
         fetch-depth: '0'
     - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
+    - name: Set up conan
+      shell: bash
+      run: ./.github/workflows/conan-setup
     - name: Build wheels
       run: |
         eval "$(pyenv init -)"
         pyenv shell tket-3.8
-        conan profile new tket --detect --force
-        conan profile update options.tklog:shared=True tket
-        conan profile update options.tket:shared=True tket
-        conan remote add tket-libs https://quantinuumsw.jfrog.io/artifactory/api/conan/tket1-libs --force
         conan create --profile=tket recipes/tket tket/stable --build=missing --build=tket
         conan create --profile=tket recipes/pybind11
         .github/workflows/build_macos_m1_wheel
@@ -132,11 +130,10 @@ jobs:
         fetch-depth: '0'
     - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
     - name: Install conan
-      run: |
-        pip install conan
-        conan profile new tket --detect
-        conan profile update options.tklog:shared=True tket
-        conan profile update options.tket:shared=True tket
+      uses: turtlebrowser/get-conan@v1.1
+    - name: Set up conan
+      shell: bash
+      run: ./.github/workflows/conan-setup
         $conan_cmd = (gcm conan).Path
         echo "CONAN_CMD=${conan_cmd}" >> $GITHUB_ENV
     - name: add remote

--- a/.github/workflows/test_libs.yml
+++ b/.github/workflows/test_libs.yml
@@ -160,7 +160,7 @@ jobs:
   publish_coverage:
     name: Publish coverage
     needs: [changes, generate_coverage]
-    if: ${{ github.event_name == 'push' && needs.changes.outputs.libs != '[]' && needs.changes.outputs.libs != '' }}
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/develop' && needs.changes.outputs.libs != '[]' && needs.changes.outputs.libs != '' }}
     strategy:
       matrix:
         lib: ${{ fromJson(needs.changes.outputs.libs) }}

--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -42,18 +42,13 @@ jobs:
     - name: apt update
       run: sudo apt update
     - name: Install conan
-      id: conan
-      run: |
-        pip install conan
-        conan profile new tket --detect
-        conan profile update settings.compiler.libcxx=libstdc++11 tket
-        conan profile update options.tklog:shared=True tket
-        conan profile update options.tket:shared=True tket
+      uses: turtlebrowser/get-conan@v1.1
+    - name: Set up conan
+      shell: bash
+      run: ./.github/workflows/conan-setup
     - name: set option to run full test suite
       if: github.event_name == 'schedule'
       run: conan profile update options.tket-tests:full=True tket
-    - name: add remote
-      run: conan remote add tket-libs https://quantinuumsw.jfrog.io/artifactory/api/conan/tket1-libs
     - name: install tex components
       run: |
         sudo apt install texlive texlive-latex-extra latexmk


### PR DESCRIPTION
As discussed [here](https://github.com/CQCL/tket/pull/529#discussion_r970694550).

The price we pay is storing the contents of `~/.conan/data/tket` in an artefact, which is then downloaded by each pytket build. But this is still a net gain in time, as well as a useful refactor.

I also factored out the script to set up the conan profile and options.

(Will require a small tweak if #540 is merged first.)