### PR TITLE
add check to get_compiled_circuit

### DIFF
--- a/pytket/pytket/backends/backend.py
+++ b/pytket/pytket/backends/backend.py
@@ -172,14 +172,20 @@ class Backend(ABC):
         ...
 
     def get_compiled_circuit(
-        self, circuit: Circuit, optimisation_level: int = 2
+        self, circuit: Circuit, optimisation_level: int = 2, check_predicates: bool = False
     ) -> Circuit:
         """
         Return a single circuit compiled with :py:meth:`default_compilation_pass`. See
         :py:meth:`Backend.get_compiled_circuits`.
+
+        Optional boolean flag to check that all :py:class:`Backend` predicates are satisfied (default=False).
         """
         return_circuit = circuit.copy()
         self.default_compilation_pass(optimisation_level).apply(return_circuit)
+        
+        if check_predicates:
+            assert self.valid_circuit(return_circuit)
+
         return return_circuit
 
     def get_compiled_circuits(

--- a/pytket/pytket/backends/backend.py
+++ b/pytket/pytket/backends/backend.py
@@ -166,7 +166,10 @@ class Backend(ABC):
             - Level 2 (the default) adds more computationally intensive optimisations
               that should give the best results from execution.
 
+        :param timeout: The time in milliseconds spent searching for new qubit placements.
+
         :type optimisation_level: int, optional
+        :type timeout: int, optional
         :return: Compilation pass guaranteeing required predicates.
         :rtype: BasePass
         """
@@ -182,9 +185,6 @@ class Backend(ABC):
         """
         Return a single circuit compiled with :py:meth:`default_compilation_pass`. See
         :py:meth:`Backend.get_compiled_circuits`.
-
-        Optional boolean flag to check that all :py:class:`Backend` predicates
-        are satisfied (default=False).
         """
         return_circuit = circuit.copy()
 
@@ -199,7 +199,11 @@ class Backend(ABC):
         return return_circuit
 
     def get_compiled_circuits(
-        self, circuits: Sequence[Circuit], optimisation_level: int = 2
+        self,
+        circuits: Sequence[Circuit],
+        optimisation_level: int = 2,
+        timeout: int = 1000,
+        check_predicates: bool = False,
     ) -> List[Circuit]:
         """Compile a sequence of circuits with :py:meth:`default_compilation_pass`
         and return the list of compiled circuits (does not act in place).
@@ -225,11 +229,18 @@ class Backend(ABC):
         :param optimisation_level: The level of optimisation to perform during
             compilation. See :py:meth:`default_compilation_pass` for a description of
             the different levels (0, 1 or 2). Defaults to 2.
+        :param timeout: The time in milliseconds spent searching for new qubit placements (defaults to 1000).
+        :param check_predicates: Whether or not to check that all backend predicates are satisfied after compilation (defaults to False)
         :type optimisation_level: int, optional
+        :type timeout: int, optional
+        :type check_predicates: bool, optional
         :return: Compiled circuits.
         :rtype: List[Circuit]
         """
-        return [self.get_compiled_circuit(c, optimisation_level) for c in circuits]
+        return [
+            self.get_compiled_circuit(c, optimisation_level, timeout, check_predicates)
+            for c in circuits
+        ]
 
     @property
     @abstractmethod

--- a/pytket/pytket/backends/backend.py
+++ b/pytket/pytket/backends/backend.py
@@ -181,7 +181,8 @@ class Backend(ABC):
         Return a single circuit compiled with :py:meth:`default_compilation_pass`. See
         :py:meth:`Backend.get_compiled_circuits`.
 
-        Optional boolean flag to check that all :py:class:`Backend` predicates are satisfied (default=False).
+        Optional boolean flag to check that all :py:class:`Backend` predicates
+        are satisfied (default=False).
         """
         return_circuit = circuit.copy()
         self.default_compilation_pass(optimisation_level).apply(return_circuit)

--- a/pytket/pytket/backends/backend.py
+++ b/pytket/pytket/backends/backend.py
@@ -166,7 +166,7 @@ class Backend(ABC):
             - Level 2 (the default) adds more computationally intensive optimisations
               that should give the best results from execution.
 
-        :param timeout: The time in milliseconds spent searching for new qubit placements.
+        :param timeout: The time in milliseconds spent searching for new qubit placements (defaults to 1000).
 
         :type optimisation_level: int, optional
         :type timeout: int, optional

--- a/pytket/pytket/backends/backend.py
+++ b/pytket/pytket/backends/backend.py
@@ -188,13 +188,13 @@ class Backend(ABC):
         """
         return_circuit = circuit.copy()
 
+        self.default_compilation_pass(optimisation_level, timeout).apply(return_circuit)
+
         if check_predicates:
             for i, predicate in enumerate(self.required_predicates):
                 compilation_error = CircuitNotValidError(i, repr(predicate))
                 if not predicate.verify(return_circuit):
                     raise compilation_error
-
-        self.default_compilation_pass(optimisation_level, timeout).apply(return_circuit)
 
         return return_circuit
 

--- a/pytket/pytket/backends/backend.py
+++ b/pytket/pytket/backends/backend.py
@@ -144,7 +144,7 @@ class Backend(ABC):
 
     @abstractmethod
     def default_compilation_pass(
-        self, optimisation_level: int = 2, timeout=1000
+        self, optimisation_level: int = 2, timeout: int = 1000
     ) -> BasePass:
         """
         A suggested compilation pass that will will, if possible, produce an equivalent

--- a/pytket/pytket/backends/backend.py
+++ b/pytket/pytket/backends/backend.py
@@ -187,9 +187,9 @@ class Backend(ABC):
         self.default_compilation_pass(optimisation_level).apply(return_circuit)
 
         if check_predicates:
-            for predicate in self.required_predicates:
-                if not predicate.verify(circuit)
-                    compilation_error = CircuitNotValidError(failed_pred=predicate)
+            for i, predicate in enumerate(self.required_predicates):
+                compilation_error = CircuitNotValidError(i, repr(predicate))
+                if not predicate.verify(return_circuit):
                     raise compilation_error
 
         return return_circuit

--- a/pytket/pytket/backends/backend.py
+++ b/pytket/pytket/backends/backend.py
@@ -107,7 +107,6 @@ class Backend(ABC):
     def _check_all_circuits(
         self, circuits: Iterable[Circuit], nomeasure_warn: Optional[bool] = None
     ) -> bool:
-
         if nomeasure_warn is None:
             nomeasure_warn = not (
                 self._supports_state
@@ -188,7 +187,10 @@ class Backend(ABC):
         self.default_compilation_pass(optimisation_level).apply(return_circuit)
 
         if check_predicates:
-            assert self.valid_circuit(return_circuit)
+            for predicate in self.required_predicates:
+                if not predicate.verify(circuit)
+                    compilation_error = CircuitNotValidError(failed_pred=predicate)
+                    raise compilation_error
 
         return return_circuit
 
@@ -275,7 +277,6 @@ class Backend(ABC):
         valid_check: bool = True,
         **kwargs: KwargTypes,
     ) -> List[ResultHandle]:
-
         """
         Submit circuits to the backend for running. The results will be stored
         in the backend's result cache to be retrieved by the corresponding

--- a/pytket/pytket/backends/backend.py
+++ b/pytket/pytket/backends/backend.py
@@ -181,8 +181,8 @@ class Backend(ABC):
         self,
         circuit: Circuit,
         optimisation_level: int = 2,
-        timeout: int = 1000,
-        check_predicates: bool = False,
+        timeout: int = 1000
+        # check_predicates: bool = False
     ) -> Circuit:
         """
         Return a single circuit compiled with :py:meth:`default_compilation_pass`. See
@@ -192,11 +192,11 @@ class Backend(ABC):
 
         self.default_compilation_pass(optimisation_level, timeout).apply(return_circuit)
 
-        if check_predicates:
-            for i, predicate in enumerate(self.required_predicates):
-                compilation_error = CircuitNotValidError(i, repr(predicate))
-                if not predicate.verify(return_circuit):
-                    raise compilation_error
+        # if check_predicates:
+        #    for i, predicate in enumerate(self.required_predicates):
+        #        compilation_error = CircuitNotValidError(i, repr(predicate))
+        #        if not predicate.verify(return_circuit):
+        #            raise compilation_error
 
         return return_circuit
 
@@ -204,8 +204,8 @@ class Backend(ABC):
         self,
         circuits: Sequence[Circuit],
         optimisation_level: int = 2,
-        timeout: int = 1000,
-        check_predicates: bool = False,
+        timeout: int = 1000
+        # check_predicates: bool = False,
     ) -> List[Circuit]:
         """Compile a sequence of circuits with :py:meth:`default_compilation_pass`
         and return the list of compiled circuits (does not act in place).
@@ -242,8 +242,7 @@ class Backend(ABC):
         :rtype: List[Circuit]
         """
         return [
-            self.get_compiled_circuit(c, optimisation_level, timeout, check_predicates)
-            for c in circuits
+            self.get_compiled_circuit(c, optimisation_level, timeout) for c in circuits
         ]
 
     @property

--- a/pytket/pytket/backends/backend.py
+++ b/pytket/pytket/backends/backend.py
@@ -166,10 +166,11 @@ class Backend(ABC):
             - Level 2 (the default) adds more computationally intensive optimisations
               that should give the best results from execution.
 
+        :type optimisation_level: int, optional
+
         :param timeout: The time in milliseconds spent searching for
                     new qubit placements (defaults to 1000).
 
-        :type optimisation_level: int, optional
         :type timeout: int, optional
         :return: Compilation pass guaranteeing required predicates.
         :rtype: BasePass
@@ -230,12 +231,12 @@ class Backend(ABC):
         :param optimisation_level: The level of optimisation to perform during
             compilation. See :py:meth:`default_compilation_pass` for a description of
             the different levels (0, 1 or 2). Defaults to 2.
+        :type optimisation_level: int, optional
         :param timeout: The time in milliseconds spent searching for
           new qubit placements (defaults to 1000).
-        :param check_predicates: Whether or not to check that all :py:class:`Backend`
-          predicates are satisfied after compilation (defaults to False).
-        :type optimisation_level: int, optional
         :type timeout: int, optional
+        :param check_predicates:  Whether or not to check that all :py:class:`Backend`
+          predicates are satisfied after compilation (defaults to False).
         :type check_predicates: bool, optional
         :return: Compiled circuits.
         :rtype: List[Circuit]

--- a/pytket/pytket/backends/backend.py
+++ b/pytket/pytket/backends/backend.py
@@ -166,7 +166,8 @@ class Backend(ABC):
             - Level 2 (the default) adds more computationally intensive optimisations
               that should give the best results from execution.
 
-        :param timeout: The time in milliseconds spent searching for new qubit placements (defaults to 1000).
+        :param timeout: The time in milliseconds spent searching for
+                    new qubit placements (defaults to 1000).
 
         :type optimisation_level: int, optional
         :type timeout: int, optional
@@ -229,8 +230,10 @@ class Backend(ABC):
         :param optimisation_level: The level of optimisation to perform during
             compilation. See :py:meth:`default_compilation_pass` for a description of
             the different levels (0, 1 or 2). Defaults to 2.
-        :param timeout: The time in milliseconds spent searching for new qubit placements (defaults to 1000).
-        :param check_predicates: Whether or not to check that all backend predicates are satisfied after compilation (defaults to False)
+        :param timeout: The time in milliseconds spent searching for
+          new qubit placements (defaults to 1000).
+        :param check_predicates: Whether or not to check that all :py:class:`Backend`
+          predicates are satisfied after compilation (defaults to False).
         :type optimisation_level: int, optional
         :type timeout: int, optional
         :type check_predicates: bool, optional

--- a/pytket/pytket/backends/backend.py
+++ b/pytket/pytket/backends/backend.py
@@ -184,13 +184,14 @@ class Backend(ABC):
         are satisfied (default=False).
         """
         return_circuit = circuit.copy()
-        self.default_compilation_pass(optimisation_level).apply(return_circuit)
 
         if check_predicates:
             for i, predicate in enumerate(self.required_predicates):
                 compilation_error = CircuitNotValidError(i, repr(predicate))
                 if not predicate.verify(return_circuit):
                     raise compilation_error
+
+        self.default_compilation_pass(optimisation_level).apply(return_circuit)
 
         return return_circuit
 

--- a/pytket/pytket/backends/backend.py
+++ b/pytket/pytket/backends/backend.py
@@ -172,7 +172,10 @@ class Backend(ABC):
         ...
 
     def get_compiled_circuit(
-        self, circuit: Circuit, optimisation_level: int = 2, check_predicates: bool = False
+        self,
+        circuit: Circuit,
+        optimisation_level: int = 2,
+        check_predicates: bool = False,
     ) -> Circuit:
         """
         Return a single circuit compiled with :py:meth:`default_compilation_pass`. See
@@ -182,7 +185,7 @@ class Backend(ABC):
         """
         return_circuit = circuit.copy()
         self.default_compilation_pass(optimisation_level).apply(return_circuit)
-        
+
         if check_predicates:
             assert self.valid_circuit(return_circuit)
 

--- a/pytket/pytket/backends/backend.py
+++ b/pytket/pytket/backends/backend.py
@@ -143,7 +143,9 @@ class Backend(ABC):
         ...
 
     @abstractmethod
-    def default_compilation_pass(self, optimisation_level: int = 2) -> BasePass:
+    def default_compilation_pass(
+        self, optimisation_level: int = 2, timeout=1000
+    ) -> BasePass:
         """
         A suggested compilation pass that will will, if possible, produce an equivalent
         circuit suitable for running on this backend.
@@ -174,6 +176,7 @@ class Backend(ABC):
         self,
         circuit: Circuit,
         optimisation_level: int = 2,
+        timeout: int = 1000,
         check_predicates: bool = False,
     ) -> Circuit:
         """
@@ -191,7 +194,7 @@ class Backend(ABC):
                 if not predicate.verify(return_circuit):
                     raise compilation_error
 
-        self.default_compilation_pass(optimisation_level).apply(return_circuit)
+        self.default_compilation_pass(optimisation_level, timeout).apply(return_circuit)
 
         return return_circuit
 

--- a/pytket/tests/backend_test.py
+++ b/pytket/tests/backend_test.py
@@ -21,7 +21,7 @@ from typing import Any, List
 
 import numpy as np
 
-from pytket.circuit import Circuit, OpType, BasisOrder, Qubit, Bit, Node  # type: ignore
+from pytket.circuit import Circuit, OpType, BasisOrder, Qubit, Bit, Node, if_bit  # type: ignore
 from pytket.predicates import CompilationUnit  # type: ignore
 from pytket.passes import PauliSimp, CliffordSimp, ContextSimp  # type: ignore
 from pytket.mapping import MappingManager, LexiRouteRoutingMethod, LexiLabellingMethod  # type: ignore
@@ -589,6 +589,18 @@ def test_postprocess_4() -> None:
     assert all(readout[0] == 1 for readout in counts.keys())
 
 
+def test_predicate_check() -> None:
+    backend = TketSimShotBackend()
+    circ = Circuit()
+    q_reg = circ.add_q_register("qr", 2)
+    c_reg = circ.add_c_register("cr", 2)
+    circ.X(q_reg[0])
+    circ.CX(q_reg[0], q_reg[1])
+    circ.Measure(q_reg[1], c_reg[1])
+    circ.X(q_reg[0], condition=if_bit(c_reg[1]))
+    compiled_circ = backend.get_compiled_circuit(circ, check_predicates=True)
+
+
 if __name__ == "__main__":
     # test_resulthandle()
     # test_bell()
@@ -597,5 +609,6 @@ if __name__ == "__main__":
     # test_swaps_basisorder()
     # test_outcomearray()
     test_backendresult()
+    test_predicate_check()
     # test_outcomearray_serialization()
     # test_backendresult_serialization()


### PR DESCRIPTION
Changes:

I've added a `check_predicates` arg to `Backend.get_compiled_circuit` which checks if all predicates are satisfied and throws an error if they aren't. Ideally this error message should tell the user exactly which predicate is not satisfied so they can fix their circuit. See https://github.com/CQCL/tket/issues/684

Another thing I thought about adding was a warning which would inform the user that their circuit is invalid. Let me know if you think this is a good idea.

For example its currently possible to compile an 80 qubit circuit to the 20 qubit `QuantinuumBackend` and the user will only see an error message when `Backend.process_circuits` is called. There are other predicates such as `NoClassicalControlPredicate` that may slip through `Backend.get_compiled_circuit` too.