### PR TITLE
Restrict concurrency group to pull requests.

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -13,7 +13,7 @@ on:
     - cron: '0 3 * * 6'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Following the suggestion here: https://docs.github.com/en/actions/using-jobs/using-concurrency#example-using-a-fallback-value