### PR TITLE
Set tket-libs as the only remote.

### DIFF
--- a/.github/workflows/build-external-packages
+++ b/.github/workflows/build-external-packages
@@ -1,0 +1,40 @@
+#! /usr/bin/env bash
+set -ex
+
+# Edit this list as required:
+PACKAGES="b2/4.9.2@ \
+          boost/1.80.0@ \
+          bzip2/1.0.8@ \
+          catch2/3.1.0@ \
+          eigen/3.4.0@ \
+          gmp/6.2.1@ \
+          libbacktrace/cci.20210118@ \
+          libiconv/1.17@ \
+          nlohmann_json/3.11.2@ \
+          pybind11_json/0.2.12@ \
+          rapidcheck/cci.20220514@ \
+          zlib/1.2.12@"
+
+BUILD_TYPES="Release Debug"
+
+conan remote add conan-center https://center.conan.io --force
+
+for PACKAGE in ${PACKAGES}
+do
+    conan remove -f ${PACKAGE} || true
+    for BUILD_TYPE in ${BUILD_TYPES}
+    do
+        echo "Installing:" ${PACKAGE} ${BUILD_TYPE} "..."
+        conan install ${PACKAGE} --profile=tket -s build_type=${BUILD_TYPE} --build=missing --update -r=conan-center
+    done
+done
+
+conan remote remove conan-center
+
+for PACKAGE in ${PACKAGES}
+do
+    echo "Uploading:" ${PACKAGE} "..."
+    conan upload ${PACKAGE} --all -r=tket-libs
+done
+
+echo "Done."

--- a/.github/workflows/build-symengine.yml
+++ b/.github/workflows/build-symengine.yml
@@ -25,7 +25,9 @@ jobs:
       if: matrix.os == 'ubuntu-22.04'
       run: conan profile update settings.compiler.libcxx=libstdc++11 tket
     - name: add remote
-      run: conan remote add tket-libs https://quantinuumsw.jfrog.io/artifactory/api/conan/tket1-libs --force
+      run: |
+        conan remote clean
+        conan remote add tket-libs https://quantinuumsw.jfrog.io/artifactory/api/conan/tket1-libs
     - name: normalize line endings in conanfile
       if: matrix.os == 'windows-2022'
       # Ensure consistent revisions across platforms.
@@ -55,7 +57,9 @@ jobs:
     - name: Set up conan profile
       run: conan profile new tket --detect --force
     - name: add remote
-      run: conan remote add tket-libs https://quantinuumsw.jfrog.io/artifactory/api/conan/tket1-libs --force
+      run: |
+        conan remote clean
+        conan remote add tket-libs https://quantinuumsw.jfrog.io/artifactory/api/conan/tket1-libs
     - name: Build symengine
       run: |
         conan remove -f symengine/*

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -128,7 +128,9 @@ jobs:
       run: conan install --profile=tket tket/${{ needs.check_changes.outputs.tket_ver }}@tket/stable
     - name: check that version is consistent
       if: matrix.os == 'ubuntu-22.04' && github.event_name == 'pull_request'
-      run: ./.github/workflows/check-tket-reqs  ${{ needs.check_changes.outputs.tket_ver }}
+      run: |
+        conan create --profile=tket recipes/pybind11
+        ./.github/workflows/check-tket-reqs  ${{ needs.check_changes.outputs.tket_ver }}
     - name: Install runtime test requirements
       if: matrix.os == 'ubuntu-22.04' && (needs.check_changes.outputs.tket_changed == 'true' || needs.check_changes.outputs.tket_tests_changed == 'true') && github.event_name == 'schedule'
       run: |

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -54,6 +54,7 @@ jobs:
     - name: See if version exists on remote
       id: test_package_exists
       run: |
+        conan remote clean
         conan remote add tket-libs https://quantinuumsw.jfrog.io/artifactory/api/conan/tket1-libs
         tket_package_exists=`conan search -r tket-libs "tket/${{ steps.tket_ver.outputs.tket_ver }}@tket/stable" > /dev/null 2>&1 && echo true || echo false`
         echo "::set-output name=tket_package_exists::${tket_package_exists}"

--- a/.github/workflows/build_libs.yml
+++ b/.github/workflows/build_libs.yml
@@ -72,7 +72,9 @@ jobs:
       if: matrix.os == 'ubuntu-22.04'
       run: conan profile update settings.compiler.libcxx=libstdc++11 tket
     - name: add remote
-      run: conan remote add tket-libs https://quantinuumsw.jfrog.io/artifactory/api/conan/tket1-libs
+      run: |
+        conan remote clean
+        conan remote add tket-libs https://quantinuumsw.jfrog.io/artifactory/api/conan/tket1-libs
     - name: build ${{ matrix.lib }}
       run: conan create --profile=tket -s build_type=${{ matrix.build_type }} -o ${{ matrix.lib }}:shared=${{ matrix.shared }} libs/${{ matrix.lib }} tket/stable --build=missing
     - name: authenticate to repository
@@ -112,7 +114,9 @@ jobs:
     - name: create profile
       run: conan profile new tket --detect --force
     - name: add remote
-      run: conan remote add tket-libs https://quantinuumsw.jfrog.io/artifactory/api/conan/tket1-libs --force
+      run: |
+        conan remote clean
+        conan remote add tket-libs https://quantinuumsw.jfrog.io/artifactory/api/conan/tket1-libs
     - name: build ${{ matrix.lib }}
       run: conan create --profile=tket -s build_type=${{ matrix.build_type }} -o ${{ matrix.lib }}:shared=${{ matrix.shared }} libs/${{ matrix.lib }} tket/stable --build=missing
     - name: authenticate to repository

--- a/.github/workflows/conan-setup
+++ b/.github/workflows/conan-setup
@@ -6,4 +6,5 @@ if [ "$(uname -s)" == "Linux" ]; then
 fi
 conan profile update options.tklog:shared=True tket
 conan profile update options.tket:shared=True tket
-conan remote add tket-libs https://quantinuumsw.jfrog.io/artifactory/api/conan/tket1-libs --force
+conan remote clean
+conan remote add tket-libs https://quantinuumsw.jfrog.io/artifactory/api/conan/tket1-libs

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -64,7 +64,9 @@ jobs:
         ${conan_cmd} profile update settings.build_type=Debug tket
         echo "CONAN_CMD=${conan_cmd}" >> $GITHUB_ENV
     - name: add remote
-      run: ${CONAN_CMD} remote add tket-libs https://quantinuumsw.jfrog.io/artifactory/api/conan/tket1-libs
+      run: |
+        ${CONAN_CMD} remote clean
+        ${CONAN_CMD} remote add tket-libs https://quantinuumsw.jfrog.io/artifactory/api/conan/tket1-libs
     - name: Build tket
       run: |
         ${CONAN_CMD} install recipes/tket tket/stable --install-folder=build/tket --profile=tket -o tket:profile_coverage=True

--- a/.github/workflows/linuxbuildlib
+++ b/.github/workflows/linuxbuildlib
@@ -28,6 +28,7 @@ export CONAN_CMD=${PYBIN}/conan
 
 ${CONAN_CMD} profile new tket --detect
 
+${CONAN_CMD} remote clean
 ${CONAN_CMD} remote add tket-libs https://quantinuumsw.jfrog.io/artifactory/api/conan/tket1-libs
 
 ${CONAN_CMD} user -p ${JFROG_ARTIFACTORY_TOKEN_2} -r tket-libs ${JFROG_ARTIFACTORY_USER_2}

--- a/.github/workflows/linuxbuildwheel
+++ b/.github/workflows/linuxbuildwheel
@@ -29,7 +29,8 @@ cd /tket
 ${CONAN_CMD} profile new tket --detect
 ${CONAN_CMD} profile update options.tklog:shared=True tket
 ${CONAN_CMD} profile update options.tket:shared=True tket
-${CONAN_CMD} remote add tket-libs https://quantinuumsw.jfrog.io/artifactory/api/conan/tket1-libs --force
+${CONAN_CMD} remote clean
+${CONAN_CMD} remote add tket-libs https://quantinuumsw.jfrog.io/artifactory/api/conan/tket1-libs
 ${CONAN_CMD} create --profile=tket --test-folder=None recipes/tket tket/stable --build=missing --build=tket
 ${CONAN_CMD} create --profile=tket --test-folder=None recipes/pybind11
 

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -1,0 +1,63 @@
+name: Packages
+
+# Before pushing to trigger this script, remember to edit the list of packages
+# in `build-external-packages`, if you don't want to rebuild all of them.
+
+on:
+  push:
+    branches:
+      - 'packages-upload-new/**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build
+    strategy:
+      matrix:
+        os: ['ubuntu-22.04', 'macos-11', 'macos-12', 'windows-2022']
+    runs-on: ${{ matrix.os }}
+    env:
+      CONAN_REVISIONS_ENABLED: 1
+    steps:
+
+    - uses: actions/checkout@v3
+
+    - name: Install conan
+      uses: turtlebrowser/get-conan@v1.1
+
+    - name: Set up conan
+      shell: bash
+      run: ./.github/workflows/conan-setup
+
+    - name: authenticate to repository
+      run: conan user -p ${{ secrets.JFROG_ARTIFACTORY_TOKEN_2 }} -r tket-libs ${{ secrets.JFROG_ARTIFACTORY_USER_2 }}
+
+    - name: Install and upload packages
+      shell: bash
+      run: ./.github/workflows/build-external-packages
+
+  build_macos_arm64:
+    name: Build on MacOS ARM64
+    runs-on: ['self-hosted', 'macOS', 'ARM64']
+    env:
+      CONAN_REVISIONS_ENABLED: 1
+    steps:
+
+    - uses: actions/checkout@v3
+
+    - name: Set up conan
+      shell: bash
+      run: ./.github/workflows/conan-setup
+
+    - name: authenticate to repository
+      run: conan user -p ${{ secrets.JFROG_ARTIFACTORY_TOKEN_2 }} -r tket-libs ${{ secrets.JFROG_ARTIFACTORY_USER_2 }}
+
+    - name: Install and upload packages
+      shell: bash
+      run: ./.github/workflows/build-external-packages
+
+    - name: unauthenticate
+      run: conan user -c

--- a/.github/workflows/publish_tket_package.yml
+++ b/.github/workflows/publish_tket_package.yml
@@ -48,7 +48,9 @@ jobs:
       if: matrix.os == 'ubuntu-22.04'
       run: conan profile update settings.compiler.libcxx=libstdc++11 tket
     - name: add remote
-      run: conan remote add tket-libs https://quantinuumsw.jfrog.io/artifactory/api/conan/tket1-libs
+      run: |
+        conan remote clean
+        conan remote add tket-libs https://quantinuumsw.jfrog.io/artifactory/api/conan/tket1-libs
     - name: build tket
       run: conan create --profile=tket -s build_type=${{ matrix.build_type }} -o tket:shared=${{ matrix.shared }} recipes/tket tket/stable --build=missing
     - name: authenticate to repository
@@ -85,7 +87,9 @@ jobs:
     - name: create profile
       run: conan profile new tket --detect --force
     - name: add remote
-      run: conan remote add tket-libs https://quantinuumsw.jfrog.io/artifactory/api/conan/tket1-libs --force
+      run: |
+        conan remote clean
+        conan remote add tket-libs https://quantinuumsw.jfrog.io/artifactory/api/conan/tket1-libs
     - name: build tket
       run: conan create --profile=tket -s build_type=${{ matrix.build_type }} -o tket:shared=${{ matrix.shared }} recipes/tket tket/stable --build=missing
     - name: authenticate to repository

--- a/.github/workflows/test_libs.yml
+++ b/.github/workflows/test_libs.yml
@@ -81,7 +81,9 @@ jobs:
       if: matrix.os == 'ubuntu-22.04'
       run: conan profile update settings.compiler.libcxx=libstdc++11 tket
     - name: add remote
-      run: conan remote add tket-libs https://quantinuumsw.jfrog.io/artifactory/api/conan/tket1-libs
+      run: |
+        conan remote clean
+        conan remote add tket-libs https://quantinuumsw.jfrog.io/artifactory/api/conan/tket1-libs
     - name: build ${{ matrix.lib }}
       run: conan create --profile=tket libs/${{ matrix.lib }} --build=missing
     - name: build ${{ matrix.lib }} tests
@@ -111,7 +113,9 @@ jobs:
     - name: create profile
       run: conan profile new tket --detect --force
     - name: add remote
-      run: conan remote add tket-libs https://quantinuumsw.jfrog.io/artifactory/api/conan/tket1-libs --force
+      run: |
+        conan remote clean
+        conan remote add tket-libs https://quantinuumsw.jfrog.io/artifactory/api/conan/tket1-libs
     - name: build ${{ matrix.lib }}
       run: conan create --profile=tket libs/${{ matrix.lib }} --build=missing
     - name: build ${{ matrix.lib }} tests
@@ -146,7 +150,9 @@ jobs:
     - name: set libcxx
       run: conan profile update settings.compiler.libcxx=libstdc++11 tket
     - name: add remote
-      run: conan remote add tket-libs https://quantinuumsw.jfrog.io/artifactory/api/conan/tket1-libs
+      run: |
+        conan remote clean
+        conan remote add tket-libs https://quantinuumsw.jfrog.io/artifactory/api/conan/tket1-libs
     - name: set Debug in profile
       run: conan profile update settings.build_type=Debug tket
     - name: build ${{ matrix.lib }}

--- a/.github/workflows/test_libs_all.yml
+++ b/.github/workflows/test_libs_all.yml
@@ -27,7 +27,9 @@ jobs:
       if: matrix.os == 'ubuntu-22.04'
       run: conan profile update settings.compiler.libcxx=libstdc++11 tket
     - name: add remote
-      run: conan remote add tket-libs https://quantinuumsw.jfrog.io/artifactory/api/conan/tket1-libs
+      run: |
+        conan remote clean
+        conan remote add tket-libs https://quantinuumsw.jfrog.io/artifactory/api/conan/tket1-libs
     - name: build ${{ matrix.lib }}
       run: conan create --profile=tket libs/${{ matrix.lib }} --build=missing
     - name: build ${{ matrix.lib }} tests
@@ -54,7 +56,9 @@ jobs:
     - name: create profile
       run: conan profile new tket --detect --force
     - name: add remote
-      run: conan remote add tket-libs https://quantinuumsw.jfrog.io/artifactory/api/conan/tket1-libs --force
+      run: |
+        conan remote clean
+        conan remote add tket-libs https://quantinuumsw.jfrog.io/artifactory/api/conan/tket1-libs
     - name: build ${{ matrix.lib }}
       run: conan create --profile=tket libs/${{ matrix.lib }} --build=missing
     - name: build ${{ matrix.lib }} tests

--- a/README.md
+++ b/README.md
@@ -82,7 +82,11 @@ recommended in the warning message:
 conan profile update settings.compiler.libcxx=libstdc++11 tket
 ```
 
-Set the `tket-libs` repository as your remote:
+Set the `tket-libs` repository as your remote. (Note that the following commands
+affect your conan configuration across all projects, so if you are working on
+other projects with conan you will want to revert them afterwards. A simple way
+is to back up the file `~/.conan/remotes.json`. You can view your current
+remotes list with `conan remote list`.)
 
 ```shell
 conan remote clean

--- a/README.md
+++ b/README.md
@@ -82,9 +82,10 @@ recommended in the warning message:
 conan profile update settings.compiler.libcxx=libstdc++11 tket
 ```
 
-Add the `tket.libs` repository to your remotes:
+Set the `tket-libs` repository as your remote:
 
 ```shell
+conan remote clean
 conan remote add tket-libs https://quantinuumsw.jfrog.io/artifactory/api/conan/tket1-libs
 ```
 


### PR DESCRIPTION
Currently, we have stored some packages on our artifactory for configurations that aren't built by default on conan-center (e.g. apple-clang 14, VSCode 17). This means that if a new _revision_ of a package recipe is uploaded to conan-center, until we upload the corresponding revision, our builds will fail (because they look for the most recent revision and then look for packages matching the configuration for that revision).

We solve that problem by only using our artifactory (not conan-center) during builds.

I've added a workflow script that can be used to uplaod latest revisions of any required packages. We can choose to run this if we want a newer revsion (or package version).

Another advantage is that we have control over the exact versions of all dependencies.