### PR TITLE
Add Circuit method for counting the number of n-qubit gates in a Circuit

### DIFF
--- a/pytket/binders/circuit/Circuit/main.cpp
+++ b/pytket/binders/circuit/Circuit/main.cpp
@@ -482,6 +482,25 @@ void init_circuit(py::module &m) {
           "number of operations matching `type`",
           py::arg("type"))
       .def(
+          "n_1qb_gates",
+          [](const Circuit &circ) { return circ.count_n_qubit_gates(1); },
+          "Returns the number of vertices in the dag with one quantum edge."
+          "Ignores Input, Create, Output, Discard, Reset, Measure and Barrier "
+          "vertices.")
+      .def(
+          "n_2qb_gates",
+          [](const Circuit &circ) { return circ.count_n_qubit_gates(2); },
+          "Returns the number of vertices in the dag with two quantum edges."
+          "Ignores Input, Create, Output, Discard, Reset, Measure and Barrier "
+          "vertices.")
+      .def(
+          "n_nqb_gates", &Circuit::count_n_qubit_gates,
+          "Returns the number of vertices in the dag with given number of  "
+          "quantum edges."
+          "Ignores Input, Create, Output, Discard, Reset, Measure and Barrier "
+          "vertices.",
+          py::arg("size"))
+      .def(
           "depth_by_type", &Circuit::depth_by_type,
           "Returns the number of vertices in the longest path through the "
           "sub-DAG consisting of vertices representing operations of the given "

--- a/pytket/tests/circuit_test.py
+++ b/pytket/tests/circuit_test.py
@@ -936,6 +936,21 @@ def test_multi_controlled_gates() -> None:
     assert c.depth() == 3
 
 
+def test_counting_n_qubit_gates() -> None:
+    c = Circuit(5).X(0).H(1).Y(2).Z(3).S(4).CX(0, 1).CX(1, 2).CX(2, 3).CX(3, 4)
+    c.add_gate(OpType.CnX, [0, 1, 2])
+    c.add_gate(OpType.CnX, [0, 1, 2, 3])
+    c.add_gate(OpType.CnX, [0, 1, 2, 3, 4])
+    c.add_barrier([0, 1, 2, 3, 4])
+    assert c.n_1qb_gates() == 5
+    assert c.n_nqb_gates(1) == 5
+    assert c.n_2qb_gates() == 4
+    assert c.n_nqb_gates(2) == 4
+    assert c.n_nqb_gates(3) == 1
+    assert c.n_nqb_gates(4) == 1
+    assert c.n_nqb_gates(5) == 1
+
+
 if __name__ == "__main__":
     test_circuit_gen()
     test_symbolic_ops()
@@ -948,3 +963,4 @@ if __name__ == "__main__":
     test_clifford_checking()
     test_measuring_registers()
     test_multi_controlled_gates()
+    test_counting_n_qubit_gates()

--- a/tket/src/Circuit/include/Circuit/Circuit.hpp
+++ b/tket/src/Circuit/include/Circuit/Circuit.hpp
@@ -1108,6 +1108,19 @@ class Circuit {
    */
   std::list<Command> get_commands_of_type(OpType op_type) const;
 
+  /**
+   * @brief Get the number of gates with the specified number of Qubits.
+   *
+   * Counts vertices, ignoring Input, Output, create, Discard, Reset,
+   * Measure and Barrier.
+   *
+   * @param size Number of quantum edges a vertex has to be counted
+   *
+   * @return Number of vertices with given number of quantum edges in the
+   * circuit
+   */
+  unsigned count_n_qubit_gates(unsigned size) const;
+
   // returns 'slices' of 'parallel' actions in dag as a vector encompassing
   // all vertices
   // O(D qlog^2(q!) alpha log(alpha!))

--- a/tket/src/Circuit/macro_circ_info.cpp
+++ b/tket/src/Circuit/macro_circ_info.cpp
@@ -92,6 +92,30 @@ std::list<Command> Circuit::get_commands_of_type(OpType op_type) const {
   }
   return coms;
 }
+unsigned Circuit::count_n_qubit_gates(unsigned size) const {
+  unsigned counter = 0;
+  if (size == 0) return counter;
+  BGL_FORALL_VERTICES(v, dag, DAG) {
+    if (n_in_edges_of_type(v, EdgeType::Quantum) == size) {
+      const Op_ptr op_ptr = get_Op_ptr_from_Vertex(v);
+      switch (op_ptr->get_type()) {
+        case OpType::Input:
+        case OpType::Create:
+        case OpType::Output:
+        case OpType::Discard:
+        case OpType::Reset:
+        case OpType::Measure:
+        case OpType::Barrier: {
+          break;
+        }
+        default: {
+          counter++;
+        }
+      }
+    }
+  }
+  return counter;
+}
 
 Circuit Circuit::subcircuit(const Subcircuit& sc) const {
   Circuit sub;

--- a/tket/tests/Circuit/test_Circ.cpp
+++ b/tket/tests/Circuit/test_Circ.cpp
@@ -2775,6 +2775,89 @@ SCENARIO("Named operation groups") {
   }
 }
 
+SCENARIO("Test count_n_qubit_gates") {
+  GIVEN("A Circuit with a range of different sized gates") {
+    Circuit c(10, 1);
+    c.add_op<unsigned>(OpType::H, {0});
+    c.add_op<unsigned>(OpType::T, {1});
+    c.add_op<unsigned>(OpType::S, {2});
+    c.add_op<unsigned>(OpType::X, {3});
+    c.add_op<unsigned>(OpType::Y, {4});
+    c.add_op<unsigned>(OpType::Z, {5});
+    c.add_op<unsigned>(OpType::S, {6});
+    c.add_op<unsigned>(OpType::Z, {7});
+    c.add_op<unsigned>(OpType::V, {8});
+    c.add_op<unsigned>(OpType::H, {9});
+
+    c.add_op<unsigned>(OpType::CX, {0, 1});
+    c.add_op<unsigned>(OpType::CZ, {1, 2});
+    c.add_op<unsigned>(OpType::CY, {2, 3});
+    c.add_op<unsigned>(OpType::CX, {3, 4});
+    c.add_op<unsigned>(OpType::CZ, {4, 5});
+    c.add_op<unsigned>(OpType::CY, {5, 6});
+    c.add_op<unsigned>(OpType::ZZMax, {6, 7});
+    c.add_op<unsigned>(OpType::CX, {7, 8});
+    c.add_op<unsigned>(OpType::CZ, {8, 9});
+
+    c.add_op<unsigned>(OpType::CCX, {0, 1, 2});
+    c.add_op<unsigned>(OpType::CCX, {1, 2, 3});
+    c.add_op<unsigned>(OpType::CCX, {2, 3, 4});
+    c.add_op<unsigned>(OpType::CCX, {3, 4, 5});
+    c.add_op<unsigned>(OpType::CCX, {4, 5, 6});
+    c.add_op<unsigned>(OpType::CCX, {5, 6, 7});
+    c.add_op<unsigned>(OpType::CCX, {6, 7, 8});
+    c.add_op<unsigned>(OpType::CCX, {7, 8, 9});
+
+    c.add_op<unsigned>(OpType::CnX, {0, 1, 2, 3});
+    c.add_op<unsigned>(OpType::CnX, {1, 2, 3, 4});
+    c.add_op<unsigned>(OpType::CnX, {2, 3, 4, 5});
+    c.add_op<unsigned>(OpType::CnX, {3, 4, 5, 6});
+    c.add_op<unsigned>(OpType::CnX, {4, 5, 6, 7});
+    c.add_op<unsigned>(OpType::CnX, {5, 6, 7, 8});
+    c.add_op<unsigned>(OpType::CnX, {6, 7, 8, 9});
+
+    c.add_op<unsigned>(OpType::CnX, {0, 1, 2, 3, 4});
+    c.add_op<unsigned>(OpType::CnX, {1, 2, 3, 4, 5});
+    c.add_op<unsigned>(OpType::CnX, {2, 3, 4, 5, 6});
+    c.add_op<unsigned>(OpType::CnX, {3, 4, 5, 6, 7});
+    c.add_op<unsigned>(OpType::CnX, {4, 5, 6, 7, 8});
+    c.add_op<unsigned>(OpType::CnX, {5, 6, 7, 8, 9});
+
+    c.add_op<unsigned>(OpType::CnX, {0, 1, 2, 3, 4, 5});
+    c.add_op<unsigned>(OpType::CnX, {1, 2, 3, 4, 5, 6});
+    c.add_op<unsigned>(OpType::CnX, {2, 3, 4, 5, 6, 7});
+    c.add_op<unsigned>(OpType::CnX, {3, 4, 5, 6, 7, 8});
+    c.add_op<unsigned>(OpType::CnX, {4, 5, 6, 7, 8, 9});
+
+    c.add_op<unsigned>(OpType::CnX, {0, 1, 2, 3, 4, 5, 6});
+    c.add_op<unsigned>(OpType::CnX, {1, 2, 3, 4, 5, 6, 7});
+    c.add_op<unsigned>(OpType::CnX, {2, 3, 4, 5, 6, 7, 8});
+    c.add_op<unsigned>(OpType::CnX, {3, 4, 5, 6, 7, 8, 9});
+
+    c.add_op<unsigned>(OpType::CnX, {0, 1, 2, 3, 4, 5, 6, 7});
+    c.add_op<unsigned>(OpType::CnX, {1, 2, 3, 4, 5, 6, 7, 8});
+    c.add_op<unsigned>(OpType::CnX, {2, 3, 4, 5, 6, 7, 8, 9});
+
+    c.add_op<unsigned>(OpType::CnX, {0, 1, 2, 3, 4, 5, 6, 7, 8});
+    c.add_op<unsigned>(OpType::CnX, {1, 2, 3, 4, 5, 6, 7, 8, 9});
+
+    c.add_op<unsigned>(OpType::CnX, {0, 1, 2, 3, 4, 5, 6, 7, 8, 9});
+    c.add_barrier({0, 1, 2, 3, 4, 5, 6, 7, 8, 9});
+    c.add_measure(Qubit(0), Bit(0));
+    c.add_conditional_gate<unsigned>(OpType::X, {}, {0}, {0}, 1);
+    REQUIRE(c.count_n_qubit_gates(0) == 0);
+    REQUIRE(c.count_n_qubit_gates(1) == 11);
+    REQUIRE(c.count_n_qubit_gates(2) == 9);
+    REQUIRE(c.count_n_qubit_gates(3) == 8);
+    REQUIRE(c.count_n_qubit_gates(4) == 7);
+    REQUIRE(c.count_n_qubit_gates(5) == 6);
+    REQUIRE(c.count_n_qubit_gates(6) == 5);
+    REQUIRE(c.count_n_qubit_gates(7) == 4);
+    REQUIRE(c.count_n_qubit_gates(8) == 3);
+    REQUIRE(c.count_n_qubit_gates(9) == 2);
+    REQUIRE(c.count_n_qubit_gates(10) == 1);
+  }
+}
 SCENARIO("Vertices in order") {
   GIVEN("A circuit with 3 qubits and 6 operations") {
     Circuit c(3);


### PR DESCRIPTION
Also expose method to pytket, with additional `Circuit.n_1qb_gates()` and `Circuit.n_2qb_gates()` methods.