### PR TITLE
Add an error wrapper for compiler passes

### DIFF
--- a/pytket/conanfile.txt
+++ b/pytket/conanfile.txt
@@ -1,5 +1,5 @@
 [requires]
-tket/1.0.47@tket/stable
+tket/1.0.48@tket/stable
 tklog/0.1.2@tket/stable
 pybind11/2.10.3
 nlohmann_json/3.11.2

--- a/recipes/tket-proptests/conanfile.py
+++ b/recipes/tket-proptests/conanfile.py
@@ -28,7 +28,7 @@ class TketProptestsConan(ConanFile):
     generators = "cmake"
     exports_sources = "../../tket/proptests/*"
     requires = (
-        "tket/1.0.47@tket/stable",
+        "tket/1.0.48@tket/stable",
         "rapidcheck/cci.20220514",
     )
 

--- a/recipes/tket-tests/conanfile.py
+++ b/recipes/tket-tests/conanfile.py
@@ -34,7 +34,7 @@ class TketTestsConan(ConanFile):
     default_options = {"with_coverage": False, "full": False, "long": False}
     generators = "cmake"
     exports_sources = "../../tket/tests/*"
-    requires = ("tket/1.0.47@tket/stable", "catch2/3.2.1")
+    requires = ("tket/1.0.48@tket/stable", "catch2/3.2.1")
 
     _cmake = None
 

--- a/recipes/tket/conanfile.py
+++ b/recipes/tket/conanfile.py
@@ -20,7 +20,7 @@ import shutil
 
 class TketConan(ConanFile):
     name = "tket"
-    version = "1.0.47"
+    version = "1.0.48"
     license = "CQC Proprietary"
     homepage = "https://github.com/CQCL/tket"
     url = "https://github.com/conan-io/conan-center-index"

--- a/tket/src/Predicates/PassGenerators.cpp
+++ b/tket/src/Predicates/PassGenerators.cpp
@@ -267,7 +267,10 @@ PassPtr gen_cx_mapping_pass(
   PassPtr return_pass =
       rebase_pass >> gen_full_mapping_pass(arc, placement_ptr, config);
   if (delay_measures) {
-    PassPtr delay_meas = WrapError<CircuitInvalidity>(DelayMeasures(), "The circuit contains measurements that cannot be delayed.");
+    PassPtr delay_meas = WrapError<CircuitInvalidity>(
+        DelayMeasures(),
+        "`delay_measures` is set, but the circuit contains measurements that "
+        "cannot be delayed.");
     return_pass = return_pass >> delay_meas;
   }
   return_pass = return_pass >> rebase_pass >>

--- a/tket/src/Predicates/PassGenerators.cpp
+++ b/tket/src/Predicates/PassGenerators.cpp
@@ -266,7 +266,10 @@ PassPtr gen_cx_mapping_pass(
       gen_rebase_pass(gate_set, CircPool::CX(), CircPool::tk1_to_tk1);
   PassPtr return_pass =
       rebase_pass >> gen_full_mapping_pass(arc, placement_ptr, config);
-  if (delay_measures) return_pass = return_pass >> DelayMeasures();
+  if (delay_measures) {
+    PassPtr delay_meas = WrapError<CircuitInvalidity>(DelayMeasures(), "The circuit contains measurements that cannot be delayed.");
+    return_pass = return_pass >> delay_meas;
+  }
   return_pass = return_pass >> rebase_pass >>
                 gen_decompose_routing_gates_to_cxs_pass(arc, directed_cx);
   return return_pass;

--- a/tket/src/Predicates/include/Predicates/PassLibrary.hpp
+++ b/tket/src/Predicates/include/Predicates/PassLibrary.hpp
@@ -123,13 +123,23 @@ const PassPtr &CnXPairwiseDecomposition();
  */
 const PassPtr &RemoveImplicitQubitPermutation();
 
-template<typename Error>
-const PassPtr &WrapError(const PassPtr pass, const std::string& error_msg) {
+/**
+ * @brief Rewraps the internal errors of a Pass with a more suitable message.
+ * Nests the old error inside it.
+ * @param pass Compilation pass to wrap
+ * @param error_msg Message to use for the new error
+ *
+ * @tparam Error Specific error type to wrap
+ * @tparam NewError Type of the new error to throw
+ *
+ * @return compilation pass to perform this transformation
+ */
+template <typename Error, class NewError = Error>
+const PassPtr &WrapError(const PassPtr pass, const std::string &error_msg) {
   static const PassPtr pp([pass, error_msg]() {
-    return std::make_shared<ErrorWrapPass<Error>>(pass, error_msg);
+    return std::make_shared<ErrorWrapPass<Error, NewError>>(pass, error_msg);
   }());
   return pp;
 }
-
 
 }  // namespace tket

--- a/tket/src/Predicates/include/Predicates/PassLibrary.hpp
+++ b/tket/src/Predicates/include/Predicates/PassLibrary.hpp
@@ -123,4 +123,13 @@ const PassPtr &CnXPairwiseDecomposition();
  */
 const PassPtr &RemoveImplicitQubitPermutation();
 
+template<typename Error>
+const PassPtr &WrapError(const PassPtr pass, const std::string& error_msg) {
+  static const PassPtr pp([pass, error_msg]() {
+    return std::make_shared<ErrorWrapPass<Error>>(pass, error_msg);
+  }());
+  return pp;
+}
+
+
 }  // namespace tket


### PR DESCRIPTION
Adds a transparent `ErrorWrapPass` transformer to catch errors in Passes and rethrow them with more contextual information.

fixes #708 with a more appropriate error message:
```python
>>> pss.apply(c)
Traceback (most recent call last):
  File "<input>", line 1, in <module>
    pss.apply(c)
RuntimeError: `delay_measures` is set, but the circuit contains measurements that cannot be delayed.
```