### PR TITLE
Fix running of long tests, and don't run them on the build_and_test schedule

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -105,9 +105,6 @@ jobs:
     - name: Set up conan
       shell: bash
       run: ./.github/workflows/conan-setup
-    - name: set option to run full test suite
-      if: github.event_name == 'schedule'
-      run: conan profile update options.tket-tests:full=True tket
     - name: normalize line endings in conanfile and src directory
       if: matrix.os == 'windows-2022'
       # This is necessary to ensure consistent revisions across platforms.
@@ -236,9 +233,6 @@ jobs:
         ./.github/workflows/conan-setup
         export CC=`which conan`
         echo "CONAN_CMD=${CC}" >> $GITHUB_ENV
-    - name: set option to run full test suite
-      if: github.event_name == 'schedule'
-      run: conan profile update options.tket-tests:full=True tket
     - name: Remove tket package from cache
       run: conan remove -f 'tket/*'
     - name: Build tket

--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -52,9 +52,6 @@ jobs:
     - name: Set up conan
       shell: bash
       run: ./.github/workflows/conan-setup
-    - name: set option to run full test suite
-      if: github.event_name == 'schedule'
-      run: conan profile update options.tket-tests:full=True tket
     - name: install valgrind
       run: sudo apt install valgrind
     - name: build tket
@@ -70,5 +67,10 @@ jobs:
         conan build recipes/tket-tests --build --build-folder=build/tket-tests
         conan package recipes/tket-tests/ --build-folder=build/tket-tests --package-folder build/tket-tests/package --source-folder=tket/tests
     - name: run tests under valgrind
+      if: github.event_name == 'pull_request'
       working-directory: ./build/tket-tests/package/bin
       run: valgrind --error-exitcode=1 ./test_tket
+    - name: run full tests under valgrind
+      if: github.event_name == 'schedule'
+      working-directory: ./build/tket-tests/package/bin
+      run: valgrind --error-exitcode=1 ./test_tket "[long],~[long]"

--- a/README.md
+++ b/README.md
@@ -193,15 +193,12 @@ To build and run the tket tests:
 conan create --profile=tket recipes/tket-tests
 ```
 
-The tests with a running time >=1 second (on a regular modern laptop) are marked as hidden,
-tagged with `"[long]"`, and are not run by default. To run the full suite of tests,
-add `-o tket-tests:full=True` to the above `conan create` command (or to the tket profile).
-The option `-o tket-tests:long=True` can also be used to run only the long tests.
-
 If you want to build the tests without running them, pass `--test-folder None` to the
 `conan` command. Then, you can manually run the binary.
-If no arguments are provided only the default (short) tests are run.
-To run the long tests use the `"[long]"` tag as an argument:
+
+The tests with a running time >=1 second (on a regular modern laptop) are marked
+as hidden, tagged with `"[long]"`, and are not run by default. To run the long
+tests use the `"[long]"` tag as an argument:
 
 ```shell
 <package_folder>/bin/test_tket "[long]"

--- a/recipes/tket-tests/conanfile.py
+++ b/recipes/tket-tests/conanfile.py
@@ -26,12 +26,8 @@ class TketTestsConan(ConanFile):
     description = "Unit tests for tket"
     topics = ("quantum", "computation", "compiler")
     settings = "os", "compiler", "build_type", "arch"
-    options = {
-        "with_coverage": [True, False],
-        "full": [True, False],
-        "long": [True, False],
-    }
-    default_options = {"with_coverage": False, "full": False, "long": False}
+    options = {"with_coverage": [True, False]}
+    default_options = {"with_coverage": False}
     generators = "cmake"
     exports_sources = "../../tket/tests/*"
     requires = ("tket/1.0.20@tket/stable", "catch2/3.1.0")


### PR DESCRIPTION
I think it's fine to omit them from the weekly `build_and_test` run, since they are run weekly by the valgrind and coverage runs (which would fail if any tests failed).

I've removed the redundant options from the tket-tests conanfile, and updated the README.