### PR TITLE
Filter maps produced by `GraphPlacement` and `NoiseAwarePlacement` to leave some `Qubit` unassigned

### DIFF
--- a/pytket/conanfile.txt
+++ b/pytket/conanfile.txt
@@ -1,5 +1,5 @@
 [requires]
-tket/1.0.20@tket/stable
+tket/1.0.21@tket/stable
 tklog/0.1.2@tket/stable
 pybind11/2.10.0
 nlohmann_json/3.11.2

--- a/pytket/conanfile.txt
+++ b/pytket/conanfile.txt
@@ -1,5 +1,5 @@
 [requires]
-tket/1.0.22@tket/stable
+tket/1.0.23@tket/stable
 tklog/0.1.2@tket/stable
 pybind11/2.10.0
 nlohmann_json/3.11.2

--- a/pytket/conanfile.txt
+++ b/pytket/conanfile.txt
@@ -1,5 +1,5 @@
 [requires]
-tket/1.0.24@tket/stable
+tket/1.0.25@tket/stable
 tklog/0.1.2@tket/stable
 pybind11/2.10.0
 nlohmann_json/3.11.2

--- a/recipes/tket-proptests/conanfile.py
+++ b/recipes/tket-proptests/conanfile.py
@@ -28,7 +28,7 @@ class TketProptestsConan(ConanFile):
     generators = "cmake"
     exports_sources = "../../tket/proptests/*"
     requires = (
-        "tket/1.0.20@tket/stable",
+        "tket/1.0.21@tket/stable",
         "rapidcheck/cci.20220514",
     )
 

--- a/recipes/tket-proptests/conanfile.py
+++ b/recipes/tket-proptests/conanfile.py
@@ -28,7 +28,7 @@ class TketProptestsConan(ConanFile):
     generators = "cmake"
     exports_sources = "../../tket/proptests/*"
     requires = (
-        "tket/1.0.24@tket/stable",
+        "tket/1.0.25@tket/stable",
         "rapidcheck/cci.20220514",
     )
 

--- a/recipes/tket-proptests/conanfile.py
+++ b/recipes/tket-proptests/conanfile.py
@@ -28,7 +28,7 @@ class TketProptestsConan(ConanFile):
     generators = "cmake"
     exports_sources = "../../tket/proptests/*"
     requires = (
-        "tket/1.0.22@tket/stable",
+        "tket/1.0.23@tket/stable",
         "rapidcheck/cci.20220514",
     )
 

--- a/recipes/tket-tests/conanfile.py
+++ b/recipes/tket-tests/conanfile.py
@@ -34,7 +34,7 @@ class TketTestsConan(ConanFile):
     default_options = {"with_coverage": False, "full": False, "long": False}
     generators = "cmake"
     exports_sources = "../../tket/tests/*"
-    requires = ("tket/1.0.20@tket/stable", "catch2/3.1.0")
+    requires = ("tket/1.0.21@tket/stable", "catch2/3.1.0")
 
     _cmake = None
 

--- a/recipes/tket-tests/conanfile.py
+++ b/recipes/tket-tests/conanfile.py
@@ -34,7 +34,7 @@ class TketTestsConan(ConanFile):
     default_options = {"with_coverage": False, "full": False, "long": False}
     generators = "cmake"
     exports_sources = "../../tket/tests/*"
-    requires = ("tket/1.0.24@tket/stable", "catch2/3.1.0")
+    requires = ("tket/1.0.25@tket/stable", "catch2/3.1.0")
 
     _cmake = None
 

--- a/recipes/tket-tests/conanfile.py
+++ b/recipes/tket-tests/conanfile.py
@@ -34,7 +34,7 @@ class TketTestsConan(ConanFile):
     default_options = {"with_coverage": False, "full": False, "long": False}
     generators = "cmake"
     exports_sources = "../../tket/tests/*"
-    requires = ("tket/1.0.22@tket/stable", "catch2/3.1.0")
+    requires = ("tket/1.0.23@tket/stable", "catch2/3.1.0")
 
     _cmake = None
 

--- a/recipes/tket/conanfile.py
+++ b/recipes/tket/conanfile.py
@@ -20,7 +20,7 @@ import shutil
 
 class TketConan(ConanFile):
     name = "tket"
-    version = "1.0.24"
+    version = "1.0.25"
     license = "CQC Proprietary"
     homepage = "https://github.com/CQCL/tket"
     url = "https://github.com/conan-io/conan-center-index"

--- a/recipes/tket/conanfile.py
+++ b/recipes/tket/conanfile.py
@@ -20,7 +20,7 @@ import shutil
 
 class TketConan(ConanFile):
     name = "tket"
-    version = "1.0.22"
+    version = "1.0.23"
     license = "CQC Proprietary"
     homepage = "https://github.com/CQCL/tket"
     url = "https://github.com/conan-io/conan-center-index"

--- a/recipes/tket/conanfile.py
+++ b/recipes/tket/conanfile.py
@@ -20,7 +20,7 @@ import shutil
 
 class TketConan(ConanFile):
     name = "tket"
-    version = "1.0.20"
+    version = "1.0.21"
     license = "CQC Proprietary"
     homepage = "https://github.com/CQCL/tket"
     url = "https://github.com/conan-io/conan-center-index"

--- a/tket/src/Placement/GraphPlacement.cpp
+++ b/tket/src/Placement/GraphPlacement.cpp
@@ -296,14 +296,14 @@ std::map<Qubit, Node> GraphPlacement::convert_bimap(
   std::map<Qubit, unsigned> qubit_vertex_map;
   auto vertex_iter_pair = boost::vertices(pattern_graph);
   while (vertex_iter_pair.first != vertex_iter_pair.second) {
-    auto vert = *vertex_iter_pair.first;
+    unsigned vert = *vertex_iter_pair.first;
     qubit_vertex_map.insert({pattern_graph[vert], vert});
     ++vertex_iter_pair.first;
   }
   for (const auto& entry : bimap.left) {
     auto qvm_it = qubit_vertex_map.find(entry.first);
     TKET_ASSERT(qvm_it != qubit_vertex_map.end());
-    auto entry_vertex = qvm_it->second;
+    unsigned entry_vertex = qvm_it->second;
     unsigned n_pattern_edges = boost::out_degree(entry_vertex, pattern_graph);
     std::set<Node> neighbour_nodes =
         this->architecture_.get_neighbour_nodes(entry.second);

--- a/tket/src/Placement/GraphPlacement.cpp
+++ b/tket/src/Placement/GraphPlacement.cpp
@@ -303,9 +303,11 @@ std::map<Qubit, Node> GraphPlacement::convert_bimap(
     TKET_ASSERT(vertex_iter_begin != vertex_iter_pair.second);
     unsigned entry_vertex = *vertex_iter_begin;
     unsigned n_pattern_edges = boost::out_degree(entry_vertex, pattern_graph);
+    std::set<Node> neighbour_nodes =
+        this->architecture_.get_neighbour_nodes(entry.second);
+    unsigned n_target_edges = neighbour_nodes.size();
     unsigned n_interacting = 0;
-    for (const Node& node :
-         this->architecture_.get_neighbour_nodes(entry.second)) {
+    for (const Node& node : neighbour_nodes) {
       auto it = bimap.right.find(node);
       // Node may be not be assigned to
       // If it is, check if Qubit are interacting
@@ -325,7 +327,8 @@ std::map<Qubit, Node> GraphPlacement::convert_bimap(
         }
       }
     }
-    if (n_pattern_edges - n_interacting <= n_interacting) {
+    if (std::min(n_pattern_edges, n_target_edges) - n_interacting <=
+        n_interacting) {
       out_map.insert({entry.first, entry.second});
     }
   }

--- a/tket/src/Placement/NoiseAwarePlacement.cpp
+++ b/tket/src/Placement/NoiseAwarePlacement.cpp
@@ -135,4 +135,13 @@ std::vector<std::map<Qubit, Node>> NoiseAwarePlacement::get_all_placement_maps(
   return all_qmaps;
 }
 
+DeviceCharacterisation NoiseAwarePlacement::get_characterisation() const {
+  return this->characterisation_;
+}
+
+void NoiseAwarePlacement::set_characterisation(
+    const DeviceCharacterisation& characterisation) {
+  this->characterisation_ = characterisation;
+}
+
 }  // namespace tket

--- a/tket/src/Placement/NoiseAwarePlacement.cpp
+++ b/tket/src/Placement/NoiseAwarePlacement.cpp
@@ -94,13 +94,13 @@ double NoiseAwarePlacement::cost_placement(
   return cost;
 }
 
-std::vector<std::map<Qubit, Node>> NoiseAwarePlacement::rank_maps(
+std::vector<boost::bimap<Qubit, Node>> NoiseAwarePlacement::rank_maps(
     const std::vector<boost::bimap<Qubit, Node>>& placement_maps,
     const Circuit& circ_,
     const std::vector<GraphPlacement::WeightedEdge>& pattern_edges) const {
   // each map is costed, sorted and returned
   // only equal best costed maps are returned
-  std::vector<std::map<Qubit, Node>> return_placement_maps;
+  std::vector<boost::bimap<Qubit, Node>> return_placement_maps;
   double best_cost = 0;
   QubitGraph q_graph =
       this->construct_pattern_graph(pattern_edges, circ_.n_qubits());
@@ -108,9 +108,9 @@ std::vector<std::map<Qubit, Node>> NoiseAwarePlacement::rank_maps(
     double cost = this->cost_placement(map, circ_, q_graph);
     if (return_placement_maps.empty() || cost < best_cost) {
       best_cost = cost;
-      return_placement_maps = {bimap_to_map(map.left)};
+      return_placement_maps = {map};
     } else if (cost == best_cost) {
-      return_placement_maps.push_back(bimap_to_map(map.left));
+      return_placement_maps.push_back(map);
     }
   }
   return return_placement_maps;
@@ -123,12 +123,16 @@ std::vector<std::map<Qubit, Node>> NoiseAwarePlacement::get_all_placement_maps(
   std::vector<boost::bimap<Qubit, Node>> placement_maps =
       this->get_all_weighted_subgraph_monomorphisms(
           circ_, weighted_pattern_edges, true);
-  std::vector<std::map<Qubit, Node>> ranked_placement_maps =
+  std::vector<boost::bimap<Qubit, Node>> ranked_placement_maps =
       this->rank_maps(placement_maps, circ_, weighted_pattern_edges);
-  if (ranked_placement_maps.size() > matches) {
-    ranked_placement_maps.resize(matches);
+  std::vector<std::map<Qubit, Node>> all_qmaps;
+  QubitGraph::UndirectedConnGraph pattern_graph =
+      this->construct_pattern_graph(weighted_pattern_edges, circ_.n_qubits())
+          .get_undirected_connectivity();
+  for (unsigned i = 0; i < ranked_placement_maps.size() && i < matches; i++) {
+    all_qmaps.push_back(convert_bimap(ranked_placement_maps[i], pattern_graph));
   }
-  return ranked_placement_maps;
+  return all_qmaps;
 }
 
 }  // namespace tket

--- a/tket/src/Placement/include/Placement/Placement.hpp
+++ b/tket/src/Placement/include/Placement/Placement.hpp
@@ -279,16 +279,14 @@ class NoiseAwarePlacement : public GraphPlacement {
       const Circuit& circ_, unsigned matches) const override;
 
   /**
-   * @return maximum depth to search to find gates to construct pattern graph
-   * from
+   * @return A DeviceCharacterisation object storing Architecture errors
    */
-  DeviceCharacterisation get_characterisation() const {
-    return this->characterisation_;
-  }
+  DeviceCharacterisation get_characterisation() const;
 
-  void set_characterisation(const DeviceCharacterisation& characterisation) {
-    this->characterisation_ = characterisation;
-  }
+  /**
+   * @param characterisation Error information for Architecture
+   */
+  void set_characterisation(const DeviceCharacterisation& characterisation);
 
  private:
   DeviceCharacterisation characterisation_;

--- a/tket/src/Placement/include/Placement/Placement.hpp
+++ b/tket/src/Placement/include/Placement/Placement.hpp
@@ -210,6 +210,10 @@ class GraphPlacement : public Placement {
       const Circuit& circ_,
       const std::vector<WeightedEdge>& weighted_pattern_edges,
       bool return_best) const;
+
+  std::map<Qubit, Node> convert_bimap(
+      boost::bimap<Qubit, Node>& bimap,
+      const QubitGraph::UndirectedConnGraph& pattern_graph) const;
 };
 
 /** Solves the pure unweighted subgraph monomorphism problem, trying
@@ -289,7 +293,7 @@ class NoiseAwarePlacement : public GraphPlacement {
  private:
   DeviceCharacterisation characterisation_;
 
-  std::vector<std::map<Qubit, Node>> rank_maps(
+  std::vector<boost::bimap<Qubit, Node>> rank_maps(
       const std::vector<boost::bimap<Qubit, Node>>& placement_maps,
       const Circuit& circ_,
       const std::vector<WeightedEdge>& pattern_edges) const;

--- a/tket/src/Predicates/PassGenerators.cpp
+++ b/tket/src/Predicates/PassGenerators.cpp
@@ -194,7 +194,6 @@ PassPtr gen_placement_pass(const Placement::Ptr& placement_ptr) {
       changed = line_placement_ptr->place(circ, maps);
     }
     return changed;
-    return placement_ptr->place(circ, maps);
   };
   Transform t = Transform(trans);
   PredicatePtr twoqbpred = std::make_shared<MaxTwoQubitGatesPredicate>();

--- a/tket/tests/Placement/test_GraphPlacement.cpp
+++ b/tket/tests/Placement/test_GraphPlacement.cpp
@@ -152,7 +152,8 @@ SCENARIO("Base GraphPlacement class") {
 
   GIVEN(
       "Nine qubit disconnected CX circuit, 15 qubit Architecture with multiple "
-      "mappings, no exact isomorphism, GraphPlacement::get_placement_map.") {
+      "mappings, no exact isomorphism, GraphPlacement::get_placement_map, one "
+      "unplaced qubit.") {
     /**
      * Architecture graph:
      * 0 -- 1 -- 2 -- 3 -- 4 -- 5
@@ -192,7 +193,7 @@ SCENARIO("Base GraphPlacement class") {
     REQUIRE(placement_map[Qubit(3)] == Node(10));
     REQUIRE(placement_map[Qubit(4)] == Node(15));
     REQUIRE(placement_map[Qubit(5)] == Node(14));
-    REQUIRE(placement_map[Qubit(6)] == Node(4));
+    REQUIRE(placement_map[Qubit(6)] == Node("unplaced", 0));
     REQUIRE(placement_map[Qubit(7)] == Node(16));
     REQUIRE(placement_map[Qubit(8)] == Node(11));
   }


### PR DESCRIPTION
We've observed before that dynamically assign Program Qubits to Architecture Nodes during routing can give an improvement in performance. In this PR I've added an extra step to the end of `GraphPlacement::get_all_placement_maps`, where it removes some Qubit->Node assignments from the constructed maps under some basic condition.
