### PR TITLE
Switch to macos-12

### DIFF
--- a/.github/workflows/build-symengine.yml
+++ b/.github/workflows/build-symengine.yml
@@ -1,0 +1,62 @@
+name: Build symengine
+
+on:
+  push:
+    branches:
+      - 'symengine-upload-new/**'
+
+jobs:
+  build:
+    name: Build
+    strategy:
+      matrix:
+        os: ['ubuntu-22.04', 'macos-12', 'windows-2022']
+    runs-on: ${{ matrix.os }}
+    env:
+      CONAN_REVISIONS_ENABLED: 1
+    steps:
+    - uses: actions/checkout@v3
+    - name: Install conan
+      uses: turtlebrowser/get-conan@v1.1
+    - name: Set up conan profile
+      run: conan profile new tket --detect --force
+    - name: Fix up libcxx in profile
+      if: matrix.os == 'ubuntu-22.04'
+      run: conan profile update settings.compiler.libcxx=libstdc++11 tket
+    - name: add remote
+      run: conan remote add tket-libs https://quantinuumsw.jfrog.io/artifactory/api/conan/tket1-libs --force
+    - name: normalize line endings in conanfile
+      if: matrix.os == 'windows-2022'
+      # Ensure consistent revisions across platforms.
+      run: |
+        $recipe_files = Get-ChildItem "recipes/symengine" -File -Recurse
+        foreach ($f in $recipe_files) {
+          $normalized_file = [IO.File]::ReadAllText($f) -replace "`r`n", "`n"
+          [IO.File]::WriteAllText($f, $normalized_file)
+        }
+    - name: Build symengine
+      run: conan create --profile=tket recipes/symengine/all symengine/0.9.0@tket/stable
+    - name: authenticate to repository
+      run: conan user -p ${{ secrets.JFROG_ARTIFACTORY_TOKEN_2 }} -r tket-libs ${{ secrets.JFROG_ARTIFACTORY_USER_2 }}
+    - name: upload package
+      run: conan upload symengine/0.9.0@tket/stable --all -r=tket-libs
+
+  build_macos_arm64:
+    name: Build on MacOS ARM64
+    runs-on: ['self-hosted', 'macOS', 'ARM64']
+    env:
+      CONAN_REVISIONS_ENABLED: 1
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up conan profile
+      run: conan profile new tket --detect --force
+    - name: add remote
+      run: conan remote add tket-libs https://quantinuumsw.jfrog.io/artifactory/api/conan/tket1-libs --force
+    - name: Build symengine
+      run: conan create --profile=tket recipes/symengine/all symengine/0.9.0@tket/stable
+    - name: authenticate to repository
+      run: conan user -p ${{ secrets.JFROG_ARTIFACTORY_TOKEN_2 }} -r tket-libs ${{ secrets.JFROG_ARTIFACTORY_USER_2 }}
+    - name: upload package
+      run: conan upload symengine/0.9.0@tket/stable --all -r=tket-libs
+    - name: unauthenticate
+      run: conan user -c

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -66,14 +66,14 @@ jobs:
     needs: check_changes
     strategy:
       matrix:
-        os: ['ubuntu-22.04', 'macos-11', 'windows-2022']
+        os: ['ubuntu-22.04', 'macos-12', 'windows-2022']
     runs-on: ${{ matrix.os }}
     env:
       CONAN_REVISIONS_ENABLED: 1
     steps:
     - uses: actions/checkout@v3
     - name: Check C++ code formatting
-      if: matrix.os == 'macos-11' && github.event_name == 'pull_request'
+      if: matrix.os == 'macos-12' && github.event_name == 'pull_request'
       run: |
         brew update
         brew install clang-format@14
@@ -90,7 +90,7 @@ jobs:
         restore-keys: |
           ${{ github.job }}-${{ runner.os }}-ccache-
     - name: Cache conan data
-      if: matrix.os == 'macos-11'
+      if: matrix.os == 'macos-12'
       uses: actions/cache@v3
       with:
         path: ~/.conan
@@ -206,7 +206,7 @@ jobs:
         pip install -r requirements.txt
         pytest --ignore=simulator/ --doctest-modules
     - name: Run mypy
-      if: matrix.os == 'macos-11' && github.event_name == 'pull_request'
+      if: matrix.os == 'macos-12' && github.event_name == 'pull_request'
       run: |
         pip install -U mypy
         cd pytket

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -164,7 +164,7 @@ jobs:
     needs: build_test_tket
     strategy:
       matrix:
-        os: ['ubuntu-22.04', 'macos-11', 'windows-2022']
+        os: ['ubuntu-22.04', 'macos-12', 'windows-2022']
         pyver: ['3.8', '3.9', '3.10']
     runs-on: ${{ matrix.os }}
     env:

--- a/.github/workflows/build_libs.yml
+++ b/.github/workflows/build_libs.yml
@@ -37,7 +37,7 @@ jobs:
     if: ${{ needs.changes.outputs.libs != '[]' && needs.changes.outputs.libs != '' }}
     strategy:
       matrix:
-        os: ['ubuntu-22.04', 'macos-11', 'windows-2022']
+        os: ['ubuntu-22.04', 'macos-12', 'windows-2022']
         lib: ${{ fromJson(needs.changes.outputs.libs) }}
         build_type: ['Release', 'Debug']
         shared: ['True', 'False']

--- a/.github/workflows/publish_tket_package.yml
+++ b/.github/workflows/publish_tket_package.yml
@@ -10,11 +10,11 @@ jobs:
     name: build and publish tket
     strategy:
       matrix:
-        os: ['ubuntu-22.04', 'macos-11', 'windows-2022']
+        os: ['ubuntu-22.04', 'macos-12', 'windows-2022']
         build_type: ['Release', 'Debug']
         shared: ['True', 'False']
         exclude:
-          - os: 'macos-11'
+          - os: 'macos-12'
             build_type: 'Debug'
             shared: 'True'
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
 
   build_macos_wheels:
     name: Build macos wheels
-    runs-on: macos-11
+    runs-on: macos-12
     env:
       CONAN_REVISIONS_ENABLED: 1
     steps:
@@ -219,7 +219,7 @@ jobs:
   test_macos_wheels:
     name: Test macos wheels
     needs: build_macos_wheels
-    runs-on: macos-11
+    runs-on: macos-12
     env:
       PYTKET_SKIP_REGISTRATION: "true"
     strategy:

--- a/.github/workflows/test_libs.yml
+++ b/.github/workflows/test_libs.yml
@@ -37,7 +37,7 @@ jobs:
     if: ${{ needs.changes.outputs.libs != '[]' && needs.changes.outputs.libs != '' }}
     strategy:
       matrix:
-        os: ['ubuntu-22.04', 'macos-11', 'windows-2022']
+        os: ['ubuntu-22.04', 'macos-12', 'windows-2022']
         lib: ${{ fromJson(needs.changes.outputs.libs) }}
     runs-on: ${{ matrix.os }}
     env:

--- a/.github/workflows/test_libs_all.yml
+++ b/.github/workflows/test_libs_all.yml
@@ -8,7 +8,7 @@ jobs:
     name: test library
     strategy:
       matrix:
-        os: ['ubuntu-22.04', 'macos-11', 'windows-2022']
+        os: ['ubuntu-22.04', 'macos-12', 'windows-2022']
         lib: ['tklog', 'tkassert', 'tkrng', 'tktokenswap', 'tkwsm']
     runs-on: ${{ matrix.os }}
     env:

--- a/pytket/conanfile.txt
+++ b/pytket/conanfile.txt
@@ -1,5 +1,5 @@
 [requires]
-tket/1.0.7@tket/stable
+tket/1.0.8@tket/stable
 tklog/0.1.2@tket/stable
 pybind11/2.10.0
 nlohmann_json/3.10.5

--- a/pytket/conanfile.txt
+++ b/pytket/conanfile.txt
@@ -1,5 +1,5 @@
 [requires]
-tket/1.0.6@tket/stable
+tket/1.0.7@tket/stable
 tklog/0.1.2@tket/stable
 pybind11/2.10.0
 nlohmann_json/3.10.5

--- a/recipes/symengine/all/CMakeLists.txt
+++ b/recipes/symengine/all/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 2.8.12)
+project(cmake_wrapper)
+
+include(conanbuildinfo.cmake)
+conan_basic_setup()
+
+add_subdirectory("source_subfolder")

--- a/recipes/symengine/all/conandata.yml
+++ b/recipes/symengine/all/conandata.yml
@@ -1,0 +1,7 @@
+sources:
+  "0.8.1":
+    url: "https://github.com/symengine/symengine/releases/download/v0.8.1/symengine-0.8.1.tar.gz"
+    sha256: "41eb6ae6901c09e53d7f61f0758f9201e81fc534bfeecd4b2bd4b4e6f6768693"
+  "0.9.0":
+    url: "https://github.com/symengine/symengine/releases/download/v0.9.0/symengine-0.9.0.tar.gz"
+    sha256: "dcf174ac708ed2acea46691f6e78b9eb946d8a2ba62f75e87cf3bf4f0d651724"

--- a/recipes/symengine/all/conanfile.py
+++ b/recipes/symengine/all/conanfile.py
@@ -1,0 +1,91 @@
+from conans import ConanFile, CMake, tools
+import os
+
+required_conan_version = ">=1.33.0"
+
+
+class SymengineConan(ConanFile):
+    name = "symengine"
+    description = "A fast symbolic manipulation library, written in C++"
+    license = "MIT"
+    topics = ("symbolic", "algebra")
+    homepage = "https://symengine.org/"
+    url = "https://github.com/conan-io/conan-center-index"
+    exports_sources = ["CMakeLists.txt", "patches/**"]
+    generators = "cmake"
+    settings = "os", "compiler", "build_type", "arch"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+        "integer_class": ["boostmp", "gmp"],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+        "integer_class": "gmp",
+    }
+    short_paths = True
+
+    _cmake = None
+
+    @property
+    def _source_subfolder(self):
+        return "source_subfolder"
+
+    @property
+    def _build_subfolder(self):
+        return "build_subfolder"
+
+    def requirements(self):
+        if self.options.integer_class == "boostmp":
+            self.requires("boost/1.79.0")
+        else:
+            self.requires("gmp/6.2.1")
+
+    def source(self):
+        tools.get(
+            **self.conan_data["sources"][self.version],
+            strip_root=True,
+            destination=self._source_subfolder,
+        )
+
+    def _configure_cmake(self):
+        if self._cmake is None:
+            self._cmake = CMake(self)
+            self._cmake.definitions["BUILD_TESTS"] = False
+            self._cmake.definitions["BUILD_BENCHMARKS"] = False
+            self._cmake.definitions["INTEGER_CLASS"] = self.options.integer_class
+            self._cmake.definitions["MSVC_USE_MT"] = False
+            self._cmake.configure(build_folder=self._build_subfolder)
+        return self._cmake
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def configure(self):
+        if self.options.shared:
+            del self.options.fPIC
+
+    def build(self):
+        for patch in self.conan_data.get("patches", {}).get(self.version, []):
+            tools.patch(**patch)
+        cmake = self._configure_cmake()
+        cmake.build()
+
+    def package(self):
+        self.copy("LICENSE", dst="licenses", src=self._source_subfolder)
+        cmake = self._configure_cmake()
+        cmake.install()
+        # [CMAKE-MODULES-CONFIG-FILES (KB-H016)]
+        tools.remove_files_by_mask(self.package_folder, "*.cmake")
+        # [DEFAULT PACKAGE LAYOUT (KB-H013)]
+        tools.rmdir(os.path.join(self.package_folder, "CMake"))
+
+    def package_info(self):
+        self.cpp_info.libs = ["symengine"]
+        if any("teuchos" in v for v in tools.collect_libs(self)):
+            self.cpp_info.libs.append("teuchos")
+        self.cpp_info.names["cmake_find_package"] = "symengine"
+        # FIXME: symengine exports a non-namespaced `symengine` target.
+        self.cpp_info.names["cmake_find_package_multi"] = "symengine"

--- a/recipes/symengine/all/test_package/CMakeLists.txt
+++ b/recipes/symengine/all/test_package/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package CXX)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+find_package(symengine REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE symengine::symengine)  # FIXME: Replace `symengine::symengine` with `symengine`

--- a/recipes/symengine/all/test_package/conanfile.py
+++ b/recipes/symengine/all/test_package/conanfile.py
@@ -1,0 +1,18 @@
+from conans import ConanFile, CMake, tools
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.definitions["CMAKE_CXX_STANDARD"] = "11"
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not tools.cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/recipes/symengine/all/test_package/test_package.cpp
+++ b/recipes/symengine/all/test_package/test_package.cpp
@@ -1,0 +1,13 @@
+#include <symengine/constants.h>
+#include <symengine/expression.h>
+#include <symengine/integer.h>
+#include <symengine/mul.h>
+
+#include <iostream>
+
+int main() {
+  SymEngine::Expression pi_by_12 =
+      SymEngine::div(SymEngine::pi, SymEngine::integer(12));
+  std::cout << pi_by_12 << std::endl;
+  return 0;
+}

--- a/recipes/symengine/config.yml
+++ b/recipes/symengine/config.yml
@@ -1,0 +1,5 @@
+versions:
+  "0.8.1":
+    folder: all
+  "0.9.0":
+    folder: all

--- a/recipes/tket-proptests/conanfile.py
+++ b/recipes/tket-proptests/conanfile.py
@@ -28,7 +28,7 @@ class TketProptestsConan(ConanFile):
     generators = "cmake"
     exports_sources = "../../tket/proptests/*"
     requires = (
-        "tket/1.0.7@tket/stable",
+        "tket/1.0.8@tket/stable",
         "rapidcheck/cci.20220514",
     )
 

--- a/recipes/tket-proptests/conanfile.py
+++ b/recipes/tket-proptests/conanfile.py
@@ -28,7 +28,7 @@ class TketProptestsConan(ConanFile):
     generators = "cmake"
     exports_sources = "../../tket/proptests/*"
     requires = (
-        "tket/1.0.6@tket/stable",
+        "tket/1.0.7@tket/stable",
         "rapidcheck/cci.20220514",
     )
 

--- a/recipes/tket-tests/conanfile.py
+++ b/recipes/tket-tests/conanfile.py
@@ -34,7 +34,7 @@ class TketTestsConan(ConanFile):
     default_options = {"with_coverage": False, "full": False, "long": False}
     generators = "cmake"
     exports_sources = "../../tket/tests/*"
-    requires = ("tket/1.0.6@tket/stable", "catch2/3.1.0")
+    requires = ("tket/1.0.7@tket/stable", "catch2/3.1.0")
 
     _cmake = None
 

--- a/recipes/tket-tests/conanfile.py
+++ b/recipes/tket-tests/conanfile.py
@@ -34,7 +34,7 @@ class TketTestsConan(ConanFile):
     default_options = {"with_coverage": False, "full": False, "long": False}
     generators = "cmake"
     exports_sources = "../../tket/tests/*"
-    requires = ("tket/1.0.7@tket/stable", "catch2/3.1.0")
+    requires = ("tket/1.0.8@tket/stable", "catch2/3.1.0")
 
     _cmake = None
 

--- a/recipes/tket/conanfile.py
+++ b/recipes/tket/conanfile.py
@@ -38,7 +38,7 @@ class TketConan(ConanFile):
         # tk* libraries may come from remote:
         # https://quantinuumsw.jfrog.io/artifactory/api/conan/tket1-libs
         "boost/1.80.0",
-        "symengine/0.9.0",
+        "symengine/0.9.0@tket/stable",
         "eigen/3.4.0",
         "nlohmann_json/3.10.5",
         "tklog/0.1.2@tket/stable",

--- a/recipes/tket/conanfile.py
+++ b/recipes/tket/conanfile.py
@@ -20,7 +20,7 @@ import shutil
 
 class TketConan(ConanFile):
     name = "tket"
-    version = "1.0.6"
+    version = "1.0.7"
     license = "CQC Proprietary"
     homepage = "https://github.com/CQCL/tket"
     url = "https://github.com/conan-io/conan-center-index"

--- a/recipes/tket/conanfile.py
+++ b/recipes/tket/conanfile.py
@@ -20,7 +20,7 @@ import shutil
 
 class TketConan(ConanFile):
     name = "tket"
-    version = "1.0.7"
+    version = "1.0.8"
     license = "CQC Proprietary"
     homepage = "https://github.com/CQCL/tket"
     url = "https://github.com/conan-io/conan-center-index"


### PR DESCRIPTION
Because it seems apple-clang 13.1 (macos-12) is not quite ABI-compatible with apple-clang 13.0 (macos-11), we have to build our own symengine package for this to work. I copied the recipe exactly from the conan-center, and uploaded the packages.