### PR TITLE
Make Pauli synthesis pass preserve name and allow implicit wire swaps

### DIFF
--- a/pytket/conanfile.txt
+++ b/pytket/conanfile.txt
@@ -1,5 +1,5 @@
 [requires]
-tket/1.0.44@tket/stable
+tket/1.0.45@tket/stable
 tklog/0.1.2@tket/stable
 pybind11/2.10.3
 nlohmann_json/3.11.2

--- a/pytket/docs/changelog.rst
+++ b/pytket/docs/changelog.rst
@@ -17,10 +17,12 @@ Minor new features:
 
 * Circuit methods ``qubit_readout`` and ``qubit_to_bit_map`` now ignore barriers.
 * New pass ``RemoveImplicitQubitPermutation``.
+* ``PauliSimp`` pass accepts circuits containing implicit wire swaps.
 
 Fixes:
 
 * ``MultiGateReorderRoutingMethod`` raising unknown edge missing error.
+* ``PauliSimp`` pass preserves circuit name.
 
 1.10.0 (December 2022)
 ----------------------

--- a/pytket/tests/predicates_test.py
+++ b/pytket/tests/predicates_test.py
@@ -514,7 +514,7 @@ def test_user_defined_swap_decomp() -> None:
 
 
 def test_pauligraph_synth() -> None:
-    circ = Circuit(4, 4)
+    circ = Circuit(4, 4, name="test")
     pg = PauliExpBox([Pauli.X, Pauli.Z, Pauli.Y, Pauli.I], 0.3)
     circ.add_pauliexpbox(pg, [0, 1, 2, 3])
     circ.measure_all()
@@ -524,6 +524,7 @@ def test_pauligraph_synth() -> None:
     assert pss.apply(cu)
     circ1 = cu.circuit
     assert circ1.depth_by_type(OpType.CX) == 4
+    assert circ1.name == "test"
 
 
 def test_squash_chains() -> None:

--- a/recipes/tket-proptests/conanfile.py
+++ b/recipes/tket-proptests/conanfile.py
@@ -28,7 +28,7 @@ class TketProptestsConan(ConanFile):
     generators = "cmake"
     exports_sources = "../../tket/proptests/*"
     requires = (
-        "tket/1.0.44@tket/stable",
+        "tket/1.0.45@tket/stable",
         "rapidcheck/cci.20220514",
     )
 

--- a/recipes/tket-tests/conanfile.py
+++ b/recipes/tket-tests/conanfile.py
@@ -34,7 +34,7 @@ class TketTestsConan(ConanFile):
     default_options = {"with_coverage": False, "full": False, "long": False}
     generators = "cmake"
     exports_sources = "../../tket/tests/*"
-    requires = ("tket/1.0.44@tket/stable", "catch2/3.2.1")
+    requires = ("tket/1.0.45@tket/stable", "catch2/3.2.1")
 
     _cmake = None
 

--- a/recipes/tket/conanfile.py
+++ b/recipes/tket/conanfile.py
@@ -20,7 +20,7 @@ import shutil
 
 class TketConan(ConanFile):
     name = "tket"
-    version = "1.0.44"
+    version = "1.0.45"
     license = "CQC Proprietary"
     homepage = "https://github.com/CQCL/tket"
     url = "https://github.com/conan-io/conan-center-index"

--- a/tket/src/Converters/PauliGraphConverters.cpp
+++ b/tket/src/Converters/PauliGraphConverters.cpp
@@ -25,14 +25,6 @@ PauliGraph circuit_to_pauli_graph(const Circuit &circ);
 Circuit pauli_graph_to_circuit(const PauliGraph &pg);
 
 PauliGraph circuit_to_pauli_graph(const Circuit &circ) {
-  for (const std::pair<const Qubit, Qubit> &pair :
-       circ.implicit_qubit_permutation()) {
-    if (pair.first != pair.second) {
-      throw ImplicitPermutationNotAllowed(
-          "Cannot build a PauliGraph from circuits with implicit "
-          "permutations");
-    }
-  }
   PauliGraph pg(circ.all_qubits(), circ.all_bits());
   for (const Command &com : circ) {
     const Op &op = *com.get_op_ptr();

--- a/tket/src/Predicates/PassGenerators.cpp
+++ b/tket/src/Predicates/PassGenerators.cpp
@@ -694,7 +694,6 @@ PassPtr gen_synthesise_pauli_graph(
   Transform t = Transforms::synthesise_pauli_graph(strat, cx_config);
   PredicatePtr ccontrol_pred = std::make_shared<NoClassicalControlPredicate>();
   PredicatePtr mid_pred = std::make_shared<NoMidMeasurePredicate>();
-  PredicatePtr wire_pred = std::make_shared<NoWireSwapsPredicate>();
   OpTypeSet ins = {OpType::Z,       OpType::X,           OpType::Y,
                    OpType::S,       OpType::Sdg,         OpType::V,
                    OpType::Vdg,     OpType::H,           OpType::CX,
@@ -708,7 +707,6 @@ PassPtr gen_synthesise_pauli_graph(
   PredicatePtrMap precons{
       CompilationUnit::make_type_pair(ccontrol_pred),
       CompilationUnit::make_type_pair(mid_pred),
-      CompilationUnit::make_type_pair(wire_pred),
       CompilationUnit::make_type_pair(in_gates)};
   PredicateClassGuarantees g_postcons = {
       {typeid(ConnectivityPredicate), Guarantee::Clear},

--- a/tket/src/Transformations/PauliOptimisation.cpp
+++ b/tket/src/Transformations/PauliOptimisation.cpp
@@ -188,6 +188,7 @@ Transform synthesise_pauli_graph(
     PauliSynthStrat strat, CXConfigType cx_config) {
   return Transform([=](Circuit &circ) {
     Expr t = circ.get_phase();
+    std::optional<std::string> name = circ.get_name();
     PauliGraph pg = circuit_to_pauli_graph(circ);
     switch (strat) {
       case PauliSynthStrat::Individual: {
@@ -206,6 +207,9 @@ Transform synthesise_pauli_graph(
         TKET_ASSERT(!"Unknown Pauli Synthesis Strategy");
     }
     circ.add_phase(t);
+    if (name) {
+      circ.set_name(*name);
+    }
     // always turn circuit into PauliGraph and back, so always return true
     return true;
   });

--- a/tket/src/Transformations/PauliOptimisation.cpp
+++ b/tket/src/Transformations/PauliOptimisation.cpp
@@ -189,6 +189,7 @@ Transform synthesise_pauli_graph(
   return Transform([=](Circuit &circ) {
     Expr t = circ.get_phase();
     std::optional<std::string> name = circ.get_name();
+    circ.replace_all_implicit_wire_swaps();
     PauliGraph pg = circuit_to_pauli_graph(circ);
     switch (strat) {
       case PauliSynthStrat::Individual: {

--- a/tket/tests/test_CompilerPass.cpp
+++ b/tket/tests/test_CompilerPass.cpp
@@ -33,6 +33,7 @@
 #include "Simulation/CircuitSimulator.hpp"
 #include "Simulation/ComparisonFunctions.hpp"
 #include "Transformations/ContextualReduction.hpp"
+#include "Transformations/OptimisationPass.hpp"
 #include "Transformations/PauliOptimisation.hpp"
 #include "Transformations/Rebase.hpp"
 #include "Utils/Expression.hpp"
@@ -1164,6 +1165,18 @@ SCENARIO("Test Pauli Graph Synthesis Pass") {
     circ.add_op<unsigned>(OpType::XXPhase, 1.5, {1, 2});
     circ.add_op<unsigned>(OpType::YYPhase, 2.5, {2, 0});
     circ.add_op<unsigned>(OpType::PhasedX, {3.5, 0.5}, {0});
+
+    CompilationUnit cu(circ);
+    graph_synth->apply(cu);
+
+    REQUIRE(test_unitary_comparison(circ, cu.get_circ_ref(), true));
+  }
+  GIVEN("Implicit qubit permutation") {
+    Circuit circ(2);
+    circ.add_op<unsigned>(OpType::CX, {0, 1});
+    circ.add_op<unsigned>(OpType::CX, {1, 0});
+    Transforms::clifford_simp().apply(circ);
+    REQUIRE(circ.has_implicit_wireswaps());
 
     CompilationUnit cu(circ);
     graph_synth->apply(cu);

--- a/tket/tests/test_CompilerPass.cpp
+++ b/tket/tests/test_CompilerPass.cpp
@@ -1117,7 +1117,7 @@ SCENARIO("Test Pauli Graph Synthesis Pass") {
   PassPtr graph_synth = gen_synthesise_pauli_graph(
       Transforms::PauliSynthStrat::Sets, CXConfigType::Star);
   GIVEN("Two PauliExpBoxes") {
-    Circuit circ(3);
+    Circuit circ(3, "test");
     PauliExpBox peb({Pauli::Z, Pauli::X, Pauli::Z}, 0.333);
     circ.add_box(peb, {0, 1, 2});
     PauliExpBox peb2({Pauli::Y, Pauli::X, Pauli::X}, 0.174);
@@ -1125,8 +1125,10 @@ SCENARIO("Test Pauli Graph Synthesis Pass") {
 
     CompilationUnit cu(circ);
     graph_synth->apply(cu);
+    const Circuit& circ1 = cu.get_circ_ref();
 
-    REQUIRE(test_unitary_comparison(circ, cu.get_circ_ref()));
+    REQUIRE(test_unitary_comparison(circ, circ1));
+    REQUIRE(circ1.get_name() == "test");
   }
   GIVEN("Lots of different gates") {
     Circuit circ(3);

--- a/tket/tests/test_PauliGraph.cpp
+++ b/tket/tests/test_PauliGraph.cpp
@@ -1008,14 +1008,5 @@ SCENARIO("Measure handling in PauliGraph") {
   }
 }
 
-SCENARIO("Error handling with implicit permutations") {
-  Circuit circ(2);
-  circ.add_op<unsigned>(OpType::CX, {0, 1});
-  circ.add_op<unsigned>(OpType::CX, {1, 0});
-  Transforms::clifford_simp().apply(circ);
-  REQUIRE_THROWS_AS(
-      circuit_to_pauli_graph(circ), ImplicitPermutationNotAllowed);
-}
-
 }  // namespace test_PauliGraph
 }  // namespace tket


### PR DESCRIPTION
Fixes #709 .
Closes #713 .