### PR TITLE
Update rzz qasm string in qasm converter

### DIFF
--- a/pytket/docs/changelog.rst
+++ b/pytket/docs/changelog.rst
@@ -12,8 +12,8 @@ Fixes:
 
 * Warn rather than abort when significant rounding errors are detected in
   TK2-to-CX rebase.
-
 * Fix incorrect QASM output for ``OpType.CopyBits``.
+* Fix incorrect QASM read in ``OpType.ZZPhase``.
 
 1.9.0 (November 2022)
 ---------------------

--- a/pytket/pytket/qasm/qasm.py
+++ b/pytket/pytket/qasm/qasm.py
@@ -142,6 +142,7 @@ PARAM_COMMANDS = {
     "ry": OpType.Ry,
     "rz": OpType.Rz,
     "RZZ": OpType.ZZPhase,
+    "rzz": OpType.ZZPhase,
     "Rz": OpType.Rz,
     "U1q": OpType.PhasedX,
     "crz": OpType.CRz,

--- a/pytket/pytket/qasm/qasm.py
+++ b/pytket/pytket/qasm/qasm.py
@@ -172,7 +172,6 @@ PARAM_EXTRA_COMMANDS = {
     "xxphase3": OpType.XXPhase3,
     "eswap": OpType.ESWAP,
     "fsim": OpType.FSim,
-    "rzz": OpType.ZZPhase,
 }
 
 _tk_to_qasm_noparams = dict(((item[1], item[0]) for item in NOPARAM_COMMANDS.items()))

--- a/pytket/pytket/qasm/qasm.py
+++ b/pytket/pytket/qasm/qasm.py
@@ -141,7 +141,7 @@ PARAM_COMMANDS = {
     "rxx": OpType.XXPhase,
     "ry": OpType.Ry,
     "rz": OpType.Rz,
-    "rzz": OpType.ZZPhase,
+    "RZZ": OpType.ZZPhase,
     "Rz": OpType.Rz,
     "U1q": OpType.PhasedX,
     "crz": OpType.CRz,
@@ -171,6 +171,7 @@ PARAM_EXTRA_COMMANDS = {
     "xxphase3": OpType.XXPhase3,
     "eswap": OpType.ESWAP,
     "fsim": OpType.FSim,
+    "rzz": OpType.ZZPhase,
 }
 
 _tk_to_qasm_noparams = dict(((item[1], item[0]) for item in NOPARAM_COMMANDS.items()))

--- a/pytket/tests/qasm_test.py
+++ b/pytket/tests/qasm_test.py
@@ -51,7 +51,7 @@ from pytket.qasm.includes.load_includes import (
     _load_gdict,
 )
 from pytket.transform import Transform  # type: ignore
-from pytket.passes import DecomposeClassicalExp  # type: ignore
+from pytket.passes import DecomposeClassicalExp, DecomposeBoxes  # type: ignore
 
 curr_file_path = Path(__file__).resolve().parent
 
@@ -671,6 +671,7 @@ def test_RZZ_read_from() -> None:
     RZZ(0.5*pi) q[0],q[1];
     """
     )
+    DecomposeBoxes().apply(c)
     assert "RZZ(0.5*pi) q[0],q[1];" in circuit_to_qasm_str(c, header="hqslib1")
     assert "rzz(0.5*pi) q[0],q[1];" in circuit_to_qasm_str(c)
 

--- a/pytket/tests/qasm_test.py
+++ b/pytket/tests/qasm_test.py
@@ -661,6 +661,20 @@ creg c1[2];\ncreg c2[2];\nc0[0] = c1[1];\nc1 = c2;\nc1[1] = c2[0];\nc1[0] = c2[1
     assert result_circ_qasm == correct_qasm
 
 
+def test_RZZ_read_from() -> None:
+    c = circuit_from_qasm_str(
+        """
+    OPENQASM 2.0;
+    include "hqslib1.inc";
+
+    qreg q[2];
+    RZZ(0.5*pi) q[0],q[1];
+    """
+    )
+    assert "RZZ(0.5*pi) q[0],q[1];" in circuit_to_qasm_str(c, header="hqslib1")
+    assert "gate rzz (param0) rzzq0,rzzq1 {" in circuit_to_qasm_str(c)
+
+
 if __name__ == "__main__":
     test_qasm_correct()
     test_qasm_qubit()

--- a/pytket/tests/qasm_test.py
+++ b/pytket/tests/qasm_test.py
@@ -672,7 +672,7 @@ def test_RZZ_read_from() -> None:
     """
     )
     assert "RZZ(0.5*pi) q[0],q[1];" in circuit_to_qasm_str(c, header="hqslib1")
-    assert "gate rzz (param0) rzzq0,rzzq1 {" in circuit_to_qasm_str(c)
+    assert "rzz(0.5*pi) q[0],q[1];" in circuit_to_qasm_str(c)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
hqs qasm header defines OpType.ZZPhase gate as "RZZ", but in converter code it's been mistakenly set to "rzz" (which is how pytket defines it as a string). This gives examples where "RZZ" is not recognised as an OpType.ZZPhase gate and so is instead read in as a custom gate. 