### PR TITLE
Add `Circuit.TK1` and `Circuit.TK2` methods that take `Qubit` arguments

### DIFF
--- a/pytket/binders/circuit/Circuit/add_op.cpp
+++ b/pytket/binders/circuit/Circuit/add_op.cpp
@@ -1455,6 +1455,32 @@ void init_circuit_add_op(py::class_<Circuit, std::shared_ptr<Circuit>> &c) {
           py::arg("angle0"), py::arg("angle1"), py::arg("angle2"),
           py::arg("qubit"))
       .def(
+          "TK1",
+          [](Circuit *circ, const Expr &angle0, const Expr &angle1,
+             const Expr &angle2, const Qubit &qb, const py::kwargs &kwargs) {
+            return add_gate_method_manyparams<UnitID>(
+                circ, OpType::TK1, {angle0, angle1, angle2}, {qb}, kwargs);
+          },
+          "Appends a TK1 gate with possibly symbolic angles "
+          "(specified in half-turns)."
+          "\n\n:return: the new :py:class:`Circuit`",
+          py::arg("angle0"), py::arg("angle1"), py::arg("angle2"),
+          py::arg("qubit"))
+      .def(
+          "TK2",
+          [](Circuit *circ, const Expr &angle0, const Expr &angle1,
+             const Expr &angle2, const Qubit &qb0, const Qubit &qb1,
+             const py::kwargs &kwargs) {
+            return add_gate_method_manyparams<UnitID>(
+                circ, OpType::TK2, {angle0, angle1, angle2}, {qb0, qb1},
+                kwargs);
+          },
+          "Appends a TK2 gate with possibly symbolic angles "
+          "(specified in half-turns)."
+          "\n\n:return: the new :py:class:`Circuit`",
+          py::arg("angle0"), py::arg("angle1"), py::arg("angle2"),
+          py::arg("qubit0"), py::arg("qubit1"))
+      .def(
           "CX",
           [](Circuit *circ, const Qubit &ctrl, const Qubit &trgt,
              const py::kwargs &kwargs) {

--- a/pytket/docs/changelog.rst
+++ b/pytket/docs/changelog.rst
@@ -17,6 +17,7 @@ Minor new features:
 * Add new ``MaxNClRegPredicate`` that checks that there are at most n classical
   registers in the circuit.
 * Allow barriers in ``QControlBoxes``. Barriers are left in place.
+* Add ``Circuit.TK1`` and ``Circuit.TK2`` methods that take ``Qubit`` arguments.
 
 1.14.0 (April 2023)
 -------------------


### PR DESCRIPTION
I checked that there aren't any others that are missing this binder.