### PR TITLE
Add sphinx version bound

### DIFF
--- a/pytket/docs/requirements.txt
+++ b/pytket/docs/requirements.txt
@@ -1,4 +1,4 @@
-sphinx >= 4.5
+sphinx >= 4.5, < 6.2.0
 sphinx_autodoc_annotation >= 1.0
 sphinx_book_theme ~= 1.0.1
 sphinx-copybutton


### PR DESCRIPTION
6.2.0 introduces a new warning causing the` build-docs` script to exit with an error:
`WARNING: The pre-Sphinx 1.0 'intersphinx_mapping' format is deprecated and will be removed in Sphinx 8. Update to the current format as described in the documentation. Hint: "intersphinx_mapping = {'<name>': ('https://docs.python.org/', None)}".https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html#confval-intersphinx_mapping`

Will make a ticket to update sphinx to 6.2.0 later.