### PR TITLE
Switch to josStorer/get-current-time.

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -80,7 +80,7 @@ jobs:
         brew install clang-format@14
         git ls-files "*.cpp" "*.hpp" | xargs clang-format -style=file --dry-run --Werror
     - name: Get current time
-      uses: srfrnk/current-time@v1.1.0
+      uses: josStorer/get-current-time@v2.0.1
       id: current_time
       with:
         format: YYYYMMDDHHmmss

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -42,7 +42,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Get current time
-      uses: srfrnk/current-time@v1.1.0
+      uses: josStorer/get-current-time@v2.0.1
       id: current_time
       with:
         format: YYYYMMDDHHmmss

--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -33,7 +33,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Get current time
-      uses: srfrnk/current-time@v1.1.0
+      uses: josStorer/get-current-time@v2.0.1
       id: current_time
       with:
         format: YYYYMMDDHHmmss


### PR DESCRIPTION
This uses Node.js v16 so avoids the warnings we were getting from the old action using v12.