### PR TITLE
Update `MappingFrontier::add_swap` to only edit struct attributes after any break conditions are passed

### DIFF
--- a/pytket/conanfile.txt
+++ b/pytket/conanfile.txt
@@ -1,5 +1,5 @@
 [requires]
-tket/1.0.30@tket/stable
+tket/1.0.31@tket/stable
 tklog/0.1.2@tket/stable
 pybind11/2.10.1
 nlohmann_json/3.11.2

--- a/pytket/docs/changelog.rst
+++ b/pytket/docs/changelog.rst
@@ -11,6 +11,8 @@ Fixes:
   relies on the circuit having gates only in the specified gate set should be
   updated to handle ``OpType.Phase`` as well when conditional operations are
   present.
+* A bug where the sequence of ``RoutingMethod`` used in ``DefaultMappingPass`` could 
+  add a cycle to the ``Circuit`` DAG has been fixed.
 
 API changes:
 

--- a/recipes/tket-proptests/conanfile.py
+++ b/recipes/tket-proptests/conanfile.py
@@ -28,7 +28,7 @@ class TketProptestsConan(ConanFile):
     generators = "cmake"
     exports_sources = "../../tket/proptests/*"
     requires = (
-        "tket/1.0.30@tket/stable",
+        "tket/1.0.31@tket/stable",
         "rapidcheck/cci.20220514",
     )
 

--- a/recipes/tket-tests/conanfile.py
+++ b/recipes/tket-tests/conanfile.py
@@ -34,7 +34,7 @@ class TketTestsConan(ConanFile):
     default_options = {"with_coverage": False, "full": False, "long": False}
     generators = "cmake"
     exports_sources = "../../tket/tests/*"
-    requires = ("tket/1.0.30@tket/stable", "catch2/3.2.0")
+    requires = ("tket/1.0.31@tket/stable", "catch2/3.2.0")
 
     _cmake = None
 

--- a/recipes/tket/conanfile.py
+++ b/recipes/tket/conanfile.py
@@ -20,7 +20,7 @@ import shutil
 
 class TketConan(ConanFile):
     name = "tket"
-    version = "1.0.30"
+    version = "1.0.31"
     license = "CQC Proprietary"
     homepage = "https://github.com/CQCL/tket"
     url = "https://github.com/conan-io/conan-center-index"

--- a/tket/src/Mapping/LexiRoute.cpp
+++ b/tket/src/Mapping/LexiRoute.cpp
@@ -719,7 +719,7 @@ bool LexiRoute::solve(unsigned lookahead) {
         auto path_it_0 = path.begin() + 1;
         auto path_it_1 = path.begin();
         // adds a SWAP between each pair of adjacent nodes on path
-        while (path_it_0 != path.end()) {
+        while (path_it_0 != path.end() - 1) {
           this->mapping_frontier_->add_swap(*path_it_0, *path_it_1);
           ++path_it_0;
           ++path_it_1;

--- a/tket/src/Mapping/LexiRoute.cpp
+++ b/tket/src/Mapping/LexiRoute.cpp
@@ -154,26 +154,8 @@ void LexiRoute::assign_valid_node(
       this->mapping_frontier_->ancilla_nodes_.end()) {
     // merge_ancilla updates bimaps
     this->mapping_frontier_->merge_ancilla(assignee, replacement);
-    this->mapping_frontier_->ancilla_nodes_.erase(Node(replacement));
     this->labelling_.erase(replacement);
     this->labelling_[assignee] = replacement;
-
-    // update linear boundaries
-    auto assignee_boundary_it =
-        this->mapping_frontier_->linear_boundary->get<TagKey>().find(assignee);
-    auto replacement_boundary_it =
-        this->mapping_frontier_->linear_boundary->get<TagKey>().find(
-            replacement);
-    TKET_ASSERT(
-        replacement_boundary_it !=
-        this->mapping_frontier_->linear_boundary->get<TagKey>().end());
-    TKET_ASSERT(
-        assignee_boundary_it !=
-        this->mapping_frontier_->linear_boundary->get<TagKey>().end());
-    this->mapping_frontier_->linear_boundary->replace(
-        replacement_boundary_it, {replacement, assignee_boundary_it->second});
-    this->mapping_frontier_->linear_boundary->erase(assignee_boundary_it);
-    this->assigned_nodes_.insert(Node(replacement));
   } else {
     // In this case, we the replacement Node is unused and can simply be
     // assigned

--- a/tket/src/Mapping/MappingFrontier.cpp
+++ b/tket/src/Mapping/MappingFrontier.cpp
@@ -627,7 +627,6 @@ bool MappingFrontier::add_swap(const UnitID& uid_0, const UnitID& uid_1) {
     this->ancilla_nodes_.insert(n0);
   }
 
-
   // add SWAP vertex to circuit_ and rewire into predecessor
   Vertex swap_v = this->circuit_.add_vertex(OpType::SWAP);
   this->circuit_.rewire(
@@ -732,11 +731,13 @@ void MappingFrontier::add_ancilla(const UnitID& ancilla) {
 void MappingFrontier::merge_ancilla(
     const UnitID& merge, const UnitID& ancilla) {
   // "front" meaning causally ahead
+  // ancilla front, merge back
   auto rewire = [&](const UnitID& front, const UnitID& back) {
     // get output and input vertices
     Vertex back_v_in = this->circuit_.get_in(back);
     Vertex back_v_out = this->circuit_.get_out(back);
     Vertex front_v_out = this->circuit_.get_out(front);
+
     // find source vertex & port of merge_v_out
     // output vertex, so can assume single edge
     Edge back_out_edge = this->circuit_.get_nth_out_edge(back_v_in, 0);
@@ -747,12 +748,29 @@ void MappingFrontier::merge_ancilla(
     // Find vertices
     Vertex back_v_target = this->circuit_.target(back_out_edge);
     Vertex front_v_source = this->circuit_.source(front_in_edge);
+
+    /**
+     * front_v_in -- [.... -- front_v_source] -- front_v_out
+     *               [......................]
+     * back_v_in  -- [back_v_target -- .....] -- back_v_out
+     */
     // remove and replace edges
     this->circuit_.remove_edge(back_out_edge);
     this->circuit_.remove_edge(front_in_edge);
+    /**
+     * front_v_in -- [.... -- front_v_source] XX front_v_out
+     *               [......................]
+     * back_v_in  XX [back_v_target -- .....] -- back_v_out
+     */
     this->circuit_.add_edge(
         {front_v_source, front_source_port}, {back_v_target, back_target_port},
         EdgeType::Quantum);
+    /**
+     * front_v_in -- [.... -- front_v_source]- XX front_v_out
+     *               [......................] \
+     * back_v_in  XX                           -[back_v_target -- ....] --
+     * back_v_out
+     */
 
     // instead of manually updating all boundaries, we change which output
     // vertex the qubit paths to
@@ -761,19 +779,38 @@ void MappingFrontier::merge_ancilla(
     Vertex back_v_source = this->circuit_.source(back_in_edge);
 
     this->circuit_.remove_edge(back_in_edge);
+
+    /**
+     * front_v_in -- [.... -- front_v_source]- XX front_v_out
+     *               [......................] \
+     * back_v_in  XX                           -[back_v_target -- ....] XX
+     * back_v_out
+     */
     this->circuit_.add_edge(
         {back_v_source, back_source_port}, {front_v_out, 0}, EdgeType::Quantum);
+    /**
+     * front_v_in -- [.... -- front_v_source]- XX -front_v_out
+     *               [......................] \                         /
+     * back_v_in  XX                           -[back_v_target -- ....]- XX
+     * back_v_out
+     */
 
     // remove empty vertex wire, relabel dag vertices
     this->circuit_.dag[back_v_in].op = get_op_ptr(OpType::noop);
     this->circuit_.dag[back_v_out].op = get_op_ptr(OpType::noop);
+
+    TKET_ASSERT(this->circuit_.n_in_edges(back_v_out) == 0);
+    TKET_ASSERT(this->circuit_.n_out_edges(back_v_in) == 0);
+    TKET_ASSERT(this->circuit_.n_in_edges(front_v_out) == 1);
     this->circuit_.remove_vertex(
         back_v_in, Circuit::GraphRewiring::No, Circuit::VertexDeletion::Yes);
     this->circuit_.remove_vertex(
         back_v_out, Circuit::GraphRewiring::No, Circuit::VertexDeletion::Yes);
-
+    /**
+     * front_v_in -- [.... -- front_v_source] -- [back_v_target -- ....] --
+     * front_v_out
+     */
     this->circuit_.boundary.get<TagID>().erase(back);
-    
   };
 
   rewire(ancilla, merge);
@@ -803,6 +840,19 @@ void MappingFrontier::merge_ancilla(
   UnitID init_ancilla_node = init_it->second;
   this->bimaps_->initial.left.erase(init_it);
   this->bimaps_->initial.left.insert({merge_q, init_ancilla_node});
+
+  // update linear boundaries
+  auto merge_boundary_it = this->linear_boundary->get<TagKey>().find(merge);
+  auto ancilla_boundary_it = this->linear_boundary->get<TagKey>().find(ancilla);
+  TKET_ASSERT(
+      ancilla_boundary_it != this->linear_boundary->get<TagKey>().end());
+  TKET_ASSERT(merge_boundary_it != this->linear_boundary->get<TagKey>().end());
+  this->linear_boundary->replace(
+      ancilla_boundary_it, {ancilla, merge_boundary_it->second});
+  this->linear_boundary->erase(merge_boundary_it);
+
+  this->ancilla_nodes_.erase(Node(ancilla));
+  this->reassignable_nodes_.erase(Node(ancilla));
 }
 
 bool MappingFrontier::valid_boundary_operation(

--- a/tket/src/Mapping/MappingFrontier.cpp
+++ b/tket/src/Mapping/MappingFrontier.cpp
@@ -773,6 +773,7 @@ void MappingFrontier::merge_ancilla(
         back_v_out, Circuit::GraphRewiring::No, Circuit::VertexDeletion::Yes);
 
     this->circuit_.boundary.get<TagID>().erase(back);
+    
   };
 
   rewire(ancilla, merge);

--- a/tket/tests/test_LexiRoute.cpp
+++ b/tket/tests/test_LexiRoute.cpp
@@ -1623,5 +1623,37 @@ SCENARIO("Test failing case") {
             std::make_shared<LexiRouteRoutingMethod>()});
   REQUIRE(r_p->apply(cu));
 }
+SCENARIO("Test adding ancilla Node, using as end of path swaps and then merging with unplaced Qubit."){
 
+    Node unplaced = Node("unplaced", 0);
+    std::vector<Node> placed = {Node("opposite", 0), Node("opposite", 1), Node("opposite", 2), Node("opposite", 3), Node("opposite", 4)};
+    std::vector<std::pair<Node, Node>> coupling = {{placed[0], placed[1]}, {placed[1], placed[2]}, {placed[2], placed[3]}, {placed[3], placed[4]}};
+    std::shared_ptr<Architecture> architecture = std::make_shared<Architecture>(coupling);
+    Circuit circuit(4);
+    std::vector<Qubit> qubits = {Qubit(0), Qubit(1), Qubit(2), Qubit(3)};
+
+    circuit.add_op<unsigned>(OpType::CX, {3,1});
+    circuit.add_op<unsigned>(OpType::CX, {2,0});
+    circuit.add_op<unsigned>(OpType::CX, {2,1});
+    circuit.add_op<unsigned>(OpType::CX, {3,0});
+    circuit.add_op<unsigned>(OpType::CX, {3,2});
+
+    std::map<Qubit, Node> p_map = {{qubits[0], placed[0]}, {qubits[1], placed[1]}, {qubits[2], placed[2]}, {qubits[3], unplaced}};
+    Placement::place_with_map(circuit, p_map);
+
+    MappingFrontier mapping_frontier(circuit);
+    mapping_frontier.advance_frontier_boundary(architecture);
+    // adds "placed[3]" as ancilla
+    mapping_frontier.add_swap(placed[2], placed[3]);
+    // provokes path swap
+    mapping_frontier.add_swap(placed[2], placed[3]);
+
+    std::cout << mapping_frontier.circuit_ << std::endl;
+    // merge into unassigned
+    mapping_frontier.merge_ancilla(unplaced, placed[3]);
+
+    std::cout << "WHY" << std::endl;
+    mapping_frontier.circuit_.get_commands();
+    REQUIRE(true);
+}
 }  // namespace tket

--- a/tket/tests/test_LexiRoute.cpp
+++ b/tket/tests/test_LexiRoute.cpp
@@ -1623,39 +1623,45 @@ SCENARIO("Test failing case") {
             std::make_shared<LexiRouteRoutingMethod>()});
   REQUIRE(r_p->apply(cu));
 }
-SCENARIO("Test adding ancilla Node, using as end of path swaps and then merging with unplaced Qubit."){
+SCENARIO(
+    "Test adding ancilla Node, using as end of path swaps and then merging "
+    "with unplaced Qubit.") {
+  Node unplaced = Node("unplaced", 0);
+  std::vector<Node> placed = {
+      Node("opposite", 0), Node("opposite", 1), Node("opposite", 2),
+      Node("opposite", 3), Node("opposite", 4)};
+  std::vector<std::pair<Node, Node>> coupling = {
+      {placed[0], placed[1]},
+      {placed[1], placed[2]},
+      {placed[2], placed[3]},
+      {placed[3], placed[4]}};
+  std::shared_ptr<Architecture> architecture =
+      std::make_shared<Architecture>(coupling);
+  Circuit circuit(4);
+  std::vector<Qubit> qubits = {Qubit(0), Qubit(1), Qubit(2), Qubit(3)};
 
-    Node unplaced = Node("unplaced", 0);
-    std::vector<Node> placed = {Node("opposite", 0), Node("opposite", 1), Node("opposite", 2), Node("opposite", 3), Node("opposite", 4)};
-    std::vector<std::pair<Node, Node>> coupling = {{placed[0], placed[1]}, {placed[1], placed[2]}, {placed[2], placed[3]}, {placed[3], placed[4]}};
-    std::shared_ptr<Architecture> architecture = std::make_shared<Architecture>(coupling);
-    Circuit circuit(4);
-    std::vector<Qubit> qubits = {Qubit(0), Qubit(1), Qubit(2), Qubit(3)};
+  circuit.add_op<unsigned>(OpType::CX, {3, 1});
+  circuit.add_op<unsigned>(OpType::CX, {2, 0});
+  circuit.add_op<unsigned>(OpType::CX, {2, 1});
+  circuit.add_op<unsigned>(OpType::CX, {3, 0});
+  circuit.add_op<unsigned>(OpType::CX, {3, 2});
 
-    circuit.add_op<unsigned>(OpType::CX, {3,1});
-    circuit.add_op<unsigned>(OpType::CX, {2,0});
-    circuit.add_op<unsigned>(OpType::CX, {2,1});
-    circuit.add_op<unsigned>(OpType::CX, {3,0});
-    circuit.add_op<unsigned>(OpType::CX, {3,2});
+  std::map<Qubit, Node> p_map = {
+      {qubits[0], placed[0]},
+      {qubits[1], placed[1]},
+      {qubits[2], placed[2]},
+      {qubits[3], unplaced}};
+  Placement::place_with_map(circuit, p_map);
 
-    std::map<Qubit, Node> p_map = {{qubits[0], placed[0]}, {qubits[1], placed[1]}, {qubits[2], placed[2]}, {qubits[3], unplaced}};
-    Placement::place_with_map(circuit, p_map);
-
-    MappingFrontier mapping_frontier(circuit);
-    mapping_frontier.advance_frontier_boundary(architecture);
-    // adds "placed[3]" as ancilla
-    mapping_frontier.add_swap(placed[2], placed[3]);
-    // provokes path swap
-    // mapping_frontier.add_swap(placed[2], placed[3]);
-
-    // std::cout << mapping_frontier.circuit_ << std::endl;
-    mapping_frontier.circuit_.to_graphviz_file("/users/silasdilkes/code/leon/pre_merge.dot");
-    // merge into unassigned
-    mapping_frontier.merge_ancilla(unplaced, placed[3]);
-    mapping_frontier.circuit_.to_graphviz_file("/users/silasdilkes/code/leon/post_merge.dot");
-
-    std::cout << "WHY" << std::endl;
-    mapping_frontier.circuit_.get_commands();
-    REQUIRE(true);
+  MappingFrontier mapping_frontier(circuit);
+  mapping_frontier.advance_frontier_boundary(architecture);
+  // adds "placed[3]" as ancilla
+  REQUIRE(mapping_frontier.add_swap(placed[2], placed[3]));
+  // provokes path swap
+  REQUIRE(!mapping_frontier.add_swap(placed[2], placed[3]));
+  // merge into unassigned
+  mapping_frontier.merge_ancilla(unplaced, placed[2]);
+  mapping_frontier.circuit_.get_commands();
+  REQUIRE(true);
 }
 }  // namespace tket

--- a/tket/tests/test_LexiRoute.cpp
+++ b/tket/tests/test_LexiRoute.cpp
@@ -1646,11 +1646,13 @@ SCENARIO("Test adding ancilla Node, using as end of path swaps and then merging 
     // adds "placed[3]" as ancilla
     mapping_frontier.add_swap(placed[2], placed[3]);
     // provokes path swap
-    mapping_frontier.add_swap(placed[2], placed[3]);
+    // mapping_frontier.add_swap(placed[2], placed[3]);
 
-    std::cout << mapping_frontier.circuit_ << std::endl;
+    // std::cout << mapping_frontier.circuit_ << std::endl;
+    mapping_frontier.circuit_.to_graphviz_file("/users/silasdilkes/code/leon/pre_merge.dot");
     // merge into unassigned
     mapping_frontier.merge_ancilla(unplaced, placed[3]);
+    mapping_frontier.circuit_.to_graphviz_file("/users/silasdilkes/code/leon/post_merge.dot");
 
     std::cout << "WHY" << std::endl;
     mapping_frontier.circuit_.get_commands();


### PR DESCRIPTION
Basically as the name says. `MappingFrontier::add_swap` returns `false` if the vertex immediately before the proposed SWAP is an identical SWAP, thus avoiding getting stuck.
If the `false` condition is met, then the proposed SWAP is not implemented, but instead a path of SWAPs is found between one of the SWAPs in the `Node` and its target `Node` for being brought adjacent to.

During `MappingFrontier::add_swap`, if one of the `Node` "A" in the proposed SWAP between "A" and "B" is a known "ancilla node", then this `Node` "A" is removed from the "ancilla nodes container" and the `Node` "B" is added. Previously, this was incorrectly being updated before the condition for returning `false` was met. This left the "ancilla nodes container" incorrect.

A container of ancilla nodes is stored incase we choose to assign an unplaced `Circuit` `Qubit` to an `Architecture` `Node` that is being used as an ancilla. In this case, we merge the paths of the `UnitID` in the DAG, such that the (unitary preserving) operations of the ancilla node are run, before the path of previously unplaced `Qubit`. This hits no causal issues because we iterate through the `Circuit` slice by slice.

However, in this case a `Node` that was assumed "fair game" in the ancilla nodes container was actually that of an important program `Qubit`, due to the returning `false` scenario described previously. When merging paths this led to a cycle in the `Circuit`.

This PR guarantees that the check for breaking from the `MappingFrontier::add_swap` is completed and any break completed before any struct attributes are amended.

