### PR TITLE
add links to source code from API docs

### DIFF
--- a/pytket/docs/conf.py
+++ b/pytket/docs/conf.py
@@ -57,6 +57,7 @@ extensions = [
     "sphinx.ext.autosummary",
     "sphinx.ext.intersphinx",
     "sphinx.ext.mathjax",
+    "sphinx.ext.viewcode",
     "sphinx_copybutton",
     "jupyter_sphinx",
     "enum_tools.autoenum",


### PR DESCRIPTION
links to the source from the pytket API docs. Only works for pure python modules currently.

Done using the [sphinx.ext.viewcode](https://www.sphinx-doc.org/en/master/usage/extensions/viewcode.html) extension

![Screenshot 2023-06-30 at 15 30 42](https://github.com/CQCL/tket/assets/93673602/71106b0e-b269-4ff7-86b4-e5d9fbc52a25)

![Screenshot 2023-06-30 at 15 30 55](https://github.com/CQCL/tket/assets/93673602/c9bfb7e6-9eae-4189-bd4f-b2b365809eb9)
