### PR TITLE
Add metadata to ops

### DIFF
--- a/tket/src/Circuit/Boxes.cpp
+++ b/tket/src/Circuit/Boxes.cpp
@@ -67,7 +67,8 @@ Op_ptr Box::deserialize(const nlohmann::json &j) {
   return OpJsonFactory::from_json(j.at("box"));
 }
 
-  CircBox::CircBox(const Circuit &circ, const nlohmann::json &meta) : Box(OpType::CircBox, {}, meta) {
+CircBox::CircBox(const Circuit &circ, const nlohmann::json &meta)
+    : Box(OpType::CircBox, {}, meta) {
   if (!circ.is_simple()) throw SimpleOnly();
   signature_ = op_signature_t(circ.n_qubits(), EdgeType::Quantum);
   op_signature_t bits(circ.n_bits(), EdgeType::Classical);

--- a/tket/src/Circuit/Boxes.cpp
+++ b/tket/src/Circuit/Boxes.cpp
@@ -67,7 +67,7 @@ Op_ptr Box::deserialize(const nlohmann::json &j) {
   return OpJsonFactory::from_json(j.at("box"));
 }
 
-CircBox::CircBox(const Circuit &circ) : Box(OpType::CircBox) {
+  CircBox::CircBox(const Circuit &circ, const nlohmann::json &meta) : Box(OpType::CircBox, {}, meta) {
   if (!circ.is_simple()) throw SimpleOnly();
   signature_ = op_signature_t(circ.n_qubits(), EdgeType::Quantum);
   op_signature_t bits(circ.n_bits(), EdgeType::Classical);

--- a/tket/src/Circuit/include/Circuit/Boxes.hpp
+++ b/tket/src/Circuit/include/Circuit/Boxes.hpp
@@ -36,8 +36,10 @@ class Circuit;
  */
 class Box : public Op {
  public:
-  explicit Box(const OpType &type, const op_signature_t &signature = {}, const nlohmann::json &meta = {})
-    : Op(type, meta), signature_(signature), circ_(), id_(idgen()) {
+  explicit Box(
+      const OpType &type, const op_signature_t &signature = {},
+      const nlohmann::json &meta = {})
+      : Op(type, meta), signature_(signature), circ_(), id_(idgen()) {
     if (!is_box_type(type)) throw BadOpType(type);
   }
 

--- a/tket/src/Circuit/include/Circuit/Boxes.hpp
+++ b/tket/src/Circuit/include/Circuit/Boxes.hpp
@@ -36,8 +36,8 @@ class Circuit;
  */
 class Box : public Op {
  public:
-  explicit Box(const OpType &type, const op_signature_t &signature = {})
-      : Op(type), signature_(signature), circ_(), id_(idgen()) {
+  explicit Box(const OpType &type, const op_signature_t &signature = {}, const nlohmann::json &meta = {})
+    : Op(type, meta), signature_(signature), circ_(), id_(idgen()) {
     if (!is_box_type(type)) throw BadOpType(type);
   }
 
@@ -116,7 +116,7 @@ class CircBox : public Box {
   /**
    * Construct from a given circuit. The circuit must be simple.
    */
-  explicit CircBox(const Circuit &circ);
+  explicit CircBox(const Circuit &circ, const nlohmann::json &meta = {});
 
   /**
    * Construct from the empty circuit

--- a/tket/src/Circuit/include/Circuit/ClassicalExpBox.hpp
+++ b/tket/src/Circuit/include/Circuit/ClassicalExpBox.hpp
@@ -40,8 +40,10 @@ class ClassicalExpBox : public Box {
    * @param exp expression stored
    * @param meta metadata as JSON object
    */
-  explicit ClassicalExpBox(unsigned n_i, unsigned n_io, unsigned n_o, T exp, const nlohmann::json &meta)
-    : Box(OpType::ClassicalExpBox, meta),
+  explicit ClassicalExpBox(
+      unsigned n_i, unsigned n_io, unsigned n_o, T exp,
+      const nlohmann::json &meta)
+      : Box(OpType::ClassicalExpBox, meta),
         n_i_(n_i),
         n_io_(n_io),
         n_o_(n_o),

--- a/tket/src/Circuit/include/Circuit/ClassicalExpBox.hpp
+++ b/tket/src/Circuit/include/Circuit/ClassicalExpBox.hpp
@@ -39,8 +39,8 @@ class ClassicalExpBox : public Box {
    * @param n_o number of output-only bits
    * @param exp expression stored
    */
-  explicit ClassicalExpBox(unsigned n_i, unsigned n_io, unsigned n_o, T exp)
-      : Box(OpType::ClassicalExpBox),
+  explicit ClassicalExpBox(unsigned n_i, unsigned n_io, unsigned n_o, T exp, const nlohmann::json &meta)
+    : Box(OpType::ClassicalExpBox, meta),
         n_i_(n_i),
         n_io_(n_io),
         n_o_(n_o),

--- a/tket/src/Circuit/include/Circuit/ClassicalExpBox.hpp
+++ b/tket/src/Circuit/include/Circuit/ClassicalExpBox.hpp
@@ -38,6 +38,7 @@ class ClassicalExpBox : public Box {
    * @param n_io number of input/output bits
    * @param n_o number of output-only bits
    * @param exp expression stored
+   * @param meta metadata as JSON object
    */
   explicit ClassicalExpBox(unsigned n_i, unsigned n_io, unsigned n_o, T exp, const nlohmann::json &meta)
     : Box(OpType::ClassicalExpBox, meta),

--- a/tket/src/Gate/Gate.cpp
+++ b/tket/src/Gate/Gate.cpp
@@ -846,8 +846,8 @@ Eigen::MatrixXcd Gate::get_unitary() const {
   }
 }
 
-Gate::Gate(OpType type, const std::vector<Expr>& params, unsigned n_qubits)
-    : Op(type), params_(params), n_qubits_(n_qubits) {
+  Gate::Gate(OpType type, const std::vector<Expr>& params, unsigned n_qubits, nlohmann::json meta)
+    : Op(type, meta), params_(params), n_qubits_(n_qubits) {
   if (!is_gate_type(type)) {
     throw BadOpType(type);
   }

--- a/tket/src/Gate/Gate.cpp
+++ b/tket/src/Gate/Gate.cpp
@@ -846,7 +846,9 @@ Eigen::MatrixXcd Gate::get_unitary() const {
   }
 }
 
-  Gate::Gate(OpType type, const std::vector<Expr>& params, unsigned n_qubits, nlohmann::json meta)
+Gate::Gate(
+    OpType type, const std::vector<Expr>& params, unsigned n_qubits,
+    nlohmann::json meta)
     : Op(type, meta), params_(params), n_qubits_(n_qubits) {
   if (!is_gate_type(type)) {
     throw BadOpType(type);

--- a/tket/src/Gate/include/Gate/Gate.hpp
+++ b/tket/src/Gate/include/Gate/Gate.hpp
@@ -78,7 +78,8 @@ class Gate : public Op {
   bool is_equal(const Op &other) const override;
 
   Gate(
-      OpType type, const std::vector<Expr> &params = {}, unsigned n_qubits = 0, nlohmann::json meta = {});
+      OpType type, const std::vector<Expr> &params = {}, unsigned n_qubits = 0,
+      nlohmann::json meta = {});
 
   Gate();
 

--- a/tket/src/Gate/include/Gate/Gate.hpp
+++ b/tket/src/Gate/include/Gate/Gate.hpp
@@ -78,7 +78,7 @@ class Gate : public Op {
   bool is_equal(const Op &other) const override;
 
   Gate(
-      OpType type, const std::vector<Expr> &params = {}, unsigned n_qubits = 0);
+      OpType type, const std::vector<Expr> &params = {}, unsigned n_qubits = 0, nlohmann::json meta = {});
 
   Gate();
 

--- a/tket/src/Ops/ClassicalOps.cpp
+++ b/tket/src/Ops/ClassicalOps.cpp
@@ -150,8 +150,8 @@ static std::shared_ptr<WASMOp> wasm_from_json(const nlohmann::json &j_class) {
 
 ClassicalOp::ClassicalOp(
     OpType type, unsigned n_i, unsigned n_io, unsigned n_o,
-    const std::string &name)
-    : Op(type), n_i_(n_i), n_io_(n_io), n_o_(n_o), name_(name), sig_() {
+    const std::string &name, const nlohmann::json &meta)
+  : Op(type, meta), n_i_(n_i), n_io_(n_io), n_o_(n_o), name_(name), sig_() {
   for (unsigned i = 0; i < n_i; i++) {
     sig_.push_back(EdgeType::Boolean);
   }

--- a/tket/src/Ops/ClassicalOps.cpp
+++ b/tket/src/Ops/ClassicalOps.cpp
@@ -151,7 +151,7 @@ static std::shared_ptr<WASMOp> wasm_from_json(const nlohmann::json &j_class) {
 ClassicalOp::ClassicalOp(
     OpType type, unsigned n_i, unsigned n_io, unsigned n_o,
     const std::string &name, const nlohmann::json &meta)
-  : Op(type, meta), n_i_(n_i), n_io_(n_io), n_o_(n_o), name_(name), sig_() {
+    : Op(type, meta), n_i_(n_i), n_io_(n_io), n_o_(n_o), name_(name), sig_() {
   for (unsigned i = 0; i < n_i; i++) {
     sig_.push_back(EdgeType::Boolean);
   }

--- a/tket/src/Ops/MetaOp.cpp
+++ b/tket/src/Ops/MetaOp.cpp
@@ -22,8 +22,8 @@
 
 namespace tket {
 
-MetaOp::MetaOp(OpType type, op_signature_t signature, const std::string& _data)
-    : Op(type), signature_(signature), data_(_data) {
+MetaOp::MetaOp(OpType type, op_signature_t signature, const std::string& _data, const nlohmann::json &meta)
+  : Op(type, meta), signature_(signature), data_(_data) {
   if (!is_metaop_type(type)) throw BadOpType(type);
 }
 

--- a/tket/src/Ops/MetaOp.cpp
+++ b/tket/src/Ops/MetaOp.cpp
@@ -22,8 +22,10 @@
 
 namespace tket {
 
-MetaOp::MetaOp(OpType type, op_signature_t signature, const std::string& _data, const nlohmann::json &meta)
-  : Op(type, meta), signature_(signature), data_(_data) {
+MetaOp::MetaOp(
+    OpType type, op_signature_t signature, const std::string& _data,
+    const nlohmann::json& meta)
+    : Op(type, meta), signature_(signature), data_(_data) {
   if (!is_metaop_type(type)) throw BadOpType(type);
 }
 

--- a/tket/src/Ops/include/Ops/ClassicalOps.hpp
+++ b/tket/src/Ops/include/Ops/ClassicalOps.hpp
@@ -40,6 +40,7 @@ class ClassicalOp : public Op {
    * @param n_io number of input/output bits
    * @param n_o number of output-only bits
    * @param name name of operation
+   * @param meta metadata as JSON object.
    */
   ClassicalOp(
       OpType type, unsigned n_i, unsigned n_io, unsigned n_o,

--- a/tket/src/Ops/include/Ops/ClassicalOps.hpp
+++ b/tket/src/Ops/include/Ops/ClassicalOps.hpp
@@ -43,7 +43,7 @@ class ClassicalOp : public Op {
    */
   ClassicalOp(
       OpType type, unsigned n_i, unsigned n_io, unsigned n_o,
-      const std::string &name = "");
+      const std::string &name = "", const nlohmann::json &meta = {});
 
   // Trivial overrides
   Op_ptr symbol_substitution(

--- a/tket/src/Ops/include/Ops/MetaOp.hpp
+++ b/tket/src/Ops/include/Ops/MetaOp.hpp
@@ -22,8 +22,8 @@ namespace tket {
 class MetaOp : public Op {
  public:
   explicit MetaOp(
-      OpType type, op_signature_t signature = {},
-      const std::string &_data = "", const nlohmann::json &meta = {});
+      OpType type, op_signature_t signature = {}, const std::string &_data = "",
+      const nlohmann::json &meta = {});
 
   Op_ptr symbol_substitution(
       const SymEngine::map_basic_basic &sub_map) const override;

--- a/tket/src/Ops/include/Ops/MetaOp.hpp
+++ b/tket/src/Ops/include/Ops/MetaOp.hpp
@@ -23,7 +23,7 @@ class MetaOp : public Op {
  public:
   explicit MetaOp(
       OpType type, op_signature_t signature = {},
-      const std::string &_data = "");
+      const std::string &_data = "", const nlohmann::json &meta = {});
 
   Op_ptr symbol_substitution(
       const SymEngine::map_basic_basic &sub_map) const override;

--- a/tket/src/Ops/include/Ops/Op.hpp
+++ b/tket/src/Ops/include/Ops/Op.hpp
@@ -190,7 +190,8 @@ class Op : public std::enable_shared_from_this<Op> {
   virtual bool is_equal(const Op &) const { return true; }
 
  protected:
-  explicit Op(const OpType &type, const nlohmann::json &meta = {}) : desc_(type), type_(type), meta_(meta) {}
+  explicit Op(const OpType &type, const nlohmann::json &meta = {})
+      : desc_(type), type_(type), meta_(meta) {}
   const OpDesc desc_; /**< Operation descriptor */
   const OpType type_; /**< Operation type */
  private:

--- a/tket/src/Ops/include/Ops/Op.hpp
+++ b/tket/src/Ops/include/Ops/Op.hpp
@@ -97,6 +97,12 @@ class Op : public std::enable_shared_from_this<Op> {
   /** Get operation type */
   OpType get_type() const { return type_; }
 
+  /** Get metadata as JSON object */
+  nlohmann::json get_meta() const { return meta_; }
+
+  /** Set metadata JSON object */
+  // void set_meta(const nlohmann::json &meta) { meta_ = meta; }
+
   /** Set of all free symbols occurring in operation parameters. */
   virtual SymSet free_symbols() const = 0;
 
@@ -184,9 +190,11 @@ class Op : public std::enable_shared_from_this<Op> {
   virtual bool is_equal(const Op &) const { return true; }
 
  protected:
-  explicit Op(const OpType &type) : desc_(type), type_(type) {}
+  explicit Op(const OpType &type, const nlohmann::json &meta = {}) : desc_(type), type_(type), meta_(meta) {}
   const OpDesc desc_; /**< Operation descriptor */
   const OpType type_; /**< Operation type */
+ private:
+  const nlohmann::json meta_;
 };
 
 // friend to stream op (print)

--- a/tket/tests/Circuit/test_Boxes.cpp
+++ b/tket/tests/Circuit/test_Boxes.cpp
@@ -28,6 +28,17 @@ using Catch::Matchers::StartsWith;
 namespace tket {
 namespace test_Boxes {
 
+SCENARIO("Attributes retrieval.") {
+  GIVEN("Metadata retrieval from  CircBox.") {
+    nlohmann::json j;
+    j["Test"] = "tag";
+    Circuit u(2);
+    u.add_op<unsigned>(OpType::Ry, -0.75, {0});
+    const CircBox ubox(u, j);
+    REQUIRE(ubox.get_meta() == j);
+  }
+}
+
 SCENARIO("CircBox requires simple circuits", "[boxes]") {
   Circuit circ(2);
   circ.add_op<unsigned>(OpType::Y, {0});

--- a/tket/tests/Ops/test_ClassicalOps.cpp
+++ b/tket/tests/Ops/test_ClassicalOps.cpp
@@ -27,6 +27,12 @@ namespace tket {
 namespace test_ClassicalOps {
 
 SCENARIO("Check that classical bundles work as expected") {
+  GIVEN("Metadata retrieval from ClassicalOps.") {
+    nlohmann::json j;
+    j["Test"] = "tag";
+    ClassicalOp clas_op = ClassicalOp(OpType::H, 0, 0, 0, "", j);
+    REQUIRE(clas_op.get_meta() == j);
+  }
   GIVEN("Out bundles on a trivial circuit") {
     Circuit circ(3, 1);
     circ.add_conditional_gate<unsigned>(OpType::CX, {}, {0, 1}, {0}, 0);

--- a/tket/tests/Ops/test_Ops.cpp
+++ b/tket/tests/Ops/test_Ops.cpp
@@ -15,8 +15,8 @@
 #include <catch2/catch_test_macros.hpp>
 #include <optional>
 #include <stdexcept>
-#include <unsupported/Eigen/MatrixFunctions>
 #include <typeinfo>
+#include <unsupported/Eigen/MatrixFunctions>
 
 #include "../testutil.hpp"
 #include "Circuit/Boxes.hpp"
@@ -291,7 +291,6 @@ SCENARIO("Check op retrieval overloads are working correctly.", "[ops]") {
     REQUIRE(h->get_meta().is_null() == true);
   }
 
- 
   GIVEN("Operations whose parameters have different domains") {
     Op_ptr op2 = get_op_ptr(OpType::U1, 6.4);
     Op_ptr op4 = get_op_ptr(OpType::CnRy, 6.4);

--- a/tket/tests/Ops/test_Ops.cpp
+++ b/tket/tests/Ops/test_Ops.cpp
@@ -16,11 +16,13 @@
 #include <optional>
 #include <stdexcept>
 #include <unsupported/Eigen/MatrixFunctions>
+#include <typeinfo>
 
 #include "../testutil.hpp"
 #include "Circuit/Boxes.hpp"
 #include "Circuit/CircUtils.hpp"
 #include "Circuit/Circuit.hpp"
+#include "Gate/Gate.hpp"
 #include "Gate/GatePtr.hpp"
 #include "Gate/SymTable.hpp"
 #include "OpType/OpType.hpp"
@@ -284,6 +286,12 @@ SCENARIO("Check op retrieval overloads are working correctly.", "[ops]") {
     REQUIRE(h->get_params() == rhs);
   }
 
+  GIVEN("An empty metadata retrieval from the defaulted value.") {
+    const Op_ptr h = (get_op_ptr(OpType::H));
+    REQUIRE(h->get_meta().is_null() == true);
+  }
+
+ 
   GIVEN("Operations whose parameters have different domains") {
     Op_ptr op2 = get_op_ptr(OpType::U1, 6.4);
     Op_ptr op4 = get_op_ptr(OpType::CnRy, 6.4);


### PR DESCRIPTION
This PR addresses the addition of a metadata member to various classes for the purposes of tag propagation.

Specifically:

- `Op` type and `MetaOp`, `Gate` and `ClassicalOp` subtypes.
- `Box` (as an `Op` subtype) and `CircuitBox` and `ClassicalExpBox` subtypes.

- [ ] Python binders.