### PR TITLE
Fix several incorrect gate conversions and add support for PhasedX in Pauli graph synthesis

### DIFF
--- a/pytket/conanfile.txt
+++ b/pytket/conanfile.txt
@@ -1,5 +1,5 @@
 [requires]
-tket/1.0.35@tket/stable
+tket/1.0.36@tket/stable
 tklog/0.1.2@tket/stable
 pybind11/2.10.1
 nlohmann_json/3.11.2

--- a/pytket/docs/changelog.rst
+++ b/pytket/docs/changelog.rst
@@ -4,9 +4,15 @@ Changelog
 Unreleased
 ----------
 
+Minor new features:
+
+* Add support for PhasedX gates in Pauli graph synthesis.
+
 Fixes:
 
 * Handle 0-qubit operations in connectivity check.
+* Fix handling of Tdg, CY, ZZMax and Clifford-angle YYPhase gates in Pauli
+  graph synthesis.
 
 1.9.1 (December 2022)
 ---------------------

--- a/recipes/tket-proptests/conanfile.py
+++ b/recipes/tket-proptests/conanfile.py
@@ -28,7 +28,7 @@ class TketProptestsConan(ConanFile):
     generators = "cmake"
     exports_sources = "../../tket/proptests/*"
     requires = (
-        "tket/1.0.35@tket/stable",
+        "tket/1.0.36@tket/stable",
         "rapidcheck/cci.20220514",
     )
 

--- a/recipes/tket-tests/conanfile.py
+++ b/recipes/tket-tests/conanfile.py
@@ -34,7 +34,7 @@ class TketTestsConan(ConanFile):
     default_options = {"with_coverage": False, "full": False, "long": False}
     generators = "cmake"
     exports_sources = "../../tket/tests/*"
-    requires = ("tket/1.0.35@tket/stable", "catch2/3.2.1")
+    requires = ("tket/1.0.36@tket/stable", "catch2/3.2.1")
 
     _cmake = None
 

--- a/recipes/tket/conanfile.py
+++ b/recipes/tket/conanfile.py
@@ -20,7 +20,7 @@ import shutil
 
 class TketConan(ConanFile):
     name = "tket"
-    version = "1.0.35"
+    version = "1.0.36"
     license = "CQC Proprietary"
     homepage = "https://github.com/CQCL/tket"
     url = "https://github.com/conan-io/conan-center-index"

--- a/tket/src/Clifford/CliffTableau.cpp
+++ b/tket/src/Clifford/CliffTableau.cpp
@@ -355,11 +355,11 @@ void CliffTableau::apply_gate_at_end(
       break;
     }
     case OpType::CY: {
-      apply_V_at_end(qbs.at(1));
-      apply_V_at_end(qbs.at(1));
-      apply_V_at_end(qbs.at(1));
+      apply_S_at_end(qbs.at(1));
+      apply_S_at_end(qbs.at(1));
+      apply_S_at_end(qbs.at(1));
       apply_CX_at_end(qbs.at(0), qbs.at(1));
-      apply_V_at_end(qbs.at(1));
+      apply_S_at_end(qbs.at(1));
       break;
     }
     case OpType::CZ: {

--- a/tket/src/PauliGraph/PauliGraph.cpp
+++ b/tket/src/PauliGraph/PauliGraph.cpp
@@ -205,9 +205,12 @@ void PauliGraph::apply_gate_at_end(
       break;
     }
     case OpType::ZZMax: {
-      cliff_.apply_gate_at_end(OpType::H, {qbs.at(1)});
+      cliff_.apply_gate_at_end(OpType::S, {qbs.at(0)});
+      cliff_.apply_gate_at_end(OpType::Z, {qbs.at(1)});
+      cliff_.apply_gate_at_end(OpType::S, {qbs.at(1)});
+      cliff_.apply_gate_at_end(OpType::V, {qbs.at(1)});
+      cliff_.apply_gate_at_end(OpType::S, {qbs.at(1)});
       cliff_.apply_gate_at_end(OpType::CX, qbs);
-      cliff_.apply_gate_at_end(OpType::Sdg, {qbs.at(0)});
       cliff_.apply_gate_at_end(OpType::S, {qbs.at(1)});
       cliff_.apply_gate_at_end(OpType::V, {qbs.at(1)});
       break;

--- a/tket/src/PauliGraph/PauliGraph.cpp
+++ b/tket/src/PauliGraph/PauliGraph.cpp
@@ -265,15 +265,15 @@ void PauliGraph::apply_gate_at_end(
         if (cliff_angle.value() != 0) {
           const Qubit &arg0 = qbs.at(0);
           const Qubit &arg1 = qbs.at(1);
-          cliff_.apply_gate_at_end(OpType::V, {arg0});
-          cliff_.apply_gate_at_end(OpType::V, {arg1});
+          cliff_.apply_gate_at_end(OpType::S, {arg0});
+          cliff_.apply_gate_at_end(OpType::S, {arg1});
           cliff_.apply_gate_at_end(OpType::CX, {arg1, arg0});
           for (unsigned i = 0; i < cliff_angle.value(); i++) {
             cliff_.apply_gate_at_end(OpType::V, {arg1});
           }
           cliff_.apply_gate_at_end(OpType::CX, {arg1, arg0});
-          cliff_.apply_gate_at_end(OpType::Vdg, {arg0});
-          cliff_.apply_gate_at_end(OpType::Vdg, {arg1});
+          cliff_.apply_gate_at_end(OpType::Sdg, {arg0});
+          cliff_.apply_gate_at_end(OpType::Sdg, {arg1});
         }
       } else {
         QubitPauliTensor pauli =

--- a/tket/src/PauliGraph/PauliGraph.cpp
+++ b/tket/src/PauliGraph/PauliGraph.cpp
@@ -201,7 +201,7 @@ void PauliGraph::apply_gate_at_end(
     }
     case OpType::Tdg: {
       QubitPauliTensor pauli = cliff_.get_zpauli(qbs.at(0));
-      apply_pauli_gadget_at_end(pauli, 0.25);
+      apply_pauli_gadget_at_end(pauli, -0.25);
       break;
     }
     case OpType::ZZMax: {

--- a/tket/src/Predicates/PassGenerators.cpp
+++ b/tket/src/Predicates/PassGenerators.cpp
@@ -25,6 +25,7 @@
 #include "Mapping/LexiLabelling.hpp"
 #include "Mapping/LexiRoute.hpp"
 #include "Mapping/MappingManager.hpp"
+#include "OpType/OpType.hpp"
 #include "Placement/Placement.hpp"
 #include "Predicates/CompilationUnit.hpp"
 #include "Predicates/CompilerPass.hpp"
@@ -701,7 +702,8 @@ PassPtr gen_synthesise_pauli_graph(
                    OpType::Rz,      OpType::Rx,          OpType::Ry,
                    OpType::T,       OpType::Tdg,         OpType::ZZMax,
                    OpType::ZZPhase, OpType::PhaseGadget, OpType::XXPhase,
-                   OpType::YYPhase, OpType::PauliExpBox, OpType::Measure};
+                   OpType::YYPhase, OpType::PauliExpBox, OpType::Measure,
+                   OpType::PhasedX};
   PredicatePtr in_gates = std::make_shared<GateSetPredicate>(ins);
   PredicatePtrMap precons{
       CompilationUnit::make_type_pair(ccontrol_pred),

--- a/tket/tests/test_CompilerPass.cpp
+++ b/tket/tests/test_CompilerPass.cpp
@@ -1116,16 +1116,58 @@ SCENARIO("Precomposed passes successfully compose") {
 SCENARIO("Test Pauli Graph Synthesis Pass") {
   PassPtr graph_synth = gen_synthesise_pauli_graph(
       Transforms::PauliSynthStrat::Sets, CXConfigType::Star);
-  Circuit circ(3);
-  PauliExpBox peb({Pauli::Z, Pauli::X, Pauli::Z}, 0.333);
-  circ.add_box(peb, {0, 1, 2});
-  PauliExpBox peb2({Pauli::Y, Pauli::X, Pauli::X}, 0.174);
-  circ.add_box(peb2, {0, 1, 2});
+  GIVEN("Two PauliExpBoxes") {
+    Circuit circ(3);
+    PauliExpBox peb({Pauli::Z, Pauli::X, Pauli::Z}, 0.333);
+    circ.add_box(peb, {0, 1, 2});
+    PauliExpBox peb2({Pauli::Y, Pauli::X, Pauli::X}, 0.174);
+    circ.add_box(peb2, {0, 1, 2});
 
-  CompilationUnit cu(circ);
-  graph_synth->apply(cu);
+    CompilationUnit cu(circ);
+    graph_synth->apply(cu);
 
-  REQUIRE(test_unitary_comparison(circ, cu.get_circ_ref()));
+    REQUIRE(test_unitary_comparison(circ, cu.get_circ_ref()));
+  }
+  GIVEN("Lots of different gates") {
+    Circuit circ(3);
+    circ.add_op<unsigned>(OpType::Z, {0});
+    circ.add_op<unsigned>(OpType::X, {1});
+    circ.add_op<unsigned>(OpType::Y, {2});
+    circ.add_op<unsigned>(OpType::S, {0});
+    circ.add_op<unsigned>(OpType::Sdg, {1});
+    circ.add_op<unsigned>(OpType::V, {2});
+    circ.add_op<unsigned>(OpType::Vdg, {0});
+    circ.add_op<unsigned>(OpType::H, {1});
+    circ.add_op<unsigned>(OpType::CX, {2, 0});
+    circ.add_op<unsigned>(OpType::CY, {0, 1});
+    circ.add_op<unsigned>(OpType::CZ, {1, 2});
+    circ.add_op<unsigned>(OpType::SWAP, {2, 0});
+    circ.add_op<unsigned>(OpType::Rz, 0.25, {0});
+    circ.add_op<unsigned>(OpType::Rx, 0.25, {1});
+    circ.add_op<unsigned>(OpType::Ry, 0.25, {2});
+    circ.add_op<unsigned>(OpType::T, {0});
+    circ.add_op<unsigned>(OpType::Tdg, {1});
+    circ.add_op<unsigned>(OpType::ZZMax, {2, 0});
+    circ.add_op<unsigned>(OpType::ZZPhase, 0.25, {0, 1});
+    circ.add_op<unsigned>(OpType::PhaseGadget, 0.25, {0, 1, 2});
+    circ.add_op<unsigned>(OpType::XXPhase, 0.25, {1, 2});
+    circ.add_op<unsigned>(OpType::YYPhase, 0.25, {2, 0});
+    circ.add_op<unsigned>(OpType::PhasedX, {0.25, 1.75}, {0});
+    // ... and some with Clifford angles...
+    circ.add_op<unsigned>(OpType::Rz, 0.5, {0});
+    circ.add_op<unsigned>(OpType::Rx, 1.0, {1});
+    circ.add_op<unsigned>(OpType::Ry, 1.5, {2});
+    circ.add_op<unsigned>(OpType::ZZPhase, 0.5, {0, 1});
+    circ.add_op<unsigned>(OpType::PhaseGadget, 1.0, {0, 1, 2});
+    circ.add_op<unsigned>(OpType::XXPhase, 1.5, {1, 2});
+    circ.add_op<unsigned>(OpType::YYPhase, 2.5, {2, 0});
+    circ.add_op<unsigned>(OpType::PhasedX, {3.5, 0.5}, {0});
+
+    CompilationUnit cu(circ);
+    graph_synth->apply(cu);
+
+    REQUIRE(test_unitary_comparison(circ, cu.get_circ_ref(), true));
+  }
 }
 
 SCENARIO("Compose Pauli Graph synthesis Passes") {


### PR DESCRIPTION
This was originally meant to be just adding `PhasedX` but in the process I found a few incorrect conversions among the other gates.