### PR TITLE
Bugfix/multi gate reorder routing method missing edge

### DIFF
--- a/pytket/conanfile.txt
+++ b/pytket/conanfile.txt
@@ -1,5 +1,5 @@
 [requires]
-tket/1.0.38@tket/stable
+tket/1.0.39@tket/stable
 tklog/0.1.2@tket/stable
 pybind11/2.10.3
 nlohmann_json/3.11.2

--- a/pytket/conanfile.txt
+++ b/pytket/conanfile.txt
@@ -1,5 +1,5 @@
 [requires]
-tket/1.0.39@tket/stable
+tket/1.0.40@tket/stable
 tklog/0.1.2@tket/stable
 pybind11/2.10.3
 nlohmann_json/3.11.2

--- a/pytket/docs/changelog.rst
+++ b/pytket/docs/changelog.rst
@@ -12,6 +12,10 @@ Minor new features:
 
 * Circuit methods ``qubit_readout`` and ``qubit_to_bit_map`` now ignore barriers.
 
+Fixes:
+
+* ``MultiGateReorderRoutingMethod`` raising unknown edge missing error.
+
 1.10.0 (December 2022)
 ----------------------
 

--- a/recipes/tket-proptests/conanfile.py
+++ b/recipes/tket-proptests/conanfile.py
@@ -28,7 +28,7 @@ class TketProptestsConan(ConanFile):
     generators = "cmake"
     exports_sources = "../../tket/proptests/*"
     requires = (
-        "tket/1.0.39@tket/stable",
+        "tket/1.0.40@tket/stable",
         "rapidcheck/cci.20220514",
     )
 

--- a/recipes/tket-proptests/conanfile.py
+++ b/recipes/tket-proptests/conanfile.py
@@ -28,7 +28,7 @@ class TketProptestsConan(ConanFile):
     generators = "cmake"
     exports_sources = "../../tket/proptests/*"
     requires = (
-        "tket/1.0.38@tket/stable",
+        "tket/1.0.39@tket/stable",
         "rapidcheck/cci.20220514",
     )
 

--- a/recipes/tket-tests/conanfile.py
+++ b/recipes/tket-tests/conanfile.py
@@ -34,7 +34,7 @@ class TketTestsConan(ConanFile):
     default_options = {"with_coverage": False, "full": False, "long": False}
     generators = "cmake"
     exports_sources = "../../tket/tests/*"
-    requires = ("tket/1.0.39@tket/stable", "catch2/3.2.1")
+    requires = ("tket/1.0.40@tket/stable", "catch2/3.2.1")
 
     _cmake = None
 

--- a/recipes/tket-tests/conanfile.py
+++ b/recipes/tket-tests/conanfile.py
@@ -34,7 +34,7 @@ class TketTestsConan(ConanFile):
     default_options = {"with_coverage": False, "full": False, "long": False}
     generators = "cmake"
     exports_sources = "../../tket/tests/*"
-    requires = ("tket/1.0.38@tket/stable", "catch2/3.2.1")
+    requires = ("tket/1.0.39@tket/stable", "catch2/3.2.1")
 
     _cmake = None
 

--- a/recipes/tket/conanfile.py
+++ b/recipes/tket/conanfile.py
@@ -20,7 +20,7 @@ import shutil
 
 class TketConan(ConanFile):
     name = "tket"
-    version = "1.0.38"
+    version = "1.0.39"
     license = "CQC Proprietary"
     homepage = "https://github.com/CQCL/tket"
     url = "https://github.com/conan-io/conan-center-index"

--- a/recipes/tket/conanfile.py
+++ b/recipes/tket/conanfile.py
@@ -20,7 +20,7 @@ import shutil
 
 class TketConan(ConanFile):
     name = "tket"
-    version = "1.0.39"
+    version = "1.0.40"
     license = "CQC Proprietary"
     homepage = "https://github.com/CQCL/tket"
     url = "https://github.com/conan-io/conan-center-index"

--- a/tket/src/Mapping/MultiGateReorder.cpp
+++ b/tket/src/Mapping/MultiGateReorder.cpp
@@ -60,18 +60,9 @@ static bool is_multiq_quantum_gate(const Circuit &circ, const Vertex &vert) {
           circ.n_out_edges(vert));
 }
 
-static bool is_physically_permitted(
-    const MappingFrontier_ptr &frontier, const ArchitecturePtr &arc_ptr,
-    const Vertex &vert) {
-  std::vector<Node> nodes;
-  for (port_t port = 0; port < frontier->circuit_.n_ports(vert); ++port) {
-    nodes.push_back(Node(get_unitid_from_vertex_port(frontier, {vert, port})));
-  }
-  return frontier->valid_boundary_operation(
-      arc_ptr, frontier->circuit_.get_Op_ptr_from_Vertex(vert), nodes);
-}
-
 // This method will try to commute a vertex to the quantum frontier
+// If successful, returns the current in-edges and the target in-edges to
+// rewire the vertex
 static std::optional<std::pair<EdgeVec, EdgeVec>> try_find_commute_edges(
     const Circuit &circ, const EdgeVec &frontier_edges, const Vertex &vert) {
   // Initialize to be the in_edges for the given vertex
@@ -189,7 +180,7 @@ static void partial_rewire(
 bool MultiGateReorder::solve(unsigned max_depth, unsigned max_size) {
   // Assume the frontier has been advanced
 
-  // store a copy of the original this->mapping_frontier_->quantum_boundray
+  // store a copy of the original this->mapping_frontier_->linear_boundary
   // this object will be updated and reset throughout the procedure
   // so need to return it to original setting at end.
   unit_vertport_frontier_t copy;
@@ -197,21 +188,82 @@ bool MultiGateReorder::solve(unsigned max_depth, unsigned max_size) {
        this->mapping_frontier_->linear_boundary->get<TagKey>()) {
     copy.insert({pair.first, pair.second});
   }
-  // Get a subcircuit only for iterating vertices
-  Subcircuit circ =
-      this->mapping_frontier_->get_frontier_subcircuit(max_depth, max_size);
+  // get subcircuit vertices in topological order
+  CutFrontier current_cut = this->mapping_frontier_->circuit_.next_cut(
+      frontier_convert_vertport_to_edge(
+          this->mapping_frontier_->circuit_,
+          this->mapping_frontier_->linear_boundary),
+      this->mapping_frontier_->boolean_boundary);
+  unsigned subcircuit_depth = 1;
+  std::vector<Vertex> subcircuit_vertices(
+      current_cut.slice->begin(), current_cut.slice->end());
+  // add cuts of vertices to subcircuit_vertices until constraints met, or end
+  // of circuit reached
+  while (subcircuit_depth < max_depth &&
+         unsigned(subcircuit_vertices.size()) < max_size &&
+         current_cut.slice->size() > 0) {
+    current_cut = this->mapping_frontier_->circuit_.next_cut(
+        current_cut.u_frontier, current_cut.b_frontier);
+    subcircuit_depth++;
+    subcircuit_vertices.insert(
+        subcircuit_vertices.end(), current_cut.slice->begin(),
+        current_cut.slice->end());
+  }
+  // For each of the multi-q vertices in the subcircuit, find its unitids
+  std::vector<std::pair<Vertex, std::vector<Node>>> vertex_nodes;
+  for (const Vertex &vert : subcircuit_vertices) {
+    if (!is_multiq_quantum_gate(this->mapping_frontier_->circuit_, vert)) {
+      continue;
+    }
+    std::vector<Node> nodes;
+    for (port_t port = 0;
+         port < this->mapping_frontier_->circuit_.n_ports(vert); ++port) {
+      nodes.push_back(Node(
+          get_unitid_from_vertex_port(this->mapping_frontier_, {vert, port})));
+    }
+    vertex_nodes.push_back({vert, nodes});
+  }
 
-  // for return value
   bool modification_made = false;
-  // since we assume that the frontier has been advanced
-  // we are certain that any multi-q vert lies after the frontier
-  for (const Vertex &vert : circ.verts) {
-    // Check if the vertex is:
-    //  1. physically permitted
-    //  2. is a multi qubit quantum operation without classical controls
-    if (is_multiq_quantum_gate(this->mapping_frontier_->circuit_, vert) &&
-        is_physically_permitted(
-            this->mapping_frontier_, this->architecture_, vert)) {
+  for (auto it = vertex_nodes.begin(); it != vertex_nodes.end(); it++) {
+    const Vertex &vert = it->first;
+    const std::vector<Node> &nodes = it->second;
+    // determine whether a vertex has been advanced by the
+    // advance_frontier_boundary call in this loop by traversing to the right by
+    // max_depth steps to see if it hits a frontier vertex.
+    // checking one port is enough
+    bool advanced = false;
+    VertPort current_vert_port(vert, 0);
+    for (unsigned i = 0; i < max_depth; i++) {
+      if (this->mapping_frontier_->linear_boundary->get<TagValue>().find(
+              current_vert_port) !=
+          this->mapping_frontier_->linear_boundary->get<TagValue>().end()) {
+        advanced = true;
+        break;
+      }
+      if (this->mapping_frontier_->circuit_.detect_boundary_Op(
+              current_vert_port.first)) {
+        break;
+      }
+      Edge current_in_edge = this->mapping_frontier_->circuit_.get_nth_in_edge(
+          current_vert_port.first, current_vert_port.second);
+      Vertex next_vert;
+      Edge next_e;
+      std::tie(next_vert, next_e) =
+          this->mapping_frontier_->circuit_.get_next_pair(
+              current_vert_port.first, current_in_edge);
+      current_vert_port = {
+          next_vert, this->mapping_frontier_->circuit_.get_target_port(next_e)};
+    }
+    if (advanced) {
+      continue;
+    }
+
+    // try to commute a vertex to the frontier if it's physically permitted
+    if (this->mapping_frontier_->valid_boundary_operation(
+            this->architecture_,
+            this->mapping_frontier_->circuit_.get_Op_ptr_from_Vertex(vert),
+            nodes)) {
       std::optional<std::pair<EdgeVec, EdgeVec>> commute_pairs =
           try_find_commute_edges(
               this->mapping_frontier_->circuit_, this->u_frontier_edges_, vert);

--- a/tket/tests/test_MultiGateReorder.cpp
+++ b/tket/tests/test_MultiGateReorder.cpp
@@ -197,6 +197,39 @@ SCENARIO("Reorder circuits") {
     REQUIRE(tket_sim::compare_statevectors_or_unitaries(
         u, u1, tket_sim::MatrixEquivalence::EQUAL));
   }
+
+  GIVEN("Reorder that frees up physically permitted gates") {
+    // TKET-2714
+    Circuit circ(5);
+    std::vector<Qubit> qubits = circ.all_qubits();
+    Vertex v1 = circ.add_op<UnitID>(OpType::CZ, {qubits[0], qubits[3]});
+    circ.add_op<UnitID>(OpType::CZ, {qubits[2], qubits[3]});
+    circ.add_op<UnitID>(OpType::CZ, {qubits[1], qubits[2]});
+    // the last CZ will be freed by reordering the second CZ
+    std::map<UnitID, UnitID> rename_map = {
+        {qubits[0], nodes[0]},
+        {qubits[1], nodes[1]},
+        {qubits[2], nodes[2]},
+        {qubits[3], nodes[3]}};
+    circ.rename_units(rename_map);
+    Circuit circ_copy(circ);
+    MappingFrontier_ptr mf = std::make_shared<MappingFrontier>(circ);
+    mf->advance_frontier_boundary(shared_arc);
+    Subcircuit subc = mf->get_frontier_subcircuit(5, 5);
+    // all gates should lie after the frontier due to the first CZ
+    REQUIRE(subc.verts.size() == 3);
+    MultiGateReorder mr(shared_arc, mf);
+    mr.solve(5, 5);
+    // advance_frontier_boundary should now be able to resolve two CZs
+    mf->advance_frontier_boundary(shared_arc);
+    subc = mf->get_frontier_subcircuit(5, 5);
+    REQUIRE(subc.verts.size() == 1);
+    REQUIRE(*subc.verts.begin() == v1);
+    const auto u = tket_sim::get_unitary(circ);
+    const auto u1 = tket_sim::get_unitary(circ_copy);
+    REQUIRE(tket_sim::compare_statevectors_or_unitaries(
+        u, u1, tket_sim::MatrixEquivalence::EQUAL));
+  }
 }
 
 SCENARIO("Reorder circuits with limited search space") {


### PR DESCRIPTION
Given a mapping frontier, the algorithm tires to commute physically permitted vertices to the frontier so advance_frontier_boundary can move pass them. The bug is caused by the algorithm trying to bring a vertex before the frontier to the frontier. This fix added a check to ignore any vertices that lie before the frontier. Additionally, the vertices will now be iterated in topological order.