### PR TITLE
[infra] Use `gcovr --decisions` for tket libs

### DIFF
--- a/.github/workflows/test_libs.yml
+++ b/.github/workflows/test_libs.yml
@@ -143,7 +143,7 @@ jobs:
     - name: build coverage report
       run: |
         mkdir ${{ matrix.lib }}-coverage
-        gcovr --print-summary --html --html-details -r ./libs/${{ matrix.lib }}/src/ --exclude-lines-by-pattern '.*\bTKET_ASSERT\(.*\);' --object-directory ${PWD}/build/${{ matrix.lib }}/ -o ${{ matrix.lib }}-coverage/index.html > ${{ matrix.lib }}-coverage/summary.txt
+        gcovr --print-summary --html --html-details -r ./libs/${{ matrix.lib }}/src/ --exclude-lines-by-pattern '.*\bTKET_ASSERT\(.*\);' --object-directory ${PWD}/build/${{ matrix.lib }}/ -o ${{ matrix.lib }}-coverage/index.html --decisions > ${{ matrix.lib }}-coverage/summary.txt
     - name: upload artefact
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/test_libs.yml
+++ b/.github/workflows/test_libs.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
     branches:
       - develop
+env:
+  ALL_LIBS: ("tklog" "tkassert" "tkrng" "tktokenswap" "tkwsm")
 jobs:
   changes:
     runs-on: ubuntu-22.04
@@ -33,14 +35,34 @@ jobs:
             - 'libs/tkwsm/**'
           gh_actions:
             - '.github/workflows/test_libs.yml'
+  set_libs_matrix:
+    name: Set the libs strategy matrix
+    needs: changes
+    runs-on: ubuntu-22.04
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - name: Set the matrix to test all the libraries
+        id: set-matrix
+        # Test all libraries if the test_libs.yml file was modified
+        if: ${{ contains(needs.changes.outputs.libs, 'gh_actions') }}
+        run: |
+          sudo apt-get -y install jq
+          echo "::set-output name=matrix::$(jq -n '$ARGS.positional' --args ${ALL_LIBS[@]})"
+      - name: Set the matrix to test the modified libraries only
+        id: set-matrix
+        if: ${{ ! contains(needs.changes.outputs.libs, 'gh_actions') }}
+        outputs:
+          matrix: ${{ needs.changes.outputs.libs }}
   test_libraries:
     name: test library
-    needs: changes
+    needs: set_libs_matrix
+    runs-on: ubuntu-22.04
     if: ${{ needs.changes.outputs.libs != '[]' && needs.changes.outputs.libs != '' }}
     strategy:
       matrix:
         os: ['ubuntu-22.04', 'macos-12', 'windows-2022']
-        lib: ${{ fromJson(needs.changes.outputs.libs) }}
+        lib: ${{ fromJson(needs.set_libs_matrix.outputs.matrix) }}
     runs-on: ${{ matrix.os }}
     env:
       CONAN_REVISIONS_ENABLED: 1

--- a/.github/workflows/test_libs.yml
+++ b/.github/workflows/test_libs.yml
@@ -7,7 +7,7 @@ on:
     branches:
       - develop
 env:
-  ALL_LIBS: ["tklog" "tkassert" "tkrng" "tktokenswap" "tkwsm"]
+  ALL_LIBS: ("tklog" "tkassert" "tkrng" "tktokenswap" "tkwsm")
 jobs:
   changes:
     runs-on: ubuntu-22.04

--- a/.github/workflows/test_libs.yml
+++ b/.github/workflows/test_libs.yml
@@ -60,6 +60,7 @@ jobs:
     needs: set_libs_matrix
     if: ${{ needs.set_libs_matrix.outputs.libs != '[]' && needs.set_libs_matrix.outputs.libs != '' }}
     strategy:
+      fail-fast: false
       matrix:
         os: ['ubuntu-22.04', 'macos-12', 'windows-2022']
         lib: ${{ fromJson(needs.set_libs_matrix.outputs.libs) }}
@@ -98,6 +99,7 @@ jobs:
     if: ${{ needs.set_libs_matrix.outputs.libs != '[]' && needs.set_libs_matrix.outputs.libs != '' }}
     runs-on: ['self-hosted', 'macOS', 'ARM64']
     strategy:
+      fail-fast: false
       matrix:
         lib: ${{ fromJson(needs.set_libs_matrix.outputs.libs) }}
     env:

--- a/.github/workflows/test_libs.yml
+++ b/.github/workflows/test_libs.yml
@@ -64,7 +64,7 @@ jobs:
     strategy:
       matrix:
         os: ['ubuntu-22.04', 'macos-12', 'windows-2022']
-        lib: ${{ fromJson(needs.set_libs_matrix.outputs.matrix) }}
+        lib: ${{ fromJSON(needs.set_libs_matrix.outputs.matrix) }}
     runs-on: ${{ matrix.os }}
     env:
       CONAN_REVISIONS_ENABLED: 1

--- a/.github/workflows/test_libs.yml
+++ b/.github/workflows/test_libs.yml
@@ -32,7 +32,7 @@ jobs:
           tkwsm:
             - 'libs/tkwsm/**'
           gh_actions:
-            - '/.github/workflows/test_libs.yml'
+            - '.github/workflows/test_libs.yml'
   test_libraries:
     name: test library
     needs: changes

--- a/.github/workflows/test_libs.yml
+++ b/.github/workflows/test_libs.yml
@@ -46,8 +46,7 @@ jobs:
         # Test all libraries if the test_libs.yml file was modified
         if: ${{ contains(needs.changes.outputs.libs, 'gh_actions') }}
         run: |
-          sudo apt-get -y install jq
-          echo "LIBS_TO_TEST=$(jq -n '$ARGS.positional' --args ${ALL_LIBS[@]})" >> $GITHUB_ENV
+          echo "LIBS_TO_TEST=${{ toJSON(env.ALL_LIBS) }}" >> $GITHUB_ENV
       - name: Set LIBS_TO_TEST to the modified libraries only
         if: ${{ ! contains(needs.changes.outputs.libs, 'gh_actions') }}
         run: |

--- a/.github/workflows/test_libs.yml
+++ b/.github/workflows/test_libs.yml
@@ -7,7 +7,7 @@ on:
     branches:
       - develop
 env:
-  ALL_LIBS: (tklog tkassert tkrng tktokenswap tkwsm)
+  ALL_LIBS: ["tklog" "tkassert" "tkrng" "tktokenswap" "tkwsm"]
 jobs:
   changes:
     runs-on: ubuntu-22.04

--- a/.github/workflows/test_libs.yml
+++ b/.github/workflows/test_libs.yml
@@ -59,7 +59,6 @@ jobs:
   test_libraries:
     name: test library
     needs: set_libs_matrix
-    runs-on: ubuntu-22.04
     if: ${{ needs.changes.outputs.libs != '[]' && needs.changes.outputs.libs != '' }}
     strategy:
       matrix:

--- a/.github/workflows/test_libs.yml
+++ b/.github/workflows/test_libs.yml
@@ -62,7 +62,7 @@ jobs:
     strategy:
       matrix:
         os: ['ubuntu-22.04', 'macos-12', 'windows-2022']
-        lib: ${{ fromJSON(needs.set_libs_matrix.libs) }}
+        lib: ${{ fromJson(needs.set_libs_matrix.outputs.libs) }}
     runs-on: ${{ matrix.os }}
     env:
       CONAN_REVISIONS_ENABLED: 1

--- a/.github/workflows/test_libs.yml
+++ b/.github/workflows/test_libs.yml
@@ -7,7 +7,7 @@ on:
     branches:
       - develop
 env:
-  ALL_LIBS: ("tklog" "tkassert" "tkrng" "tktokenswap" "tkwsm")
+  ALL_LIBS: (tklog tkassert tkrng tktokenswap tkwsm)
 jobs:
   changes:
     runs-on: ubuntu-22.04

--- a/.github/workflows/test_libs.yml
+++ b/.github/workflows/test_libs.yml
@@ -31,6 +31,8 @@ jobs:
             - 'libs/tktokenswap/**'
           tkwsm:
             - 'libs/tkwsm/**'
+          gh_actions:
+            - '/.github/workflows/test_libs.yml'
   test_libraries:
     name: test library
     needs: changes

--- a/.github/workflows/test_libs.yml
+++ b/.github/workflows/test_libs.yml
@@ -42,18 +42,20 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
-      - name: Set the matrix to test all the libraries
-        id: set-matrix
+      - name: Set LIBS_TO_TEST to all the libraries
         # Test all libraries if the test_libs.yml file was modified
         if: ${{ contains(needs.changes.outputs.libs, 'gh_actions') }}
         run: |
           sudo apt-get -y install jq
-          echo "::set-output name=matrix::$(jq -n '$ARGS.positional' --args ${ALL_LIBS[@]})"
-      - name: Set the matrix to test the modified libraries only
-        id: set-matrix
+          echo "LIBS_TO_TEST=$(jq -n '$ARGS.positional' --args ${ALL_LIBS[@]})" >> $GITHUB_ENV
+      - name: Set LIBS_TO_TEST to the modified libraries only
         if: ${{ ! contains(needs.changes.outputs.libs, 'gh_actions') }}
-        outputs:
-          matrix: ${{ needs.changes.outputs.libs }}
+        run: |
+          echo "LIBS_TO_TEST=${{ toJSON(needs.changes.outputs.libs) }}" >> $GITHUB_ENV
+      - name: Set libs matrix
+        id: set-matrix
+        run: |
+          echo "::set-output name=matrix::$LIBS_TO_TEST"
   test_libraries:
     name: test library
     needs: set_libs_matrix

--- a/.github/workflows/test_libs.yml
+++ b/.github/workflows/test_libs.yml
@@ -7,7 +7,7 @@ on:
     branches:
       - develop
 env:
-  ALL_LIBS: ("tklog" "tkassert" "tkrng" "tktokenswap" "tkwsm")
+  ALL_LIBS: '["tklog", "tkassert", "tkrng", "tktokenswap", "tkwsm"]'
 jobs:
   changes:
     runs-on: ubuntu-22.04

--- a/.github/workflows/test_libs.yml
+++ b/.github/workflows/test_libs.yml
@@ -40,7 +40,7 @@ jobs:
     needs: changes
     runs-on: ubuntu-22.04
     outputs:
-      matrix: ${{ steps.set-matrix.outputs.matrix }}
+      libs: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - name: Set LIBS_TO_TEST to all the libraries
         # Test all libraries if the test_libs.yml file was modified
@@ -58,11 +58,11 @@ jobs:
   test_libraries:
     name: test library
     needs: set_libs_matrix
-    if: ${{ needs.changes.outputs.libs != '[]' && needs.changes.outputs.libs != '' }}
+    if: ${{ needs.set_libs_matrix.outputs.libs != '[]' && needs.set_libs_matrix.outputs.libs != '' }}
     strategy:
       matrix:
         os: ['ubuntu-22.04', 'macos-12', 'windows-2022']
-        lib: ${{ fromJSON(needs.set_libs_matrix.outputs.matrix) }}
+        lib: ${{ fromJSON(needs.set_libs_matrix.libs) }}
     runs-on: ${{ matrix.os }}
     env:
       CONAN_REVISIONS_ENABLED: 1
@@ -94,12 +94,12 @@ jobs:
       run: ./test-${{ matrix.lib }}
   macos-m1:
     name: test library (macos-m1)
-    needs: changes
-    if: ${{ needs.changes.outputs.libs != '[]' && needs.changes.outputs.libs != '' }}
+    needs: set_libs_matrix
+    if: ${{ needs.set_libs_matrix.outputs.libs != '[]' && needs.set_libs_matrix.outputs.libs != '' }}
     runs-on: ['self-hosted', 'macOS', 'ARM64']
     strategy:
       matrix:
-        lib: ${{ fromJson(needs.changes.outputs.libs) }}
+        lib: ${{ fromJson(needs.set_libs_matrix.outputs.libs) }}
     env:
       CONAN_REVISIONS_ENABLED: 1
     steps:
@@ -123,11 +123,11 @@ jobs:
       run: ./test-${{ matrix.lib }}
   generate_coverage:
     name: Generate coverage report
-    needs: changes
-    if: ${{ needs.changes.outputs.libs != '[]' && needs.changes.outputs.libs != '' }}
+    needs: set_libs_matrix
+    if: ${{ needs.set_libs_matrix.outputs.libs != '[]' && needs.set_libs_matrix.outputs.libs != '' }}
     strategy:
       matrix:
-        lib: ${{ fromJson(needs.changes.outputs.libs) }}
+        lib: ${{ fromJson(needs.set_libs_matrix.outputs.libs) }}
     runs-on: 'ubuntu-22.04'
     env:
       CONAN_REVISIONS_ENABLED: 1
@@ -183,11 +183,11 @@ jobs:
         fi
   publish_coverage:
     name: Publish coverage
-    needs: [changes, generate_coverage]
-    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/develop' && needs.changes.outputs.libs != '[]' && needs.changes.outputs.libs != '' }}
+    needs: [set_libs_matrix, generate_coverage]
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/develop' && needs.set_libs_matrix.outputs.libs != '[]' && needs.set_libs_matrix.outputs.libs != '' }}
     strategy:
       matrix:
-        lib: ${{ fromJson(needs.changes.outputs.libs) }}
+        lib: ${{ fromJson(needs.set_libs_matrix.outputs.libs) }}
     concurrency: gh_pages
     runs-on: ubuntu-22.04
     steps:


### PR DESCRIPTION
This PR enables the use of the `--decisions` flag for `gcovr` when generating the coverage report of the tket libs. It also changes the `test_libs.yml` workflow a bit so that all the libs are built and tested when changes to the yaml file itself are made.