### PR TITLE
bugfix/upldate-zlib-version

### DIFF
--- a/.github/workflows/build-external-packages
+++ b/.github/workflows/build-external-packages
@@ -15,7 +15,7 @@ PACKAGES="b2/4.9.2@ \
           pybind11_json/0.2.12@ \
           rapidcheck/cci.20220514@ \
           symengine/0.9.0@ \
-          zlib/1.2.12@"
+          zlib/1.2.13@"
 
 BUILD_TYPES="Release Debug"
 

--- a/.github/workflows/linuxbuildpackages
+++ b/.github/workflows/linuxbuildpackages
@@ -44,7 +44,7 @@ PACKAGES="b2/4.9.2@ \
           nlohmann_json/3.11.2@ \
           pybind11_json/0.2.12@ \
           symengine/0.9.0@ \
-          zlib/1.2.12@"
+          zlib/1.2.13@"
 
 for PACKAGE in ${PACKAGES}
 do


### PR DESCRIPTION
Boost 1.81 requires zlib 1.2.13, so I updated to that version in the build scripts