### PR TITLE
nb viewer link

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,7 @@ selection of example notebooks, please follow the links from the
 [pytket](https://github.com/CQCL/pytket) main page.
 
 Note that the various pytket extensions (which allow pytket to interface with
-other software packages and with quantum devices) live in the separate
-[pytket-extensions](https://github.com/CQCL/pytket-extensions) repository.
+other software packages and with quantum devices) live in the separate github repositories. A list of extensions can be found in [this page](https://cqcl.github.io/pytket-extensions/api/index.html).
 
 If you would like to build tket yourself and help to improve it, read on!
 

--- a/pytket/docs/examples.rst
+++ b/pytket/docs/examples.rst
@@ -1,0 +1,51 @@
+Example notebooks
+=================
+
+Here you can find notebooks showing features and example usage of pytket.
+
+Below are some links which allow pytket example notebooks to be viewed though `nbviewer <https://nbviewer.org/>`_. The notebook examples repository can also be found on `github <https://github.com/CQCL/pytket/tree/main/examples>`_ or viewed in nb viewer by clicking `here <https://nbviewer.org/github/CQCL/pytket/tree/main/examples/>`_ .
+You can also run all the examples below, and try out all pytket code (including extensions) in your browser using `Binder <https://mybinder.org/v2/gh/CQCL/pytket/main?filepath=examples>`_ .
+
+Feature Examples
+----------------
+
+These are example notebooks that demonstrate key features of the core pytket package including circuit optimisation, routing and targeting different quantum devices.
+
+* `Circuit Analysis <https://nbviewer.org/github/CQCL/pytket/blob/main/examples/circuit_analysis_example.ipynb>`_ - Basic methods of analysis and visualisation of circuits.
+
+* `Circuit Generation <https://nbviewer.org/github/CQCL/pytket/blob/main/examples/circuit_generation_example.ipynb>`_ - More advanced methods of circuit generation.
+
+* `Symbolic Circuits <https://nbviewer.org/github/CQCL/pytket/blob/main/examples/symbolics_example.ipynb>`_ - Constructing and using circuits with symbolic parameters.
+
+* `Compilation <https://nbviewer.org/github/CQCL/pytket/blob/main/examples/compilation_example.ipynb>`_ - Compilation passes and how to combine and apply them.
+
+* `Backends <https://nbviewer.org/github/CQCL/pytket/blob/main/examples/backends_example.ipynb>`_ - How to run circuits on different backends.
+
+* `Contextual Optimization <https://nbviewer.org/github/CQCL/pytket/blob/main/examples/contextual_optimization.ipynb>`_ - How to eliminate gates by taking advantage of initial state and classical postprocessing.
+
+* `Comparing Simulators <https://nbviewer.org/github/CQCL/pytket/blob/main/examples/contextual_optimization.ipynb>`_ - An overview of the differences between each of the simulators supported by pytket.
+
+* `Mapping Example <https://nbviewer.org/github/CQCL/pytket/blob/main/examples/mapping_example.ipynb>`_ - An introduction to mapping, the process of making logical circuits respect physical quantum computer architecture.
+
+* `Conditional Gates <https://nbviewer.org/github/CQCL/pytket/blob/main/examples/conditional_gate_example.ipynb>`_ - Mid-circuit measurements and classical control.
+
+* `Calculating Expectation Values <https://nbviewer.org/github/CQCL/pytket/blob/main/examples/expectation_value_example.ipynb>`_ - Computing expectation values of Hamiltonians.
+
+* `Measurement Reduction <https://nbviewer.org/github/CQCL/pytket/blob/main/examples/measurement_reduction_example.ipynb>`_ - Advanced methods for reducing the number of circuits required for measurement.
+
+* `Ansatz Sequencing <https://nbviewer.org/github/CQCL/pytket/blob/main/examples/ansatz_sequence_example.ipynb>`_ - Advanced methods for synthesising an ansatz circuit from Trotterised Hamiltonians.
+
+* `SPAM Mitigation <https://nbviewer.org/github/CQCL/pytket/blob/main/examples/spam_example.ipynb>`_ - Calibration and correction of state preparation and measurement in the presence of noise.
+
+* `Creating Backends <https://nbviewer.org/github/CQCL/pytket/blob/main/examples/creating_backends.ipynb>`_ - How to write your own pytket backend. 
+
+Application Focussed Examples
+-----------------------------
+
+* `UCC VQE example <https://nbviewer.org/github/CQCL/pytket/blob/main/examples/ucc_vqe.ipynb>`_ - Exploring features to help code an efficient implementation of the Variational Quantum Eigensolver using the Unitary Coupled Cluster method for electronic structure.
+
+* `Entanglement swapping <https://nbviewer.org/github/CQCL/pytket/blob/main/examples/entanglement_swapping.ipynb>`_ - Using tomography to analyse the effect of noise channels when iterating the Entanglement Swapping protocol.
+
+* `Forest portability example <https://nbviewer.org/github/CQCL/pytket/blob/main/examples/Forest_portability_example.ipynb>`_ - Examples illustrating portability between different backends.
+
+* `qiskit integration <https://nbviewer.org/github/CQCL/pytket/blob/main/examples/qiskit_integration.ipynb>`_ - Wrapping a pytket backend as a qiskit backend.

--- a/pytket/docs/examples.rst
+++ b/pytket/docs/examples.rst
@@ -6,6 +6,11 @@ Here you can find notebooks showing features and example usage of pytket.
 Below are some links which allow pytket example notebooks to be viewed though `nbviewer <https://nbviewer.org/>`_. The notebook examples repository can also be found on `github <https://github.com/CQCL/pytket/tree/main/examples>`_ or viewed in nb viewer by clicking `here <https://nbviewer.org/github/CQCL/pytket/tree/main/examples/>`_ .
 You can also run all the examples below, and try out all pytket code (including extensions) in your browser using `Binder <https://mybinder.org/v2/gh/CQCL/pytket/main?filepath=examples>`_ .
 
+.. note:: 
+    In order to download the notebooks from nbviewer right click the download button and click "Save Link As...".
+    
+    You can also run the notebooks by clicking the "execute on binder" button to the left of the download option in nbviewer.
+
 Feature Examples
 ----------------
 

--- a/pytket/docs/examples.rst
+++ b/pytket/docs/examples.rst
@@ -44,8 +44,8 @@ Application Focussed Examples
 
 * `UCC VQE example <https://nbviewer.org/github/CQCL/pytket/blob/main/examples/ucc_vqe.ipynb>`_ - Exploring features to help code an efficient implementation of the Variational Quantum Eigensolver using the Unitary Coupled Cluster method for electronic structure.
 
-* `Entanglement swapping <https://nbviewer.org/github/CQCL/pytket/blob/main/examples/entanglement_swapping.ipynb>`_ - Using tomography to analyse the effect of noise channels when iterating the Entanglement Swapping protocol.
+* `Entanglement Swapping <https://nbviewer.org/github/CQCL/pytket/blob/main/examples/entanglement_swapping.ipynb>`_ - Using tomography to analyse the effect of noise channels when iterating the Entanglement Swapping protocol.
 
-* `Forest portability example <https://nbviewer.org/github/CQCL/pytket/blob/main/examples/Forest_portability_example.ipynb>`_ - Examples illustrating portability between different backends.
+* `Forest Portability Example <https://nbviewer.org/github/CQCL/pytket/blob/main/examples/Forest_portability_example.ipynb>`_ - Examples illustrating portability between different backends.
 
-* `qiskit integration <https://nbviewer.org/github/CQCL/pytket/blob/main/examples/qiskit_integration.ipynb>`_ - Wrapping a pytket backend as a qiskit backend.
+* `Qiskit Integration <https://nbviewer.org/github/CQCL/pytket/blob/main/examples/qiskit_integration.ipynb>`_ - Wrapping a pytket backend as a qiskit backend.

--- a/pytket/docs/examples.rst
+++ b/pytket/docs/examples.rst
@@ -3,7 +3,7 @@ Example notebooks
 
 Here you can find notebooks showing features and example usage of pytket.
 
-Below are some links which allow pytket example notebooks to be viewed though `nbviewer <https://nbviewer.org/>`_. The notebook examples repository can also be found on `github <https://github.com/CQCL/pytket/tree/main/examples>`_ or viewed in nb viewer by clicking `here <https://nbviewer.org/github/CQCL/pytket/tree/main/examples/>`_ .
+Below are some links which allow pytket example notebooks to be viewed though `nbviewer <https://nbviewer.org/>`_. The notebook examples repository can also be found on `github <https://github.com/CQCL/pytket/tree/main/examples>`_ or viewed in nbviewer by clicking `here <https://nbviewer.org/github/CQCL/pytket/tree/main/examples/>`_ .
 You can also run all the examples below, and try out all pytket code (including extensions) in your browser using `Binder <https://mybinder.org/v2/gh/CQCL/pytket/main?filepath=examples>`_ .
 
 .. note:: 

--- a/pytket/docs/examples.rst
+++ b/pytket/docs/examples.rst
@@ -23,7 +23,7 @@ These are example notebooks that demonstrate key features of the core pytket pac
 
 * `Contextual Optimization <https://nbviewer.org/github/CQCL/pytket/blob/main/examples/contextual_optimization.ipynb>`_ - How to eliminate gates by taking advantage of initial state and classical postprocessing.
 
-* `Comparing Simulators <https://nbviewer.org/github/CQCL/pytket/blob/main/examples/contextual_optimization.ipynb>`_ - An overview of the differences between each of the simulators supported by pytket.
+* `Comparing Simulators <https://nbviewer.org/github/CQCL/pytket/blob/main/examples/comparing_simulators.ipynb>`_ - An overview of the differences between each of the simulators supported by pytket.
 
 * `Mapping Example <https://nbviewer.org/github/CQCL/pytket/blob/main/examples/mapping_example.ipynb>`_ - An introduction to mapping, the process of making logical circuits respect physical quantum computer architecture.
 

--- a/pytket/docs/examples.rst
+++ b/pytket/docs/examples.rst
@@ -47,9 +47,11 @@ These are example notebooks that demonstrate key features of the core pytket pac
 Application Focussed Examples
 -----------------------------
 
-* `UCC VQE example <https://nbviewer.org/github/CQCL/pytket/blob/main/examples/ucc_vqe.ipynb>`_ - Exploring features to help code an efficient implementation of the Variational Quantum Eigensolver using the Unitary Coupled Cluster method for electronic structure.
+* `UCC VQE Example <https://nbviewer.org/github/CQCL/pytket/blob/main/examples/ucc_vqe.ipynb>`_ - Exploring features to help code an efficient implementation of the Variational Quantum Eigensolver using the Unitary Coupled Cluster method for electronic structure.
 
-* `Heisenberg VQE exammple (pytket-qujax) <https://nbviewer.org/github/CQCL/pytket/blob/main/examples/pytket-qujax_heisenberg_vqe.ipynb>`_ - Simulating a VQE experiment with jax using the pytket-qujax extension.
+* `Heisenberg VQE Example (pytket-qujax) <https://nbviewer.org/github/CQCL/pytket/blob/main/examples/pytket-qujax_heisenberg_vqe.ipynb>`_ - Simulating a VQE experiment with jax using the pytket-qujax extension.
+
+* `Classifier Example (pytket-qujax) <https://nbviewer.org/github/CQCL/pytket/blob/main/examples/pytket-qujax-classification.ipynb>`_ - Variational classifier using pytket-qujax.
 
 * `QAOA Example (pytket-qujax) <https://nbviewer.org/github/CQCL/pytket/blob/main/examples/pytket-qujax_qaoa.ipynb>`_ - Solving the Ising model with QAOA using the pytket-qujax extension.
 

--- a/pytket/docs/examples.rst
+++ b/pytket/docs/examples.rst
@@ -49,6 +49,10 @@ Application Focussed Examples
 
 * `UCC VQE example <https://nbviewer.org/github/CQCL/pytket/blob/main/examples/ucc_vqe.ipynb>`_ - Exploring features to help code an efficient implementation of the Variational Quantum Eigensolver using the Unitary Coupled Cluster method for electronic structure.
 
+* `Heisenberg VQE exammple (pytket-qujax) <https://nbviewer.org/github/CQCL/pytket/blob/main/examples/pytket-qujax_heisenberg_vqe.ipynb>`_ - Simulating a VQE experiment with jax using the pytket-qujax extension.
+
+* `QAOA Example (pytket-qujax) https://nbviewer.org/github/CQCL/pytket/blob/main/examples/pytket-qujax_qaoa.ipynb`_ - Solving the Ising model with QAOA using the pytket-qujax extension.
+
 * `Entanglement Swapping <https://nbviewer.org/github/CQCL/pytket/blob/main/examples/entanglement_swapping.ipynb>`_ - Using tomography to analyse the effect of noise channels when iterating the Entanglement Swapping protocol.
 
 * `Forest Portability Example <https://nbviewer.org/github/CQCL/pytket/blob/main/examples/Forest_portability_example.ipynb>`_ - Examples illustrating portability between different backends.

--- a/pytket/docs/examples.rst
+++ b/pytket/docs/examples.rst
@@ -51,7 +51,7 @@ Application Focussed Examples
 
 * `Heisenberg VQE exammple (pytket-qujax) <https://nbviewer.org/github/CQCL/pytket/blob/main/examples/pytket-qujax_heisenberg_vqe.ipynb>`_ - Simulating a VQE experiment with jax using the pytket-qujax extension.
 
-* `QAOA Example (pytket-qujax) https://nbviewer.org/github/CQCL/pytket/blob/main/examples/pytket-qujax_qaoa.ipynb`_ - Solving the Ising model with QAOA using the pytket-qujax extension.
+* `QAOA Example (pytket-qujax) <https://nbviewer.org/github/CQCL/pytket/blob/main/examples/pytket-qujax_qaoa.ipynb>`_ - Solving the Ising model with QAOA using the pytket-qujax extension.
 
 * `Entanglement Swapping <https://nbviewer.org/github/CQCL/pytket/blob/main/examples/entanglement_swapping.ipynb>`_ - Using tomography to analyse the effect of noise channels when iterating the Entanglement Swapping protocol.
 

--- a/pytket/docs/getting_started.rst
+++ b/pytket/docs/getting_started.rst
@@ -20,8 +20,8 @@ those using an older version of pytket, keep up to date by installing with the
 
 There are separate packages for managing the interoperability between pytket and
 other quantum software packages which can also be installed via PyPI. For
-details of these, see the
-`pytket-extensions <https://github.com/CQCL/pytket-extensions>`_ repo.
+a list of these extensions, see the
+`extensions documentation <https://cqcl.github.io/pytket-extensions/api/index.html>`_.
 
 
 The quantum circuit is an abstraction of computation using quantum resources,

--- a/pytket/docs/index.rst
+++ b/pytket/docs/index.rst
@@ -15,7 +15,7 @@ pytket
    :align: right 
 
 ``pytket`` is a python module for interfacing with tket, a quantum computing toolkit and optimising compiler developed by `Quantinuum`_. We currently support circuits and device architectures from
-`numerous providers <https://github.com/CQCL/pytket-extensions>`_, allowing the
+`numerous providers <https://cqcl.github.io/pytket-extensions/api/index.html>`_, allowing the
 tket tools to be used in conjunction with projects on their platforms.
 
 ``pytket`` is available for Python 3.8, 3.9 and 3.10, on Linux, MacOS and

--- a/pytket/docs/index.rst
+++ b/pytket/docs/index.rst
@@ -137,7 +137,7 @@ Licensed under the `Apache 2 License <http://www.apache.org/licenses/LICENSE-2.0
     
     Manual <https://cqcl.github.io/pytket/manual/index.html>
     Extensions <https://cqcl.github.io/pytket-extensions/api/index.html>
-    Example notebooks <https://github.com/CQCL/pytket/tree/main/examples#pytket-examples>
+    Example notebooks <https://nbviewer.org/github/CQCL/pytket/tree/main/examples/>
 
 .. toctree::
     :caption: API Reference:

--- a/pytket/docs/index.rst
+++ b/pytket/docs/index.rst
@@ -137,7 +137,7 @@ Licensed under the `Apache 2 License <http://www.apache.org/licenses/LICENSE-2.0
     
     Manual <https://cqcl.github.io/pytket/manual/index.html>
     Extensions <https://cqcl.github.io/pytket-extensions/api/index.html>
-    Example notebooks <https://nbviewer.org/github/CQCL/pytket/tree/main/examples/>
+    examples.rst
 
 .. toctree::
     :caption: API Reference:

--- a/pytket/package.md
+++ b/pytket/package.md
@@ -16,7 +16,7 @@ To install the pytket extension modules add a hyphen and the extension name to t
 
 `` pip install pytket-quantinuum ``
 
-For a list of pytket extensions see this page: https://cqcl.github.io/pytket-extensions/api/index.html.
+For a list of pytket extensions modules see this page: https://cqcl.github.io/pytket-extensions/api/index.html.
 
 ## Documentation and Examples
 


### PR DESCRIPTION

I created an examples.html documentation page with the links to the various examples which can be viewed through the nbviewer.

This will allow the notebooks to be downloaded but the notebooks themselves will not be executed (this requires binder which takes ages to build for the pytket examples).

This is a small change but seems minimally invasive for now and will not require conversion to .rst files or refactoring of our examples repository.

There is a download option available but it seems that you have to right click on the download button and click "save as" for it to work properly. I haven't figured out why this is the case but it seems to be addressed in this issue.

https://github.com/jupyter/nbviewer/issues/756