### PR TITLE
Use test circuit directory macro to find test file

### DIFF
--- a/pytket/conanfile.txt
+++ b/pytket/conanfile.txt
@@ -1,5 +1,5 @@
 [requires]
-tket/1.0.47@tket/stable
+tket/1.0.48@tket/stable
 tklog/0.1.2@tket/stable
 pybind11/2.10.3
 nlohmann_json/3.11.2

--- a/recipes/tket-proptests/conanfile.py
+++ b/recipes/tket-proptests/conanfile.py
@@ -28,7 +28,7 @@ class TketProptestsConan(ConanFile):
     generators = "cmake"
     exports_sources = "../../tket/proptests/*"
     requires = (
-        "tket/1.0.47@tket/stable",
+        "tket/1.0.48@tket/stable",
         "rapidcheck/cci.20220514",
     )
 

--- a/recipes/tket-tests/conanfile.py
+++ b/recipes/tket-tests/conanfile.py
@@ -34,7 +34,7 @@ class TketTestsConan(ConanFile):
     default_options = {"with_coverage": False, "full": False, "long": False}
     generators = "cmake"
     exports_sources = "../../tket/tests/*"
-    requires = ("tket/1.0.47@tket/stable", "catch2/3.2.1")
+    requires = ("tket/1.0.48@tket/stable", "catch2/3.2.1")
 
     _cmake = None
 

--- a/recipes/tket/conanfile.py
+++ b/recipes/tket/conanfile.py
@@ -20,7 +20,7 @@ import shutil
 
 class TketConan(ConanFile):
     name = "tket"
-    version = "1.0.47"
+    version = "1.0.48"
     license = "CQC Proprietary"
     homepage = "https://github.com/CQCL/tket"
     url = "https://github.com/conan-io/conan-center-index"

--- a/tket/tests/test_LexiRoute.cpp
+++ b/tket/tests/test_LexiRoute.cpp
@@ -2137,7 +2137,10 @@ SCENARIO(
         {5, 6},  {5, 9},   {6, 8},   {7, 8},  {9, 8},  {9, 10},
         {11, 3}, {11, 10}, {11, 12}, {12, 2}, {13, 1}, {13, 12}};
     Architecture architecture(coupling_map);
-    std::ifstream circuit_file("lexiroute_circuit_relabel_to_ancilla.json");
+    auto lexiroute_circuit_path =
+        std::filesystem::path(TEST_CIRCUITS_DIR)
+            .append("lexiroute_circuit_relabel_to_ancilla.json");
+    std::ifstream circuit_file(lexiroute_circuit_path);
     nlohmann::json j = nlohmann::json::parse(circuit_file);
     auto c = j.get<Circuit>();
     std::map<Qubit, Node> p_map = {


### PR DESCRIPTION
- In test_LexiRoute.cpp, use the macro TEST_CIRCUITS_DIR to look for test json file (as done analogously in line 1614)
- Allows test binary to be started from any directory