### PR TITLE
Use xcode 14 on CI

### DIFF
--- a/.github/workflows/build-symengine.yml
+++ b/.github/workflows/build-symengine.yml
@@ -16,11 +16,6 @@ jobs:
     env:
       CONAN_REVISIONS_ENABLED: 1
     steps:
-    - name: Set xcode version
-      if: matrix.os == 'macos-12'
-      uses: maxim-lobanov/setup-xcode@v1
-      with:
-        xcode-version: '13.4.1'
     - uses: actions/checkout@v3
     - name: Install conan
       uses: turtlebrowser/get-conan@v1.1

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -71,11 +71,6 @@ jobs:
     env:
       CONAN_REVISIONS_ENABLED: 1
     steps:
-    - name: Set xcode version
-      if: matrix.os == 'macos-12'
-      uses: maxim-lobanov/setup-xcode@v1
-      with:
-        xcode-version: '13.4.1'
     - uses: actions/checkout@v3
     - name: Check C++ code formatting
       if: matrix.os == 'macos-12' && github.event_name == 'pull_request'
@@ -167,11 +162,6 @@ jobs:
     env:
       CONAN_REVISIONS_ENABLED: 1
     steps:
-    - name: Set xcode version
-      if: matrix.os == 'macos-12'
-      uses: maxim-lobanov/setup-xcode@v1
-      with:
-        xcode-version: '13.4.1'
     - uses: actions/checkout@v3
     - name: Install conan
       uses: turtlebrowser/get-conan@v1.1

--- a/.github/workflows/build_libs.yml
+++ b/.github/workflows/build_libs.yml
@@ -45,11 +45,6 @@ jobs:
     env:
       CONAN_REVISIONS_ENABLED: 1
     steps:
-    - name: Set xcode version
-      if: matrix.os == 'macos-12'
-      uses: maxim-lobanov/setup-xcode@v1
-      with:
-        xcode-version: '13.4.1'
     - uses: actions/checkout@v3
     - name: normalize line endings in conanfile and src directory
       if: matrix.os == 'windows-2022'

--- a/.github/workflows/publish_tket_package.yml
+++ b/.github/workflows/publish_tket_package.yml
@@ -21,11 +21,6 @@ jobs:
     env:
       CONAN_REVISIONS_ENABLED: 1
     steps:
-    - name: Set xcode version
-      if: matrix.os == 'macos-12'
-      uses: maxim-lobanov/setup-xcode@v1
-      with:
-        xcode-version: '13.4.1'
     - uses: actions/checkout@v3
     - name: normalize line endings in conanfile and src directory
       if: matrix.os == 'windows-2022'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,11 +42,6 @@ jobs:
     env:
       CONAN_REVISIONS_ENABLED: 1
     steps:
-    - name: Set xcode version
-      if: matrix.os == 'macos-12'
-      uses: maxim-lobanov/setup-xcode@v1
-      with:
-        xcode-version: '13.4.1'
     - uses: actions/checkout@v3
       with:
         fetch-depth: '0'
@@ -212,11 +207,6 @@ jobs:
       matrix:
         python-version: ['3.8', '3.9', '3.10']
     steps:
-    - name: Set xcode version
-      if: matrix.os == 'macos-12'
-      uses: maxim-lobanov/setup-xcode@v1
-      with:
-        xcode-version: '13.4.1'
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:

--- a/.github/workflows/test_libs.yml
+++ b/.github/workflows/test_libs.yml
@@ -68,11 +68,6 @@ jobs:
     env:
       CONAN_REVISIONS_ENABLED: 1
     steps:
-    - name: Set xcode version
-      if: matrix.os == 'macos-12'
-      uses: maxim-lobanov/setup-xcode@v1
-      with:
-        xcode-version: '13.4.1'
     - uses: actions/checkout@v3
     - name: Set up Python 3.9
       uses: actions/setup-python@v4

--- a/.github/workflows/test_libs_all.yml
+++ b/.github/workflows/test_libs_all.yml
@@ -14,11 +14,6 @@ jobs:
     env:
       CONAN_REVISIONS_ENABLED: 1
     steps:
-    - name: Set xcode version
-      if: matrix.os == 'macos-12'
-      uses: maxim-lobanov/setup-xcode@v1
-      with:
-        xcode-version: '13.4.1'
     - uses: actions/checkout@v3
     - name: Set up Python 3.9
       uses: actions/setup-python@v4

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The following compiler toolchains are used to build tket on the CI and are
 therefore known to work:
 
 * Linux: gcc-11
-* MacOS: apple-clang 13
+* MacOS: apple-clang 14
 * Windows: MSVC 19
 
 It is recommended that you use these versions to build locally, as code may

--- a/pytket/conanfile.txt
+++ b/pytket/conanfile.txt
@@ -1,5 +1,5 @@
 [requires]
-tket/1.0.13@tket/stable
+tket/1.0.14@tket/stable
 tklog/0.1.2@tket/stable
 pybind11/2.10.0
 nlohmann_json/3.11.2

--- a/recipes/tket-proptests/conanfile.py
+++ b/recipes/tket-proptests/conanfile.py
@@ -28,7 +28,7 @@ class TketProptestsConan(ConanFile):
     generators = "cmake"
     exports_sources = "../../tket/proptests/*"
     requires = (
-        "tket/1.0.13@tket/stable",
+        "tket/1.0.14@tket/stable",
         "rapidcheck/cci.20220514",
     )
 

--- a/recipes/tket-tests/conanfile.py
+++ b/recipes/tket-tests/conanfile.py
@@ -34,7 +34,7 @@ class TketTestsConan(ConanFile):
     default_options = {"with_coverage": False, "full": False, "long": False}
     generators = "cmake"
     exports_sources = "../../tket/tests/*"
-    requires = ("tket/1.0.13@tket/stable", "catch2/3.1.0")
+    requires = ("tket/1.0.14@tket/stable", "catch2/3.1.0")
 
     _cmake = None
 

--- a/recipes/tket/conanfile.py
+++ b/recipes/tket/conanfile.py
@@ -20,7 +20,7 @@ import shutil
 
 class TketConan(ConanFile):
     name = "tket"
-    version = "1.0.13"
+    version = "1.0.14"
     license = "CQC Proprietary"
     homepage = "https://github.com/CQCL/tket"
     url = "https://github.com/conan-io/conan-center-index"


### PR DESCRIPTION
Support was added in conan version 1.53.0, released yesterday.
I have uploaded builds of the tk* libraries, symengine, boost, catch2 etc to our artifactory, so they don't have to built on each run.