### PR TITLE
Update `circuit_to_qasm` methods to auto generate ECR definition

### DIFF
--- a/pytket/pytket/qasm/qasm.py
+++ b/pytket/pytket/qasm/qasm.py
@@ -160,6 +160,7 @@ NOPARAM_EXTRA_COMMANDS = {
     "bridge": OpType.BRIDGE,
     "iswapmax": OpType.ISWAPMax,
     "zzmax": OpType.ZZMax,
+    "ecr": OpType.ECR,
 }
 
 PARAM_EXTRA_COMMANDS = {

--- a/pytket/tests/qasm_test.py
+++ b/pytket/tests/qasm_test.py
@@ -525,6 +525,7 @@ def test_non_lib_gates() -> None:
     c.add_gate(OpType.ESWAP, [0.7], [0, 1])
     c.add_gate(OpType.FSim, [0.3, 0.4], [1, 2])
     c.add_gate(OpType.ISWAPMax, [1, 2])
+    c.add_gate(OpType.ECR, [2, 0])
     # add copies
     c.add_gate(OpType.TK2, [0.3, 0.6, 0.8], [2, 1])
     c.add_gate(OpType.CV, [1, 0])
@@ -538,6 +539,7 @@ def test_non_lib_gates() -> None:
     c.add_gate(OpType.ESWAP, [0.8], [2, 1])
     c.add_gate(OpType.FSim, [0.9, 0.2], [0, 2])
     c.add_gate(OpType.ISWAPMax, [0, 2])
+    c.add_gate(OpType.ECR, [0, 1])
 
     qs = circuit_to_qasm_str(c)
     c2 = circuit_from_qasm_str(qs)


### PR DESCRIPTION
The ECR operation was missed when adding new supported OpType in https://github.com/CQCL/tket/pull/612.