### PR TITLE
Update to clang-format v15

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -77,7 +77,7 @@ jobs:
       if: matrix.os == 'macos-12' && github.event_name == 'pull_request'
       run: |
         brew update
-        brew install clang-format@14
+        brew install clang-format@15
         git ls-files "*.cpp" "*.hpp" | xargs clang-format -style=file --dry-run --Werror
     - name: Get current time
       uses: josStorer/get-current-time@v2.0.2

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ add a test that demonstrates the fix.
 C++20 features may be used whenever they are supported by all the compilers
 used on the CI (listed in the README).
 
-All C++ code should be formatted with `clang-format` (v13) using the
+All C++ code should be formatted with `clang-format` (v15) using the
 configuration file `.clang-format` in the root directory. This is checked on
 the CI. The script `do-clang-format` will run this over all C++ files in the
 repository and fix them up.


### PR DESCRIPTION
Since v14 is no longer available via homebrew.