### PR TITLE
Further workflow improvements

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -89,14 +89,6 @@ jobs:
         key: ${{ github.job }}-${{ runner.os }}-ccache-${{ steps.current_time.outputs.formattedTime }}
         restore-keys: |
           ${{ github.job }}-${{ runner.os }}-ccache-
-    - name: Cache conan data
-      if: matrix.os == 'macos-12'
-      uses: actions/cache@v3
-      with:
-        path: ~/.conan
-        key: ${{ github.job }}-${{ runner.os }}-conan-${{ steps.current_time.outputs.formattedTime }}
-        restore-keys: |
-          ${{ github.job }}-${{ runner.os }}-conan-
     - name: apt update
       if: matrix.os == 'ubuntu-22.04'
       run: sudo apt update

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -221,7 +221,6 @@ jobs:
     if: github.event_name == 'push' || github.event_name == 'schedule' || github.event.pull_request.head.repo.full_name == github.repository
     env:
       CONAN_REVISIONS_ENABLED: 1
-      PYTKET_SKIP_REGISTRATION: "true"
     steps:
     - uses: actions/checkout@v3
       with:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -29,10 +29,10 @@ jobs:
       tket_package_exists: ${{ steps.tket_package_exists.outputs.tket_package_exists }}
     steps:
     - uses: actions/checkout@v3
-    - uses: actions/setup-python@v3
+    - uses: actions/setup-python@v4
       with:
         python-version: '3.10'
-    - uses: dorny/paths-filter@v2
+    - uses: dorny/paths-filter@v2.10.2
       id: filter
       with:
         base: ${{ github.ref }}
@@ -176,7 +176,7 @@ jobs:
     - name: Install pybind11
       run: conan create --profile=tket recipes/pybind11
     - name: Set up Python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.pyver }}
     - name: Build pytket

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -223,9 +223,6 @@ jobs:
       CONAN_REVISIONS_ENABLED: 1
     steps:
     - uses: actions/checkout@v3
-      with:
-        fetch-depth: '0'
-    - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
     - name: Set up conan
       shell: bash
       run: |

--- a/.github/workflows/build_libs.yml
+++ b/.github/workflows/build_libs.yml
@@ -16,7 +16,7 @@ jobs:
       libs: ${{ steps.filter.outputs.changes }}
     steps:
     - uses: actions/checkout@v3
-    - uses: dorny/paths-filter@v2
+    - uses: dorny/paths-filter@v2.10.2
       id: filter
       with:
         base: ${{ github.ref }}
@@ -61,7 +61,7 @@ jobs:
           [IO.File]::WriteAllText($f, $normalized_file)
         }
     - name: Set up Python 3.9
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: '3.9'
     - name: install conan

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -41,9 +41,6 @@ jobs:
       CONAN_REVISIONS_ENABLED: 1
     steps:
     - uses: actions/checkout@v3
-      with:
-        fetch-depth: '0'
-    - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
     - name: Get current time
       uses: srfrnk/current-time@v1.1.0
       id: current_time

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -46,13 +46,12 @@ jobs:
       id: current_time
       with:
         format: YYYYMMDDHHmmss
-    - name: Cache ccache data
-      uses: actions/cache@v3
+    - name: Use ccache
+      uses: hendrikmuhs/ccache-action@v1.2.2
       with:
-        path: ~/.ccache
-        key: ${{ runner.os }}-tket-ccache-${{ steps.current_time.outputs.formattedTime }}
+        key: ${{ github.job }}-${{ runner.os }}-ccache-${{ steps.current_time.outputs.formattedTime }}
         restore-keys: |
-          ${{ runner.os }}-tket-ccache-
+          ${{ github.job }}-${{ runner.os }}-ccache-
     - name: Install conan
       id: conan
       run: |
@@ -66,10 +65,6 @@ jobs:
         echo "CONAN_CMD=${conan_cmd}" >> $GITHUB_ENV
     - name: add remote
       run: ${CONAN_CMD} remote add tket-libs https://quantinuumsw.jfrog.io/artifactory/api/conan/tket1-libs
-    - name: Install ninja and ccache
-      run: |
-        sudo apt-get update
-        sudo apt-get install ninja-build ccache
     - name: Build tket
       run: |
         ${CONAN_CMD} install recipes/tket tket/stable --install-folder=build/tket --profile=tket -o tket:profile_coverage=True
@@ -84,6 +79,7 @@ jobs:
         ${CONAN_CMD} package recipes/tket-tests/ --build-folder=build/tket-tests --package-folder build/tket-tests/package --source-folder=tket/tests
     - name: Install runtime test requirements
       run: |
+        sudo apt-get update
         sudo apt-get install texlive texlive-latex-extra latexmk
         mkdir -p ~/texmf/tex/latex
         wget http://mirrors.ctan.org/graphics/pgf/contrib/quantikz/tikzlibraryquantikz.code.tex -P ~/texmf/tex/latex

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -23,7 +23,7 @@ jobs:
       tket: ${{ steps.filter.outputs.tket }}
     steps:
     - uses: actions/checkout@v3
-    - uses: dorny/paths-filter@v2
+    - uses: dorny/paths-filter@v2.10.2
       id: filter
       with:
         base: ${{ github.ref }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,9 +12,6 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
-      with:
-        fetch-depth: '0'
-    - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
     - name: Install Doxygen
       run: sudo apt update && sudo apt install -y doxygen graphviz
     - name: Build Doxygen docs

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python 3.x
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: '3.x'
     - name: Install black and pylint

--- a/.github/workflows/publish_tket_package.yml
+++ b/.github/workflows/publish_tket_package.yml
@@ -37,7 +37,7 @@ jobs:
           [IO.File]::WriteAllText($f, $normalized_file)
         }
     - name: Set up Python 3.9
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: '3.9'
     - name: install conan

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -306,7 +306,7 @@ jobs:
         mkdir dist
         for w in `find wheelhouse/ -type f -name "*.whl"` ; do cp $w dist/ ; done
     - name: Publish wheels
-      uses: pypa/gh-action-pypi-publish@release/v1
+      uses: pypa/gh-action-pypi-publish@release/v1.5.1
       with:
         user: __token__
         password: ${{ secrets.PYPI_PYTKET_API_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,18 +46,6 @@ jobs:
       with:
         fetch-depth: '0'
     - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
-    - name: Get current time
-      uses: srfrnk/current-time@v1.1.0
-      id: current_time
-      with:
-        format: YYYYMMDDHHmmss
-    - name: Cache conan data
-      uses: actions/cache@v3
-      with:
-        path: ~/.conan
-        key: ${{ runner.os }}-tket-conan-${{ steps.current_time.outputs.formattedTime }}
-        restore-keys: |
-          ${{ runner.os }}-tket-conan-
     - name: Set up Python 3.8
       uses: actions/setup-python@v3
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
         fetch-depth: '0'
     - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
     - name: Set up Python 3.8
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: '3.8'
     - name: Install conan
@@ -62,13 +62,13 @@ jobs:
     - name: Build wheel (3.8)
       run: .github/workflows/build_macos_wheel
     - name: Set up Python 3.9
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: '3.9'
     - name: Build wheel (3.9)
       run: .github/workflows/build_macos_wheel
     - name: Set up Python 3.10
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: '3.10'
     - name: Build wheel (3.10)
@@ -131,7 +131,7 @@ jobs:
     - name: Install pybind11
       run: conan create --profile=tket recipes/pybind11
     - name: Set up Python 3.8
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: '3.8'
     - name: Build wheel (3.8)
@@ -144,7 +144,7 @@ jobs:
         name: Windows_wheels
         path: wheelhouse/
     - name: Set up Python 3.9
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: '3.9'
     - name: Build wheel (3.9)
@@ -157,7 +157,7 @@ jobs:
         name: Windows_wheels
         path: wheelhouse/
     - name: Set up Python 3.10
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: '3.10'
     - name: Build wheel (3.10)
@@ -179,7 +179,7 @@ jobs:
         python-version: ['3.8', '3.9', '3.10']
     steps:
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Download wheels
@@ -208,7 +208,7 @@ jobs:
         python-version: ['3.8', '3.9', '3.10']
     steps:
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Download wheels
@@ -270,7 +270,7 @@ jobs:
         python-version: ['3.8', '3.9', '3.10']
     steps:
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Download wheels
@@ -320,7 +320,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python 3.9
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: '3.9'
     - name: Download wheels

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -319,8 +319,6 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
-      with:
-        fetch-depth: '0'
     - name: Set up Python 3.9
       uses: actions/setup-python@v3
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -174,8 +174,6 @@ jobs:
     name: Test linux wheels
     needs: build_Linux_wheels
     runs-on: ubuntu-22.04
-    env:
-      PYTKET_SKIP_REGISTRATION: "true"
     strategy:
       matrix:
         python-version: ['3.8', '3.9', '3.10']
@@ -205,8 +203,6 @@ jobs:
     name: Test macos wheels
     needs: build_macos_wheels
     runs-on: macos-12
-    env:
-      PYTKET_SKIP_REGISTRATION: "true"
     strategy:
       matrix:
         python-version: ['3.8', '3.9', '3.10']
@@ -238,7 +234,6 @@ jobs:
     runs-on: ['self-hosted', 'macOS', 'ARM64']
     env:
       PRIVATE_PYPI_PASS: ${{ secrets.PRIVATE_PYPI_PASS }}
-      PYTKET_SKIP_REGISTRATION: "true"
     strategy:
       matrix:
         python-version: ['3.8', '3.9', '3.10']
@@ -270,8 +265,6 @@ jobs:
     name: Test Windows wheels
     needs: build_Windows_wheels
     runs-on: windows-2022
-    env:
-      PYTKET_SKIP_REGISTRATION: "true"
     strategy:
       matrix:
         python-version: ['3.8', '3.9', '3.10']

--- a/.github/workflows/test_libs.yml
+++ b/.github/workflows/test_libs.yml
@@ -16,7 +16,7 @@ jobs:
       libs: ${{ steps.filter.outputs.changes }}
     steps:
     - uses: actions/checkout@v3
-    - uses: dorny/paths-filter@v2
+    - uses: dorny/paths-filter@v2.10.2
       id: filter
       with:
         base: ${{ github.ref }}
@@ -45,7 +45,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python 3.9
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: '3.9'
     - name: install conan
@@ -110,7 +110,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python 3.9
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: '3.9'
     - name: install conan

--- a/.github/workflows/test_libs_all.yml
+++ b/.github/workflows/test_libs_all.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python 3.9
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: '3.9'
     - name: install conan

--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -17,7 +17,7 @@ jobs:
       tket: ${{ steps.filter.outputs.tket }}
     steps:
     - uses: actions/checkout@v3
-    - uses: dorny/paths-filter@v2
+    - uses: dorny/paths-filter@v2.10.2
       id: filter
       with:
         base: ${{ github.ref }}

--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -32,13 +32,17 @@ jobs:
       CONAN_REVISIONS_ENABLED: 1
     steps:
     - uses: actions/checkout@v3
-    - name: cache ccache data
-      uses: actions/cache@v3
+    - name: Get current time
+      uses: srfrnk/current-time@v1.1.0
+      id: current_time
       with:
-        path: ~/.ccache
-        key: ${{ runner.os }}-tket-ccache-${{ steps.current_time.outputs.formattedTime }}
+        format: YYYYMMDDHHmmss
+    - name: Use ccache
+      uses: hendrikmuhs/ccache-action@v1.2.2
+      with:
+        key: ${{ github.job }}-${{ runner.os }}-ccache-${{ steps.current_time.outputs.formattedTime }}
         restore-keys: |
-          ${{ runner.os }}-tket-ccache-
+          ${{ github.job }}-${{ runner.os }}-ccache-
     - name: apt update
       run: sudo apt update
     - name: Install conan
@@ -56,8 +60,6 @@ jobs:
         wget http://mirrors.ctan.org/graphics/pgf/contrib/quantikz/tikzlibraryquantikz.code.tex -P ~/texmf/tex/latex
     - name: install valgrind
       run: sudo apt install valgrind
-    - name: install ninja and ccache
-      run: sudo apt-get install ninja-build ccache
     - name: build tket
       run: |
         conan install recipes/tket tket/stable --install-folder=build/tket --profile=tket


### PR DESCRIPTION
A final (for now) round of improvements:
* Don't cache conan data on MacOS (not necessary any more, and saves time).
* Remove unused environment variable.
* Remove unnecessary fetches of whole repo history.
* Install ccache using external action.
* Update actions versions and pin marketplace actions to specific versions.