### PR TITLE
Renderer update

### DIFF
--- a/pytket/pytket/circuit/display/__init__.py
+++ b/pytket/pytket/circuit/display/__init__.py
@@ -104,10 +104,11 @@ class CircuitRenderer:
                 HTML,
                 display,
             )  # pylint: disable=C0415
+
             fp = tempfile.NamedTemporaryFile(
                 mode="w", suffix=".html", delete=False, dir=os.getcwd()
             )
-            fp.write(cast(str, html))
+            fp.write(html)
             fp.close()
             try:
                 with warnings.catch_warnings(record=True):  # supress iframe suggestion

--- a/pytket/pytket/circuit/display/static/circuit.html
+++ b/pytket/pytket/circuit/display/static/circuit.html
@@ -25,9 +25,11 @@
 
 {% if jupyter %}
 
-<iframe srcdoc="{{ show_circuit_page(display_options, circuit_json, uid)|escape }}"
-        width="100%" height="200px"
-        style="border: none; outline: none; resize: vertical; overflow: auto"></iframe>
+<div style="resize: vertical; overflow: auto; height: 200px; display: block">
+    <iframe srcdoc="{{ show_circuit_page(display_options, circuit_json, uid)|escape }}"
+            width="100%" height="100%"
+            style="border: none; outline: none; overflow: auto"></iframe>
+</div>
 
 {% else %}
 

--- a/pytket/pytket/circuit/display/static/circuit.html
+++ b/pytket/pytket/circuit/display/static/circuit.html
@@ -8,6 +8,12 @@
     {% include "html/head_imports.html" %}
 </head>
 <body>
+
+{% if not jupyter %}
+<div style="position:absolute;top:0;bottom:0;left:0;right:0;margin:auto;resize:both;display:block;overflow:hidden;
+width:min(500px, 100%);height:min(300px,100%);max-width:100%;max-height:100%;">
+{% endif %}
+
     <div id="circuit-display-vue-container-{{uid}}" class="pytket-circuit-display-container">
         <div style="display: none">
             <div id="circuit-json-to-display">{{ circuit_json }}</div>
@@ -19,6 +25,11 @@
 
       {% include_raw "js/main.js" %}
     </script>
+
+{% if not jupyter %}
+</div>
+{% endif %}
+
 </body>
 </html>
 {% endmacro %}

--- a/pytket/pytket/circuit/display/static/head_imports.html
+++ b/pytket/pytket/circuit/display/static/head_imports.html
@@ -1,5 +1,5 @@
 <!-- Download Vue 3-->
 <script type="application/javascript" src="https://cdn.jsdelivr.net/npm/vue@3"></script>
 <!-- Download Circuit Renderer with styles -->
-<script type="application/javascript" src="https://unpkg.com/pytket-circuit-renderer@0.5/dist/pytket-circuit-renderer.umd.js"></script>
-<link rel="stylesheet" href="https://unpkg.com/pytket-circuit-renderer@0.5/dist/pytket-circuit-renderer.css">
+<script type="application/javascript" src="https://unpkg.com/pytket-circuit-renderer@0.6/dist/pytket-circuit-renderer.umd.js"></script>
+<link rel="stylesheet" href="https://unpkg.com/pytket-circuit-renderer@0.6/dist/pytket-circuit-renderer.css">


### PR DESCRIPTION
Bump renderer version to 0.6

-- Edit

This PR also includes some more recent bugfixes:
- Allow resizing the circuit display container on firefox
- Display container when viewing circuit in the browser is by default smaller