### PR TITLE
Fix a couple of minor doc issues.

### DIFF
--- a/pytket/binders/circuit/boxes.cpp
+++ b/pytket/binders/circuit/boxes.cpp
@@ -392,11 +392,11 @@ void init_boxes(py::module &m) {
       m, "MultiplexorBox",
       "A user-defined multiplexor (i.e. uniformly controlled operations) "
       "specified by a "
-      "map from bitstrings to :py:class:`Op`s")
+      "map from bitstrings to " CLSOBJS(Op))
       .def(
           py::init<const ctrl_op_map_t &>(),
-          "Construct from a map from bitstrings to :py:class:`Op`s\n\n"
-          ":param op_map: Map from bitstrings to :py:class:`Op`s\n",
+          "Construct from a map from bitstrings to " CLSOBJS(Op) "\n\n"
+          ":param op_map: Map from bitstrings to " CLSOBJS(Op) "\n",
           py::arg("op_map"))
       .def(
           "get_circuit", [](MultiplexorBox &box) { return *box.to_circuit(); },
@@ -412,13 +412,13 @@ void init_boxes(py::module &m) {
       m, "MultiplexedRotationBox",
       "A user-defined multiplexed rotation gate (i.e. "
       "uniformly controlled single-axis rotations) specified by "
-      "a map from bitstrings to :py:class:`Op`s")
+      "a map from bitstrings to " CLSOBJS(Op))
       .def(
           py::init<const ctrl_op_map_t &>(),
           "Construct from a map from bitstrings to :py:class:`Op`s."
-          "All :py:class:`Op`s must share the same single-qubit rotation type: "
+          "All " CLSOBJS(Op) "  must share the same single-qubit rotation type: "
           "Rx, Ry, or Rz.\n\n"
-          ":param op_map: Map from bitstrings to :py:class:`Op`s\n",
+          ":param op_map: Map from bitstrings to " CLSOBJS(Op) "\n",
           py::arg("op_map"))
       .def(
           py::init([](const std::vector<double> &angles, const OpType &axis) {
@@ -463,13 +463,13 @@ void init_boxes(py::module &m) {
       m, "MultiplexedU2Box",
       "A user-defined multiplexed U2 gate (i.e. uniformly controlled U2 "
       "gate) specified by a "
-      "map from bitstrings to :py:class:`Op`s")
+      "map from bitstrings to " CLSOBJS(Op))
       .def(
           py::init<const ctrl_op_map_t &, bool>(),
-          "Construct from a map from bitstrings to :py:class:`Op`s."
+          "Construct from a map from bitstrings to " CLSOBJS(Op) "."
           "Only supports single qubit unitary gate types and "
           ":py:class:`Unitary1qBox`.\n\n"
-          ":param op_map: Map from bitstrings to :py:class:`Op`s\n"
+          ":param op_map: Map from bitstrings to " CLSOBJS(Op) "\n"
           ":param impl_diag: Whether to implement the final diagonal gate, "
           "default to True.",
           py::arg("op_map"), py::arg("impl_diag") = true)
@@ -491,14 +491,14 @@ void init_boxes(py::module &m) {
       MultiplexedTensoredU2Box, std::shared_ptr<MultiplexedTensoredU2Box>, Op>(
       m, "MultiplexedTensoredU2Box",
       "A user-defined multiplexed tensor product of U2 gates specified by a "
-      "map from bitstrings to lists of :py:class:`Op`s")
+      "map from bitstrings to lists of " CLSOBJS(Op))
       .def(
           py::init<const ctrl_tensored_op_map_t &>(),
           "Construct from a map from bitstrings to equal-sized lists of "
-          ":py:class:`Op`s. "
+          CLSOBJS(Op) ". "
           "Only supports single qubit unitary gate types and "
           ":py:class:`Unitary1qBox`.\n\n"
-          ":param op_map: Map from bitstrings to lists of :py:class:`Op`s",
+          ":param op_map: Map from bitstrings to lists of " CLSOBJS(Op),
           py::arg("op_map"))
       .def(
           "get_circuit",

--- a/pytket/conanfile.py
+++ b/pytket/conanfile.py
@@ -32,7 +32,7 @@ class pytketRecipe(ConanFile):
         cmake.install()
 
     def requirements(self):
-        self.requires("tket/1.2.12@tket/stable")
+        self.requires("tket/1.2.13@tket/stable")
         self.requires("tklog/0.3.3@tket/stable")
         self.requires("tkrng/0.3.3@tket/stable")
         self.requires("tkassert/0.3.3@tket/stable")

--- a/tket/conanfile.py
+++ b/tket/conanfile.py
@@ -19,7 +19,7 @@ from conan.errors import ConanInvalidConfiguration
 
 class TketConan(ConanFile):
     name = "tket"
-    version = "1.2.12"
+    version = "1.2.13"
     package_type = "library"
     license = "Apache 2"
     homepage = "https://github.com/CQCL/tket"

--- a/tket/include/tket/OpType/OpType.hpp
+++ b/tket/include/tket/OpType/OpType.hpp
@@ -266,7 +266,7 @@ enum class OpType {
   TK1,
 
   /**
-   * \f$ \mathrm{TK1}(\alpha, \beta, \gamma) = \mathrm{XXPhase}(\alpha)
+   * \f$ \mathrm{TK2}(\alpha, \beta, \gamma) = \mathrm{XXPhase}(\alpha)
    * \mathrm{YYPhase}(\beta) \mathrm{ZZPhase}(\gamma) \f$
    */
   TK2,

--- a/tket/proptest/conanfile.py
+++ b/tket/proptest/conanfile.py
@@ -47,5 +47,5 @@ class proptest_tketRecipe(ConanFile):
         cmake.install()
 
     def requirements(self):
-        self.requires("tket/1.2.12@tket/stable")
+        self.requires("tket/1.2.13@tket/stable")
         self.requires("rapidcheck/cci.20220514")

--- a/tket/test/conanfile.py
+++ b/tket/test/conanfile.py
@@ -60,7 +60,7 @@ class test_tketRecipe(ConanFile):
         cmake.install()
 
     def requirements(self):
-        self.requires("tket/1.2.12@tket/stable")
+        self.requires("tket/1.2.13@tket/stable")
         self.requires("tkrng/0.3.3@tket/stable")
         self.requires("tktokenswap/0.3.3@tket/stable")
         self.requires("catch2/3.3.2")


### PR DESCRIPTION
* Typo in C++ docs: `TK1` should say `TK2`.
* Fix pluralization of `:py:class:...` in Python docs. (Sphinx doesn't handle it if the `s` follows the backtick, so use macro to insert a Narrow No-Break Space).