### PR TITLE
Add py to list of test requirements.

### DIFF
--- a/pytket/conanfile.txt
+++ b/pytket/conanfile.txt
@@ -1,5 +1,5 @@
 [requires]
-tket/1.0.23@tket/stable
+tket/1.0.24@tket/stable
 tklog/0.1.2@tket/stable
 pybind11/2.10.0
 nlohmann_json/3.11.2

--- a/pytket/tests/requirements.txt
+++ b/pytket/tests/requirements.txt
@@ -3,6 +3,7 @@
 pytest
 pytest-cov
 pytest-benchmark
+py
 hypothesis
 docker
 jsonschema

--- a/recipes/tket-proptests/conanfile.py
+++ b/recipes/tket-proptests/conanfile.py
@@ -28,7 +28,7 @@ class TketProptestsConan(ConanFile):
     generators = "cmake"
     exports_sources = "../../tket/proptests/*"
     requires = (
-        "tket/1.0.23@tket/stable",
+        "tket/1.0.24@tket/stable",
         "rapidcheck/cci.20220514",
     )
 

--- a/recipes/tket-tests/conanfile.py
+++ b/recipes/tket-tests/conanfile.py
@@ -34,7 +34,7 @@ class TketTestsConan(ConanFile):
     default_options = {"with_coverage": False, "full": False, "long": False}
     generators = "cmake"
     exports_sources = "../../tket/tests/*"
-    requires = ("tket/1.0.23@tket/stable", "catch2/3.1.0")
+    requires = ("tket/1.0.24@tket/stable", "catch2/3.1.0")
 
     _cmake = None
 

--- a/recipes/tket/conanfile.py
+++ b/recipes/tket/conanfile.py
@@ -20,7 +20,7 @@ import shutil
 
 class TketConan(ConanFile):
     name = "tket"
-    version = "1.0.23"
+    version = "1.0.24"
     license = "CQC Proprietary"
     homepage = "https://github.com/CQCL/tket"
     url = "https://github.com/conan-io/conan-center-index"


### PR DESCRIPTION
Bumping tket version to force a new version since version 23 won't be uploaded (because of the error this is fixing...).