### PR TITLE
Add workflow dispatch to workflows

### DIFF
--- a/.github/workflows/build-without-conan.yml
+++ b/.github/workflows/build-without-conan.yml
@@ -3,7 +3,7 @@ on:
   schedule:
     # 01:00 every Monday morning
     - cron: '0 1 * * 1'
-  workflow_dispatch:
+  workflow_dispatch: {}
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/build-without-conan.yml
+++ b/.github/workflows/build-without-conan.yml
@@ -3,6 +3,7 @@ on:
   schedule:
     # 01:00 every Monday morning
     - cron: '0 1 * * 1'
+  workflow_dispatch:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -11,7 +11,7 @@ on:
   schedule:
     # 03:00 every Saturday morning
     - cron: '0 3 * * 6'
-  workflow_dispatch:
+  workflow_dispatch: {}
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -11,6 +11,7 @@ on:
   schedule:
     # 03:00 every Saturday morning
     - cron: '0 3 * * 6'
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -450,7 +450,7 @@ jobs:
         eval "$(pyenv init -)"
         pyenv shell tket-3.9
         PKG_CONFIG_PATH="$(brew --prefix openblas)"/lib/pkgconfig pip install -U scipy
-        pip install -U conan
+        pip install conan==${{ env.conan_version }}
         conan remove -c "pybind11/*"
         conan remove -c "pytket/*"
         conan create recipes/pybind11
@@ -468,7 +468,7 @@ jobs:
         eval "$(pyenv init -)"
         pyenv shell tket-3.10
         PKG_CONFIG_PATH="$(brew --prefix openblas)"/lib/pkgconfig pip install -U scipy
-        pip install -U conan
+        pip install conan==${{ env.conan_version }}
         conan remove -c "pybind11/*"
         conan remove -c "pytket/*"
         conan create recipes/pybind11
@@ -486,7 +486,7 @@ jobs:
         eval "$(pyenv init -)"
         pyenv shell tket-3.11
         PKG_CONFIG_PATH="$(brew --prefix openblas)"/lib/pkgconfig pip install -U scipy
-        pip install -U conan
+        pip install conan==${{ env.conan_version }}
         conan remove -c "pybind11/*"
         conan remove -c "pytket/*"
         conan create recipes/pybind11

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -13,6 +13,9 @@ on:
     - cron: '0 3 * * 6'
   workflow_dispatch: {}
 
+env:
+  conan_version: 2.0.5
+
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
@@ -48,6 +51,8 @@ jobs:
             - 'pytket/**'
     - name: Install conan
       uses: turtlebrowser/get-conan@v1.2
+      with:
+        version: ${{ env.conan_version }}
     - name: parse version from conanfile
       id: tket_ver
       run: |
@@ -93,6 +98,8 @@ jobs:
         python-version: '3.10'
     - name: Install conan
       uses: turtlebrowser/get-conan@v1.2
+      with:
+        version: ${{ env.conan_version }}
     - name: Set up conan
       run: |
         conan profile detect
@@ -155,6 +162,8 @@ jobs:
     - uses: actions/checkout@v3
     - name: Install conan
       uses: turtlebrowser/get-conan@v1.2
+      with:
+        version: ${{ env.conan_version }}
     - name: Set up conan
       run: |
         conan profile detect --force
@@ -192,6 +201,8 @@ jobs:
     - uses: actions/checkout@v3
     - name: Install conan
       uses: turtlebrowser/get-conan@v1.2
+      with:
+        version: ${{ env.conan_version }}
     - name: Set up conan
       run: |
         conan profile detect
@@ -282,6 +293,8 @@ jobs:
         python-version: '3.10'
     - name: Install conan
       uses: turtlebrowser/get-conan@v1.2
+      with:
+        version: ${{ env.conan_version }}
     - name: Set up conan
       run: |
         conan profile detect
@@ -345,6 +358,8 @@ jobs:
     - uses: actions/checkout@v3
     - name: Install conan
       uses: turtlebrowser/get-conan@v1.2
+      with:
+        version: ${{ env.conan_version }}
     - name: Set up conan
       run: |
         conan profile detect
@@ -416,6 +431,8 @@ jobs:
     - uses: actions/checkout@v3
     - name: Install conan
       uses: turtlebrowser/get-conan@v1.2
+      with:
+        version: ${{ env.conan_version }}
     - name: Set up conan
       run: |
         conan profile detect --force
@@ -483,6 +500,8 @@ jobs:
         pytest --ignore=simulator/
     - name: Install conan
       uses: turtlebrowser/get-conan@v1.2
+      with:
+        version: ${{ env.conan_version }}
     - name: Upload package
       if: github.event_name == 'push' && github.ref == 'refs/heads/develop' && needs.check_changes.outputs.tket_changed == 'true'
       run: |

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -73,7 +73,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Check C++ code formatting
-      if: matrix.os == 'macos-12' && github.event_name == 'pull_request'
+      if: matrix.os == 'macos-12' && (github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch')
       run: |
         brew update
         brew install clang-format@16
@@ -82,7 +82,7 @@ jobs:
       if: matrix.os == 'ubuntu-22.04'
       run: sudo apt update
     - name: Check doxygen
-      if: matrix.os == 'ubuntu-22.04' && github.event_name == 'pull_request'
+      if: matrix.os == 'ubuntu-22.04' && (github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch')
       run: |
         sudo apt install -y doxygen graphviz
         cd tket && doxygen
@@ -118,7 +118,7 @@ jobs:
       if: needs.check_changes.outputs.tket_changed != 'true'
       run: conan install tket --version ${{ needs.check_changes.outputs.tket_ver }} --user tket --channel stable --build=missing -o boost/*:header_only=True
     - name: check that version is consistent
-      if: matrix.os == 'ubuntu-22.04' && github.event_name == 'pull_request'
+      if: matrix.os == 'ubuntu-22.04' && (github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch')
       run: ./.github/workflows/check-tket-reqs  ${{ needs.check_changes.outputs.tket_ver }}
     - name: Install runtime test requirements
       if: matrix.os == 'ubuntu-22.04' && (needs.check_changes.outputs.tket_changed == 'true' || needs.check_changes.outputs.tket_tests_changed == 'true') && github.event_name == 'schedule'
@@ -150,7 +150,7 @@ jobs:
     name: Build and test tket (macos-arm64)
     runs-on: ['self-hosted', 'macOS', 'ARM64']
     needs: check_changes
-    if: github.event_name == 'push' || github.event_name == 'schedule' || github.event.pull_request.head.repo.full_name == github.repository
+    if: github.event_name == 'push' || github.event_name == 'schedule' || github.event.pull_request.head.repo.full_name == github.repository || github.event.workflow_dispatch.repository == github.repository
     steps:
     - uses: actions/checkout@v3
     - name: Install conan
@@ -207,10 +207,10 @@ jobs:
         conan create recipes/pybind11
         conan create recipes/pybind11_json/all --version 0.2.13
     - name: check that version is consistent
-      if: github.event_name == 'pull_request'
+      if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
       run: ./.github/workflows/check-tket-reqs  ${{ needs.check_changes.outputs.tket_ver }}
     - name: Set up Python (pull request)
-      if: github.event_name == 'pull_request'
+      if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
       uses: actions/setup-python@v4
       with:
         python-version: "3.9"
@@ -234,31 +234,31 @@ jobs:
         pip install pytest
         pytest --doctest-modules pytket
     - name: Test pytket with coverage
-      if: github.event_name == 'pull_request' || github.event_name == 'push'
+      if: github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'workflow_dispatch'
       run: |
         cd pytket/tests
         pip install -r requirements.txt
         pytest --ignore=simulator/ --hypothesis-seed=1 --cov=../pytket --cov-branch --cov-report=html --cov-report=xml:htmlcov/cov.xml
     - name: Test pytket
-      if: github.event_name != 'pull_request'
+      if: github.event_name != 'pull_request' || github.event_name == 'workflow_dispatch'
       run: |
         cd pytket/tests
         pip install -r requirements.txt
         pytest --ignore=simulator/
     - name: Test building docs
-      if: github.event_name == 'pull_request'
+      if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
       timeout-minutes: 20
       run: |
         pip install -r pytket/docs/requirements.txt
         ./.github/workflows/build-docs
     - name: Upload artefact
-      if: github.event_name == 'pull_request'
+      if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
       uses: actions/upload-artifact@v3
       with:
         name: pytket_docs
         path: pytket/docs/build/html/
     - name: Upload pytket coverage artefact
-      if: github.event_name == 'pull_request' || github.event_name == 'push'
+      if: github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'workflow_dispatch'
       uses: actions/upload-artifact@v3
       with:
         name: pytket_test_coverage
@@ -297,7 +297,7 @@ jobs:
         conan create recipes/pybind11
         conan create recipes/pybind11_json/all --version 0.2.13
     - name: Set up Python (pull request)
-      if: github.event_name == 'pull_request'
+      if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
       uses: actions/setup-python@v4
       with:
         python-version: "3.9"
@@ -326,7 +326,7 @@ jobs:
         pip install -r requirements.txt
         pytest --ignore=simulator/
     - name: Run mypy
-      if: github.event_name == 'pull_request'
+      if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
       run: |
         pip install -U mypy
         cd pytket
@@ -373,7 +373,7 @@ jobs:
         conan create recipes/pybind11
         conan create recipes/pybind11_json/all --version 0.2.13
     - name: Set up Python (3.9)
-      if: github.event_name == 'pull_request'
+      if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
       uses: actions/setup-python@v4
       with:
         python-version: "3.9"
@@ -411,7 +411,7 @@ jobs:
     name: Build and test pytket (macos-arm64)
     runs-on: ['self-hosted', 'macOS', 'ARM64']
     needs: check_changes
-    if: github.event_name == 'push' || github.event_name == 'schedule' || github.event.pull_request.head.repo.full_name == github.repository
+    if: github.event_name == 'push' || github.event_name == 'schedule' || github.event.pull_request.head.repo.full_name == github.repository || github.event.workflow_dispatch.repository == github.repository
     steps:
     - uses: actions/checkout@v3
     - name: Install conan
@@ -428,7 +428,7 @@ jobs:
     - name: Uninstall conan
       run: pip3 uninstall -y conan
     - name: Build and test pytket (3.9)
-      if: github.event_name == 'pull_request'
+      if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
       run: |
         eval "$(pyenv init -)"
         pyenv shell tket-3.9
@@ -522,7 +522,7 @@ jobs:
   check_pytket_coverage:
     name: Check pytket line and branch coverage
     needs: build_test_pytket_ubuntu
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/build_libs.yml
+++ b/.github/workflows/build_libs.yml
@@ -7,6 +7,10 @@ on:
     branches:
       - develop
   workflow_dispatch: {}
+
+env:
+  conan_version: 2.0.5
+
 jobs:
   changes:
     runs-on: ubuntu-22.04
@@ -66,6 +70,8 @@ jobs:
         python-version: '3.10'
     - name: Install conan
       uses: turtlebrowser/get-conan@v1.2
+      with:
+        version: ${{ env.conan_version }}
     - name: create profile
       run: conan profile detect
     - name: add remote
@@ -95,6 +101,8 @@ jobs:
     - uses: actions/checkout@v3
     - name: Install conan
       uses: turtlebrowser/get-conan@v1.2
+      with:
+        version: ${{ env.conan_version }}
     - name: create profile
       run: conan profile detect --force
     - name: set remotes

--- a/.github/workflows/build_libs.yml
+++ b/.github/workflows/build_libs.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
     branches:
       - develop
+  workflow_dispatch:
 jobs:
   changes:
     runs-on: ubuntu-22.04

--- a/.github/workflows/build_libs.yml
+++ b/.github/workflows/build_libs.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
     branches:
       - develop
-  workflow_dispatch:
+  workflow_dispatch: {}
 jobs:
   changes:
     runs-on: ubuntu-22.04

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -10,7 +10,7 @@ on:
   schedule:
     # 03:00 every Saturday morning
     - cron: '0 3 * * 6'
-  workflow_dispatch:
+  workflow_dispatch: {}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -10,6 +10,7 @@ on:
   schedule:
     # 03:00 every Saturday morning
     - cron: '0 3 * * 6'
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -12,6 +12,9 @@ on:
     - cron: '0 3 * * 6'
   workflow_dispatch: {}
 
+env:
+  conan_version: 2.0.5
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -42,6 +45,8 @@ jobs:
     - uses: actions/checkout@v3
     - name: Install conan
       uses: turtlebrowser/get-conan@v1.2
+      with:
+        version: ${{ env.conan_version }}
     - name: create profile
       run: conan profile detect
     - name: add remote

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -68,7 +68,7 @@ jobs:
         mkdir -p ~/texmf/tex/latex
         wget http://mirrors.ctan.org/graphics/pgf/contrib/quantikz/tikzlibraryquantikz.code.tex -P ~/texmf/tex/latex
     - name: Run tket tests
-      if: github.event_name == 'pull_request' || github.event_name == 'push'
+      if: github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'workflow_dispatch'
       working-directory: ./build/tket-tests/build/Debug
       run: ./test-tket
     - name: Run full tket tests
@@ -91,7 +91,7 @@ jobs:
   check_coverage:
     name: Check coverage
     needs: generate_coverage
-    if: (github.event_name == 'pull_request' && needs.changes.outputs.tket == 'true') || github.event_name == 'schedule'
+    if: ((github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch') && needs.changes.outputs.tket == 'true') || github.event_name == 'schedule'
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
@@ -101,7 +101,7 @@ jobs:
         name: test_coverage
         path: test-coverage/
     - name: Compare with latest report from develop (short tests)
-      if: github.event_name == 'pull_request'
+      if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
       run: |
         wget https://cqcl.github.io/tket/tket/test-coverage-short/summary.txt
         ./.github/workflows/compare-coverage summary.txt test-coverage/summary.txt

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,7 +6,6 @@ on:
       - develop
     paths:
       - 'tket/src/**'
-  workflow_dispatch:
 
 jobs:
   build_docs:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,6 +6,7 @@ on:
       - develop
     paths:
       - 'tket/src/**'
+  workflow_dispatch:
 
 jobs:
   build_docs:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,8 +1,8 @@
 name: Lint python projects
 
 on:
-  pull_request:
-  workflow_dispatch:
+  pull_request: {}
+  workflow_dispatch: {}
 
 jobs:
   lint:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,8 @@
 name: Lint python projects
 
-on: [pull_request]
+on:
+  pull_request:
+  workflow_dispatch:
 
 jobs:
   lint:

--- a/.github/workflows/linuxbuildwheel
+++ b/.github/workflows/linuxbuildwheel
@@ -23,6 +23,7 @@ export PYEX=${PYBIN}/python
 ${PYEX} -m venv env
 . env/bin/activate
 ${PYEX} -m pip install -U pip build conan
+${PYEX} -m pip install conan==2.0.5
 CONAN_CMD=${PYBIN}/conan
 ${CONAN_CMD} profile detect
 ${CONAN_CMD} remote add tket-libs https://quantinuumsw.jfrog.io/artifactory/api/conan/tket1-libs

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - 'packages-upload-new/**'
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -7,6 +7,9 @@ on:
   push:
     branches:
       - 'packages-upload-new/**'
+      -
+env:
+  conan_version: 2.0.5
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -31,6 +34,8 @@ jobs:
 
     - name: Install conan
       uses: turtlebrowser/get-conan@v1.2
+      with:
+        version: ${{ env.conan_version }}
 
     - name: Set up conan
       run: |
@@ -53,6 +58,8 @@ jobs:
 
     - name: Install conan
       uses: turtlebrowser/get-conan@v1.2
+      with:
+        version: ${{ env.conan_version }}
 
     - name: Set up conan
       run: |

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -7,7 +7,6 @@ on:
   push:
     branches:
       - 'packages-upload-new/**'
-  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -130,7 +130,7 @@ jobs:
       run: |
         eval "$(pyenv init -)"
         pyenv shell tket-${{ matrix.python-version }}
-        python -m pip install -U conan
+        python -m pip install conan==${{ env.conan_version }}
         conan profile detect --force
         conan remote add tket-libs https://quantinuumsw.jfrog.io/artifactory/api/conan/tket1-libs --force
         conan remove -c 'tket/*'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,6 @@ on:
   push:
     branches:
       - 'wheel/**'
-  workflow_dispatch:
 
 jobs:
   build_Linux_wheels:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - 'wheel/**'
+  workflow_dispatch:
 
 jobs:
   build_Linux_wheels:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,8 @@ on:
   push:
     branches:
       - 'wheel/**'
+env:
+  conan_version: 2.0.5
 
 jobs:
   build_Linux_wheels:
@@ -88,6 +90,8 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install conan
       uses: turtlebrowser/get-conan@v1.2
+      with:
+        version: ${{ env.conan_version }}
     - name: Set up conan
       run: |
         conan profile detect
@@ -164,6 +168,8 @@ jobs:
     - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
     - name: Install conan
       uses: turtlebrowser/get-conan@v1.2
+      with:
+        version: ${{ env.conan_version }}
     - name: Set up conan
       run: |
         conan profile detect

--- a/.github/workflows/test_libs.yml
+++ b/.github/workflows/test_libs.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
     branches:
       - develop
+  workflow_dispatch:
+
 env:
   ALL_LIBS: '["tklog", "tkassert", "tkrng", "tktokenswap", "tkwsm"]'
 jobs:

--- a/.github/workflows/test_libs.yml
+++ b/.github/workflows/test_libs.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
     branches:
       - develop
-  workflow_dispatch:
+  workflow_dispatch: {}
 
 env:
   ALL_LIBS: '["tklog", "tkassert", "tkrng", "tktokenswap", "tkwsm"]'

--- a/.github/workflows/test_libs.yml
+++ b/.github/workflows/test_libs.yml
@@ -10,6 +10,7 @@ on:
 
 env:
   ALL_LIBS: '["tklog", "tkassert", "tkrng", "tktokenswap", "tkwsm"]'
+  conan_version: 2.0.5
 jobs:
   changes:
     runs-on: ubuntu-22.04
@@ -74,6 +75,8 @@ jobs:
         python-version: '3.10'
     - name: Install conan
       uses: turtlebrowser/get-conan@v1.2
+      with:
+        version: ${{ env.conan_version }}
     - name: create profile
       run: conan profile detect
     - name: add remote
@@ -101,6 +104,8 @@ jobs:
     - uses: actions/checkout@v3
     - name: Install conan
       uses: turtlebrowser/get-conan@v1.2
+      with:
+        version: ${{ env.conan_version }}
     - name: create profile
       shell: bash
       run: conan profile detect --force
@@ -127,6 +132,8 @@ jobs:
     - uses: actions/checkout@v3
     - name: Install conan
       uses: turtlebrowser/get-conan@v1.2
+      with:
+        version: ${{ env.conan_version }}
     - name: create profile
       run: conan profile detect
     - name: add remote

--- a/.github/workflows/test_libs.yml
+++ b/.github/workflows/test_libs.yml
@@ -156,7 +156,7 @@ jobs:
         name: ${{ matrix.lib }}_coverage
         path: ${{ matrix.lib }}-coverage/
     - name: check coverage against latest published data from develop
-      if: github.event_name == 'pull_request'
+      if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
       run: |
         # File may not exist if this is the very first time, so don't error.
         wget https://cqcl.github.io/tket/${{ matrix.lib }}/test-coverage/summary.txt || true

--- a/.github/workflows/test_libs_all.yml
+++ b/.github/workflows/test_libs_all.yml
@@ -3,7 +3,7 @@ on:
   schedule:
     # 03:00 every Wednesday morning
     - cron: '0 3 * * 3'
-  workflow_dispatch:
+  workflow_dispatch: {}
 
 jobs:
   test_libraries:

--- a/.github/workflows/test_libs_all.yml
+++ b/.github/workflows/test_libs_all.yml
@@ -5,6 +5,9 @@ on:
     - cron: '0 3 * * 3'
   workflow_dispatch: {}
 
+env:
+  conan_version: 2.0.5
+
 jobs:
   test_libraries:
     name: test library
@@ -21,6 +24,8 @@ jobs:
         python-version: '3.10'
     - name: Install conan
       uses: turtlebrowser/get-conan@v1.2
+      with:
+        version: ${{ env.conan_version }}
     - name: create profile
       run: conan profile detect
     - name: add remote
@@ -45,6 +50,8 @@ jobs:
     - uses: actions/checkout@v3
     - name: Install conan
       uses: turtlebrowser/get-conan@v1.2
+      with:
+        version: ${{ env.conan_version }}
     - name: create profile
       shell: bash
       run: conan profile detect --force

--- a/.github/workflows/test_libs_all.yml
+++ b/.github/workflows/test_libs_all.yml
@@ -3,6 +3,8 @@ on:
   schedule:
     # 03:00 every Wednesday morning
     - cron: '0 3 * * 3'
+  workflow_dispatch:
+
 jobs:
   test_libraries:
     name: test library

--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -8,6 +8,10 @@ on:
   schedule:
     # 03:00 every Monday morning
     - cron: '0 3 * * 1'
+
+env:
+  conan_version: 2.0.5
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -36,6 +40,8 @@ jobs:
       run: sudo apt update
     - name: Install conan
       uses: turtlebrowser/get-conan@v1.2
+      with:
+        version: ${{ env.conan_version }}
     - name: Set up conan
       run: |
         conan profile detect

--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
     branches:
       - develop
-  workflow_dispatch:
+  workflow_dispatch: {}
 
   schedule:
     # 03:00 every Monday morning

--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -3,6 +3,7 @@ on:
   pull_request:
     branches:
       - develop
+  workflow_dispatch:
 
   schedule:
     # 03:00 every Monday morning

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
     rev: 19.10b0
     hooks:
       - id: black
-        language_version: python36
+        language_version: python311
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v2.4.0
     hooks:
@@ -15,4 +15,4 @@ repos:
       - id: check-added-large-files
 
 default_language_version:
-    python: python36
+    python: python311

--- a/pytket/pyproject.toml
+++ b/pytket/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools>=45", "wheel", "setuptools_scm>=6.4", "conan>=2.0", "cmake>=3.26"]
+requires = ["setuptools>=45", "wheel", "setuptools_scm>=6.4", "conan>=2.0,<2.0.6", "cmake>=3.26"]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
- allows to trigger workflow from the github UI on any branch (without needing to open a PR and run other workflows)
- I left out issue.yml,  didn't seem necessary...
- Can't actually trigger manually until this is merged I think
- Drive-By: Pin Conan version to 2.0.5 or lower, Conan 2.0.6 breaks pytket installs (with pip) and the `rootpath` script