### PR TITLE
Run doctests

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -200,18 +200,23 @@ jobs:
       run: |
         cd pytket
         pip install -e . -v
+    - name: Run doctests
+      run: |
+        cd pytket
+        pip install pytest
+        pytest --doctest-modules pytket
     - name: Test pytket with coverage
       if: matrix.os == 'ubuntu-22.04' && matrix.pyver == '3.8'
       run: |
         cd pytket/tests
         pip install -r requirements.txt
-        pytest --ignore=simulator/ --doctest-modules --hypothesis-seed=1 --cov=../pytket --cov-branch --cov-report=html --cov-report=xml:htmlcov/cov.xml
+        pytest --ignore=simulator/ --hypothesis-seed=1 --cov=../pytket --cov-branch --cov-report=html --cov-report=xml:htmlcov/cov.xml
     - name: Test pytket
       if: matrix.os != 'ubuntu-22.04' || matrix.pyver != '3.8'
       run: |
         cd pytket/tests
         pip install -r requirements.txt
-        pytest --ignore=simulator/ --doctest-modules
+        pytest --ignore=simulator/
     - name: Test building docs
       if: matrix.os == 'ubuntu-22.04' && matrix.pyver == '3.9' && github.event_name == 'pull_request'
       timeout-minutes: 20
@@ -276,9 +281,11 @@ jobs:
       run: |
         eval "$(pyenv init -)"
         pyenv shell tket-3.8
-        cd pytket/tests
+        cd pytket
+        pytest --doctest-modules pytket
+        cd tests
         pip install -r requirements.txt
-        pytest --ignore=simulator/ --doctest-modules
+        pytest --ignore=simulator/
     - name: Build pytket (3.9)
       if: github.event_name == 'pull_request'
       run: |
@@ -293,9 +300,11 @@ jobs:
       run: |
         eval "$(pyenv init -)"
         pyenv shell tket-3.9
-        cd pytket/tests
+        cd pytket
+        pytest --doctest-modules pytket
+        cd tests
         pip install -r requirements.txt
-        pytest --ignore=simulator/ --doctest-modules
+        pytest --ignore=simulator/
     - name: Build pytket (3.10)
       if: github.event_name == 'schedule'
       run: |
@@ -310,9 +319,11 @@ jobs:
       run: |
         eval "$(pyenv init -)"
         pyenv shell tket-3.10
-        cd pytket/tests
+        cd pytket
+        pytest --doctest-modules pytket
+        cd tests
         pip install -r requirements.txt
-        pytest --ignore=simulator/ --doctest-modules
+        pytest --ignore=simulator/
     - name: Upload package
       if: github.event_name == 'push' && github.ref == 'refs/heads/develop' && needs.check_changes.outputs.tket_changed == 'true'
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -202,7 +202,7 @@ jobs:
           cd tket/pytket/tests
           pip install -r requirements.txt
       - name: Run tests
-        run: cd tket/pytket/tests && pytest --ignore=simulator/ --doctest-modules
+        run: cd tket/pytket/tests && pytest --ignore=simulator/
 
   test_macos_wheels:
     name: Test macos wheels
@@ -232,7 +232,7 @@ jobs:
       run: |
         cd tket/pytket/tests
         pip install -r requirements.txt
-        pytest --ignore=simulator/ --doctest-modules
+        pytest --ignore=simulator/
 
   test_macos_M1_wheels:
     name: Test macos (M1) wheels
@@ -265,7 +265,7 @@ jobs:
         pyenv shell tket-${{ matrix.python-version }}
         cd pytket/tests
         pip install -r requirements.txt
-        pytest --ignore=simulator/ --doctest-modules
+        pytest --ignore=simulator/
 
   test_Windows_wheels:
     name: Test Windows wheels
@@ -295,7 +295,7 @@ jobs:
         pip install pytest hypothesis
         cd tket/pytket/tests
         pip install -r requirements.txt
-        pytest --ignore=simulator/ --doctest-modules
+        pytest --ignore=simulator/
 
   publish_to_pypi:
     name: Publish to pypi

--- a/pytket/pytket/utils/results.py
+++ b/pytket/pytket/utils/results.py
@@ -228,6 +228,14 @@ def permute_qubits_in_statevector(
 ) -> np.ndarray:
     """Rearranges a statevector according to a permutation of the qubit indices.
 
+    >>> # A 3-qubit state:
+    >>> state = np.array([0.0, 0.0625, 0.1875, 0.25, 0.375, 0.4375, 0.5, 0.5625])
+    >>> permutation = [1, 0, 2] # swap qubits 0 and 1
+    >>> # Apply the permutation that swaps indices 2 (="010") and 4 (="100"), and swaps
+    >>> # indices 3 (="011") and 5 (="101"):
+    >>> permute_qubits_in_statevector(state, permutation)
+    array([0.    , 0.0625, 0.375 , 0.4375, 0.1875, 0.25  , 0.5   , 0.5625])
+
     :param state: Original statevector.
     :type state: np.ndarray
     :param permutation: Map from current qubit index (big-endian) to its new position,


### PR DESCRIPTION
Although we already pass the `--doctest-modules` to pytest on the CI, no doctests are run because it is executed from the `tests` directory. We have to execute from there in order to find certain files used by the tests, so (rather than modify a lot of test code), I just added a separate step to run the doctests from the `pytket` directory.

In fact, there were no existing doctests. I added one (to show the idea). I think we should add a lot more of these. Not only do they test the code, but they improve the API documentation by giving short examples showing how the methods and classes are used:
![Screenshot from 2022-11-10 15-18-39](https://user-images.githubusercontent.com/54802828/201134127-b4ed3045-95eb-47bb-b875-45ed01df0add.png)
