### PR TITLE
Select Python 3.10 before running turtlebrowser/get-conan@v1.1

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -98,6 +98,11 @@ jobs:
       run: |
         sudo apt install -y doxygen graphviz
         cd tket && doxygen
+    - name: Select Python 3.10
+      # otherwise turtlebrowser/get-conan@v1.1 fails on macos-12
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.10'
     - name: Install conan
       uses: turtlebrowser/get-conan@v1.1
       with:
@@ -168,6 +173,11 @@ jobs:
       CONAN_REVISIONS_ENABLED: 1
     steps:
     - uses: actions/checkout@v3
+    - name: Select Python 3.10
+      # otherwise turtlebrowser/get-conan@v1.1 fails on macos-12
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.10'
     - name: Install conan
       uses: turtlebrowser/get-conan@v1.1
       with:

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -25,6 +25,12 @@ jobs:
 
     - uses: actions/checkout@v3
 
+    - name: Select Python 3.10
+      # otherwise turtlebrowser/get-conan@v1.1 fails on macos-12
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.10'
+
     - name: Install conan
       uses: turtlebrowser/get-conan@v1.1
       with:


### PR DESCRIPTION
With the [latest macos-12 image](https://github.com/actions/runner-images/tree/macOS-12/20221027.1) it seems that Python 3.11 is the default system Python 3 and this breaks the `turtlebrowser/get-conan` action. Work around this by explicitly selecting Python 3.10 before running it.