### PR TITLE
Feature/circuit renderer default options

### DIFF
--- a/pytket/docs/changelog.rst
+++ b/pytket/docs/changelog.rst
@@ -18,6 +18,7 @@ Minor new features:
   registers in the circuit.
 * Allow barriers in ``QControlBoxes``. Barriers are left in place.
 * Add ``Circuit.TK1`` and ``Circuit.TK2`` methods that take ``Qubit`` arguments.
+* Expose ``CircuitRenderer`` instance so users can set their own default options.
 
 Fixes:
 

--- a/pytket/docs/display.rst
+++ b/pytket/docs/display.rst
@@ -10,21 +10,49 @@ Contains several functions for rendering interactive circuit diagrams.
         pip install pytket-offline-display
 
 .. automodule:: pytket.circuit.display
-    :members: render_circuit_jupyter, render_circuit_as_html, view_browser
+    :members: get_circuit_renderer, CircuitRenderer
+
+Example usage:
+--------------
 
 .. jupyter-execute::
 
     from pytket import Circuit
-    from pytket.circuit.display import render_circuit_jupyter
+    from pytket.circuit.display import get_circuit_renderer
 
-    circ = Circuit(2) # Define Circuit
-    circ.H(0).H(1).CX(0, 1).Rz(0.4, 1).CX(0, 1).H(0).H(1)
-    render_circuit_jupyter(circ) # Render interactive display
-    
+    circuit_renderer = get_circuit_renderer() # Instantiate a circuit renderer
+    circuit_renderer.set_render_options(zx_style=False) # Configure render options
+    circuit_renderer.condense_c_bits = False # You can also set the properties on the instance directly
+    print("Render options:")
+    print(circuit_renderer.get_render_options()) # View currently set render options
+
+    circuit_renderer.min_height = "300px" # Change the display height
+
+    circ = Circuit(2,2) # Define Circuit
+    circ.H(0).H(1).CX(0, 1).Rz(0.4, 1).CX(0, 1).H(0).H(1).measure_all()
+
+    circuit_renderer.render_circuit_jupyter(circ) # Render interactive display
+
+If you are happy with the default render options, you can import the render
+functions directly:
+
+.. jupyter-execute::
+
+        from pytket import Circuit
+        from pytket.circuit.display import render_circuit_jupyter
+
+        circ = Circuit(2,2) # Define Circuit
+        circ.H(0).H(1).CX(0, 1).Rz(0.4, 1).CX(0, 1).H(0).H(1).measure_all()
+
+        render_circuit_jupyter(circ) # Render with default options
+
 This same diagram can be rendered with the offline renderer as follows
  
     ::
-        
-        from pytket.extensions.offline_display import render_circuit_jupyter
-        
-        render_circuit_jupyter(circ) # Render display as above
+
+        from pytket.extensions.offline_display import get_circuit_renderer, render_circuit_jupyter
+
+        custom_renderer = get_circuit_renderer()
+        custom_renderer.render_circuit_jupyter(circ) # Render configurable display as above
+        render_circuit_jupyter(circ) # Render using default options
+

--- a/pytket/pytket/circuit/display/__init__.py
+++ b/pytket/pytket/circuit/display/__init__.py
@@ -71,8 +71,65 @@ RenderCircuit = Union[Dict[str, Union[str, float, dict]], Circuit]
 class CircuitRenderer:
     """Class to manage circuit rendering within a given jinja2 environment."""
 
+    _ALLOWED_RENDER_OPTIONS = {
+        "zx_style": "zxStyle",
+        "condense_c_bits": "condenseCBits",
+        "recursive": "recursive",
+        "condensed": "condensed",
+        "dark_theme": "darkTheme",
+        "transparent_bg": "transparentBg",
+        "crop_params": "cropParams",
+    }
+    zx_style: Optional[bool] = None
+    condense_c_bits: Optional[bool] = None
+    recursive: Optional[bool] = None
+    condensed: Optional[bool] = None
+    dark_theme: Optional[bool] = None
+    transparent_bg: Optional[bool] = None
+    crop_params: Optional[bool] = None
+
+    _ALLOWED_CONFIG_OPTIONS = ["min_height", "min_width"]
+    min_height: str = "400px"
+    min_width: str = "500px"
+
     def __init__(self, env: Environment):
         self.env = env
+
+    def set_render_options(self, **kwargs: Dict[str, Union[bool, str]]) -> None:
+        """
+        Set rendering defaults.
+
+        :param min_height: str, initial height of circuit display.
+        :param min_width: str, initial width of circuit display.
+        :param zx_style: bool, display zx style gates where possible.
+        :param condense_c_bits: bool, collapse classical bits into a single wire.
+        :param recursive: bool, display nested circuits inline.
+        :param condensed: bool, display circuit on one line only.
+        :param dark_theme: bool, use dark mode.
+        :param transparent_bg: bool, remove the circuit background.
+        :param crop_params: bool, shorten parameter expressions for display.
+        """
+        for key, val in kwargs.items():
+            if key in self._ALLOWED_RENDER_OPTIONS:
+                self.__setattr__(key, val)
+            elif key in self._ALLOWED_CONFIG_OPTIONS and val is not None:
+                self.__setattr__(key, val)
+
+    def get_render_options(
+        self, full: bool = False, _for_js: bool = False
+    ) -> Dict[str, bool]:
+        """
+        Get a dict of the current render options.
+
+        :param full: whether to list all available options, even if not set.
+        :param _for_js: Whether to convert options to js-compatible format,
+            for internal use only.
+        """
+        return {
+            (js_key if _for_js else key): self.__getattribute__(key)
+            for key, js_key in self._ALLOWED_RENDER_OPTIONS.items()
+            if full or self.__getattribute__(key) is not None
+        }
 
     def render_circuit_as_html(
         self, circuit: RenderCircuit, jupyter: bool = False
@@ -94,6 +151,9 @@ class CircuitRenderer:
                 "circuit_json": json.dumps(circuit.to_dict()),
                 "uid": uid,
                 "jupyter": jupyter,
+                "display_options": json.dumps(self.get_render_options(_for_js=True)),
+                "min_height": self.min_height,
+                "min_width": self.min_width,
             }
         )
         if jupyter:
@@ -155,9 +215,13 @@ class CircuitRenderer:
             os.remove(fp.name)
 
 
-# Export the render functions scoped to the default jinja environment.
-circuit_renderer = CircuitRenderer(jinja_env)
+def get_circuit_renderer() -> CircuitRenderer:
+    """Get a configurable instance of the circuit renderer."""
+    return CircuitRenderer(jinja_env)
 
-render_circuit_as_html = circuit_renderer.render_circuit_as_html
-render_circuit_jupyter = circuit_renderer.render_circuit_jupyter
-view_browser = circuit_renderer.view_browser
+
+# Export the render functions scoped to the default jinja environment.
+_default_circuit_renderer = get_circuit_renderer()
+render_circuit_as_html = _default_circuit_renderer.render_circuit_as_html
+render_circuit_jupyter = _default_circuit_renderer.render_circuit_jupyter
+view_browser = _default_circuit_renderer.view_browser

--- a/pytket/pytket/circuit/display/__init__.py
+++ b/pytket/pytket/circuit/display/__init__.py
@@ -110,7 +110,9 @@ class CircuitRenderer:
         :param crop_params: bool, shorten parameter expressions for display.
         """
         for key, val in kwargs.items():
-            if key in self._ALLOWED_RENDER_OPTIONS and (isinstance(val, bool) or val is None):
+            if key in self._ALLOWED_RENDER_OPTIONS and (
+                isinstance(val, bool) or val is None
+            ):
                 self.__setattr__(key, val)
             elif key in self._ALLOWED_CONFIG_OPTIONS and isinstance(val, str):
                 self.__setattr__(key, val)

--- a/pytket/pytket/circuit/display/__init__.py
+++ b/pytket/pytket/circuit/display/__init__.py
@@ -95,7 +95,7 @@ class CircuitRenderer:
     def __init__(self, env: Environment):
         self.env = env
 
-    def set_render_options(self, **kwargs: Dict[str, Union[bool, str]]) -> None:
+    def set_render_options(self, **kwargs: Union[bool, str]) -> None:
         """
         Set rendering defaults.
 
@@ -110,9 +110,9 @@ class CircuitRenderer:
         :param crop_params: bool, shorten parameter expressions for display.
         """
         for key, val in kwargs.items():
-            if key in self._ALLOWED_RENDER_OPTIONS:
+            if key in self._ALLOWED_RENDER_OPTIONS and (isinstance(val, bool) or val is None):
                 self.__setattr__(key, val)
-            elif key in self._ALLOWED_CONFIG_OPTIONS and val is not None:
+            elif key in self._ALLOWED_CONFIG_OPTIONS and isinstance(val, str):
                 self.__setattr__(key, val)
 
     def get_render_options(

--- a/pytket/pytket/circuit/display/js/main.js
+++ b/pytket/pytket/circuit/display/js/main.js
@@ -10,6 +10,11 @@ if (typeof window.pytketCircuitDisplays === "undefined") {
 const app = createApp({
     delimiters: ['[[#', '#]]'],
     components: { circuitDisplayContainer },
+    data () {
+      return {
+        initRenderOptions: displayOptions,
+      }
+    }
 })
 app.config.unwrapInjectedRef = true;
 app.mount("#circuit-display-vue-container-"+circuitRendererUid);

--- a/pytket/pytket/circuit/display/static/circuit.html
+++ b/pytket/pytket/circuit/display/static/circuit.html
@@ -1,6 +1,6 @@
 
 
-{% macro show_circuit_page(display_options, circuit_json, uid) %}
+{% macro show_circuit_page(display_options, circuit_json, uid, min_width, min_height) %}
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -10,18 +10,28 @@
 <body>
 
 {% if not jupyter %}
-<div style="position:absolute;top:0;bottom:0;left:0;right:0;margin:auto;resize:both;display:block;overflow:hidden;
-width:min(500px, 100%);height:min(300px,100%);max-width:100%;max-height:100%;">
+<div style="
+    position:absolute;
+    top:0;bottom:0;left:0;right:0;
+    margin:auto;resize:both;display:block;overflow:hidden;
+    width:min({{ min_width }}, 100%);
+    height:min({{ min_height }},100%);
+    max-width:100%;
+    max-height:100%;">
 {% endif %}
 
     <div id="circuit-display-vue-container-{{uid}}" class="pytket-circuit-display-container">
         <div style="display: none">
             <div id="circuit-json-to-display">{{ circuit_json }}</div>
         </div>
-        <circuit-display-container :circuit-element-str="'#circuit-json-to-display'"></circuit-display-container>
+        <circuit-display-container
+                :circuit-element-str="'#circuit-json-to-display'"
+                :init-render-options="initRenderOptions"
+        ></circuit-display-container>
     </div>
     <script type="application/javascript">
       const circuitRendererUid = "{{ uid }}";
+      const displayOptions = JSON.parse('{{display_options}}');
 
       {% include_raw "js/main.js" %}
     </script>
@@ -36,7 +46,7 @@ width:min(500px, 100%);height:min(300px,100%);max-width:100%;max-height:100%;">
 
 {% if jupyter %}
 
-<div style="resize: vertical; overflow: auto; height: 200px; display: block">
+<div style="resize: vertical; overflow: auto; height: {{ min_height }}; display: block">
     <iframe srcdoc="{{ show_circuit_page(display_options, circuit_json, uid)|escape }}"
             width="100%" height="100%"
             style="border: none; outline: none; overflow: auto"></iframe>
@@ -44,6 +54,6 @@ width:min(500px, 100%);height:min(300px,100%);max-width:100%;max-height:100%;">
 
 {% else %}
 
-{{ show_circuit_page(display_options, circuit_json, uid) }}
+{{ show_circuit_page(display_options, circuit_json, uid, min_width, min_height) }}
 
 {% endif %}

--- a/pytket/tests/circuit_test.py
+++ b/pytket/tests/circuit_test.py
@@ -45,7 +45,7 @@ from pytket.circuit import (  # type: ignore
     BitRegister,
     QubitRegister,
 )
-from pytket.circuit.display import render_circuit_as_html
+from pytket.circuit.display import get_circuit_renderer, render_circuit_as_html
 
 from pytket.pauli import Pauli  # type: ignore
 from pytket.passes import PauliSimp, CliffordSimp, SynthesiseTket, DecomposeBoxes, RemoveRedundancies  # type: ignore
@@ -714,6 +714,19 @@ def test_circuit_from_to_serializable(circuit: Circuit) -> None:
 def test_circuit_display(circuit: Circuit) -> None:
     html_str_circ = render_circuit_as_html(circuit, jupyter=False)
     html_str_dict = render_circuit_as_html(circuit.to_dict(), jupyter=False)
+    assert isinstance(html_str_circ, str)
+    assert isinstance(html_str_dict, str)
+
+
+@given(st.circuits())
+@settings(deadline=None)
+def test_circuit_display_with_options(circuit: Circuit) -> None:
+    circuit_renderer = get_circuit_renderer()
+    circuit_renderer.set_render_options(zx_style=False)
+    html_str_circ = circuit_renderer.render_circuit_as_html(circuit, jupyter=False)
+    html_str_dict = circuit_renderer.render_circuit_as_html(
+        circuit.to_dict(), jupyter=False
+    )
     assert isinstance(html_str_circ, str)
     assert isinstance(html_str_dict, str)
 


### PR DESCRIPTION
Allow user to set default options for the circuit renderer:
The usual functions with default options remain available, but now the an instance of the renderer class is also exposed, with methods to set user preferences.

Also make the initial display size in jupyter taller.