### PR TITLE
Update GraphPlacement to allow Barrier gates

### DIFF
--- a/pytket/conanfile.txt
+++ b/pytket/conanfile.txt
@@ -1,5 +1,5 @@
 [requires]
-tket/1.0.26@tket/stable
+tket/1.0.27@tket/stable
 tklog/0.1.2@tket/stable
 pybind11/2.10.1
 nlohmann_json/3.11.2

--- a/recipes/tket-proptests/conanfile.py
+++ b/recipes/tket-proptests/conanfile.py
@@ -28,7 +28,7 @@ class TketProptestsConan(ConanFile):
     generators = "cmake"
     exports_sources = "../../tket/proptests/*"
     requires = (
-        "tket/1.0.26@tket/stable",
+        "tket/1.0.27@tket/stable",
         "rapidcheck/cci.20220514",
     )
 

--- a/recipes/tket-tests/conanfile.py
+++ b/recipes/tket-tests/conanfile.py
@@ -34,7 +34,7 @@ class TketTestsConan(ConanFile):
     default_options = {"with_coverage": False, "full": False, "long": False}
     generators = "cmake"
     exports_sources = "../../tket/tests/*"
-    requires = ("tket/1.0.26@tket/stable", "catch2/3.1.0")
+    requires = ("tket/1.0.27@tket/stable", "catch2/3.1.0")
 
     _cmake = None
 

--- a/recipes/tket/conanfile.py
+++ b/recipes/tket/conanfile.py
@@ -20,7 +20,7 @@ import shutil
 
 class TketConan(ConanFile):
     name = "tket"
-    version = "1.0.26"
+    version = "1.0.27"
     license = "CQC Proprietary"
     homepage = "https://github.com/CQCL/tket"
     url = "https://github.com/conan-io/conan-center-index"

--- a/tket/src/Placement/GraphPlacement.cpp
+++ b/tket/src/Placement/GraphPlacement.cpp
@@ -47,11 +47,11 @@ GraphPlacement::default_pattern_weighting(const Circuit& circuit) const {
        gate_counter < this->maximum_pattern_gates_ && !frontier.slice->empty();
        i++) {
     for (const Vertex& vert : *frontier.slice) {
-      OpType optype = circuit.get_OpType_from_Vertex(vert);
+      if(circuit.get_OpType_from_Vertex(vert) == OpType::Barrier) continue;
       EdgeVec q_out_edges =
           circuit.get_out_edges_of_type(vert, EdgeType::Quantum);
       unsigned n_q_edges = q_out_edges.size();
-      if (n_q_edges == 2 && optype != OpType::Barrier) {
+      if (n_q_edges == 2) {
         UnitID uid_0, uid_1;
         Edge edge_0 = q_out_edges[0];
         Edge edge_1 = q_out_edges[1];
@@ -85,7 +85,7 @@ GraphPlacement::default_pattern_weighting(const Circuit& circuit) const {
         }
         gate_counter++;
       }
-      if (n_q_edges > 2 && optype != OpType::Barrier) {
+      if (n_q_edges > 2) {
         throw std::invalid_argument(
             "Can only weight for Circuits with maximum two qubit quantum "
             "gates.");

--- a/tket/src/Placement/GraphPlacement.cpp
+++ b/tket/src/Placement/GraphPlacement.cpp
@@ -47,7 +47,7 @@ GraphPlacement::default_pattern_weighting(const Circuit& circuit) const {
        gate_counter < this->maximum_pattern_gates_ && !frontier.slice->empty();
        i++) {
     for (const Vertex& vert : *frontier.slice) {
-      if(circuit.get_OpType_from_Vertex(vert) == OpType::Barrier) continue;
+      if (circuit.get_OpType_from_Vertex(vert) == OpType::Barrier) continue;
       EdgeVec q_out_edges =
           circuit.get_out_edges_of_type(vert, EdgeType::Quantum);
       unsigned n_q_edges = q_out_edges.size();

--- a/tket/src/Placement/GraphPlacement.cpp
+++ b/tket/src/Placement/GraphPlacement.cpp
@@ -47,10 +47,11 @@ GraphPlacement::default_pattern_weighting(const Circuit& circuit) const {
        gate_counter < this->maximum_pattern_gates_ && !frontier.slice->empty();
        i++) {
     for (const Vertex& vert : *frontier.slice) {
+      OpType optype = circuit.get_OpType_from_Vertex(vert);
       EdgeVec q_out_edges =
           circuit.get_out_edges_of_type(vert, EdgeType::Quantum);
       unsigned n_q_edges = q_out_edges.size();
-      if (n_q_edges == 2) {
+      if (n_q_edges == 2 && optype != OpType::Barrier) {
         UnitID uid_0, uid_1;
         Edge edge_0 = q_out_edges[0];
         Edge edge_1 = q_out_edges[1];
@@ -84,8 +85,7 @@ GraphPlacement::default_pattern_weighting(const Circuit& circuit) const {
         }
         gate_counter++;
       }
-      if (n_q_edges > 2 &&
-          circuit.get_OpType_from_Vertex(vert) != OpType::Barrier) {
+      if (n_q_edges > 2 && optype != OpType::Barrier) {
         throw std::invalid_argument(
             "Can only weight for Circuits with maximum two qubit quantum "
             "gates.");

--- a/tket/src/Placement/GraphPlacement.cpp
+++ b/tket/src/Placement/GraphPlacement.cpp
@@ -84,9 +84,11 @@ GraphPlacement::default_pattern_weighting(const Circuit& circuit) const {
         }
         gate_counter++;
       }
-      if (n_q_edges > 2) {
+      if (n_q_edges > 2 &&
+          circuit.get_OpType_from_Vertex(vert) != OpType::Barrier) {
         throw std::invalid_argument(
-            "Can only weight for Circuits with maximum two qubit gates.");
+            "Can only weight for Circuits with maximum two qubit quantum "
+            "gates.");
       }
     }
     frontier.next_slicefrontier();

--- a/tket/tests/Placement/test_GraphPlacement.cpp
+++ b/tket/tests/Placement/test_GraphPlacement.cpp
@@ -291,16 +291,22 @@ SCENARIO("Base GraphPlacement class") {
     }
   }
   GIVEN("A Circuit with a Barrier.") {
-    Circuit circuit(3);
+    Circuit circuit(3, 3);
     std::vector<std::pair<unsigned, unsigned>> edges = {{0, 1}, {1, 2}};
     Architecture architecture(edges);
+    circuit.add_op<unsigned>(OpType::H, {1});
+    circuit.add_op<unsigned>(OpType::CX, {1, 2});
+    circuit.add_measure(Qubit(0), Bit(0));
+    circuit.add_measure(Qubit(1), Bit(1));
     circuit.add_barrier({Qubit(0), Qubit(1), Qubit(2)});
+    circuit.add_op<unsigned>(OpType::CX, {1, 0});
+    circuit.add_op<unsigned>(OpType::H, {0});
+    circuit.add_measure(Qubit(2), Bit(2));
+
     GraphPlacement placement(architecture);
     std::map<Qubit, Node> placement_map = placement.get_placement_map(circuit);
     std::map<Qubit, Node> comparison_map = {
-        {Qubit(0), Node("unplaced", 0)},
-        {Qubit(1), Node("unplaced", 1)},
-        {Qubit(2), Node("unplaced", 2)}};
+        {Qubit(0), Node(2)}, {Qubit(1), Node(1)}, {Qubit(2), Node(0)}};
     REQUIRE(placement_map == comparison_map);
   }
 }

--- a/tket/tests/Placement/test_GraphPlacement.cpp
+++ b/tket/tests/Placement/test_GraphPlacement.cpp
@@ -290,6 +290,19 @@ SCENARIO("Base GraphPlacement class") {
       REQUIRE(pmap[Qubit(4)] == Node(4));
     }
   }
+  GIVEN("A Circuit with a Barrier.") {
+    Circuit circuit(3);
+    std::vector<std::pair<unsigned, unsigned>> edges = {{0, 1}, {1, 2}};
+    Architecture architecture(edges);
+    circuit.add_barrier({Qubit(0), Qubit(1), Qubit(2)});
+    GraphPlacement placement(architecture);
+    std::map<Qubit, Node> placement_map = placement.get_placement_map(circuit);
+    std::map<Qubit, Node> comparison_map = {
+        {Qubit(0), Node("unplaced", 0)},
+        {Qubit(1), Node("unplaced", 1)},
+        {Qubit(2), Node("unplaced", 2)}};
+    REQUIRE(placement_map == comparison_map);
+  }
 }
 
 }  // namespace tket


### PR DESCRIPTION
There is a condition in `default_pattern_weighting` that stops `GraphPlacement` from being run on `Circuits` with multi-qubit quantum gates with more than two qubits. However, Barrier gates are multi qubit (non-quantum) gates with more than two qubits and this condition does not make a special case for them. This PR updates the condition to make sure an error isn't thrown for Barrier gates. It also makes sure that two-qubit Barrier gates aren't placed.