### PR TITLE
Update dorny/paths-filter

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -32,7 +32,7 @@ jobs:
     - uses: actions/setup-python@v4
       with:
         python-version: '3.10'
-    - uses: dorny/paths-filter@v2.10.2
+    - uses: dorny/paths-filter@v2.11.0
       id: filter
       with:
         base: ${{ github.ref }}

--- a/.github/workflows/build_libs.yml
+++ b/.github/workflows/build_libs.yml
@@ -16,7 +16,7 @@ jobs:
       libs: ${{ steps.filter.outputs.changes }}
     steps:
     - uses: actions/checkout@v3
-    - uses: dorny/paths-filter@v2.10.2
+    - uses: dorny/paths-filter@v2.11.0
       id: filter
       with:
         base: ${{ github.ref }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -23,7 +23,7 @@ jobs:
       tket: ${{ steps.filter.outputs.tket }}
     steps:
     - uses: actions/checkout@v3
-    - uses: dorny/paths-filter@v2.10.2
+    - uses: dorny/paths-filter@v2.11.0
       id: filter
       with:
         base: ${{ github.ref }}

--- a/.github/workflows/test_libs.yml
+++ b/.github/workflows/test_libs.yml
@@ -18,7 +18,7 @@ jobs:
       libs: ${{ steps.filter.outputs.changes }}
     steps:
     - uses: actions/checkout@v3
-    - uses: dorny/paths-filter@v2.10.2
+    - uses: dorny/paths-filter@v2.11.0
       id: filter
       with:
         base: ${{ github.ref }}

--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -17,7 +17,7 @@ jobs:
       tket: ${{ steps.filter.outputs.tket }}
     steps:
     - uses: actions/checkout@v3
-    - uses: dorny/paths-filter@v2.10.2
+    - uses: dorny/paths-filter@v2.11.0
       id: filter
       with:
         base: ${{ github.ref }}


### PR DESCRIPTION
Among other things this updates the version of `Node.js`, which removes a deprecation warning due to https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/ .

(A similar warning is coming from `srfrnk/current-time`.)