### PR TITLE
Warn about rounding errors instead of asserting

### DIFF
--- a/pytket/conanfile.txt
+++ b/pytket/conanfile.txt
@@ -1,5 +1,5 @@
 [requires]
-tket/1.0.31@tket/stable
+tket/1.0.32@tket/stable
 tklog/0.1.2@tket/stable
 pybind11/2.10.1
 nlohmann_json/3.11.2

--- a/pytket/docs/changelog.rst
+++ b/pytket/docs/changelog.rst
@@ -8,7 +8,10 @@ Minor new features:
 
 * New ``view_browser`` function for opening a browser with circuit render.
 
+Fixes:
 
+* Warn rather than abort when significant rounding errors are detected in
+  TK2-to-CX rebase.
 
 1.9.0 (November 2022)
 ---------------------

--- a/recipes/tket-proptests/conanfile.py
+++ b/recipes/tket-proptests/conanfile.py
@@ -28,7 +28,7 @@ class TketProptestsConan(ConanFile):
     generators = "cmake"
     exports_sources = "../../tket/proptests/*"
     requires = (
-        "tket/1.0.31@tket/stable",
+        "tket/1.0.32@tket/stable",
         "rapidcheck/cci.20220514",
     )
 

--- a/recipes/tket-tests/conanfile.py
+++ b/recipes/tket-tests/conanfile.py
@@ -34,7 +34,7 @@ class TketTestsConan(ConanFile):
     default_options = {"with_coverage": False, "full": False, "long": False}
     generators = "cmake"
     exports_sources = "../../tket/tests/*"
-    requires = ("tket/1.0.31@tket/stable", "catch2/3.2.0")
+    requires = ("tket/1.0.32@tket/stable", "catch2/3.2.0")
 
     _cmake = None
 

--- a/recipes/tket/conanfile.py
+++ b/recipes/tket/conanfile.py
@@ -20,7 +20,7 @@ import shutil
 
 class TketConan(ConanFile):
     name = "tket"
-    version = "1.0.31"
+    version = "1.0.32"
     license = "CQC Proprietary"
     homepage = "https://github.com/CQCL/tket"
     url = "https://github.com/conan-io/conan-center-index"

--- a/tket/tests/Circuit/test_Circ.cpp
+++ b/tket/tests/Circuit/test_Circ.cpp
@@ -1617,6 +1617,19 @@ SCENARIO("Test substitute_all") {
 
 SCENARIO("Decomposing a multi-qubit operation into CXs") {
   const double sq = 1 / std::sqrt(2.);
+  GIVEN("Trivial (single-qubit) case") {
+    Circuit circ(1);
+    Vertex v = circ.add_op<unsigned>(OpType::X, {0});
+    const Op_ptr op = circ.get_Op_ptr_from_Vertex(v);
+    Circuit rep;
+    WHEN("Default circuit replacement") { rep = CX_circ_from_multiq(op); }
+    WHEN("ZX circuit replacement") { rep = CX_ZX_circ_from_op(op); }
+
+    const Eigen::MatrixXcd u = tket_sim::get_unitary(rep);
+    Eigen::MatrixXcd correct(2, 2);
+    correct << 0, 1, 1, 0;
+    REQUIRE(u.isApprox(correct));
+  }
   GIVEN("A CZ gate") {
     Circuit circ(2);
     Vertex v = circ.add_op<unsigned>(OpType::CZ, {0, 1});

--- a/tket/tests/test_PhaseGadget.cpp
+++ b/tket/tests/test_PhaseGadget.cpp
@@ -289,6 +289,12 @@ SCENARIO("Decompose phase gadgets") {
     Circuit circ = pauli_gadget(nZ, 0.2);
     return std::make_pair(circ, phase_gadget(n_qubits, 0.2, config));
   };
+  GIVEN("Trivial gadget on 0 qubits") {
+    auto [circ, decomp] = get_circ_decomposition(0, CXConfigType::Star);
+    auto u1 = tket_sim::get_unitary(circ);
+    auto u2 = tket_sim::get_unitary(decomp);
+    REQUIRE(u1.isApprox(u2));
+  }
   GIVEN("Using Star strategy") {
     CXConfigType config = CXConfigType::Star;
     auto [circ, decomp] = get_circ_decomposition(4, config);


### PR DESCRIPTION
Fixes #672 .

Since this reduces branch coverage (I am not sure if I can easily reproduce it in a test), I have added a couple of unrelated edge-case tests to bring up the coverage numbers.