### PR TITLE
Make new versions of tktokenswap and tkwsm depending on boost 1.82.0

### DIFF
--- a/libs/tktokenswap/conanfile.py
+++ b/libs/tktokenswap/conanfile.py
@@ -19,7 +19,7 @@ from conan.errors import ConanInvalidConfiguration
 
 class TktokenswapConan(ConanFile):
     name = "tktokenswap"
-    version = "0.3.3"
+    version = "0.3.4"
     package_type = "library"
     license = "Apache 2"
     url = "https://github.com/CQCL/tket"
@@ -72,4 +72,4 @@ class TktokenswapConan(ConanFile):
         self.requires("tklog/0.3.3@tket/stable")
         self.requires("tkassert/0.3.3@tket/stable", transitive_headers=True)
         self.requires("tkrng/0.3.3@tket/stable")
-        self.requires("boost/1.81.0", transitive_libs=False)
+        self.requires("boost/1.82.0", transitive_libs=False)

--- a/libs/tktokenswap/test/conanfile.py
+++ b/libs/tktokenswap/test/conanfile.py
@@ -59,6 +59,6 @@ class test_tktokenswapRecipe(ConanFile):
         cmake.install()
 
     def requirements(self):
-        self.requires("tktokenswap/0.3.3")
+        self.requires("tktokenswap/0.3.4")
         self.requires("tkrng/0.3.3@tket/stable")
         self.requires("catch2/3.3.2")

--- a/libs/tkwsm/conanfile.py
+++ b/libs/tkwsm/conanfile.py
@@ -19,7 +19,7 @@ from conan.errors import ConanInvalidConfiguration
 
 class TkwsmConan(ConanFile):
     name = "tkwsm"
-    version = "0.3.3"
+    version = "0.3.4"
     package_type = "library"
     license = "Apache 2"
     url = "https://github.com/CQCL/tket"
@@ -71,4 +71,4 @@ class TkwsmConan(ConanFile):
     def requirements(self):
         self.requires("tkassert/0.3.3@tket/stable")
         self.requires("tkrng/0.3.3@tket/stable")
-        self.requires("boost/1.81.0", transitive_headers=True, transitive_libs=False)
+        self.requires("boost/1.82.0", transitive_headers=True, transitive_libs=False)

--- a/libs/tkwsm/test/conanfile.py
+++ b/libs/tkwsm/test/conanfile.py
@@ -59,7 +59,7 @@ class test_tkwsmRecipe(ConanFile):
         cmake.install()
 
     def requirements(self):
-        self.requires("tkwsm/0.3.3")
+        self.requires("tkwsm/0.3.4")
         self.requires("tkassert/0.3.3@tket/stable")
         self.requires("tkrng/0.3.3@tket/stable")
         self.requires("catch2/3.3.2")


### PR DESCRIPTION
Once merged we can update tket to depend on these versions and boost 1.82.0.