### PR TITLE
Don't run release workflow when a release is edited

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,6 @@ on:
   release:
     types:
       - created
-      - edited
   push:
     branches:
       - 'wheel/**'


### PR DESCRIPTION
E.g. editing the name of a release shouldn't trigger a new build.