### PR TITLE
Upload more conan packages to repo

### DIFF
--- a/.github/workflows/build-external-packages
+++ b/.github/workflows/build-external-packages
@@ -13,6 +13,7 @@ PACKAGES="b2/4.9.2@ \
           nlohmann_json/3.11.2@ \
           pybind11_json/0.2.12@ \
           rapidcheck/cci.20220514@ \
+          symengine/0.9.0@ \
           zlib/1.2.12@"
 
 BUILD_TYPES="Release Debug"

--- a/.github/workflows/build-external-packages
+++ b/.github/workflows/build-external-packages
@@ -30,12 +30,12 @@ do
     done
 done
 
-conan remote remove conan-center
-
 for PACKAGE in ${PACKAGES}
 do
     echo "Uploading:" ${PACKAGE} "..."
     conan upload ${PACKAGE} --all -r=tket-libs
 done
+
+conan remote remove conan-center
 
 echo "Done."

--- a/.github/workflows/linuxbuildpackages
+++ b/.github/workflows/linuxbuildpackages
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+# Copyright 2019-2022 Cambridge Quantum Computing
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -evu
+
+# Choose a Python to install conan
+export PYBIN=/opt/python/cp310-cp310/bin
+
+${PYBIN}/pip install conan
+
+export CONAN_CMD=${PYBIN}/conan
+
+export CONAN_REVISIONS_ENABLED=1
+
+cd /tket
+
+${CONAN_CMD} profile new tket --detect
+
+${CONAN_CMD} remote clean
+${CONAN_CMD} remote add conan-center https://center.conan.io --force
+
+# Edit this list as required:
+PACKAGES="b2/4.9.2@ \
+          boost/1.80.0@ \
+          bzip2/1.0.8@ \
+          eigen/3.4.0@ \
+          gmp/6.2.1@ \
+          libbacktrace/cci.20210118@ \
+          libiconv/1.17@ \
+          nlohmann_json/3.11.2@ \
+          pybind11_json/0.2.12@ \
+          zlib/1.2.12@"
+
+for PACKAGE in ${PACKAGES}
+do
+    echo "Installing:" ${PACKAGE} "..."
+    ${CONAN_CMD} remove -f ${PACKAGE} || true
+    ${CONAN_CMD} install ${PACKAGE} --profile=tket -s build_type=Release --build=missing --update -r=conan-center
+done
+
+${CONAN_CMD} remote add tket-libs https://quantinuumsw.jfrog.io/artifactory/api/conan/tket1-libs
+
+${CONAN_CMD} user -p ${JFROG_ARTIFACTORY_TOKEN_2} -r tket-libs ${JFROG_ARTIFACTORY_USER_2}
+
+for PACKAGE in ${PACKAGES}
+do
+    echo "Uploading:" ${PACKAGE} "..."
+    ${CONAN_CMD} upload ${PACKAGE} --all -r=tket-libs
+done
+
+echo "Done."

--- a/.github/workflows/linuxbuildpackages
+++ b/.github/workflows/linuxbuildpackages
@@ -42,6 +42,7 @@ PACKAGES="b2/4.9.2@ \
           libiconv/1.17@ \
           nlohmann_json/3.11.2@ \
           pybind11_json/0.2.12@ \
+          symengine/0.9.0@ \
           zlib/1.2.12@"
 
 for PACKAGE in ${PACKAGES}

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -61,3 +61,20 @@ jobs:
 
     - name: unauthenticate
       run: conan user -c
+
+  build_manylinux:
+    name: Build on manylinux
+    runs-on: 'ubuntu-22.04'
+    steps:
+
+    - uses: actions/checkout@v3
+
+    - name: Set up container
+      run: |
+        docker create --name linux_build -i -v /:/host quay.io/pypa/manylinux2014_x86_64:latest /bin/bash
+        docker cp . linux_build:/tket/
+
+    - name: Install and upload packages
+      run: |
+        docker start linux_build
+        docker exec -e JFROG_ARTIFACTORY_TOKEN_2="${{ secrets.JFROG_ARTIFACTORY_TOKEN_2 }}" -e JFROG_ARTIFACTORY_USER_2="${{ secrets.JFROG_ARTIFACTORY_USER_2 }}" linux_build /bin/bash -c "/tket/.github/workflows/linuxbuildpackages"

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -64,6 +64,9 @@ jobs:
 
   build_manylinux:
     name: Build on manylinux
+    strategy:
+      matrix:
+        manylinux: ['manylinux2014_x86_64', 'manylinux_2_28_x86_64']
     runs-on: 'ubuntu-22.04'
     steps:
 
@@ -71,7 +74,7 @@ jobs:
 
     - name: Set up container
       run: |
-        docker create --name linux_build -i -v /:/host quay.io/pypa/manylinux2014_x86_64:latest /bin/bash
+        docker create --name linux_build -i -v /:/host quay.io/pypa/${{ matrix.manylinux }}:latest /bin/bash
         docker cp . linux_build:/tket/
 
     - name: Install and upload packages


### PR DESCRIPTION
* Add symengine to the list. This should allow us to use `symengine/0.9.0@` instead of `symengine/0.9.0@tket/stable`, and to remove the existing scripts for building symengine.
* Build on manylinux as well (in Release mode), to speed up release builds.
* Build on `manylinux_2_28_x64_64` as well, to facilitate migration to that image.