### PR TITLE
Fix deprecations and errors in update_tket_version script

### DIFF
--- a/dev-tools/helper_scripts/update_tket_version.sh
+++ b/dev-tools/helper_scripts/update_tket_version.sh
@@ -10,15 +10,15 @@ set -euo pipefail
 TKET_SRC_DIR=$1
 NEW_TKET_VERSION=$2
 
-CURRENT_TKET_VERSION=$(cat ${TKET_SRC_DIR}/recipes/tket/conanfile.py  | grep version | egrep -o "\d+\.\d+\.\d+")
+CURRENT_TKET_VERSION=$(cat ${TKET_SRC_DIR}/recipes/tket/conanfile.py  | grep version | grep -E -o "[0-9]+\.[0-9]+\.[0-9]+")
 
 set_local_tket_version() {
   echo "Setting local tket version to: ${NEW_TKET_VERSION}"
 
-  sed -i '' -e "s/${CURRENT_TKET_VERSION}/${NEW_TKET_VERSION}/" "${TKET_SRC_DIR}/recipes/tket/conanfile.py"
-  sed -i '' -e "s/tket\/.*\@/tket\/${NEW_TKET_VERSION}\@/" "${TKET_SRC_DIR}/recipes/tket-tests/conanfile.py"
-  sed -i '' -e "s/tket\/.*\@/tket\/${NEW_TKET_VERSION}\@/" "${TKET_SRC_DIR}/recipes/tket-proptests/conanfile.py"
-  sed -i '' -e "s/tket\/.*\@/tket\/${NEW_TKET_VERSION}\@/" "${TKET_SRC_DIR}/pytket/conanfile.txt"
+  sed -i'' -e "s/${CURRENT_TKET_VERSION}/${NEW_TKET_VERSION}/" "${TKET_SRC_DIR}/recipes/tket/conanfile.py"
+  sed -i'' -e "s/tket\/.*\@/tket\/${NEW_TKET_VERSION}\@/" "${TKET_SRC_DIR}/recipes/tket-tests/conanfile.py"
+  sed -i'' -e "s/tket\/.*\@/tket\/${NEW_TKET_VERSION}\@/" "${TKET_SRC_DIR}/recipes/tket-proptests/conanfile.py"
+  sed -i'' -e "s/tket\/.*\@/tket\/${NEW_TKET_VERSION}\@/" "${TKET_SRC_DIR}/pytket/conanfile.txt"
 
 }
 


### PR DESCRIPTION
- egrep has been deprecated since 2007, and throws warnings in newer versions
- The '\d' regex in grep is not standard, it throws errors in GNU grep.
- GNU sed also doesn't like spaces after the -i flag