### PR TITLE
Replace `PauliGraph::TopSortIterator` with `boost::topological_sort`

### DIFF
--- a/pytket/conanfile.txt
+++ b/pytket/conanfile.txt
@@ -1,5 +1,5 @@
 [requires]
-tket/1.0.22@tket/stable
+tket/1.0.23@tket/stable
 tklog/0.1.2@tket/stable
 pybind11/2.10.0
 nlohmann_json/3.11.2

--- a/recipes/tket-proptests/conanfile.py
+++ b/recipes/tket-proptests/conanfile.py
@@ -28,7 +28,7 @@ class TketProptestsConan(ConanFile):
     generators = "cmake"
     exports_sources = "../../tket/proptests/*"
     requires = (
-        "tket/1.0.22@tket/stable",
+        "tket/1.0.23@tket/stable",
         "rapidcheck/cci.20220514",
     )
 

--- a/recipes/tket-tests/conanfile.py
+++ b/recipes/tket-tests/conanfile.py
@@ -34,7 +34,7 @@ class TketTestsConan(ConanFile):
     default_options = {"with_coverage": False, "full": False, "long": False}
     generators = "cmake"
     exports_sources = "../../tket/tests/*"
-    requires = ("tket/1.0.22@tket/stable", "catch2/3.1.0")
+    requires = ("tket/1.0.23@tket/stable", "catch2/3.1.0")
 
     _cmake = None
 

--- a/recipes/tket/conanfile.py
+++ b/recipes/tket/conanfile.py
@@ -20,7 +20,7 @@ import shutil
 
 class TketConan(ConanFile):
     name = "tket"
-    version = "1.0.22"
+    version = "1.0.23"
     license = "CQC Proprietary"
     homepage = "https://github.com/CQCL/tket"
     url = "https://github.com/conan-io/conan-center-index"

--- a/tket/src/Converters/PauliGraphConverters.cpp
+++ b/tket/src/Converters/PauliGraphConverters.cpp
@@ -85,8 +85,7 @@ Circuit pauli_graph_to_circuit_individually(
   for (const Bit &b : pg.bits_) {
     circ.add_bit(b);
   }
-  for (PauliGraph::TopSortIterator it = pg.begin(); it != pg.end(); ++it) {
-    PauliVert vert = *it;
+  for (const PauliVert &vert : pg.vertices_in_order()) {
     const QubitPauliTensor &pauli = pg.graph_[vert].tensor_;
     const Expr &angle = pg.graph_[vert].angle_;
     append_single_pauli_gadget(circ, pauli, angle, cx_config);
@@ -109,13 +108,14 @@ Circuit pauli_graph_to_circuit_pairwise(
   for (const Bit &b : pg.bits_) {
     circ.add_bit(b);
   }
-  PauliGraph::TopSortIterator it = pg.begin();
-  while (it != pg.end()) {
+  std::vector<PauliVert> vertices = pg.vertices_in_order();
+  auto it = vertices.begin();
+  while (it != vertices.end()) {
     PauliVert vert0 = *it;
     const QubitPauliTensor &pauli0 = pg.graph_[vert0].tensor_;
     const Expr &angle0 = pg.graph_[vert0].angle_;
     ++it;
-    if (it == pg.end()) {
+    if (it == vertices.end()) {
       append_single_pauli_gadget(circ, pauli0, angle0, cx_config);
     } else {
       PauliVert vert1 = *it;
@@ -147,13 +147,14 @@ Circuit pauli_graph_to_circuit_sets(
   for (const Bit &b : pg.bits_) {
     circ.add_bit(b);
   }
-  PauliGraph::TopSortIterator it = pg.begin();
-  while (it != pg.end()) {
+  std::vector<PauliVert> vertices = pg.vertices_in_order();
+  auto it = vertices.begin();
+  while (it != vertices.end()) {
     const PauliGadgetProperties &pgp = pg.graph_[*it];
     QubitOperator gadget_map;
     gadget_map[pgp.tensor_] = pgp.angle_;
     ++it;
-    while (it != pg.end()) {
+    while (it != vertices.end()) {
       const PauliGadgetProperties &pauli_gadget = pg.graph_[*it];
       QubitOperator::iterator pgs_iter = gadget_map.find(pauli_gadget.tensor_);
       if (pgs_iter != gadget_map.end()) {
@@ -200,8 +201,8 @@ Circuit pauli_graph_to_circuit_sets(
   }
   Circuit cliff_circuit = tableau_to_circuit(pg.cliff_);
   circ.append(cliff_circuit);
-  for (auto it = pg.measures_.begin(); it != pg.measures_.end(); ++it) {
-    circ.add_measure(it->left, it->right);
+  for (auto it1 = pg.measures_.begin(); it1 != pg.measures_.end(); ++it1) {
+    circ.add_measure(it1->left, it1->right);
   }
   return circ;
 }

--- a/tket/src/Converters/PauliGraphConverters.cpp
+++ b/tket/src/Converters/PauliGraphConverters.cpp
@@ -71,13 +71,11 @@ PauliGraph circuit_to_pauli_graph(const Circuit &circ) {
           "and Paulis",
           od.type());
   }
-  pg.sanity_check();
   return pg;
 }
 
 Circuit pauli_graph_to_circuit_individually(
     const PauliGraph &pg, CXConfigType cx_config) {
-  pg.sanity_check();
   Circuit circ;
   for (const Qubit &qb : pg.cliff_.get_qubits()) {
     circ.add_qubit(qb);
@@ -100,7 +98,6 @@ Circuit pauli_graph_to_circuit_individually(
 
 Circuit pauli_graph_to_circuit_pairwise(
     const PauliGraph &pg, CXConfigType cx_config) {
-  pg.sanity_check();
   Circuit circ;
   for (const Qubit &qb : pg.cliff_.get_qubits()) {
     circ.add_qubit(qb);
@@ -136,7 +133,6 @@ Circuit pauli_graph_to_circuit_pairwise(
 /* Currently follows a greedy set-building method */
 Circuit pauli_graph_to_circuit_sets(
     const PauliGraph &pg, CXConfigType cx_config) {
-  pg.sanity_check();
   Circuit circ;
   const std::set<Qubit> qbs = pg.cliff_.get_qubits();
   Circuit spare_circ;

--- a/tket/src/Converters/PauliGraphConverters.cpp
+++ b/tket/src/Converters/PauliGraphConverters.cpp
@@ -71,11 +71,13 @@ PauliGraph circuit_to_pauli_graph(const Circuit &circ) {
           "and Paulis",
           od.type());
   }
+  pg.sanity_check();
   return pg;
 }
 
 Circuit pauli_graph_to_circuit_individually(
     const PauliGraph &pg, CXConfigType cx_config) {
+  pg.sanity_check();
   Circuit circ;
   for (const Qubit &qb : pg.cliff_.get_qubits()) {
     circ.add_qubit(qb);
@@ -99,6 +101,7 @@ Circuit pauli_graph_to_circuit_individually(
 
 Circuit pauli_graph_to_circuit_pairwise(
     const PauliGraph &pg, CXConfigType cx_config) {
+  pg.sanity_check();
   Circuit circ;
   for (const Qubit &qb : pg.cliff_.get_qubits()) {
     circ.add_qubit(qb);
@@ -133,6 +136,7 @@ Circuit pauli_graph_to_circuit_pairwise(
 /* Currently follows a greedy set-building method */
 Circuit pauli_graph_to_circuit_sets(
     const PauliGraph &pg, CXConfigType cx_config) {
+  pg.sanity_check();
   Circuit circ;
   const std::set<Qubit> qbs = pg.cliff_.get_qubits();
   Circuit spare_circ;

--- a/tket/src/PauliGraph/include/PauliGraph/PauliGraph.hpp
+++ b/tket/src/PauliGraph/include/PauliGraph/PauliGraph.hpp
@@ -99,6 +99,9 @@ class PauliGraph {
    */
   std::vector<PauliVert> vertices_in_order() const;
 
+  /**
+   * Perform a simple sanity check on the DAG.
+   */
   void sanity_check() const;
 
   friend PauliGraph circuit_to_pauli_graph(const Circuit &circ);

--- a/tket/src/PauliGraph/include/PauliGraph/PauliGraph.hpp
+++ b/tket/src/PauliGraph/include/PauliGraph/PauliGraph.hpp
@@ -34,7 +34,9 @@ struct PauliGadgetProperties {
 struct DependencyEdgeProperties {};
 
 typedef boost::adjacency_list<
-    boost::listS, boost::listS, boost::bidirectionalS, PauliGadgetProperties,
+    boost::listS, boost::listS, boost::bidirectionalS,
+    // indexing needed for algorithms such as topological sort
+    boost::property<boost::vertex_index_t, int, PauliGadgetProperties>,
     DependencyEdgeProperties>
     PauliDAG;
 typedef boost::graph_traits<PauliDAG>::vertex_descriptor PauliVert;
@@ -42,6 +44,11 @@ typedef boost::graph_traits<PauliDAG>::edge_descriptor PauliEdge;
 
 typedef sequence_set_t<PauliVert> PauliVertSet;
 typedef sequence_set_t<PauliEdge> PauliEdgeSet;
+
+typedef boost::adj_list_vertex_property_map<
+    PauliDAG, int, int &, boost::vertex_index_t>
+    PauliVIndex;
+
 typedef std::list<std::pair<OpType, qubit_vector_t>> Conjugations;
 
 class Circuit;
@@ -83,6 +90,15 @@ class PauliGraph {
   const CliffTableau &get_clifford_ref() { return cliff_; }
   unsigned n_vertices() const { return boost::num_vertices(this->graph_); }
 
+  /**
+   * All vertices of the DAG, topologically sorted.
+   *
+   * This method is "morally" const, but it sets the vertex indices in the DAG.
+   *
+   * @return vector of vertices in a topological (causal) order
+   */
+  std::vector<PauliVert> vertices_in_order() const;
+
   void sanity_check() const;
 
   friend PauliGraph circuit_to_pauli_graph(const Circuit &circ);
@@ -94,8 +110,15 @@ class PauliGraph {
       const PauliGraph &pg, CXConfigType cx_config);
 
  private:
-  /** The dependency graph of Pauli gadgets */
-  PauliDAG graph_;
+
+  /**
+   * The dependency graph of Pauli gadgets
+   *
+   * This is mutated by \ref vertices_in_order which indexes the vertices
+   * without changing the structure.
+   */
+  mutable PauliDAG graph_;
+
   /** The tableau of the Clifford effect of the circuit */
   CliffTableau cliff_;
   /** The record of measurements at the very end of the circuit */
@@ -122,35 +145,6 @@ class PauliGraph {
    */
   void apply_pauli_gadget_at_end(
       const QubitPauliTensor &pauli, const Expr &angle);
-
-  /**
-   * Iterates through the vertices of a PauliGraph in a topological ordering.
-   * When there are multiple commuting vertices that could be emitted, this
-   * selects the one with the lowest lexicographic ordering on the Pauli string.
-   */
-  class TopSortIterator {
-   public:
-    TopSortIterator();
-    explicit TopSortIterator(const PauliGraph &pg);
-
-    const PauliVert &operator*() const;
-    const PauliVert *operator->() const;
-    bool operator==(const TopSortIterator &other) const;
-    bool operator!=(const TopSortIterator &other) const;
-
-    TopSortIterator operator++(int);
-    TopSortIterator &operator++();
-
-   private:
-    const PauliGraph *pg_;
-    PauliVert current_vert_;
-    std::set<std::pair<QubitPauliTensor, PauliVert>>
-        search_set_;  // Use pair to force ordering by string
-    std::unordered_set<PauliVert> visited_;
-  };
-
-  TopSortIterator begin() const;
-  TopSortIterator end() const;
 };
 
 }  // namespace tket

--- a/tket/src/PauliGraph/include/PauliGraph/PauliGraph.hpp
+++ b/tket/src/PauliGraph/include/PauliGraph/PauliGraph.hpp
@@ -113,7 +113,6 @@ class PauliGraph {
       const PauliGraph &pg, CXConfigType cx_config);
 
  private:
-
   /**
    * The dependency graph of Pauli gadgets
    *

--- a/tket/src/PauliGraph/include/PauliGraph/PauliGraph.hpp
+++ b/tket/src/PauliGraph/include/PauliGraph/PauliGraph.hpp
@@ -83,6 +83,8 @@ class PauliGraph {
   const CliffTableau &get_clifford_ref() { return cliff_; }
   unsigned n_vertices() const { return boost::num_vertices(this->graph_); }
 
+  void sanity_check() const;
+
   friend PauliGraph circuit_to_pauli_graph(const Circuit &circ);
   friend Circuit pauli_graph_to_circuit_individually(
       const PauliGraph &pg, CXConfigType cx_config);

--- a/tket/tests/test_PauliGraph.cpp
+++ b/tket/tests/test_PauliGraph.cpp
@@ -244,8 +244,10 @@ SCENARIO("Synthesising PauliGraphs") {
     circ.add_op<unsigned>(OpType::Ry, 0.3, {3});
     const Eigen::MatrixXcd circ_unitary = tket_sim::get_unitary(circ);
     PauliGraph pg = circuit_to_pauli_graph(circ);
+    pg.sanity_check();
     WHEN("Synthesising individually") {
       Circuit synth = pauli_graph_to_circuit_individually(pg);
+      pg.sanity_check();
       Eigen::MatrixXcd synth_unitary = tket_sim::get_unitary(synth);
       REQUIRE((synth_unitary - circ_unitary).cwiseAbs().sum() < ERR_EPS);
     }
@@ -291,7 +293,9 @@ SCENARIO("Test mutual diagonalisation of fully commuting sets") {
     Circuit test1 = prepend >> circ;
 
     PauliGraph pg = circuit_to_pauli_graph(circ);
+    pg.sanity_check();
     Circuit out = pauli_graph_to_circuit_sets(pg);
+    pg.sanity_check();
     Circuit test2 = prepend >> out;
     REQUIRE(test_statevector_comparison(test1, test2));
   }
@@ -975,6 +979,7 @@ SCENARIO("Measure handling in PauliGraph") {
     circ.add_op<unsigned>(OpType::Measure, {0, 1});
     circ.add_op<unsigned>(OpType::Measure, {1, 0});
     PauliGraph pg = circuit_to_pauli_graph(circ);
+    pg.sanity_check();
     std::map<Qubit, unsigned> correct_readout = {{Qubit(0), 1}, {Qubit(1), 0}};
     WHEN("Synthesise individually") {
       Circuit circ2 = pauli_graph_to_circuit_individually(pg);
@@ -982,6 +987,7 @@ SCENARIO("Measure handling in PauliGraph") {
     }
     WHEN("Synthesise pairwise") {
       Circuit circ2 = pauli_graph_to_circuit_pairwise(pg);
+      pg.sanity_check();
       REQUIRE(circ2.qubit_readout() == correct_readout);
     }
     WHEN("Synthesise in sets") {


### PR DESCRIPTION
While working on build system refactoring I encountered a mysterious segfault on Windows in the PauliGraph tests. This turned out to be due to corrupt graph iterators. The `TopSortIterator` has a raw pointer to a graph, which is only initialized when `begin()` is called and is assumed to remain valid.

I added a `PauliGraph::sanity_check()` method which provoked the segfault on Linux. This method doesn't do a great deal of sanity checking; it could be extended in the future if we wish. It's only called from the tests.

I replaced the `TopSortIterator` with `boost::topological_sort`, copying the method used in `Circuit`. The price we pay for this (in order to retain constness of other methods) is having to make `PauliGraph::graph_` an explicitly mutable member, because sorting requires indexing of the vertices.