### PR TITLE
Add a best-effort delay measures pass

### DIFF
--- a/pytket/binders/passes.cpp
+++ b/pytket/binders/passes.cpp
@@ -510,7 +510,10 @@ PYBIND11_MODULE(passes, m) {
       "Commutes Measure operations to the end of the circuit. Throws an "
       "exception when this is not possible because of gates following the "
       "measure which are dependent on either the resulting quantum state "
-      "or classical values.",
+      "or classical values."
+      "\n\n:param allow_partial: Whether to allow measurements that cannot be commuted to "
+      "the end, and delay them as much as possible instead. If false, the pass "
+      "includes a :py:class:`CommutableMeasuresPredicate` precondition.",
       py::arg("allow_partial") = true);
   m.def(
       "RemoveDiscarded", &RemoveDiscarded,

--- a/pytket/binders/passes.cpp
+++ b/pytket/binders/passes.cpp
@@ -511,7 +511,8 @@ PYBIND11_MODULE(passes, m) {
       "exception when this is not possible because of gates following the "
       "measure which are dependent on either the resulting quantum state "
       "or classical values."
-      "\n\n:param allow_partial: Whether to allow measurements that cannot be commuted to "
+      "\n\n:param allow_partial: Whether to allow measurements that cannot be "
+      "commuted to "
       "the end, and delay them as much as possible instead. If false, the pass "
       "includes a :py:class:`CommutableMeasuresPredicate` precondition.",
       py::arg("allow_partial") = true);

--- a/pytket/binders/passes.cpp
+++ b/pytket/binders/passes.cpp
@@ -510,7 +510,8 @@ PYBIND11_MODULE(passes, m) {
       "Commutes Measure operations to the end of the circuit. Throws an "
       "exception when this is not possible because of gates following the "
       "measure which are dependent on either the resulting quantum state "
-      "or classical values.");
+      "or classical values.",
+      py::arg("allow_partial") = true);
   m.def(
       "RemoveDiscarded", &RemoveDiscarded,
       "A pass to remove all operations that have no ``OpType.Output`` or "

--- a/pytket/conanfile.txt
+++ b/pytket/conanfile.txt
@@ -1,5 +1,5 @@
 [requires]
-tket/1.0.50@tket/stable
+tket/1.0.51@tket/stable
 tklog/0.1.2@tket/stable
 pybind11/2.10.3
 nlohmann_json/3.11.2

--- a/pytket/docs/changelog.rst
+++ b/pytket/docs/changelog.rst
@@ -8,6 +8,9 @@ Minor new features:
 
 * New ``CommutableMeasuresPredicate`` predicate, added as precondition to the
   ``DelayMeasures`` pass.
+* Added an ``allow_partial`` parameter to the ``DelayMeasures`` pass to delay
+  the measurements as much as possible when they cannot be fully delayed to the
+  end.
 
 Fixes:
 

--- a/pytket/pytket/passes/script.py
+++ b/pytket/pytket/passes/script.py
@@ -64,6 +64,7 @@ basic_pass:
     | decompose_multi_qubits_cx
     | decompose_single_qubits_tk1
     | delay_measures
+    | delay_measures_try
     | euler_angle_reduction
     | flatten_registers
     | full_peephole_optimise
@@ -105,6 +106,7 @@ decompose_classical_exp: "DecomposeClassicalExp"
 decompose_multi_qubits_cx: "DecomposeMultiQubitsCX"
 decompose_single_qubits_tk1: "DecomposeSingleQubitsTK1"
 delay_measures: "DelayMeasures"
+delay_measures_try: "TryDelayMeasures"
 euler_angle_reduction: "EulerAngleReduction" "(" op_type "," op_type ")"
 flatten_registers: "FlattenRegisters"
 full_peephole_optimise: "FullPeepholeOptimise"
@@ -212,7 +214,10 @@ class PassTransformer(Transformer):
         return DecomposeSingleQubitsTK1()
 
     def delay_measures(self, t: List) -> BasePass:
-        return DelayMeasures()
+        return DelayMeasures(False)
+
+    def delay_measures_try(self, t: List) -> BasePass:
+        return DelayMeasures(True)
 
     def euler_angle_reduction(self, t: List) -> BasePass:
         return EulerAngleReduction(t[0], t[1])

--- a/pytket/tests/passes_script_test.py
+++ b/pytket/tests/passes_script_test.py
@@ -20,6 +20,7 @@ from pytket.passes import (  # type: ignore
     CliffordSimp,
     ContextSimp,
     DecomposeBoxes,
+    DelayMeasures,
     EulerAngleReduction,
     FullPeepholeOptimise,
     OptimisePhaseGadgets,
@@ -110,6 +111,10 @@ def test_grammar() -> None:
         (
             "FullPeepholeOptimiseNoSwaps",
             FullPeepholeOptimise(allow_swaps=False),
+        ),
+        (
+            "TryDelayMeasures",
+            DelayMeasures(allow_partial=True),
         ),
     ],
 )

--- a/pytket/tests/passes_serialisation_test.py
+++ b/pytket/tests/passes_serialisation_test.py
@@ -262,6 +262,12 @@ TWO_WAY_PARAM_PASSES = {
             "x_circuit": example_1q_circuit,
         }
     ),
+    "DelayMeasures": standard_pass_dict(
+        {
+            "name": "DelayMeasures",
+            "allow_partial": False,
+        }
+    ),
 }
 
 # non-parametrized passes that satisfy pass.from_dict(d).to_dict()==d
@@ -283,7 +289,6 @@ TWO_WAY_NONPARAM_PASSES = [
     "SquashTK1",
     "SquashRzPhasedX",
     "FlattenRegisters",
-    "DelayMeasures",
     "ZZPhaseToRz",
     "RemoveDiscarded",
     "SimplifyMeasured",
@@ -634,6 +639,7 @@ def test_pass_deserialisation_only() -> None:
     np_pass = dm_pass.get_sequence()[0].get_sequence()[2]
     d_pass = dm_pass.get_sequence()[1]
     assert d_pass.to_dict()["StandardPass"]["name"] == "DelayMeasures"
+    assert d_pass.to_dict()["StandardPass"]["allow_partial"] == "False"
     assert p_pass.to_dict()["StandardPass"]["name"] == "PlacementPass"
     assert np_pass.to_dict()["StandardPass"]["name"] == "NaivePlacementPass"
     assert r_pass.to_dict()["StandardPass"]["name"] == "RoutingPass"
@@ -683,6 +689,7 @@ def test_pass_deserialisation_only() -> None:
     p001 = p00.get_sequence()[1]
     assert p000.to_dict()["pass_class"] == "SequencePass"
     assert p001.to_dict()["StandardPass"]["name"] == "DelayMeasures"
+    assert p001.to_dict()["StandardPass"]["allow_partial"] == "False"
     p0000 = p000.get_sequence()[0]
     p0001 = p000.get_sequence()[1]
     assert p0000.to_dict()["StandardPass"]["name"] == "RebaseCustom"

--- a/pytket/tests/passes_serialisation_test.py
+++ b/pytket/tests/passes_serialisation_test.py
@@ -639,7 +639,7 @@ def test_pass_deserialisation_only() -> None:
     np_pass = dm_pass.get_sequence()[0].get_sequence()[2]
     d_pass = dm_pass.get_sequence()[1]
     assert d_pass.to_dict()["StandardPass"]["name"] == "DelayMeasures"
-    assert d_pass.to_dict()["StandardPass"]["allow_partial"] == "False"
+    assert d_pass.to_dict()["StandardPass"]["allow_partial"] == False
     assert p_pass.to_dict()["StandardPass"]["name"] == "PlacementPass"
     assert np_pass.to_dict()["StandardPass"]["name"] == "NaivePlacementPass"
     assert r_pass.to_dict()["StandardPass"]["name"] == "RoutingPass"
@@ -689,7 +689,7 @@ def test_pass_deserialisation_only() -> None:
     p001 = p00.get_sequence()[1]
     assert p000.to_dict()["pass_class"] == "SequencePass"
     assert p001.to_dict()["StandardPass"]["name"] == "DelayMeasures"
-    assert p001.to_dict()["StandardPass"]["allow_partial"] == "False"
+    assert p001.to_dict()["StandardPass"]["allow_partial"] == False
     p0000 = p000.get_sequence()[0]
     p0001 = p000.get_sequence()[1]
     assert p0000.to_dict()["StandardPass"]["name"] == "RebaseCustom"

--- a/recipes/tket-proptests/conanfile.py
+++ b/recipes/tket-proptests/conanfile.py
@@ -28,7 +28,7 @@ class TketProptestsConan(ConanFile):
     generators = "cmake"
     exports_sources = "../../tket/proptests/*"
     requires = (
-        "tket/1.0.50@tket/stable",
+        "tket/1.0.51@tket/stable",
         "rapidcheck/cci.20220514",
     )
 

--- a/recipes/tket-tests/conanfile.py
+++ b/recipes/tket-tests/conanfile.py
@@ -34,7 +34,7 @@ class TketTestsConan(ConanFile):
     default_options = {"with_coverage": False, "full": False, "long": False}
     generators = "cmake"
     exports_sources = "../../tket/tests/*"
-    requires = ("tket/1.0.50@tket/stable", "catch2/3.2.1")
+    requires = ("tket/1.0.51@tket/stable", "catch2/3.2.1")
 
     _cmake = None
 

--- a/recipes/tket/conanfile.py
+++ b/recipes/tket/conanfile.py
@@ -20,7 +20,7 @@ import shutil
 
 class TketConan(ConanFile):
     name = "tket"
-    version = "1.0.50"
+    version = "1.0.51"
     license = "CQC Proprietary"
     homepage = "https://github.com/CQCL/tket"
     url = "https://github.com/conan-io/conan-center-index"

--- a/schemas/compiler_pass_v1.json
+++ b/schemas/compiler_pass_v1.json
@@ -274,6 +274,10 @@
           "type": "boolean",
           "description": "Whether to include a \"DelayMeasures\" pass in a \"CXMappingPass\"."
         },
+        "allow_partial": {
+          "type": "boolean",
+          "description": "Whether to allow partial delays in \"DelayMeasures\" when the circuit has non-commutable operations after the measure."
+        },
         "target_2qb_gate": {
           "type": "string",
           "enum": [
@@ -697,6 +701,21 @@
           "if": {
             "properties": {
               "name": {
+                "const": "DelayMeasures"
+              }
+            }
+          },
+          "then": {
+            "required": [
+              "allow_partial"
+            ],
+            "maxProperties": 2
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "name": {
                 "$comment": "List all non-parametrized passes",
                 "enum": [
                   "CommuteThroughMultis",
@@ -716,7 +735,6 @@
                   "SquashTK1",
                   "SquashRzPhasedX",
                   "FlattenRegisters",
-                  "DelayMeasures",
                   "ZZPhaseToRz",
                   "RemoveDiscarded",
                   "SimplifyMeasured",

--- a/tket/src/Predicates/CompilerPass.cpp
+++ b/tket/src/Predicates/CompilerPass.cpp
@@ -416,7 +416,8 @@ void from_json(const nlohmann::json& j, PassPtr& pp) {
     } else if (passname == "SquashCustom") {
       throw PassNotSerializable(passname);
     } else if (passname == "DelayMeasures") {
-      pp = DelayMeasures();
+      bool allow_partial = content.at("allow_partial").get<bool>();
+      pp = DelayMeasures(allow_partial);
     } else if (passname == "ZZPhaseToRz") {
       pp = ZZPhaseToRz();
     } else if (passname == "RemoveDiscarded") {

--- a/tket/src/Predicates/Predicates.cpp
+++ b/tket/src/Predicates/Predicates.cpp
@@ -552,7 +552,8 @@ bool CommutableMeasuresPredicate::verify(const Circuit& circ) const {
   if (circ.n_bits() == 0) return true;
   // run_delay_measures_ will not modify the circuit when dry_run is true
   Circuit& mutable_circ = const_cast<Circuit&>(circ);
-  return Transforms::DelayMeasures::run_delay_measures(mutable_circ, false, true)
+  return Transforms::DelayMeasures::run_delay_measures(
+             mutable_circ, false, true)
       .second;
 }
 

--- a/tket/src/Predicates/Predicates.cpp
+++ b/tket/src/Predicates/Predicates.cpp
@@ -552,7 +552,7 @@ bool CommutableMeasuresPredicate::verify(const Circuit& circ) const {
   if (circ.n_bits() == 0) return true;
   // run_delay_measures_ will not modify the circuit when dry_run is true
   Circuit& mutable_circ = const_cast<Circuit&>(circ);
-  return Transforms::DelayMeasures::run_delay_measures(mutable_circ, true)
+  return Transforms::DelayMeasures::run_delay_measures(mutable_circ, false, true)
       .second;
 }
 

--- a/tket/src/Predicates/include/Predicates/PassLibrary.hpp
+++ b/tket/src/Predicates/include/Predicates/PassLibrary.hpp
@@ -67,7 +67,7 @@ const PassPtr &RemoveBarriers();
  * the end, and delay them as much as possible instead. If false, the pass
  * includes a @ref CommutableMeasuresPredicate precondition.
  */
-const PassPtr &DelayMeasures(bool allow_partial=false);
+const PassPtr &DelayMeasures(bool allow_partial = false);
 
 /**
  * Remove all operations that have no @ref OpType::Output or

--- a/tket/src/Predicates/include/Predicates/PassLibrary.hpp
+++ b/tket/src/Predicates/include/Predicates/PassLibrary.hpp
@@ -62,8 +62,12 @@ const PassPtr &FlattenRegisters();
 /** Remove all& \ref OpType::Barrier from the circuit. */
 const PassPtr &RemoveBarriers();
 
-/** Commutes measurements to the end of the circuit. */
-const PassPtr &DelayMeasures();
+/** Commutes measurements to the end of the circuit.
+ * @param allow_partial Whether to allow measurements that cannot be commuted to
+ * the end, and delay them as much as possible instead. If false, the pass
+ * includes a @ref CommutableMeasuresPredicate precondition.
+ */
+const PassPtr &DelayMeasures(bool allow_partial=false);
 
 /**
  * Remove all operations that have no @ref OpType::Output or

--- a/tket/src/Transformations/include/Transformations/MeasurePass.hpp
+++ b/tket/src/Transformations/include/Transformations/MeasurePass.hpp
@@ -37,11 +37,11 @@ namespace DelayMeasures {
  * the end, and delay them as much as possible instead.
  * @param dry_run If true, do not modify the circuit, just check if it is
  * possible to delay.
- * @throws CircuitInvalidity if it is not possible to delay and both
- * \p allow_partial and \p dry_run are false.
+ * @throws CircuitInvalidity if it is not possible to delay and both \p
+ * allow_partial and \p dry_run are false.
  * @return A pair of booleans. The first indicates when the circuit was changed,
- * and the second indicates if there where no undelayable gates (i.e. there
- * where no errors).
+ * and the second indicates if the run found no errors (i.e. it was possible to
+ * delay all measures to the end, or \p allow_partial was true).
  **/
 std::pair<bool, bool> run_delay_measures(
     Circuit& circ, bool allow_partial = false, bool dry_run = false);

--- a/tket/src/Transformations/include/Transformations/MeasurePass.hpp
+++ b/tket/src/Transformations/include/Transformations/MeasurePass.hpp
@@ -22,23 +22,29 @@ namespace Transforms {
 
 /**
  * Commute all measurement gates to the end of the circuit.
- * Throws a CircuitInvalidity exception if it is not possible to delay.
+ * @param allow_partial Whether to allow measurements that cannot be commuted to
+ * the end, and delay them as much as possible instead.
+ * @throws CircuitInvalidity if it is not possible to delay a measurement, and
+ * \p allow_partial is false.
  */
-Transform delay_measures();
+Transform delay_measures(bool allow_partial = false);
 
 namespace DelayMeasures {
 
 /** Commute all measurement gates to the end of the circuit.
  * @param circ The circuit to delay measurements in.
+ * @param allow_partial Whether to allow measurements that cannot be commuted to
+ * the end, and delay them as much as possible instead.
  * @param dry_run If true, do not modify the circuit, just check if it is
  * possible to delay.
- * @throws CircuitInvalidity if it is not possible to delay and dry_run is
- * false.
+ * @throws CircuitInvalidity if it is not possible to delay and both
+ * \p allow_partial and \p dry_run are false.
  * @return A pair of booleans. The first indicates when the circuit was changed,
  * and the second indicates if there where no undelayable gates (i.e. there
  * where no errors).
  **/
-std::pair<bool, bool> run_delay_measures(Circuit& circ, bool dry_run = false);
+std::pair<bool, bool> run_delay_measures(
+    Circuit& circ, bool allow_partial = false, bool dry_run = false);
 
 /**
  * Gathers all end-measurements, and adds the measured units to the list.

--- a/tket/tests/test_CompilerPass.cpp
+++ b/tket/tests/test_CompilerPass.cpp
@@ -1208,6 +1208,7 @@ SCENARIO("Compose Pauli Graph synthesis Passes") {
 
 SCENARIO("Commute measurements to the end of a circuit") {
   PassPtr delay_pass = DelayMeasures();
+  PassPtr try_delay_pass = DelayMeasures(true);
   PredicatePtr mid_meas_pred = std::make_shared<NoMidMeasurePredicate>();
   GIVEN("Measurements already at end") {
     Circuit c(2, 2);
@@ -1247,6 +1248,13 @@ SCENARIO("Commute measurements to the end of a circuit") {
     CompilationUnit cu(c);
     REQUIRE_THROWS_AS(delay_pass->apply(cu), UnsatisfiedPredicate);
   }
+  GIVEN("Measure blocked by quantum gate, using a partial delay pass") {
+    Circuit c(1, 1);
+    c.add_op<unsigned>(OpType::Measure, {0, 0});
+    c.add_op<unsigned>(OpType::Rx, 0.3, {0});
+    CompilationUnit cu(c);
+    REQUIRE_FALSE(try_delay_pass->apply(cu));
+  }
   GIVEN("Measure blocked by classical operation") {
     Circuit c(2, 1);
     add_2qb_gates(c, OpType::Measure, {{0, 0}, {1, 0}});
@@ -1255,6 +1263,14 @@ SCENARIO("Commute measurements to the end of a circuit") {
     CompilationUnit cu(c);
     REQUIRE_THROWS_AS(delay_pass->apply(cu), UnsatisfiedPredicate);
   }
+  GIVEN("Measure blocked by classical operation, using a partial delay pass") {
+    Circuit c(2, 1);
+    add_2qb_gates(c, OpType::Measure, {{0, 0}, {1, 0}});
+    c.add_op<unsigned>(OpType::Measure, {0, 0});
+    c.add_op<unsigned>(OpType::Measure, {1, 0});
+    CompilationUnit cu(c);
+    REQUIRE_FALSE(try_delay_pass->apply(cu));
+  }
   GIVEN("Measure blocked by conditional operation") {
     Circuit c(2, 2);
     c.add_op<unsigned>(OpType::CZ, {0, 1});
@@ -1262,6 +1278,15 @@ SCENARIO("Commute measurements to the end of a circuit") {
     c.add_conditional_gate<unsigned>(OpType::Z, {}, {1}, {0}, 1);
     CompilationUnit cu(c);
     REQUIRE_THROWS_AS(delay_pass->apply(cu), UnsatisfiedPredicate);
+  }
+  GIVEN("Measure partially blocked by conditional operation, using a partial delay pass") {
+    Circuit c(2, 2);
+    c.add_op<unsigned>(OpType::CZ, {0, 1});
+    c.add_op<unsigned>(OpType::Measure, {0, 0});
+    c.add_op<unsigned>(OpType::Z, {0});
+    c.add_conditional_gate<unsigned>(OpType::Z, {}, {1}, {0}, 1);
+    CompilationUnit cu(c);
+    REQUIRE(try_delay_pass->apply(cu));
   }
   GIVEN("Call on invalid circuit without checking the predicate throws") {
     Circuit c(2, 2);

--- a/tket/tests/test_CompilerPass.cpp
+++ b/tket/tests/test_CompilerPass.cpp
@@ -1279,7 +1279,9 @@ SCENARIO("Commute measurements to the end of a circuit") {
     CompilationUnit cu(c);
     REQUIRE_THROWS_AS(delay_pass->apply(cu), UnsatisfiedPredicate);
   }
-  GIVEN("Measure partially blocked by conditional operation, using a partial delay pass") {
+  GIVEN(
+      "Measure partially blocked by conditional operation, using a partial "
+      "delay pass") {
     Circuit c(2, 2);
     c.add_op<unsigned>(OpType::CZ, {0, 1});
     c.add_op<unsigned>(OpType::Measure, {0, 0});

--- a/tket/tests/test_json.cpp
+++ b/tket/tests/test_json.cpp
@@ -669,6 +669,7 @@ SCENARIO("Test compiler pass serializations") {
   COMPPASSJSONTEST(SquashRzPhasedX, SquashRzPhasedX())
   COMPPASSJSONTEST(FlattenRegisters, FlattenRegisters())
   COMPPASSJSONTEST(DelayMeasures, DelayMeasures())
+  COMPPASSJSONTEST(DelayMeasures(true), DelayMeasures(true))
   COMPPASSJSONTEST(RemoveDiscarded, RemoveDiscarded())
   COMPPASSJSONTEST(SimplifyMeasured, SimplifyMeasured())
   COMPPASSJSONTEST(ZZPhaseToRz, ZZPhaseToRz())

--- a/tket/tests/test_json.cpp
+++ b/tket/tests/test_json.cpp
@@ -669,7 +669,7 @@ SCENARIO("Test compiler pass serializations") {
   COMPPASSJSONTEST(SquashRzPhasedX, SquashRzPhasedX())
   COMPPASSJSONTEST(FlattenRegisters, FlattenRegisters())
   COMPPASSJSONTEST(DelayMeasures, DelayMeasures())
-  COMPPASSJSONTEST(DelayMeasures(true), DelayMeasures(true))
+  COMPPASSJSONTEST(TryDelayMeasures, DelayMeasures(true))
   COMPPASSJSONTEST(RemoveDiscarded, RemoveDiscarded())
   COMPPASSJSONTEST(SimplifyMeasured, SimplifyMeasured())
   COMPPASSJSONTEST(ZZPhaseToRz, ZZPhaseToRz())


### PR DESCRIPTION
Adds an `allow_partial` parameter to the `DelayMeasures` pass to push the measurements as much as possible, without failing if it cannot reach the end of the circuit.