### PR TITLE
Update criteria for test coverage to pass in compare-coverage

### DIFF
--- a/.github/workflows/compare-coverage
+++ b/.github/workflows/compare-coverage
@@ -64,8 +64,8 @@ def compare(summary, summary1):
     if fpercent1 < fpercent:
         print("Percentage function coverage has decreased.")
         exit(1)
-    if bpercent1 + 0.5 < bpercent:
-        print("Percentage branch coverage has decreased by more than 0.5%.")
+    if bpercent1 + 0.1 < bpercent:
+        print("Percentage branch coverage has decreased by more than 0.1%.")
         exit(1)
 
 

--- a/.github/workflows/compare-coverage
+++ b/.github/workflows/compare-coverage
@@ -64,8 +64,8 @@ def compare(summary, summary1):
     if fpercent1 < fpercent:
         print("Percentage function coverage has decreased.")
         exit(1)
-    if bpercent1 < bpercent:
-        print("Percentage branch coverage has decreased.")
+    if bpercent1 + 0.5 < bpercent:
+        print("Percentage branch coverage has decreased by more than 0.5%.")
         exit(1)
 
 


### PR DESCRIPTION
In the compare-coverage workflow we automatically check c++ test coverage when generating pull requests to make sure that our test coverage isn't being decreased. This comprises three checks: that the percentage of number of lines of code being tested does not decrease, that the percentage of defined functions being tested does not decrease, and that the percentage of potential branches being tested does not decrease.

In practice the first of these are very helpful, or more importantly if they do decrease the generated coverage report makes it easy to spot which new lines of code aren't being tested and so to include new tests to cover them.
However, the branch coverage tests are quite unpredictable and more frequently than desirable a pull request can be made that covers all new lines of code and functions with 100% test coverage, but that are still faltering on branch coverage. Sometimes this has led to pull requests making test changes in other areas of the codebase just to up this.

This pull request relaxes the coverage criteria slightly. It still requires that line and function coverage does not decrease, but if these two criteria are met, then it permits a small decrease in branch coverage. 