### PR TITLE
Fix CI scripts for MacOS ARM64

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -473,67 +473,64 @@ jobs:
     - name: Build tket
       if: needs.check_changes.outputs.tket_changed == 'true'
       run: conan create tket --user tket --channel stable --build=missing -o boost/*:header_only=True -o tklog/*:shared=True -o tket/*:shared=True -tf ""
-    - name: Install pytket requirements
+    - name: Uninstall conan
+      run: pip3 uninstall -y conan
+    - name: Build and test pytket (3.9)
+      if: github.event_name == 'pull_request'
       run: |
+        eval "$(pyenv init -)"
+        pyenv shell tket-3.9
+        PKG_CONFIG_PATH="$(brew --prefix openblas)"/lib/pkgconfig pip install -U scipy
+        pip install -U conan
+        conan remove -c "pybind11/*"
+        conan remove -c "pytket/*"
         conan create recipes/pybind11
         conan create recipes/pybind11_json/all --version 0.2.13
-    - name: Build pytket (3.9)
-      if: github.event_name == 'pull_request'
-      run: |
-        eval "$(pyenv init -)"
-        pyenv shell tket-3.9
-        PKG_CONFIG_PATH="$(brew --prefix openblas)"/lib/pkgconfig pip install -U scipy
         cd pytket
         pip uninstall -y pytket
         pip install -e . -v
-    - name: Test pytket (3.9)
-      if: github.event_name == 'pull_request'
-      run: |
-        eval "$(pyenv init -)"
-        pyenv shell tket-3.9
-        cd pytket
         pytest --doctest-modules pytket
         cd tests
         pip install -r requirements.txt
         pytest --ignore=simulator/
-    - name: Build pytket (3.10)
+    - name: Build and test pytket (3.10)
       if: github.event_name == 'push'
       run: |
         eval "$(pyenv init -)"
         pyenv shell tket-3.10
         PKG_CONFIG_PATH="$(brew --prefix openblas)"/lib/pkgconfig pip install -U scipy
+        pip install -U conan
+        conan remove -c "pybind11/*"
+        conan remove -c "pytket/*"
+        conan create recipes/pybind11
+        conan create recipes/pybind11_json/all --version 0.2.13
         cd pytket
         pip uninstall -y pytket
         pip install -e . -v
-    - name: Test pytket (3.10)
-      if: github.event_name == 'push'
-      run: |
-        eval "$(pyenv init -)"
-        pyenv shell tket-3.10
-        cd pytket
         pytest --doctest-modules pytket
         cd tests
         pip install -r requirements.txt
         pytest --ignore=simulator/
-    - name: Build pytket (3.11)
+    - name: Build and test pytket (3.11)
       if: github.event_name == 'schedule'
       run: |
         eval "$(pyenv init -)"
         pyenv shell tket-3.11
         PKG_CONFIG_PATH="$(brew --prefix openblas)"/lib/pkgconfig pip install -U scipy
+        pip install -U conan
+        conan remove -c "pybind11/*"
+        conan remove -c "pytket/*"
+        conan create recipes/pybind11
+        conan create recipes/pybind11_json/all --version 0.2.13
         cd pytket
         pip uninstall -y pytket
         pip install -e . -v
-    - name: Test pytket (3.11)
-      if: github.event_name == 'schedule'
-      run: |
-        eval "$(pyenv init -)"
-        pyenv shell tket-3.11
-        cd pytket
         pytest --doctest-modules pytket
         cd tests
         pip install -r requirements.txt
         pytest --ignore=simulator/
+    - name: Install conan
+      uses: turtlebrowser/get-conan@v1.2
     - name: Upload package
       if: github.event_name == 'push' && github.ref == 'refs/heads/develop' && needs.check_changes.outputs.tket_changed == 'true'
       run: |


### PR DESCRIPTION
When building pytket, take care to remove and rebuild pybind11 and pytket in each new python environment.