### PR TITLE
Generate documentation for enums

### DIFF
--- a/pytket/docs/conf.py
+++ b/pytket/docs/conf.py
@@ -59,6 +59,7 @@ extensions = [
     "sphinx.ext.mathjax",
     "sphinx_copybutton",
     "jupyter_sphinx",
+    "enum_tools.autoenum",
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/pytket/docs/requirements.txt
+++ b/pytket/docs/requirements.txt
@@ -4,3 +4,4 @@ sphinx_book_theme ~= 1.0.1
 sphinx-copybutton
 jupyter-sphinx
 ipykernel
+enum-tools[sphinx]


### PR DESCRIPTION
Make sphinx generate documentation for Python Enum values. It is not currently doing so.

Before:

![image](https://github.com/CQCL/tket/assets/54802828/61ade160-0803-4ce8-b130-fd4579579a4f)

After:

![image](https://github.com/CQCL/tket/assets/54802828/5f728478-511a-4f9f-ac59-5df52442b044)
