### PR TITLE
Add utility classes for empirical and probability distributions

### DIFF
--- a/pytket/docs/changelog.rst
+++ b/pytket/docs/changelog.rst
@@ -18,6 +18,9 @@ Minor new features:
   ``CU3``, ``ISWAP``, ``PhasedISWAP``, ``ESWAP``, ``PhasedX``, ``FSim``, ``Sycamore``
   and ``ISWAPMax`` gates to a ``pytket`` ``Circuit``.
 * New ``Circuit`` methods ``n_1qb_gates``, ``n_2qb_gates``, ``n_nqb_gates``.
+* New ``EmpriricalDistribution`` and ``ProbabilityDistribution`` utility classes
+  for manipulating distributions, and methods to extract them from
+  ``BackendResult`` objects.
 
 1.8.1 (November 2022)
 ---------------------

--- a/pytket/docs/utils.rst
+++ b/pytket/docs/utils.rst
@@ -15,6 +15,18 @@ pytket.utils
     :special-members: __init__
     :members:
 
+pytket.utils.distribution
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. automodule:: pytket.utils.distribution
+
+.. autoclass:: pytket.utils.distribution.EmpiricalDistribution
+    :special-members: __eq__, __getitem__, __add__
+    :members:
+
+.. autoclass:: pytket.utils.distribution.ProbabilityDistribution
+    :special-members: _eq__, __getitem__, __add__, __mul__
+    :members:
+
 pytket.utils.spam
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 .. automodule:: pytket.utils.spam

--- a/pytket/docs/utils.rst
+++ b/pytket/docs/utils.rst
@@ -17,8 +17,6 @@ pytket.utils
 
 pytket.utils.distribution
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-.. automodule:: pytket.utils.distribution
-
 .. autoclass:: pytket.utils.distribution.EmpiricalDistribution
     :special-members: __eq__, __getitem__, __add__
     :members:
@@ -26,6 +24,9 @@ pytket.utils.distribution
 .. autoclass:: pytket.utils.distribution.ProbabilityDistribution
     :special-members: _eq__, __getitem__, __add__, __mul__
     :members:
+
+.. automodule:: pytket.utils.distribution
+    :members: convex_combination
 
 pytket.utils.spam
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/pytket/pytket/backends/backendresult.py
+++ b/pytket/pytket/backends/backendresult.py
@@ -30,6 +30,7 @@ from typing import (
 )
 import operator
 from functools import reduce
+import warnings
 
 import numpy as np
 
@@ -42,6 +43,7 @@ from pytket.circuit import (  # type: ignore
     _DEBUG_ZERO_REG_PREFIX,
     _DEBUG_ONE_REG_PREFIX,
 )
+from pytket.utils.distribution import EmpiricalDistribution, ProbabilityDistribution
 from pytket.utils.results import (
     probs_from_state,
     get_n_qb_from_statevector,
@@ -514,12 +516,21 @@ class BackendResult:
         returned. Otherwise, if measured results are available the distribution
         is estimated from these results.
 
+        This method is deprecated. Please use :py:meth:`get_empirical_distribution` or
+        :py:meth:`get_probability_distribution` instead.
+
         :param units: Optionally provide the Qubits or Bits
             to marginalise the distribution over, defaults to None
         :type units: Optional[Sequence[UnitID]], optional
         :return: A distribution as a map from bitstring to probability.
         :rtype: Dict[Tuple[int, ...], float]
         """
+        warnings.warn(
+            "The `BackendResult.get_distribution()` method is deprecated: "
+            "please use `get_empirical_distribution()` or "
+            "`get_probability_distribution()` instead.",
+            DeprecationWarning,
+        )
         try:
             state = self.get_state(units)
             return probs_from_state(state)
@@ -528,6 +539,39 @@ class BackendResult:
             total = sum(counts.values())
             dist = {outcome: count / total for outcome, count in counts.items()}
             return dist
+
+    def get_empirical_distribution(
+        self, bits: Optional[Sequence[Bit]] = None
+    ) -> EmpiricalDistribution:
+        """Convert to a :py:class:`pytket.utils.distribution.EmpiricalDistribution`
+        where the observations are sequences of 0s and 1s.
+
+        :param bits: Optionally provide the :py:class:`Bit` s over which to
+            marginalize the distribution.
+        :return: A distribution where the observations are sequences of 0s and 1s.
+        """
+        if not self.contains_measured_results:
+            raise InvalidResultType(
+                "Empirical distribution only available for measured result types."
+            )
+        return EmpiricalDistribution(self.get_counts(bits))
+
+    def get_probability_distribution(
+        self, qubits: Optional[Sequence[Qubit]] = None
+    ) -> ProbabilityDistribution:
+        """Convert to a :py:class:`pytket.utils.distribution.ProbabilityDistribution`
+        where the possible outcomes are sequences of 0s and 1s.
+
+        :param qubits: Optionally provide the :py:class:`Qubit` s over which to
+            marginalize the distribution.
+        :return: A distribution where the possible outcomes are tuples of 0s and 1s.
+        """
+        if not self.contains_state_results:
+            raise InvalidResultType(
+                "Probability distribution only available for statevector result types."
+            )
+        state = self.get_state(qubits)
+        return ProbabilityDistribution(probs_from_state(state))
 
     def get_debug_info(self) -> Dict[str, float]:
         """Calculate the success rate of each assertion averaged across shots.

--- a/pytket/pytket/backends/backendresult.py
+++ b/pytket/pytket/backends/backendresult.py
@@ -542,7 +542,7 @@ class BackendResult:
 
     def get_empirical_distribution(
         self, bits: Optional[Sequence[Bit]] = None
-    ) -> EmpiricalDistribution:
+    ) -> EmpiricalDistribution[Tuple[int, ...]]:
         """Convert to a :py:class:`pytket.utils.distribution.EmpiricalDistribution`
         where the observations are sequences of 0s and 1s.
 
@@ -558,7 +558,7 @@ class BackendResult:
 
     def get_probability_distribution(
         self, qubits: Optional[Sequence[Qubit]] = None
-    ) -> ProbabilityDistribution:
+    ) -> ProbabilityDistribution[Tuple[int, ...]]:
         """Convert to a :py:class:`pytket.utils.distribution.ProbabilityDistribution`
         where the possible outcomes are sequences of 0s and 1s.
 

--- a/pytket/pytket/utils/__init__.py
+++ b/pytket/pytket/utils/__init__.py
@@ -37,3 +37,4 @@ from .operators import QubitPauliOperator
 from .outcomearray import OutcomeArray, readout_counts
 from .graph import Graph
 from .symbolic import circuit_to_symbolic_unitary, circuit_apply_symbolic_statevector
+from .distribution import ProbabilityDistribution, EmpiricalDistribution

--- a/pytket/pytket/utils/__init__.py
+++ b/pytket/pytket/utils/__init__.py
@@ -37,4 +37,8 @@ from .operators import QubitPauliOperator
 from .outcomearray import OutcomeArray, readout_counts
 from .graph import Graph
 from .symbolic import circuit_to_symbolic_unitary, circuit_apply_symbolic_statevector
-from .distribution import ProbabilityDistribution, EmpiricalDistribution
+from .distribution import (
+    ProbabilityDistribution,
+    EmpiricalDistribution,
+    convex_combination,
+)

--- a/pytket/pytket/utils/distribution.py
+++ b/pytket/pytket/utils/distribution.py
@@ -24,8 +24,10 @@ class EmpiricalDistribution:
 
     Supports methods for combination, marginalization, expectation value, etc.
 
-    >>> dist1 = EmpiricalDistribution(Counter({(0, 0): 3, (0, 1): 2, (1, 0): 4, (1, 1): 0}))
-    >>> dist2 = EmpiricalDistribution(Counter({(0, 0): 1, (0, 1): 0, (1, 0): 2, (1, 1): 1}))
+    >>> dist1 = EmpiricalDistribution(Counter({(0, 0): 3, (0, 1): 2, (1, 0): 4, (1, 1):
+    ... 0}))
+    >>> dist2 = EmpiricalDistribution(Counter({(0, 0): 1, (0, 1): 0, (1, 0): 2, (1, 1):
+    ... 1}))
     >>> dist1.sample_mean(lambda x : x[0] + 2*x[1])
     0.8888888888888888
     >>> dist3 = dist2.condition(lambda x: x[0] == 1)
@@ -113,7 +115,8 @@ class EmpiricalDistribution:
             observations."""
         if self.total < 2:
             raise RuntimeError(
-                "At least two samples are required in order to compute the sample variance."
+                "At least two samples are required in order to compute the sample "
+                "variance."
             )
         fs = [(f(x), c) for x, c in self._C.items()]
         M0 = self.total

--- a/pytket/pytket/utils/distribution.py
+++ b/pytket/pytket/utils/distribution.py
@@ -66,7 +66,7 @@ class EmpiricalDistribution(Generic[T0]):
         return sum(self._C.values())  # Counter.total() new in 3.10
 
     @property
-    def support(self) -> Set:
+    def support(self) -> Set[T0]:
         """Return the support of the distribution (set of all observations)."""
         return set(self._C.keys())
 
@@ -165,7 +165,7 @@ class ProbabilityDistribution(Generic[T0]):
         """Return the distribution as a :py:class:`dict` object."""
         return self._P
 
-    def as_rv_discrete(self) -> Tuple[rv_discrete, List]:
+    def as_rv_discrete(self) -> Tuple[rv_discrete, List[T0]]:
         """Return the distribution as a :py:class:`scipy.stats.rv_discrete` object.
 
         This method returns an RV over integers {0, 1, ..., k-1} where k is the size of
@@ -273,7 +273,7 @@ def convex_combination(
     >>> dist3.expectation(lambda x : x**2)
     0.75
     """
-    P: DefaultDict[Any, float] = defaultdict(float)
+    P: DefaultDict[T0, float] = defaultdict(float)
     S = 0.0
     for pd, a in dists:
         if a < 0:

--- a/pytket/pytket/utils/distribution.py
+++ b/pytket/pytket/utils/distribution.py
@@ -156,7 +156,7 @@ class ProbabilityDistribution(Generic[OT]):
         """
         if any(x < 0 for x in P.values()):
             raise ValueError("Distribution contains negative probabilities")
-        S = sum(P.values())
+        S = sum(p for p in P.values() if not np.isclose(p, 0))
         if not np.isclose(S, 1):
             raise ValueError("Probabilities do not sum to 1")
         self._P: Dict[OT, float] = {x: p for x, p in P.items() if not np.isclose(p, 0)}

--- a/pytket/pytket/utils/distribution.py
+++ b/pytket/pytket/utils/distribution.py
@@ -15,6 +15,7 @@
 from collections import Counter, defaultdict
 from typing import cast, Any, Callable, DefaultDict, Dict, List, Set, Tuple, Union
 import numpy as np
+from scipy.stats import rv_discrete  # type: ignore
 
 Number = Union[float, complex]
 
@@ -147,6 +148,16 @@ class ProbabilityDistribution:
     def as_dict(self) -> Dict[Any, float]:
         """Return the distribution as a :py:class:`dict` object."""
         return self._P
+
+    def as_rv_discrete(self) -> Tuple[rv_discrete, List]:
+        """Return the distribution as a :py:class:`scipy.stats.rv_discrete` object.
+
+        This method returns an RV over integers {0, 1, ..., k-1} where k is the size of
+        the support, and a list whose i'th member is the item corresponding to the value
+        i of the RV.
+        """
+        X = list(self._P.keys())
+        return (rv_discrete(values=(range(len(X)), [self._P[x] for x in X])), X)
 
     @property
     def support(self) -> Set:

--- a/pytket/pytket/utils/distribution.py
+++ b/pytket/pytket/utils/distribution.py
@@ -152,7 +152,7 @@ class ProbabilityDistribution(Generic[OT]):
     def __init__(self, P: Dict[OT, float]):
         """Initialize with a dictionary of probabilities.
 
-        The values must be non-negative and add up to at most 1.
+        The values must be non-negative and add up to 1.
         """
         if any(x < 0 for x in P.values()):
             raise ValueError("Distribution contains negative probabilities")

--- a/pytket/pytket/utils/distribution.py
+++ b/pytket/pytket/utils/distribution.py
@@ -154,12 +154,11 @@ class ProbabilityDistribution(Generic[T0]):
 
         The values must be non-negative and add up to 1.
         """
-        if any(x < 0 for x in P.values()):
+        self._P = {x: p for x, p in P.items() if not np.isclose(p, 0)}
+        if any(x < 0 for x in self._P.values()):
             raise ValueError("Distribution contains negative probabilities")
-        S = sum(p for p in P.values() if not np.isclose(p, 0))
-        if not np.isclose(S, 1):
+        if not np.isclose(sum(self._P.values()), 1):
             raise ValueError("Probabilities do not sum to 1")
-        self._P: Dict[T0, float] = {x: p for x, p in P.items() if not np.isclose(p, 0)}
 
     def as_dict(self) -> Dict[T0, float]:
         """Return the distribution as a :py:class:`dict` object."""

--- a/pytket/tests/backend_test.py
+++ b/pytket/tests/backend_test.py
@@ -329,14 +329,30 @@ def test_backendresult() -> None:
 
     assert np.array_equal(backres_unitary.get_state(), teststate)
 
-    shots_dist = backres_shots.get_distribution()
-    assert len(shots_dist) == 2
-    assert shots_dist[tuple(shots_list[0])] == 0.5
-    assert shots_dist[tuple(shots_list[1])] == 0.5
+    with pytest.deprecated_call():
+        shots_dist0 = backres_shots.get_distribution()
+        assert len(shots_dist0) == 2
+        assert shots_dist0[tuple(shots_list[0])] == 0.5
+        assert shots_dist0[tuple(shots_list[1])] == 0.5
 
-    state_dist = backres_state.get_distribution([qbits[1], qbits[0]])
+        state_dist0 = backres_state.get_distribution([qbits[1], qbits[0]])
+        assert np.isclose(state_dist0[(0, 1)], abs(teststate[2]) ** 2)
+        assert np.isclose(state_dist0[(1, 0)], abs(teststate[1]) ** 2)
+
+    shots_dist = backres_shots.get_empirical_distribution()
+    assert len(shots_dist.support) == 2
+    assert shots_dist[tuple(shots_list[0])] == 1
+    assert shots_dist[tuple(shots_list[1])] == 1
+
+    with pytest.raises(InvalidResultType):
+        backres_shots.get_probability_distribution()
+
+    state_dist = backres_state.get_probability_distribution([qbits[1], qbits[0]])
     assert np.isclose(state_dist[(0, 1)], abs(teststate[2]) ** 2)
     assert np.isclose(state_dist[(1, 0)], abs(teststate[1]) ** 2)
+
+    with pytest.raises(InvalidResultType):
+        backres_state.get_empirical_distribution()
 
 
 def test_backendresult_ppcirc() -> None:

--- a/pytket/tests/distribution_test.py
+++ b/pytket/tests/distribution_test.py
@@ -49,7 +49,7 @@ def test_empirical_distribution() -> None:
     ed4 = ed1 + ed2 + ed3
     assert ed4 == EmpiricalDistribution(Counter({"a": 3, "b": 3, "c": 3, "e": 4}))
 
-    ed0 = EmpiricalDistribution(Counter())
+    ed0: EmpiricalDistribution[str] = EmpiricalDistribution(Counter())
     with pytest.raises(ValueError):
         pd6 = ProbabilityDistribution.from_empirical_distribution(ed0)
     pd6 = ProbabilityDistribution.from_empirical_distribution(ed4)

--- a/pytket/tests/distribution_test.py
+++ b/pytket/tests/distribution_test.py
@@ -1,0 +1,105 @@
+# Copyright 2019-2022 Cambridge Quantum Computing
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from collections import Counter
+from typing import cast
+from numpy import isclose
+from pytket.utils import ProbabilityDistribution, EmpiricalDistribution
+import pytest
+
+
+def test_distribution() -> None:
+    pd = ProbabilityDistribution({"a": 1 / 3, "b": 2 / 3})
+    with pytest.raises(ValueError):
+        pd = ProbabilityDistribution({"a": 1 / 3, "b": 1, "c": -1 / 3})
+    pd1 = ProbabilityDistribution({"a": 1 / 3, "b": 2 / 3 - 1e-15, "c": 1e-15})
+    assert pd1.support == set(["a", "b"])
+    assert isclose(pd1["a"], 1 / 3)
+    assert pd1["c"] == 0.0
+    assert pd == pd1
+    with pytest.raises(ValueError):
+        pd2 = ProbabilityDistribution({"a": 2 / 3, "b": 4 / 3})
+    pd2 = ProbabilityDistribution({"a": 1 / 6, "b": 1 / 3})
+    assert pd == pd2
+    pd3 = ProbabilityDistribution({"a": 1 / 12, "b": 1 / 6, "c": 1 / 8})
+    pd4 = pd2 + pd3
+    assert pd4 == ProbabilityDistribution({"a": 0.2, "b": 0.4, "c": 0.1})
+    pd2.normalize()  # a:1/3, b:2/3
+    pd3.normalize()  # a:2/9, b:4/9, c:1/3
+    pd4 = (1 / 3) * pd2 + (2 / 3) * pd3
+    assert pd4 == ProbabilityDistribution({"a": 7 / 27, "b": 14 / 27, "c": 2 / 9})
+    pd5 = pd3 * (2 / 3) + pd2 * (1 / 3)
+    assert pd4 == pd5
+
+    ed1 = EmpiricalDistribution(Counter({"a": 1, "b": 2}))
+    ed2 = EmpiricalDistribution(Counter({"b": 1, "c": 3, "d": 0}))
+    assert ed2.support == set(["b", "c"])
+    assert ed2["b"] == 1
+    assert ed2["d"] == 0
+    ed3 = EmpiricalDistribution(Counter({"a": 2, "c": 0, "e": 4}))
+    ed4 = ed1 + ed2 + ed3
+    assert ed4 == EmpiricalDistribution(Counter({"a": 3, "b": 3, "c": 3, "e": 4}))
+
+    ed0 = EmpiricalDistribution(Counter())
+    with pytest.raises(ValueError):
+        pd6 = ProbabilityDistribution.from_empirical_distribution(ed0)
+    pd6 = ProbabilityDistribution.from_empirical_distribution(ed4)
+    assert pd6.is_normalized
+    assert isclose(pd6.as_dict()["a"], ed4.as_counter()["a"] / ed4.total)
+
+
+def test_marginalization() -> None:
+    ed = EmpiricalDistribution(Counter({(0, 0): 3, (0, 1): 2, (1, 0): 4, (1, 1): 0}))
+    ed0_ = ed.condition(lambda x: cast(bool, x[0] == 0))
+    ed1_ = ed.condition(lambda x: cast(bool, x[0] == 1))
+    ed_0 = ed.condition(lambda x: cast(bool, x[1] == 0))
+    ed_1 = ed.condition(lambda x: cast(bool, x[1] == 1))
+    assert ed0_.total == 5
+    assert ed1_.total == 4
+    assert ed_0.total == 7
+    assert ed_1.total == 2
+
+    pd = ProbabilityDistribution.from_empirical_distribution(ed)
+    pd0 = pd.condition(lambda x: cast(bool, x[0] == x[1]))
+    pd1 = pd.condition(lambda x: cast(bool, x[0] != x[1]))
+    assert isclose(pd0.weight + pd1.weight, 1)
+
+
+def test_representation() -> None:
+    ed = EmpiricalDistribution(Counter({"a": 1, "b": 3, 7: 0, (1, 1): 3}))
+    assert ed == eval(repr(ed))
+
+    pd = ProbabilityDistribution({"a": 1 / 3, "b": 1 / 7, 7: 0, (1, 1): 1 / 2})
+    assert pd == eval(repr(pd))
+
+
+def test_mapping() -> None:
+    ed = EmpiricalDistribution(Counter({(0, 0): 3, (0, 1): 2, (1, 0): 4, (1, 1): 0}))
+    ed0 = ed.map(lambda x: x[0])
+    ed1 = ed.map(lambda x: x[1])
+    assert ed0 == EmpiricalDistribution(Counter({0: 5, 1: 4}))
+    assert ed1 == EmpiricalDistribution(Counter({0: 7, 1: 2}))
+
+    pd = ProbabilityDistribution({(0, 0): 0.3, (0, 1): 0.2, (1, 0): 0.4, (1, 1): 0.0})
+    pd0 = pd.map(lambda x: sum(x))
+    assert pd0 == ProbabilityDistribution({0: 0.3, 1: 0.6})
+
+
+def test_expectation_and_variance() -> None:
+    ed = EmpiricalDistribution(Counter({(0, 0): 3, (0, 1): 2, (1, 0): 4, (1, 1): 0}))
+    assert isclose(ed.sample_mean(sum), 2 / 3)
+    assert isclose(ed.sample_variance(sum), 1 / 4)
+    pd = ProbabilityDistribution.from_empirical_distribution(ed)
+    assert isclose(pd.expectation(sum), 2 / 3)
+    assert isclose(pd.variance(sum), 2 / 9)

--- a/pytket/tests/distribution_test.py
+++ b/pytket/tests/distribution_test.py
@@ -53,6 +53,10 @@ def test_distribution() -> None:
     pd6 = ProbabilityDistribution.from_empirical_distribution(ed4)
     assert isclose(pd6.as_dict()["a"], ed4.as_counter()["a"] / ed4.total)
 
+    rv, X = pd6.as_rv_discrete()
+    for i, x in enumerate(X):
+        assert isclose(pd6[x], rv.pmf(i))
+
 
 def test_marginalization() -> None:
     ed = EmpiricalDistribution(Counter({(0, 0): 3, (0, 1): 2, (1, 0): 4, (1, 1): 0}))

--- a/pytket/tests/distribution_test.py
+++ b/pytket/tests/distribution_test.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 from collections import Counter
-from typing import cast
 from numpy import isclose
 from pytket.utils import (
     ProbabilityDistribution,
@@ -62,18 +61,18 @@ def test_empirical_distribution() -> None:
 
 def test_marginalization() -> None:
     ed = EmpiricalDistribution(Counter({(0, 0): 3, (0, 1): 2, (1, 0): 4, (1, 1): 0}))
-    ed0_ = ed.condition(lambda x: cast(bool, x[0] == 0))
-    ed1_ = ed.condition(lambda x: cast(bool, x[0] == 1))
-    ed_0 = ed.condition(lambda x: cast(bool, x[1] == 0))
-    ed_1 = ed.condition(lambda x: cast(bool, x[1] == 1))
+    ed0_ = ed.condition(lambda x: x[0] == 0)
+    ed1_ = ed.condition(lambda x: x[0] == 1)
+    ed_0 = ed.condition(lambda x: x[1] == 0)
+    ed_1 = ed.condition(lambda x: x[1] == 1)
     assert ed0_.total == 5
     assert ed1_.total == 4
     assert ed_0.total == 7
     assert ed_1.total == 2
 
     pd = ProbabilityDistribution.from_empirical_distribution(ed)
-    pd0 = pd.condition(lambda x: cast(bool, x[0] == x[1]))
-    pd1 = pd.condition(lambda x: cast(bool, x[0] != x[1]))
+    pd0 = pd.condition(lambda x: x[0] == x[1])
+    pd1 = pd.condition(lambda x: x[0] != x[1])
     assert pd0.support == set([(0, 0)])
     assert isclose(pd1[(0, 1)], 1 / 3)
 

--- a/pytket/tests/distribution_test.py
+++ b/pytket/tests/distribution_test.py
@@ -23,7 +23,7 @@ from pytket.utils import (
 import pytest
 
 
-def test_distribution() -> None:
+def test_probability_distribution() -> None:
     pd = ProbabilityDistribution({"a": 1 / 3, "b": 2 / 3})
     with pytest.raises(ValueError):
         pd = ProbabilityDistribution({"a": 1 / 3, "b": 1, "c": -1 / 3})
@@ -38,6 +38,8 @@ def test_distribution() -> None:
     pd4 = convex_combination([(pd, 1 / 3), (pd3, 2 / 3)])
     assert pd4 == ProbabilityDistribution({"a": 7 / 27, "b": 14 / 27, "c": 2 / 9})
 
+
+def test_empirical_distribution() -> None:
     ed1 = EmpiricalDistribution(Counter({"a": 1, "b": 2}))
     ed2 = EmpiricalDistribution(Counter({"b": 1, "c": 3, "d": 0}))
     assert ed2.support == set(["b", "c"])


### PR DESCRIPTION
@rossduncan I am adding you as a reviewer since this was mainly your request. Please let me know if you think there is essential functionality I have missed (sampling? Shannon entropy?... this sort of thing can be added if needed) -- or if I have struck the wrong level of abstraction.

Distributions can be derived from `BackendResult` objects, but you can't go back the other way. This didn't make much sense to me, since they are essentially more abstract structures and can be manipulated in ways that make reversal meaningless. Was there a concrete use case for this?