### PR TITLE
Feature/support qubit permutation in q control box decomp

### DIFF
--- a/pytket/binders/circuit/Circuit/main.cpp
+++ b/pytket/binders/circuit/Circuit/main.cpp
@@ -755,6 +755,13 @@ void init_circuit(py::module &m) {
           ":return: dictionary mapping input qubit to output qubit on "
           "the same path")
       .def(
+          "replace_SWAPs", &Circuit::replace_SWAPs,
+          "Replace all SWAP gates with implicit wire swaps.")
+      .def(
+          "replace_implicit_wire_swaps",
+          &Circuit::replace_all_implicit_wire_swaps,
+          "Replace all implicit wire swaps with SWAP gates")
+      .def(
           "ops_of_type",
           [](const Circuit &circ, OpType optype) {
             VertexSet vset = circ.get_gates_of_type(optype);

--- a/pytket/binders/circuit/Circuit/main.cpp
+++ b/pytket/binders/circuit/Circuit/main.cpp
@@ -760,7 +760,7 @@ void init_circuit(py::module &m) {
       .def(
           "replace_implicit_wire_swaps",
           &Circuit::replace_all_implicit_wire_swaps,
-          "Replace all implicit wire swaps with SWAP gates")
+          "Replace all implicit wire swaps with SWAP gates.")
       .def(
           "ops_of_type",
           [](const Circuit &circ, OpType optype) {

--- a/pytket/conanfile.txt
+++ b/pytket/conanfile.txt
@@ -1,5 +1,5 @@
 [requires]
-tket/1.0.20@tket/stable
+tket/1.0.21@tket/stable
 tklog/0.1.2@tket/stable
 pybind11/2.10.0
 nlohmann_json/3.11.2

--- a/pytket/conanfile.txt
+++ b/pytket/conanfile.txt
@@ -1,5 +1,5 @@
 [requires]
-tket/1.0.21@tket/stable
+tket/1.0.22@tket/stable
 tklog/0.1.2@tket/stable
 pybind11/2.10.0
 nlohmann_json/3.11.2

--- a/pytket/docs/changelog.rst
+++ b/pytket/docs/changelog.rst
@@ -8,11 +8,15 @@ Minor new features:
 
 * New ``OpType::Phase`` 0-qubit gate affecting global phase.
 * New ``CnXPairwiseDecomposition`` pass.
+* Allow ``QControlBox`` with implicit wire swaps to be decomposed.
+* New ``Circuit`` methods ``replace_SWAPs`` and ``replace_implicit_wire_swaps``.
 
 Fixes:
 
 * Remove unused ``tk_SCRATCH_BIT`` registers from qasm output.
 * Update the ``LogicExp`` in every ``ClassicalExpBox`` when calling ``Circuit.rename_units``.
+* Fix issue with ``QControlBox`` throwing error during decomposition
+  if the controlled circuit contains identity gates.
 
 1.7.3 (October 2022)
 --------------------

--- a/recipes/tket-proptests/conanfile.py
+++ b/recipes/tket-proptests/conanfile.py
@@ -28,7 +28,7 @@ class TketProptestsConan(ConanFile):
     generators = "cmake"
     exports_sources = "../../tket/proptests/*"
     requires = (
-        "tket/1.0.20@tket/stable",
+        "tket/1.0.21@tket/stable",
         "rapidcheck/cci.20220514",
     )
 

--- a/recipes/tket-proptests/conanfile.py
+++ b/recipes/tket-proptests/conanfile.py
@@ -28,7 +28,7 @@ class TketProptestsConan(ConanFile):
     generators = "cmake"
     exports_sources = "../../tket/proptests/*"
     requires = (
-        "tket/1.0.21@tket/stable",
+        "tket/1.0.22@tket/stable",
         "rapidcheck/cci.20220514",
     )
 

--- a/recipes/tket-tests/conanfile.py
+++ b/recipes/tket-tests/conanfile.py
@@ -34,7 +34,7 @@ class TketTestsConan(ConanFile):
     default_options = {"with_coverage": False, "full": False, "long": False}
     generators = "cmake"
     exports_sources = "../../tket/tests/*"
-    requires = ("tket/1.0.20@tket/stable", "catch2/3.1.0")
+    requires = ("tket/1.0.21@tket/stable", "catch2/3.1.0")
 
     _cmake = None
 

--- a/recipes/tket-tests/conanfile.py
+++ b/recipes/tket-tests/conanfile.py
@@ -34,7 +34,7 @@ class TketTestsConan(ConanFile):
     default_options = {"with_coverage": False, "full": False, "long": False}
     generators = "cmake"
     exports_sources = "../../tket/tests/*"
-    requires = ("tket/1.0.21@tket/stable", "catch2/3.1.0")
+    requires = ("tket/1.0.22@tket/stable", "catch2/3.1.0")
 
     _cmake = None
 

--- a/recipes/tket/conanfile.py
+++ b/recipes/tket/conanfile.py
@@ -20,7 +20,7 @@ import shutil
 
 class TketConan(ConanFile):
     name = "tket"
-    version = "1.0.21"
+    version = "1.0.22"
     license = "CQC Proprietary"
     homepage = "https://github.com/CQCL/tket"
     url = "https://github.com/conan-io/conan-center-index"

--- a/recipes/tket/conanfile.py
+++ b/recipes/tket/conanfile.py
@@ -20,7 +20,7 @@ import shutil
 
 class TketConan(ConanFile):
     name = "tket"
-    version = "1.0.20"
+    version = "1.0.21"
     license = "CQC Proprietary"
     homepage = "https://github.com/CQCL/tket"
     url = "https://github.com/conan-io/conan-center-index"

--- a/tket/src/Circuit/CircUtils.cpp
+++ b/tket/src/Circuit/CircUtils.cpp
@@ -924,7 +924,9 @@ static Circuit with_controls_numerical(const Circuit &c, unsigned n_controls) {
   std::vector<CnGateBlock> blocks;
 
   for (const Command &cmd : commands) {
-    if (cmd.get_op_ptr()->get_type() != OpType::noop) {
+    // drop any gates that apply identity to the target qubit
+    if (cmd.get_op_ptr()->commuting_basis(cmd.get_args().size() - 1) !=
+        Pauli::I) {
       blocks.push_back(CnGateBlock(cmd));
     }
   }

--- a/tket/src/Circuit/include/Circuit/Circuit.hpp
+++ b/tket/src/Circuit/include/Circuit/Circuit.hpp
@@ -1342,14 +1342,23 @@ class Circuit {
 
   /**
    * this function replaces an implicit wire swap between the two given qubits
-   * with three CX operations
+   * with a SWAP gate or three CX operations
    *
    * @param first qubits to add the wireswap on
    * @param second qubits to add the wireswap on
+   * @param using_cx use three CX gates instead of a SWAP gate
    *
    * O(c)
    */
-  void replace_implicit_wire_swap(const Qubit first, const Qubit second);
+  void replace_implicit_wire_swap(
+      const Qubit first, const Qubit second, const bool using_cx = true);
+
+  /**
+   * replaces all implicit wire swaps with SWAP gates
+   *
+   * O(n_qubits)
+   */
+  void replace_all_implicit_wire_swaps();
 
   // O(E+V+q)
   Circuit dagger() const;

--- a/tket/src/Circuit/include/Circuit/Circuit.hpp
+++ b/tket/src/Circuit/include/Circuit/Circuit.hpp
@@ -1351,7 +1351,7 @@ class Circuit {
    * O(c)
    */
   void replace_implicit_wire_swap(
-      const Qubit first, const Qubit second, const bool using_cx = true);
+      const Qubit first, const Qubit second, bool using_cx = true);
 
   /**
    * replaces all implicit wire swaps with SWAP gates

--- a/tket/src/Circuit/macro_manipulation.cpp
+++ b/tket/src/Circuit/macro_manipulation.cpp
@@ -382,15 +382,53 @@ void Circuit::replace_SWAPs() {
 }
 
 void Circuit::replace_implicit_wire_swap(
-    const Qubit first, const Qubit second) {
-  add_op<UnitID>(OpType::CX, {first, second});
-  add_op<UnitID>(OpType::CX, {second, first});
-  Vertex cxvertex = add_op<UnitID>(OpType::CX, {first, second});
-  EdgeVec outs = get_all_out_edges(cxvertex);
+    const Qubit first, const Qubit second, const bool using_cx) {
+  Vertex last_v;
+  if (using_cx) {
+    add_op<UnitID>(OpType::CX, {first, second});
+    add_op<UnitID>(OpType::CX, {second, first});
+    last_v = add_op<UnitID>(OpType::CX, {first, second});
+  } else {
+    last_v = add_op<UnitID>(OpType::SWAP, {first, second});
+  }
+  EdgeVec outs = get_all_out_edges(last_v);
   Edge out1 = outs[0];
   dag[out1].ports.first = 1;
   Edge out2 = outs[1];
   dag[out2].ports.first = 0;
+}
+
+void Circuit::replace_all_implicit_wire_swaps() {
+  qubit_map_t perm = implicit_qubit_permutation();
+  std::set<Qubit> fixed_qubits;
+  // iterate permutation cycles and add swap for every adjacent elements
+  for (const std::pair<const Qubit, Qubit>& pair : perm) {
+    if (fixed_qubits.find(pair.first) != fixed_qubits.end()) {
+      // skip if visited
+      continue;
+    }
+    // start traverse a cycle
+    Qubit head = pair.first;
+    Qubit current = pair.first;
+    Qubit next = pair.second;
+    while (true) {
+      if (next == head) {
+        // break if reaches the end of the cycle
+        fixed_qubits.insert(current);
+        break;
+      }
+      replace_implicit_wire_swap(current, next, false);
+      fixed_qubits.insert(current);
+      auto it = perm.find(next);
+      if (it == perm.end()) {
+        throw CircuitInvalidity(
+            "Unknown error in replace_all_implicit_wire_swaps: invalid qubit "
+            "permutation.");
+      }
+      current = it->first;
+      next = it->second;
+    }
+  }
 }
 
 // helper functions for the dagger and transpose

--- a/tket/src/Circuit/macro_manipulation.cpp
+++ b/tket/src/Circuit/macro_manipulation.cpp
@@ -408,7 +408,7 @@ void Circuit::replace_all_implicit_wire_swaps() {
       continue;
     }
     // start traverse a cycle
-    Qubit head = pair.first;
+    const Qubit head = pair.first;
     Qubit current = pair.first;
     Qubit next = pair.second;
     while (true) {

--- a/tket/src/Circuit/macro_manipulation.cpp
+++ b/tket/src/Circuit/macro_manipulation.cpp
@@ -382,7 +382,7 @@ void Circuit::replace_SWAPs() {
 }
 
 void Circuit::replace_implicit_wire_swap(
-    const Qubit first, const Qubit second, const bool using_cx) {
+    const Qubit first, const Qubit second, bool using_cx) {
   Vertex last_v;
   if (using_cx) {
     add_op<UnitID>(OpType::CX, {first, second});
@@ -420,11 +420,7 @@ void Circuit::replace_all_implicit_wire_swaps() {
       replace_implicit_wire_swap(current, next, false);
       fixed_qubits.insert(current);
       auto it = perm.find(next);
-      if (it == perm.end()) {
-        throw CircuitInvalidity(
-            "Unknown error in replace_all_implicit_wire_swaps: invalid qubit "
-            "permutation.");
-      }
+      TKET_ASSERT(it != perm.end());
       current = it->first;
       next = it->second;
     }

--- a/tket/tests/Circuit/test_Boxes.cpp
+++ b/tket/tests/Circuit/test_Boxes.cpp
@@ -929,6 +929,19 @@ SCENARIO("QControlBox", "[boxes]") {
     const Eigen::MatrixXcd U2 = tket_sim::get_unitary(*c_numerical);
     REQUIRE(U2.isApprox(V));
   }
+  GIVEN("controlled CircBox with identity gates") {
+    Circuit c0(2);
+    c0.add_op<unsigned>(OpType::TK1, {0., 0., 0.}, {0});
+    c0.add_op<unsigned>(OpType::Rx, 0., {0});
+    c0.add_op<unsigned>(OpType::CRx, 4., {0, 1});
+    c0.add_op<unsigned>(OpType::noop, {0});
+    CircBox cbox(c0);
+    Op_ptr op = std::make_shared<CircBox>(cbox);
+    QControlBox qcbox(op, 1);
+    std::shared_ptr<Circuit> c = qcbox.to_circuit();
+    REQUIRE(c->n_gates() == 0);
+    REQUIRE(equiv_0(c->get_phase()));
+  }
 }
 
 SCENARIO("Unitary3qBox", "[boxes]") {

--- a/tket/tests/Circuit/test_Boxes.cpp
+++ b/tket/tests/Circuit/test_Boxes.cpp
@@ -942,6 +942,22 @@ SCENARIO("QControlBox", "[boxes]") {
     REQUIRE(c->n_gates() == 0);
     REQUIRE(equiv_0(c->get_phase()));
   }
+  GIVEN("controlled gate that is identity up to a phase") {
+    // phase = 1.
+    Op_ptr op = get_op_ptr(OpType::U3, {2., 0.5, -0.5});
+    QControlBox qcbox(op, 1);
+    std::shared_ptr<Circuit> c = qcbox.to_circuit();
+    // Check the second qubit is empty
+    Vertex q1_in = c->get_in(Qubit(1));
+    EdgeVec q1_out_es = c->get_all_out_edges(q1_in);
+    REQUIRE(q1_out_es.size() == 1);
+    REQUIRE(c->target(q1_out_es[0]) == c->get_out(Qubit(1)));
+    Eigen::MatrixXcd U = tket_sim::get_unitary(*c);
+    Eigen::MatrixXcd V = Eigen::MatrixXcd::Identity(4, 4);
+    V(2, 2) = std::exp(i_ * PI);
+    V(3, 3) = std::exp(i_ * PI);
+    REQUIRE(U.isApprox(V));
+  }
 }
 
 SCENARIO("Unitary3qBox", "[boxes]") {


### PR DESCRIPTION
Resolves #615 
Fix the issue that the `QControlBox` decomposition doesn't ignore all identities.

I've also added two circuit methods `replace_SWAPs` and `replace_implicit_wire_swaps` to the python binder because I think they can be useful.
