### PR TITLE
add note to qasm API documentation

### DIFF
--- a/pytket/docs/qasm.rst
+++ b/pytket/docs/qasm.rst
@@ -11,5 +11,7 @@ to save your :py:class:`Circuit` objects.
 
 However, we do support symbolic parameters of gates, both on import and export.
 
+.. note:: Unlke pytket backends the qasm converters do not handle `implicit qubit permutations <https://cqcl.github.io/pytket/manual/manual_circuit.html#implicit-qubit-permutations>`_ . In other words if a circuit containing an implicit qubit permutation is converted to a qasm file the implicit permutation will not be accounted for and the circuit may appear to be different when reimported.
+
 .. automodule:: pytket.qasm
     :members: circuit_from_qasm, circuit_from_qasm_wasm, circuit_to_qasm, circuit_from_qasm_str, circuit_to_qasm_str, circuit_from_qasm_io, circuit_to_qasm_io

--- a/pytket/docs/qasm.rst
+++ b/pytket/docs/qasm.rst
@@ -11,7 +11,7 @@ to save your :py:class:`Circuit` objects.
 
 However, we do support symbolic parameters of gates, both on import and export.
 
-.. note:: Unlke pytket backends the qasm converters do not handle `implicit qubit permutations <https://cqcl.github.io/pytket/manual/manual_circuit.html#implicit-qubit-permutations>`_ . In other words if a circuit containing an implicit qubit permutation is converted to a qasm file the implicit permutation will not be accounted for and the circuit may appear to be different when reimported.
+.. note:: Unlke pytket backends the qasm converters do not handle `implicit qubit permutations <https://cqcl.github.io/pytket/manual/manual_circuit.html#implicit-qubit-permutations>`_ . In other words if a circuit containing an implicit qubit permutation is converted to a qasm file the implicit permutation will not be accounted for and the circuit will be missing this permutation when reimported.
 
 .. automodule:: pytket.qasm
     :members: circuit_from_qasm, circuit_from_qasm_wasm, circuit_to_qasm, circuit_from_qasm_str, circuit_to_qasm_str, circuit_from_qasm_io, circuit_to_qasm_io

--- a/pytket/pytket/qasm/qasm.py
+++ b/pytket/pytket/qasm/qasm.py
@@ -930,7 +930,8 @@ def circuit_from_qasm_wasm(
 
 
 def circuit_to_qasm(circ: Circuit, output_file: str, header: str = "qelib1") -> None:
-    """A method to generate a qasm file from a tket Circuit"""
+    """A method to generate a qasm file from a tket Circuit.
+    Note that this will not account for implicit qubit permutations in the Circuit."""
     with open(output_file, "w") as out:
         circuit_to_qasm_io(circ, out, header=header)
 
@@ -960,7 +961,8 @@ def _filtered_qasm_str(qasm: str) -> str:
 
 
 def circuit_to_qasm_str(circ: Circuit, header: str = "qelib1") -> str:
-    """A method to generate a qasm str from a tket Circuit"""
+    """A method to generate a qasm str from a tket Circuit.
+    Note that this will not account for implicit qubit permutations in the Circuit."""
     buffer = io.StringIO()
     circuit_to_qasm_io(circ, buffer, header=header)
     return buffer.getvalue()
@@ -1069,7 +1071,8 @@ def circuit_to_qasm_io(
     header: str = "qelib1",
     include_gate_defs: Optional[Set[str]] = None,
 ) -> None:
-    """A method to generate a qasm text stream from a tket Circuit"""
+    """A method to generate a qasm text stream from a tket Circuit.
+    Note that this will not account for implicit qubit permutations in the Circuit."""
     # Write to a buffer since the output qasm might need additional filtering.
     # e.g. remove unused tket scratch bits.
     buffer = io.StringIO()


### PR DESCRIPTION
Updating the documentation to alert users to the fact that implicit qubit permutations are not handled by the qasm converters. Will also update the user manual in a separate PR.