### PR TITLE
Stricter rules on conditional expressions being converted to QASM

### DIFF
--- a/pytket/docs/changelog.rst
+++ b/pytket/docs/changelog.rst
@@ -14,7 +14,7 @@ Fixes:
 * Fix handling of Tdg, CY, ZZMax and Clifford-angle YYPhase gates in Pauli
   graph synthesis.
 * Disallow conversion to QASM of operations conditioned on strict subregisters
-  larger than one bit.
+  larger than one bit, or reordered registers.
 
 1.9.1 (December 2022)
 ---------------------

--- a/pytket/docs/changelog.rst
+++ b/pytket/docs/changelog.rst
@@ -13,6 +13,8 @@ Fixes:
 * Handle 0-qubit operations in connectivity check.
 * Fix handling of Tdg, CY, ZZMax and Clifford-angle YYPhase gates in Pauli
   graph synthesis.
+* Disallow conversion to QASM of operations conditioned on strict subregisters
+  larger than one bit.
 
 1.9.1 (December 2022)
 ---------------------

--- a/pytket/pytket/qasm/qasm.py
+++ b/pytket/pytket/qasm/qasm.py
@@ -1144,8 +1144,8 @@ def circuit_to_qasm_io(
                     variable = control_bit.reg_name
                     if hqs_header(header) and bits != list(cregs[variable]):
                         raise QASMUnsupportedError(
-                            "HQS QASM conditions must be an entire classical register "
-                            "or a single bit"
+                            "hqslib1 QASM conditions must be an entire classical "
+                            "register or a single bit"
                         )
             if not hqs_header(header):
                 if op.width != cregs[variable].size:

--- a/pytket/pytket/qasm/qasm.py
+++ b/pytket/pytket/qasm/qasm.py
@@ -1152,7 +1152,7 @@ def circuit_to_qasm_io(
                     raise QASMUnsupportedError(
                         "OpenQASM conditions must be an entire classical register"
                     )
-                if sorted(bits) != list(cregs[variable]):
+                if bits != list(cregs[variable]):
                     raise QASMUnsupportedError(
                         "OpenQASM conditions must be a single classical register"
                     )

--- a/pytket/pytket/qasm/qasm.py
+++ b/pytket/pytket/qasm/qasm.py
@@ -1142,6 +1142,11 @@ def circuit_to_qasm_io(
                     variable = control_bit
                 else:
                     variable = control_bit.reg_name
+                    if hqs_header(header) and bits != list(cregs[variable]):
+                        raise QASMUnsupportedError(
+                            "HQS QASM conditions must be an entire classical register "
+                            "or a single bit"
+                        )
             if not hqs_header(header):
                 if op.width != cregs[variable].size:
                     raise QASMUnsupportedError(

--- a/pytket/tests/qasm_test.py
+++ b/pytket/tests/qasm_test.py
@@ -701,6 +701,11 @@ def test_conditional_expressions() -> None:
     c0123 = cond_circ([0, 1, 2, 3])
     assert "if(c==3)" in circuit_to_qasm_str(c0123)
     assert "if(c==3)" in circuit_to_qasm_str(c0123, header="hqslib1")
+    c0132 = cond_circ([0, 1, 3, 2])
+    with pytest.raises(QASMUnsupportedError):
+        circuit_to_qasm_str(c0132)
+    with pytest.raises(QASMUnsupportedError):
+        circuit_to_qasm_str(c0132, header="hqslib1")
 
 
 if __name__ == "__main__":

--- a/pytket/tests/qasm_test.py
+++ b/pytket/tests/qasm_test.py
@@ -15,6 +15,7 @@
 from io import StringIO
 import re
 from pathlib import Path
+from typing import List
 
 import pytest  # type: ignore
 
@@ -677,7 +678,7 @@ def test_RZZ_read_from() -> None:
 
 
 def test_conditional_expressions() -> None:
-    def cond_circ(bits):
+    def cond_circ(bits: List[int]) -> Circuit:
         c = Circuit(4, 4)
         c.X(0)
         c.X(1)

--- a/pytket/tests/qasm_test.py
+++ b/pytket/tests/qasm_test.py
@@ -676,6 +676,33 @@ def test_RZZ_read_from() -> None:
     assert "rzz(0.5*pi) q[0],q[1];" in circuit_to_qasm_str(c)
 
 
+def test_conditional_expressions() -> None:
+    def cond_circ(bits):
+        c = Circuit(4, 4)
+        c.X(0)
+        c.X(1)
+        c.X(2)
+        c.Measure(0, 0)
+        c.Measure(1, 1)
+        c.Measure(2, 2)
+        c.X(3, condition_bits=bits, condition_value=3)
+        c.Measure(3, 3)
+        return c
+
+    c1 = cond_circ([1])
+    with pytest.raises(QASMUnsupportedError):
+        circuit_to_qasm_str(c1)
+    assert "if(c[1]==3)" in circuit_to_qasm_str(c1, header="hqslib1")
+    c12 = cond_circ([1, 2])
+    with pytest.raises(QASMUnsupportedError):
+        circuit_to_qasm_str(c12)
+    with pytest.raises(QASMUnsupportedError):
+        circuit_to_qasm_str(c12, header="hqslib1")
+    c0123 = cond_circ([0, 1, 2, 3])
+    assert "if(c==3)" in circuit_to_qasm_str(c0123)
+    assert "if(c==3)" in circuit_to_qasm_str(c0123, header="hqslib1")
+
+
 if __name__ == "__main__":
     test_qasm_correct()
     test_qasm_qubit()


### PR DESCRIPTION
This fixes two bugs:

* converting conditions defined on a strict subset of bits of a register (of a size larger than 1) to conditions on the whole register;
* ignoring the order of bits in conditions on a whole register.

In both cases, it should be possible to do the translation by being more clever. However, disallowing the conversions is better than converting them erroneously -- and matches what we were doing already in other similar situations.