### PR TITLE
Support MacOS >= 11.0 on both x86_64 and arm64

### DIFF
--- a/.github/workflows/build_macos_m1_wheel
+++ b/.github/workflows/build_macos_m1_wheel
@@ -18,6 +18,8 @@ set -evu
 
 cd $GITHUB_WORKSPACE/pytket
 export PYVER=`python -c 'import sys; print(".".join(map(str, sys.version_info[:3])))'`
+# Ensure wheels are compatible with MacOS 11.0 and later:
+export WHEEL_PLAT_NAME=macosx_11_0_arm64
 python -m pip uninstall -y pytket
 python -m pip install -U pip build delocate
 python -m build --outdir "$GITHUB_WORKSPACE/tmp/tmpwheel_${PYVER}"

--- a/.github/workflows/build_macos_wheel
+++ b/.github/workflows/build_macos_wheel
@@ -18,8 +18,8 @@ set -evu
 
 cd $GITHUB_WORKSPACE/pytket
 export PYVER=`python -c 'import sys; print(".".join(map(str, sys.version_info[:3])))'`
-# Ensure wheels are compatible with MacOS 10.14 and later:
-export WHEEL_PLAT_NAME=macosx_10_14_x86_64
+# Ensure wheels are compatible with MacOS 11.0 and later:
+export WHEEL_PLAT_NAME=macosx_11_0_x86_64
 python -m pip install -U pip build delocate
 python -m build --outdir "$GITHUB_WORKSPACE/tmp/tmpwheel_${PYVER}"
 delocate-wheel -v -w "$GITHUB_WORKSPACE/wheelhouse/${PYVER}/" "$GITHUB_WORKSPACE/tmp/tmpwheel_${PYVER}/pytket-"*".whl"

--- a/pytket/docs/changelog.rst
+++ b/pytket/docs/changelog.rst
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+Unreleased
+----------
+
+General:
+
+* Support for MacOS >= 11.0 on both x86_64 and arm64.
+
 1.11.0 (January 2023)
 ---------------------
 

--- a/pytket/docs/getting_started.rst
+++ b/pytket/docs/getting_started.rst
@@ -8,7 +8,7 @@ API for interacting with tket and transpiling to and from other popular quantum
 circuit specifications.
 
 Pytket is compatible with 64-bit Python 3.9, 3.10 and 3.11, on Linux, MacOS
-(10.14 or later) and Windows. Install pytket from PyPI using:
+(11.0 or later) and Windows. Install pytket from PyPI using:
 
 ::
 


### PR DESCRIPTION
I think dropping support for 10.14 is OK -- we can't test it on the CI anyway.
@CalMacCQ has tested a wheel built [here](https://github.com/CQCL/tket/actions/runs/3957597044) and checked that it works.