### PR TITLE
Use `std::size t` everywhere instead of `size_t`

### DIFF
--- a/libs/tkrng/include/tkrng/RNG.hpp
+++ b/libs/tkrng/include/tkrng/RNG.hpp
@@ -63,7 +63,7 @@ class RNG {
    * which can be returned.
    * @return A size_t from the inclusive range {0,1,2,...,N}.
    */
-  size_t get_size_t(size_t max_value);
+  std::size_t get_size_t(std::size_t max_value);
 
   /** Returns the next 64-bit integer; guaranteed by the C++ standard
    * to be portable.
@@ -77,7 +77,7 @@ class RNG {
    * @param max_value The largest value (inclusive) that can be returned.
    * @return A size_t from the inclusive range {a, a+1, a+2, ... , b}.
    */
-  size_t get_size_t(size_t min_value, size_t max_value);
+  std::size_t get_size_t(std::size_t min_value, std::size_t max_value);
 
   /**
    * The behaviour of the RAW BITS of the Mersenne twister random engine
@@ -86,7 +86,7 @@ class RNG {
    * @param seed A seed value, to alter the RNG state.
    *    By default, uses the value specified by the standard.
    */
-  void set_seed(size_t seed = 5489);
+  void set_seed(std::size_t seed = 5489);
 
   /** Return true p% of the time.
    * (Very quick and dirty, doesn't check for, e.g., 110% effort...)
@@ -96,7 +96,7 @@ class RNG {
    *  a percentage.
    * @return A random bool, returns true with specified probability.
    */
-  bool check_percentage(size_t percentage);
+  bool check_percentage(std::size_t percentage);
 
   /**
    * Simply shuffle the elements around at random.
@@ -117,7 +117,7 @@ class RNG {
       return;
     }
     m_shuffling_data.resize(elements.size());
-    for (size_t i = 0; i < m_shuffling_data.size(); ++i) {
+    for (std::size_t i = 0; i < m_shuffling_data.size(); ++i) {
       m_shuffling_data[i].first = m_engine();
       // Tricky subtle point: without this extra entry to break ties,
       // std::sort could give DIFFERENT results across platforms and compilers,
@@ -126,14 +126,14 @@ class RNG {
     }
     std::sort(
         m_shuffling_data.begin(), m_shuffling_data.end(),
-        [](const std::pair<std::uintmax_t, size_t>& lhs,
-           const std::pair<std::uintmax_t, size_t>& rhs) {
+        [](const std::pair<std::uintmax_t, std::size_t>& lhs,
+           const std::pair<std::uintmax_t, std::size_t>& rhs) {
           return lhs.first < rhs.first ||
                  (lhs.first == rhs.first && lhs.second < rhs.second);
         });
     // Don't need to make a copy of "elements"! Just do repeated swaps...
-    for (size_t i = 0; i < m_shuffling_data.size(); ++i) {
-      const size_t& j = m_shuffling_data[i].second;
+    for (std::size_t i = 0; i < m_shuffling_data.size(); ++i) {
+      const std::size_t& j = m_shuffling_data[i].second;
       if (i != j) {
         std::swap(elements[i], elements[j]);
       }
@@ -167,7 +167,7 @@ class RNG {
       throw std::runtime_error(
           "RNG: get_and_remove_element called on empty vector");
     }
-    size_t index = get_size_t(elements.size() - 1);
+    std::size_t index = get_size_t(elements.size() - 1);
     const T copy = elements[index];
     elements[index] = elements.back();
     elements.pop_back();
@@ -179,13 +179,13 @@ class RNG {
    *  @return An interval of nonnegative numbers, starting at zero,
    *    but rearranged randomly.
    */
-  std::vector<size_t> get_permutation(size_t size);
+  std::vector<std::size_t> get_permutation(std::size_t size);
 
  private:
   std::mt19937_64 m_engine;
 
   // Avoids repeated memory reallocation.
-  std::vector<std::pair<std::uintmax_t, size_t>> m_shuffling_data;
+  std::vector<std::pair<std::uintmax_t, std::size_t>> m_shuffling_data;
 };
 
 }  // namespace tket

--- a/libs/tkrng/src/RNG.cpp
+++ b/libs/tkrng/src/RNG.cpp
@@ -18,7 +18,7 @@ using std::vector;
 
 namespace tket {
 
-size_t RNG::get_size_t(size_t max_value) {
+std::size_t RNG::get_size_t(std::size_t max_value) {
   if (max_value == 0) {
     return 0;
   }
@@ -128,14 +128,14 @@ size_t RNG::get_size_t(size_t max_value) {
 
   // interval_width cannot be zero, because we ensured above that
   // max_value + 1 <= m_engine.max().
-  const size_t result = random_int / interval_width;
+  const std::size_t result = random_int / interval_width;
 
   // Modulo arithmetic shouldn't be necessary, but be paranoid,
   // in case there are mistakes in the above analysis (very likely!)
   return result % (max_value + 1);
 }
 
-size_t RNG::get_size_t(size_t min_value, size_t max_value) {
+std::size_t RNG::get_size_t(std::size_t min_value, std::size_t max_value) {
   if (min_value > max_value) {
     std::swap(min_value, max_value);
   }
@@ -144,18 +144,18 @@ size_t RNG::get_size_t(size_t min_value, size_t max_value) {
 
 std::uint64_t RNG::operator()() { return m_engine(); }
 
-vector<size_t> RNG::get_permutation(size_t size) {
-  vector<size_t> numbers(size);
-  for (size_t i = 0; i < size; ++i) {
+vector<std::size_t> RNG::get_permutation(std::size_t size) {
+  vector<std::size_t> numbers(size);
+  for (std::size_t i = 0; i < size; ++i) {
     numbers[i] = i;
   }
   do_shuffle(numbers);
   return numbers;
 }
 
-void RNG::set_seed(size_t seed) { m_engine.seed(seed); }
+void RNG::set_seed(std::size_t seed) { m_engine.seed(seed); }
 
-bool RNG::check_percentage(size_t percentage) {
+bool RNG::check_percentage(std::size_t percentage) {
   // e.g. the numbers {0,1,2,3,4} are 5%
   // of the numbers {0,1,...,99}.
   return get_size_t(99) < percentage;

--- a/libs/tkrng/test/src/test_RNG.cpp
+++ b/libs/tkrng/test/src/test_RNG.cpp
@@ -30,9 +30,9 @@ SCENARIO("RNG: test get_size_t") {
   RNG rng;
   stringstream ss;
   {
-    std::array<size_t, 5> counts;
+    std::array<std::size_t, 5> counts;
     counts.fill(0);
-    const size_t max_v = counts.size() - 1;
+    const std::size_t max_v = counts.size() - 1;
 
     // Crudely check that we don't have too much bias.
     for (int nn = 0; nn < 100000; ++nn) {
@@ -44,15 +44,15 @@ SCENARIO("RNG: test get_size_t") {
     }
   }
   {
-    const size_t max_v = 99;
+    const std::size_t max_v = 99;
     ss << "Values for v=" << max_v << " : ";
     for (int nn = 0; nn < 30; ++nn) {
       ss << rng.get_size_t(max_v) << " ";
     }
   }
   {
-    const size_t min_v = 100;
-    const size_t max_v = 105;
+    const std::size_t min_v = 100;
+    const std::size_t max_v = 105;
     ss << "Values for min_v=" << min_v << ", max_v=" << max_v << " : ";
     for (int nn = 0; nn < 20; ++nn) {
       ss << rng.get_size_t(min_v, max_v) << " ";
@@ -72,7 +72,7 @@ SCENARIO("RNG: check_percentage bool sequence") {
   RNG rng;
   rng.set_seed(11111);
   stringstream ss;
-  size_t number_of_true = 0;
+  std::size_t number_of_true = 0;
   for (int nn = 0; nn < 100; ++nn) {
     if (rng.check_percentage(30)) {
       ++number_of_true;
@@ -119,11 +119,11 @@ SCENARIO("RNG: vector operations") {
 
 SCENARIO("RNG: permutations") {
   RNG rng;
-  const size_t size = 100;
+  const std::size_t size = 100;
   const auto numbers = rng.get_permutation(size);
   REQUIRE(numbers.size() == size);
 
-  const std::set<size_t> numbers_again(numbers.cbegin(), numbers.cend());
+  const std::set<std::size_t> numbers_again(numbers.cbegin(), numbers.cend());
   REQUIRE(numbers_again.size() == size);
   REQUIRE(*numbers_again.crbegin() == size - 1);
   stringstream ss;
@@ -142,14 +142,14 @@ SCENARIO("RNG: permutations") {
 }
 
 SCENARIO("RNG: default seed") {
-  vector<size_t> numbers;
+  vector<std::size_t> numbers;
   {
     RNG rng;
     for (unsigned ii = 0; ii < 10; ++ii) {
       numbers.emplace_back(rng.get_size_t(100));
     }
   }
-  vector<size_t> numbers_again;
+  vector<std::size_t> numbers_again;
   {
     RNG rng;
     rng.set_seed();
@@ -158,7 +158,7 @@ SCENARIO("RNG: default seed") {
     }
   }
   CHECK(numbers == numbers_again);
-  CHECK(numbers == vector<size_t>{79, 25, 71, 95, 1, 40, 25, 2, 52, 34});
+  CHECK(numbers == vector<std::size_t>{79, 25, 71, 95, 1, 40, 25, 2, 52, 34});
 }
 
 SCENARIO("RNG: 64-bit uints") {

--- a/libs/tkrng/test_package/src/example.cpp
+++ b/libs/tkrng/test_package/src/example.cpp
@@ -20,7 +20,7 @@ using namespace tket;
 
 int main() {
   RNG rng;
-  size_t a = rng.get_size_t(10);
+  std::size_t a = rng.get_size_t(10);
   std::cout << "0 <= " << a << " <= 10" << std::endl;
   return 0;
 }

--- a/libs/tktokenswap/include/tktokenswap/CanonicalRelabelling.hpp
+++ b/libs/tktokenswap/include/tktokenswap/CanonicalRelabelling.hpp
@@ -64,7 +64,7 @@ class CanonicalRelabelling {
     /** Element[i], for new vertex i, is the old vertex number which corresponds
      * to i. Empty if too many vertices.
      */
-    std::vector<size_t> new_to_old_vertices;
+    std::vector<std::size_t> new_to_old_vertices;
 
     /** Set equal to zero if too many vertices. Any permutation on <= 6 vertices
      * is assigned a number, to be looked up in the table. 0 is the identity
@@ -99,7 +99,7 @@ class CanonicalRelabelling {
    * arbitrarily labelled permutation into disjoint cycles, then relabelling the
    * vertices within the cycles in a reasonable way.
    */
-  std::vector<std::vector<size_t>> m_cycles;
+  std::vector<std::vector<std::size_t>> m_cycles;
 
   /** The indices in "m_cycles" after sorting appropriately. */
   std::vector<unsigned> m_sorted_cycles_indices;

--- a/libs/tktokenswap/include/tktokenswap/CyclesCandidateManager.hpp
+++ b/libs/tktokenswap/include/tktokenswap/CyclesCandidateManager.hpp
@@ -119,7 +119,7 @@ class CyclesCandidateManager {
      *  we don't know which final vertices will occur, so we can get many
      *  duplicate subpaths. Is there a clever data structure to improve this?)
      */
-    size_t first_vertex_index;
+    std::size_t first_vertex_index;
   };
 
   /** Key: a hash of the vertices in the cycle
@@ -130,7 +130,7 @@ class CyclesCandidateManager {
    *  Used to find duplicate cycles (the same vertices in the same cyclic
    *  order, but with different start vertex in the vector).
    */
-  std::map<size_t, CycleData> m_cycle_with_vertex_hash;
+  std::map<std::size_t, CycleData> m_cycle_with_vertex_hash;
 
   /** We will discard duplicate cycles. For better constness, we don't delete
    *  cycles, we just store the IDs of those ones we want to use.
@@ -143,12 +143,12 @@ class CyclesCandidateManager {
    *  This will be used to select a large subset of pairwise disjoint
    *  cycles, with a simple greedy algorithm.
    */
-  std::map<Cycles::ID, size_t> m_touching_data;
+  std::map<Cycles::ID, std::size_t> m_touching_data;
 
   /** Used by should_add_swaps_for_candidate, to see whether a cycle
    *  is disjoint from those already selected.
    */
-  std::set<size_t> m_vertices_used;
+  std::set<std::size_t> m_vertices_used;
 
   /** Fills m_cycles_to_keep (so, effectively discarding unsuitable cycles),
    *  returns the common cycle length.
@@ -156,7 +156,7 @@ class CyclesCandidateManager {
    *  @return The number of vertices in each cycle
    *    (all cycles should be the same length).
    */
-  size_t fill_initial_cycle_ids(const Cycles& cycles);
+  std::size_t fill_initial_cycle_ids(const Cycles& cycles);
 
   /** Updates m_cycles_to_keep. Keep only those solutions with the
    *  highest L-decrease.

--- a/libs/tktokenswap/include/tktokenswap/CyclesGrowthManager.hpp
+++ b/libs/tktokenswap/include/tktokenswap/CyclesGrowthManager.hpp
@@ -56,7 +56,7 @@ struct Cycle {
    *  [v0,v1,v2,v3,...,vN] must be a genuine path (the edges must exist),
    *  BUT the edge vN -> v0 to close the cycle does NOT have to exist.
    */
-  std::vector<size_t> vertices;
+  std::vector<std::size_t> vertices;
 
   /** We need this to maintain paths without duplicate vertices.
    *  Maintaining a std::set of vertices for quick lookup would work,
@@ -65,7 +65,7 @@ struct Cycle {
    *  @param vertex A vertex
    *  @return whether that vertex already exists in "vertices".
    */
-  bool contains(size_t vertex) const;
+  bool contains(std::size_t vertex) const;
 };
 
 typedef VectorListHybrid<Cycle> Cycles;
@@ -94,7 +94,7 @@ class CyclesGrowthManager {
    *  to find the best values.
    */
   struct Options {
-    size_t max_cycle_size = 6;
+    std::size_t max_cycle_size = 6;
 
     /** The worst-case total number of cycles grows exponentially,
      *  e.g. the complete graph with n vertices has ~ 0.5 n^2 edges,
@@ -103,7 +103,7 @@ class CyclesGrowthManager {
      *  We avoid exponential time/space blowup by limiting the number
      *  of cycles under consideration; any more are just discarded.
      */
-    size_t max_number_of_cycles = 1000;
+    std::size_t max_number_of_cycles = 1000;
 
     /** Discard a partially built up cycle as soon as the L-decrease
      *  (decrease of total distances of vertices from their targets)

--- a/libs/tktokenswap/include/tktokenswap/DistanceFunctions.hpp
+++ b/libs/tktokenswap/include/tktokenswap/DistanceFunctions.hpp
@@ -33,7 +33,7 @@ namespace tsa_internal {
  *  @return the sum, over all tokens, of (current vertex)->(target vertex)
  * distances.
  */
-size_t get_total_home_distances(
+std::size_t get_total_home_distances(
     const VertexMapping& vertex_mapping, DistancesInterface& distances);
 
 /** For just the abstract move v1->v2, ignoring the token on v2,
@@ -49,7 +49,7 @@ size_t get_total_home_distances(
  * course, although positive numbers are good.
  */
 int get_move_decrease(
-    const VertexMapping& vertex_mapping, size_t v1, size_t v2,
+    const VertexMapping& vertex_mapping, std::size_t v1, std::size_t v2,
     DistancesInterface& distances);
 
 /** The same as get_move_decrease, but for an abstract swap(v1,v2).
@@ -63,7 +63,7 @@ int get_move_decrease(
  *    left unchanged.
  */
 int get_swap_decrease(
-    const VertexMapping& vertex_mapping, size_t v1, size_t v2,
+    const VertexMapping& vertex_mapping, std::size_t v1, std::size_t v2,
     DistancesInterface& distances);
 
 }  // namespace tsa_internal

--- a/libs/tktokenswap/include/tktokenswap/DistancesInterface.hpp
+++ b/libs/tktokenswap/include/tktokenswap/DistancesInterface.hpp
@@ -31,7 +31,7 @@ class DistancesInterface {
    *  @param vertex2 Second vertex
    *  @return distance from v1 to v2 within the graph.
    */
-  virtual size_t operator()(size_t vertex1, size_t vertex2) = 0;
+  virtual std::size_t operator()(std::size_t vertex1, std::size_t vertex2) = 0;
 
   /** If you KNOW a path from v1 to v2 which is shortest, then
    *  extra information about distances can be deduced from subpaths
@@ -42,7 +42,7 @@ class DistancesInterface {
    * shortest path from v0 to vn. The caller must not call this without being
    * SURE that it really is a shortest path, or incorrect results may occur.
    */
-  virtual void register_shortest_path(const std::vector<size_t>& path);
+  virtual void register_shortest_path(const std::vector<std::size_t>& path);
 
   /** If you know the neighbours of a vertex, you can tell this class
    *  and it MIGHT choose to cache the distances.
@@ -51,14 +51,14 @@ class DistancesInterface {
    *  @param neighbours A list of vertices adjacent to the given vertex.
    */
   virtual void register_neighbours(
-      size_t vertex, const std::vector<size_t>& neighbours);
+      std::size_t vertex, const std::vector<std::size_t>& neighbours);
 
   /** Does nothing unless overridden. Stores the fact that v1,v2 are adjacent,
    *  to save later recalculation.
    *  @param vertex1 First vertex
    *  @param vertex2 Second vertex
    */
-  virtual void register_edge(size_t vertex1, size_t vertex2);
+  virtual void register_edge(std::size_t vertex1, std::size_t vertex2);
 
   virtual ~DistancesInterface();
 };

--- a/libs/tktokenswap/include/tktokenswap/DynamicTokenTracker.hpp
+++ b/libs/tktokenswap/include/tktokenswap/DynamicTokenTracker.hpp
@@ -76,7 +76,7 @@ class DynamicTokenTracker {
    *  @return The token at that vertex, or equal to the vertex number
    *    IF it doesn't already exist.
    */
-  size_t get_token_at_vertex(size_t vertex);
+  std::size_t get_token_at_vertex(std::size_t vertex);
 
   /** Does every token mentioned in this object lie at the same vertex in
    *  the other object?

--- a/libs/tktokenswap/include/tktokenswap/FilteredSwapSequences.hpp
+++ b/libs/tktokenswap/include/tktokenswap/FilteredSwapSequences.hpp
@@ -128,7 +128,7 @@ class FilteredSwapSequences {
   /** For testing, just count how many entries we've stored.
    *  @return The total number of encoded swap sequences stored internally.
    */
-  size_t get_total_number_of_entries() const;
+  std::size_t get_total_number_of_entries() const;
 
  private:
   /** We recalculate the number of swaps each time, rather than storing.

--- a/libs/tktokenswap/include/tktokenswap/NeighboursInterface.hpp
+++ b/libs/tktokenswap/include/tktokenswap/NeighboursInterface.hpp
@@ -36,7 +36,7 @@ class NeighboursInterface {
    *  @param vertex A vertex.
    *  @return A sorted list of all adjacent vertices, stored internally.
    */
-  virtual const std::vector<size_t>& operator()(size_t vertex);
+  virtual const std::vector<std::size_t>& operator()(std::size_t vertex);
 
   virtual ~NeighboursInterface();
 };

--- a/libs/tktokenswap/include/tktokenswap/PartialMappingLookup.hpp
+++ b/libs/tktokenswap/include/tktokenswap/PartialMappingLookup.hpp
@@ -61,14 +61,14 @@ class PartialMappingLookup {
    */
   const ExactMappingLookup::Result& operator()(
       const VertexMapping& desired_mapping, const std::vector<Swap>& edges,
-      const std::set<size_t>& vertices_with_tokens_at_start,
+      const std::set<std::size_t>& vertices_with_tokens_at_start,
       unsigned max_number_of_swaps = 16);
 
  private:
   Parameters m_parameters;
   ExactMappingLookup m_exact_mapping_lookup;
-  std::vector<size_t> m_empty_source_vertices;
-  std::vector<size_t> m_empty_target_vertices;
+  std::vector<std::size_t> m_empty_source_vertices;
+  std::vector<std::size_t> m_empty_target_vertices;
   VertexMapping m_altered_mapping;
 };
 

--- a/libs/tktokenswap/include/tktokenswap/RiverFlowPathFinder.hpp
+++ b/libs/tktokenswap/include/tktokenswap/RiverFlowPathFinder.hpp
@@ -75,7 +75,8 @@ class RiverFlowPathFinder {
    *  @return A list of vertices, starting with v1 and ending with v2,
    *    giving a shortest path from v1 to v2.
    */
-  const std::vector<size_t>& operator()(size_t vertex1, size_t vertex2);
+  const std::vector<std::size_t>& operator()(
+      std::size_t vertex1, std::size_t vertex2);
 
   ~RiverFlowPathFinder();
 
@@ -86,7 +87,7 @@ class RiverFlowPathFinder {
    * solution.
    * @param vertex2 Second vertex v2 of the edge.
    */
-  void register_edge(size_t vertex1, size_t vertex2);
+  void register_edge(std::size_t vertex1, std::size_t vertex2);
 
  private:
   struct Impl;

--- a/libs/tktokenswap/include/tktokenswap/SwapFunctions.hpp
+++ b/libs/tktokenswap/include/tktokenswap/SwapFunctions.hpp
@@ -22,7 +22,7 @@
 
 namespace tket {
 
-typedef std::pair<size_t, size_t> Swap;
+typedef std::pair<std::size_t, std::size_t> Swap;
 typedef VectorListHybrid<Swap> SwapList;
 typedef SwapList::ID SwapID;
 
@@ -33,7 +33,7 @@ typedef SwapList::ID SwapID;
  *  @param v2 The second vertex (throws if equal to the first).
  *  @return A swap object.
  */
-Swap get_swap(size_t v1, size_t v2);
+Swap get_swap(std::size_t v1, std::size_t v2);
 
 /** Do the swaps act on 4 different vertices?
  *  @param swap1 The first swap.

--- a/libs/tktokenswap/include/tktokenswap/SwapListOptimiser.hpp
+++ b/libs/tktokenswap/include/tktokenswap/SwapListOptimiser.hpp
@@ -122,7 +122,7 @@ class SwapListOptimiser {
       SwapList& list, VertexMapping vertex_mapping);
 
  private:
-  std::map<Swap, size_t> m_data;
+  std::map<Swap, std::size_t> m_data;
 
   DynamicTokenTracker m_token_tracker;
 

--- a/libs/tktokenswap/include/tktokenswap/SwapListSegmentOptimiser.hpp
+++ b/libs/tktokenswap/include/tktokenswap/SwapListSegmentOptimiser.hpp
@@ -38,11 +38,11 @@ class SwapListSegmentOptimiser {
     /** The length of the segment that was replaced.
      * Of course, this will be zero if no optimisation takes place.
      */
-    size_t initial_segment_size;
+    std::size_t initial_segment_size;
 
     /** The length of the segment after replacement. Always <=
      * initial_segment_size. */
-    size_t final_segment_size;
+    std::size_t final_segment_size;
 
     /** If we did replace a segment with a shorter one, give the ID of the last
      * swap of the segment. It might be null because the new segment might be
@@ -71,7 +71,8 @@ class SwapListSegmentOptimiser {
    * replacement/reduction (if any).
    */
   const Output& optimise_segment(
-      SwapID initial_id, const std::set<size_t>& vertices_with_tokens_at_start,
+      SwapID initial_id,
+      const std::set<std::size_t>& vertices_with_tokens_at_start,
       VertexMapResizing& map_resizing, SwapList& swap_list);
 
  private:

--- a/libs/tktokenswap/include/tktokenswap/SwapListTableOptimiser.hpp
+++ b/libs/tktokenswap/include/tktokenswap/SwapListTableOptimiser.hpp
@@ -58,7 +58,7 @@ class SwapListTableOptimiser {
    * (i.e., clustering interacting swaps together).
    */
   void optimise(
-      const std::set<size_t>& vertices_with_tokens_at_start,
+      const std::set<std::size_t>& vertices_with_tokens_at_start,
       VertexMapResizing& map_resizing, SwapList& swap_list,
       SwapListOptimiser& swap_list_optimiser);
 
@@ -82,7 +82,7 @@ class SwapListTableOptimiser {
    * @param swap_list_optimiser An object to handle non-table optimisations.
    */
   void optimise_in_forward_direction(
-      const std::set<size_t>& vertices_with_tokens_at_start,
+      const std::set<std::size_t>& vertices_with_tokens_at_start,
       VertexMapResizing& map_resizing, SwapList& swap_list,
       SwapListOptimiser& swap_list_optimiser);
 };

--- a/libs/tktokenswap/include/tktokenswap/TrivialTSA.hpp
+++ b/libs/tktokenswap/include/tktokenswap/TrivialTSA.hpp
@@ -102,10 +102,10 @@ class TrivialTSA : public PartialTsaInterface {
    *  object m_cycle_endpoints will store information about where
    *  each cycle starts and ends.
    */
-  VectorListHybrid<size_t> m_abstract_cycles_vertices;
-  mutable std::set<size_t> m_vertices_seen;
+  VectorListHybrid<std::size_t> m_abstract_cycles_vertices;
+  mutable std::set<std::size_t> m_vertices_seen;
 
-  typedef VectorListHybrid<size_t>::ID ID;
+  typedef VectorListHybrid<std::size_t>::ID ID;
 
   /** For an abstract cycle: the first is the ID of the start vertex in
    *  "m_abstract_cycles_vertices" (which already has a builtin linked list
@@ -117,7 +117,7 @@ class TrivialTSA : public PartialTsaInterface {
    *  using the vertices in m_abstract_cycles_vertices.
    */
   std::vector<Endpoints> m_cycle_endpoints;
-  std::vector<size_t> m_vertices_work_vector;
+  std::vector<std::size_t> m_vertices_work_vector;
 
   /** Fills m_abstract_cycles_vertices, m_cycle_endpoints with the cycles.
    *  @param vertex_mapping The current desired mapping.
@@ -209,8 +209,8 @@ class TrivialTSA : public PartialTsaInterface {
    *    pair of vertices.
    *  @return the actual L-decrease (will be strictly positive).
    */
-  size_t append_partial_solution_with_single_cycle(
-      const Endpoints& endpoints, size_t start_v_index,
+  std::size_t append_partial_solution_with_single_cycle(
+      const Endpoints& endpoints, std::size_t start_v_index,
       // L (the sum of the distances to home) must decrease
       // by at least this amount, to break off early.
       SwapList& swaps, VertexMapping& vertex_mapping,

--- a/libs/tktokenswap/include/tktokenswap/VectorListHybrid.hpp
+++ b/libs/tktokenswap/include/tktokenswap/VectorListHybrid.hpp
@@ -23,7 +23,7 @@
 namespace tket {
 
 struct OverwriteIntervalResult {
-  size_t number_of_overwritten_elements;
+  std::size_t number_of_overwritten_elements;
   tsa_internal::VectorListHybridSkeleton::Index final_overwritten_element_id;
 };
 
@@ -114,7 +114,7 @@ class VectorListHybrid {
    *  to be reused).
    *  @return The number of active elements stored.
    */
-  size_t size() const;
+  std::size_t size() const;
 
   /** Exactly like std::vector push_back. Fine if T is lightweight.
    *  Otherwise, maybe better to reuse elements.
@@ -233,7 +233,7 @@ class VectorListHybrid {
    * @param number_of_elements The number of elements to erase. The list MUST
    * contain enough elements to be erased.
    */
-  void erase_interval(ID id, size_t number_of_elements);
+  void erase_interval(ID id, std::size_t number_of_elements);
 
   /** Starting with the given ID, and given cbegin, cend iterators to a
    * container of T objects, overwrite whatever T objects are currently stored
@@ -334,7 +334,7 @@ bool VectorListHybrid<T>::empty() const {
 }
 
 template <class T>
-size_t VectorListHybrid<T>::size() const {
+std::size_t VectorListHybrid<T>::size() const {
   return m_links_data.size();
 }
 
@@ -458,7 +458,7 @@ void VectorListHybrid<T>::erase(ID id) {
 
 template <class T>
 void VectorListHybrid<T>::erase_interval(
-    typename VectorListHybrid<T>::ID id, size_t number_of_elements) {
+    typename VectorListHybrid<T>::ID id, std::size_t number_of_elements) {
   m_links_data.erase_interval(id, number_of_elements);
 }
 
@@ -523,7 +523,7 @@ template <class T>
 std::string VectorListHybrid<T>::debug_str() const {
   std::stringstream ss;
   ss << "\nRaw stored elems:";
-  for (size_t nn = 0; nn < m_data.size(); ++nn) {
+  for (std::size_t nn = 0; nn < m_data.size(); ++nn) {
     ss << "\nData[" << nn << "] = " << m_data[nn];
   }
   ss << "\n" << m_links_data.debug_str() << "\n";

--- a/libs/tktokenswap/include/tktokenswap/VectorListHybridSkeleton.hpp
+++ b/libs/tktokenswap/include/tktokenswap/VectorListHybridSkeleton.hpp
@@ -38,7 +38,7 @@ class VectorListHybridSkeleton {
    *  the objects we care about (templated on the object type; but this
    *  class stores no data except indexing information).
    */
-  typedef size_t Index;
+  typedef std::size_t Index;
 
   VectorListHybridSkeleton();
 
@@ -70,7 +70,7 @@ class VectorListHybridSkeleton {
    *  NOT equal to the underlying vector size!
    *  @return The number of valid elements stored.
    */
-  size_t size() const;
+  std::size_t size() const;
 
   /** The index of the front element (or the same index as returned by
    * get_invalid_index() if currently empty).
@@ -115,7 +115,7 @@ class VectorListHybridSkeleton {
    * @param number_of_elements Number of elements to erase; these MUST exist
    * (the list must be big enough).
    */
-  void erase_interval(Index index, size_t number_of_elements);
+  void erase_interval(Index index, std::size_t number_of_elements);
 
   /** The list must currently be empty, but not checked. */
   void insert_for_empty_list();
@@ -142,7 +142,7 @@ class VectorListHybridSkeleton {
   };
 
   std::vector<Link> m_links;
-  size_t m_size;
+  std::size_t m_size;
   Index m_front;
   Index m_back;
 

--- a/libs/tktokenswap/include/tktokenswap/VertexMapResizing.hpp
+++ b/libs/tktokenswap/include/tktokenswap/VertexMapResizing.hpp
@@ -52,7 +52,8 @@ class VertexMapResizing : public NeighboursInterface {
    * @param vertex A vertex in the graph.
    * @return A cached list of neighbours of that vertex, stored internally.
    */
-  virtual const std::vector<size_t>& operator()(size_t vertex) override;
+  virtual const std::vector<std::size_t>& operator()(
+      std::size_t vertex) override;
 
   /** The result of resizing a mapping by deleting fixed vertices if too big,
    * or adding new vertices if too small.
@@ -86,7 +87,7 @@ class VertexMapResizing : public NeighboursInterface {
   Result m_result;
 
   // KEY: a vertex. VALUE: all its neighbours.
-  std::map<size_t, std::vector<size_t>> m_cached_neighbours;
+  std::map<std::size_t, std::vector<std::size_t>> m_cached_neighbours;
   std::set<Swap> m_cached_full_edges;
 
   /** How many edges join the given vertex to other existing vertices?
@@ -96,7 +97,7 @@ class VertexMapResizing : public NeighboursInterface {
    * @return The total number of edges within the LARGER graph joining the
    * vertex to other vertices within the mapping.
    */
-  size_t get_edge_count(const VertexMapping& mapping, size_t vertex);
+  std::size_t get_edge_count(const VertexMapping& mapping, std::size_t vertex);
 
   /** Try to add a single new fixed vertex to the mapping, i.e. a new v with
    * map[v]=v.

--- a/libs/tktokenswap/include/tktokenswap/VertexMappingFunctions.hpp
+++ b/libs/tktokenswap/include/tktokenswap/VertexMappingFunctions.hpp
@@ -24,7 +24,7 @@ namespace tket {
 
 /// The desired result of swapping is to move a token on each "key"
 /// vertex to the "value" vertex.
-typedef std::map<size_t, size_t> VertexMapping;
+typedef std::map<std::size_t, std::size_t> VertexMapping;
 
 /** Are all tokens on their target vertices?
  *  @param vertex_mapping The desired mapping.
@@ -56,7 +56,7 @@ void check_mapping(
  *  @param swap_list The list of swaps, which will be updated.
  */
 void append_swaps_to_interchange_path_ends(
-    const std::vector<size_t>& path, VertexMapping& vertex_mapping,
+    const std::vector<std::size_t>& path, VertexMapping& vertex_mapping,
     SwapList& swap_list);
 
 /** Given a source->target vertex mapping and a TARGET vertex, find the
@@ -68,8 +68,8 @@ void append_swaps_to_interchange_path_ends(
  * @return The source vertex corresponding to the target (possibly newly created
  * if the target was not present).
  */
-size_t get_source_vertex(
-    VertexMapping& source_to_target_map, size_t target_vertex);
+std::size_t get_source_vertex(
+    VertexMapping& source_to_target_map, std::size_t target_vertex);
 
 /** We currently have a source->target mapping. Perform the vertex swap,
  * but if any vertex in the swap is not present in the map, add it to the map as

--- a/libs/tktokenswap/include/tktokenswap/VertexSwapResult.hpp
+++ b/libs/tktokenswap/include/tktokenswap/VertexSwapResult.hpp
@@ -41,7 +41,8 @@ struct VertexSwapResult {
    *  @param vertex_mapping The source to target mapping,
    *    will be updated with the swap.
    */
-  VertexSwapResult(size_t v1, size_t v2, VertexMapping& vertex_mapping);
+  VertexSwapResult(
+      std::size_t v1, std::size_t v2, VertexMapping& vertex_mapping);
 
   /** If the swap moves at least one nonempty token, carry out the swap.
    *  Otherwise, does nothing.
@@ -52,7 +53,8 @@ struct VertexSwapResult {
    *  @param swap_list The list of swaps, which will be updated with the swap.
    */
   VertexSwapResult(
-      size_t v1, size_t v2, VertexMapping& vertex_mapping, SwapList& swap_list);
+      std::size_t v1, std::size_t v2, VertexMapping& vertex_mapping,
+      SwapList& swap_list);
 };
 
 }  // namespace tsa_internal

--- a/libs/tktokenswap/src/BestFullTsa.cpp
+++ b/libs/tktokenswap/src/BestFullTsa.cpp
@@ -39,7 +39,7 @@ void BestFullTsa::append_partial_solution(
   m_swap_list_optimiser.full_optimise(swaps, vertex_mapping);
 
   VertexMapResizing map_resizing(neighbours);
-  std::set<size_t> vertices_with_tokens_at_start;
+  std::set<std::size_t> vertices_with_tokens_at_start;
   for (const auto& entry : vertex_mapping) {
     vertices_with_tokens_at_start.insert(entry.first);
   }

--- a/libs/tktokenswap/src/CyclesCandidateManager.cpp
+++ b/libs/tktokenswap/src/CyclesCandidateManager.cpp
@@ -26,10 +26,11 @@ using std::vector;
 namespace tket {
 namespace tsa_internal {
 
-size_t CyclesCandidateManager::fill_initial_cycle_ids(const Cycles& cycles) {
+std::size_t CyclesCandidateManager::fill_initial_cycle_ids(
+    const Cycles& cycles) {
   m_cycle_with_vertex_hash.clear();
   m_cycles_to_keep.clear();
-  size_t cycle_length = 0;
+  std::size_t cycle_length = 0;
   for (auto id_opt = cycles.front_id(); id_opt;
        id_opt = cycles.next(id_opt.value())) {
     const auto& cycle = cycles.at(id_opt.value());
@@ -53,13 +54,13 @@ size_t CyclesCandidateManager::fill_initial_cycle_ids(const Cycles& cycles) {
     CycleData cycle_data;
     cycle_data.id = id_opt.value();
     cycle_data.first_vertex_index = 0;
-    for (size_t ii = 1; ii < vertices.size(); ++ii) {
+    for (std::size_t ii = 1; ii < vertices.size(); ++ii) {
       if (vertices[ii] < vertices[cycle_data.first_vertex_index]) {
         cycle_data.first_vertex_index = ii;
       }
     }
-    size_t hash = static_cast<size_t>(cycle.decrease);
-    for (size_t ii = 0; ii < cycle_length; ++ii) {
+    std::size_t hash = static_cast<std::size_t>(cycle.decrease);
+    for (std::size_t ii = 0; ii < cycle_length; ++ii) {
       boost::hash_combine(
           hash, vertices[(ii + cycle_data.first_vertex_index) % cycle_length]);
     }
@@ -72,7 +73,7 @@ size_t CyclesCandidateManager::fill_initial_cycle_ids(const Cycles& cycles) {
       const auto& previous_cycle = cycles.at(previous_cycle_data.id);
       if (previous_cycle.decrease == cycle.decrease) {
         bool equal_vertices = true;
-        for (size_t ii = 0; ii < cycle_length; ++ii) {
+        for (std::size_t ii = 0; ii < cycle_length; ++ii) {
           if (previous_cycle.vertices
                   [(ii + previous_cycle_data.first_vertex_index) %
                    cycle_length] !=
@@ -102,7 +103,7 @@ void CyclesCandidateManager::discard_lower_power_solutions(
   }
   TKET_ASSERT(highest_decrease > 0);
 
-  for (size_t ii = 0; ii < m_cycles_to_keep.size();) {
+  for (std::size_t ii = 0; ii < m_cycles_to_keep.size();) {
     if (cycles.at(m_cycles_to_keep[ii]).decrease < highest_decrease) {
       // This cycle is not good enough.
       // Erase this ID, by swapping with the back
@@ -120,11 +121,11 @@ void CyclesCandidateManager::sort_candidates(const Cycles& cycles) {
   // So, choose those which touch few others first.
   // Experimentation is needed with other algorithms!
   m_touching_data.clear();
-  for (size_t ii = 0; ii < m_cycles_to_keep.size(); ++ii) {
+  for (std::size_t ii = 0; ii < m_cycles_to_keep.size(); ++ii) {
     // Automatically set to zero on first use.
     m_touching_data[m_cycles_to_keep[ii]];
 
-    for (size_t jj = ii + 1; jj < m_cycles_to_keep.size(); ++jj) {
+    for (std::size_t jj = ii + 1; jj < m_cycles_to_keep.size(); ++jj) {
       bool touches = false;
       // For short cycles, not much slower than using sets
       // or sorted vectors.
@@ -180,7 +181,7 @@ void CyclesCandidateManager::append_partial_solution(
     const CyclesGrowthManager& growth_manager, SwapList& swaps,
     VertexMapping& vertex_mapping) {
   const auto& cycles = growth_manager.get_cycles();
-  const size_t cycle_size = fill_initial_cycle_ids(cycles);
+  const std::size_t cycle_size = fill_initial_cycle_ids(cycles);
 
   if (m_cycles_to_keep.empty()) {
     return;
@@ -203,7 +204,7 @@ void CyclesCandidateManager::append_partial_solution(
       continue;
     }
     const auto& vertices = cycles.at(id).vertices;
-    for (size_t ii = vertices.size() - 1; ii > 0; --ii) {
+    for (std::size_t ii = vertices.size() - 1; ii > 0; --ii) {
       VertexSwapResult(vertices[ii], vertices[ii - 1], vertex_mapping, swaps);
     }
   }

--- a/libs/tktokenswap/src/CyclesGrowthManager.cpp
+++ b/libs/tktokenswap/src/CyclesGrowthManager.cpp
@@ -24,7 +24,7 @@ using std::vector;
 namespace tket {
 namespace tsa_internal {
 
-bool Cycle::contains(size_t vertex) const {
+bool Cycle::contains(std::size_t vertex) const {
   for (auto vv : vertices) {
     if (vertex == vv) {
       return true;

--- a/libs/tktokenswap/src/CyclesPartialTsa.cpp
+++ b/libs/tktokenswap/src/CyclesPartialTsa.cpp
@@ -33,7 +33,7 @@ void CyclesPartialTsa::append_partial_solution(
   // reduce/reorder swaps, and so it would be invalid just to go back through
   // the appended swaps. However, THIS class knows that no reordering or
   // reduction occurs.
-  const size_t initial_swap_size = swaps.size();
+  const std::size_t initial_swap_size = swaps.size();
   for (;;) {
     const auto swap_size_before = swaps.size();
     single_iteration_partial_solution(
@@ -44,7 +44,7 @@ void CyclesPartialTsa::append_partial_solution(
       break;
     }
   }
-  const size_t final_swap_size = swaps.size();
+  const std::size_t final_swap_size = swaps.size();
   TKET_ASSERT(initial_swap_size <= final_swap_size);
   if (initial_swap_size == final_swap_size) {
     return;
@@ -53,7 +53,7 @@ void CyclesPartialTsa::append_partial_solution(
   const auto current_back_id_opt = swaps.back_id();
   TKET_ASSERT(current_back_id_opt);
   auto current_id = current_back_id_opt.value();
-  for (size_t remaining_swaps = final_swap_size - initial_swap_size;;) {
+  for (std::size_t remaining_swaps = final_swap_size - initial_swap_size;;) {
     const auto& swap = swaps.at(current_id);
     path_finder.register_edge(swap.first, swap.second);
     --remaining_swaps;

--- a/libs/tktokenswap/src/CyclicShiftCostEstimate.cpp
+++ b/libs/tktokenswap/src/CyclicShiftCostEstimate.cpp
@@ -22,20 +22,20 @@ namespace tket {
 namespace tsa_internal {
 
 CyclicShiftCostEstimate::CyclicShiftCostEstimate(
-    const std::vector<size_t>& vertices, DistancesInterface& distances) {
+    const std::vector<std::size_t>& vertices, DistancesInterface& distances) {
   TKET_ASSERT(vertices.size() >= 2);
   // We first work out the total distance v(0)->v(1)-> .. -> v(n) -> v(0).
   // If we snip out v(i)->v(i+1), the remaining path tells us how many swaps
   // we need. So, we must snip out the LARGEST distance(v(i), v(i+1)).
-  size_t largest_distance = distances(vertices.back(), vertices[0]);
-  size_t total_distance = largest_distance;
+  std::size_t largest_distance = distances(vertices.back(), vertices[0]);
+  std::size_t total_distance = largest_distance;
 
   if (vertices.size() == 2) {
     start_v_index = 0;
   } else {
     // The value i such that distance(v(i), v(i+1)) is largest.
-    size_t v_index_with_largest_distance = vertices.size() - 1;
-    for (size_t ii = 0; ii + 1 < vertices.size(); ++ii) {
+    std::size_t v_index_with_largest_distance = vertices.size() - 1;
+    for (std::size_t ii = 0; ii + 1 < vertices.size(); ++ii) {
       const auto distance_i = distances(vertices[ii], vertices[ii + 1]);
       TKET_ASSERT(distance_i > 0);
       total_distance += distance_i;

--- a/libs/tktokenswap/src/CyclicShiftCostEstimate.hpp
+++ b/libs/tktokenswap/src/CyclicShiftCostEstimate.hpp
@@ -53,14 +53,14 @@ namespace tsa_internal {
  */
 struct CyclicShiftCostEstimate {
   /** A simple estimate of how many swaps will be needed. */
-  size_t estimated_concrete_swaps = 0;
+  std::size_t estimated_concrete_swaps = 0;
 
   /** If the stored vertices are v[0], v[1], ..., v[n],
    *  this is the value of i such that swapping along the abstract path
    *  v[i], v[i+1], ..., v[i+n] gives the smallest number of swaps.
    *  (Remembering that each abstract move is v[j] -> v[j+1]).
    */
-  size_t start_v_index = std::numeric_limits<size_t>::max();
+  std::size_t start_v_index = std::numeric_limits<std::size_t>::max();
 
   /** Calculate the data upon construction.
    *  @param vertices The list of vertices, in order, for a cyclic shift.
@@ -69,7 +69,7 @@ struct CyclicShiftCostEstimate {
    *    WHICH path between vertices will be used, at this stage).
    */
   CyclicShiftCostEstimate(
-      const std::vector<size_t>& vertices, DistancesInterface& distances);
+      const std::vector<std::size_t>& vertices, DistancesInterface& distances);
 };
 
 }  // namespace tsa_internal

--- a/libs/tktokenswap/src/DistancesInterface.cpp
+++ b/libs/tktokenswap/src/DistancesInterface.cpp
@@ -19,17 +19,17 @@ using std::vector;
 namespace tket {
 
 void DistancesInterface::register_shortest_path(
-    const vector<size_t>& /*path*/) {}
+    const vector<std::size_t>& /*path*/) {}
 
 void DistancesInterface::register_neighbours(
-    size_t vertex, const vector<size_t>& neighbours) {
-  for (size_t nv : neighbours) {
+    std::size_t vertex, const vector<std::size_t>& neighbours) {
+  for (std::size_t nv : neighbours) {
     register_edge(vertex, nv);
   }
 }
 
-void DistancesInterface::register_edge(size_t /*vertex1*/, size_t /*vertex2*/) {
-}
+void DistancesInterface::register_edge(
+    std::size_t /*vertex1*/, std::size_t /*vertex2*/) {}
 
 DistancesInterface::~DistancesInterface() {}
 

--- a/libs/tktokenswap/src/DynamicTokenTracker.cpp
+++ b/libs/tktokenswap/src/DynamicTokenTracker.cpp
@@ -64,7 +64,7 @@ bool DynamicTokenTracker::tokens_here_have_equal_locations_in_the_other_object(
   return true;
 }
 
-size_t DynamicTokenTracker::get_token_at_vertex(size_t vertex) {
+std::size_t DynamicTokenTracker::get_token_at_vertex(std::size_t vertex) {
   const auto iter = m_vertex_to_token.find(vertex);
   if (iter == m_vertex_to_token.end()) {
     m_vertex_to_token[vertex] = vertex;

--- a/libs/tktokenswap/src/HybridTsa.cpp
+++ b/libs/tktokenswap/src/HybridTsa.cpp
@@ -33,7 +33,7 @@ void HybridTsa::append_partial_solution(
     DistancesInterface& distances, NeighboursInterface& neighbours,
     RiverFlowPathFinder& path_finder) {
   const auto initial_L = get_total_home_distances(vertex_mapping, distances);
-  for (size_t counter = initial_L + 1; counter > 0; --counter) {
+  for (std::size_t counter = initial_L + 1; counter > 0; --counter) {
     const auto swaps_before = swaps.size();
     m_cycles_tsa.append_partial_solution(
         swaps, vertex_mapping, distances, neighbours, path_finder);

--- a/libs/tktokenswap/src/NeighboursInterface.cpp
+++ b/libs/tktokenswap/src/NeighboursInterface.cpp
@@ -18,7 +18,7 @@
 
 namespace tket {
 
-const std::vector<size_t>& NeighboursInterface::operator()(size_t) {
+const std::vector<std::size_t>& NeighboursInterface::operator()(std::size_t) {
   throw std::logic_error("NeighboursInterface::operator() not implemented");
 }
 

--- a/libs/tktokenswap/src/RiverFlowPathFinder.cpp
+++ b/libs/tktokenswap/src/RiverFlowPathFinder.cpp
@@ -42,7 +42,7 @@ struct RiverFlowPathFinder::Impl {
   std::map<Swap, EdgeCount> edge_counts;
 
   struct ArrowData {
-    size_t end_vertex;
+    std::size_t end_vertex;
     EdgeCount count;
   };
 
@@ -53,7 +53,7 @@ struct RiverFlowPathFinder::Impl {
   vector<ArrowData> candidate_moves;
 
   /// A work vector, will be built up
-  vector<size_t> path;
+  vector<std::size_t> path;
 
   Impl(
       DistancesInterface& distances_interface,
@@ -65,7 +65,7 @@ struct RiverFlowPathFinder::Impl {
   void reset();
 
   /// Increases nonempty "path" towards the target vertex.
-  void grow_path(size_t target_vertex, size_t required_path_size);
+  void grow_path(std::size_t target_vertex, std::size_t required_path_size);
 
   /// Once "path" has been filled, update the counts (so that future paths
   /// through similar vertices are more likely to overlap).
@@ -80,7 +80,7 @@ void RiverFlowPathFinder::Impl::reset() {
 }
 
 void RiverFlowPathFinder::Impl::grow_path(
-    size_t target_vertex, size_t required_path_size) {
+    std::size_t target_vertex, std::size_t required_path_size) {
   TKET_ASSERT(path.size() < required_path_size);
   TKET_ASSERT(!path.empty());
 
@@ -92,7 +92,7 @@ void RiverFlowPathFinder::Impl::grow_path(
   const auto& neighbours = neighbours_calculator(path.back());
   distances_calculator.register_neighbours(path.back(), neighbours);
 
-  for (size_t neighbour : neighbours) {
+  for (std::size_t neighbour : neighbours) {
     const auto neighbour_distance_to_target =
         distances_calculator(neighbour, target_vertex);
 
@@ -138,7 +138,7 @@ void RiverFlowPathFinder::Impl::grow_path(
 }
 
 void RiverFlowPathFinder::Impl::update_data_with_path() {
-  for (size_t ii = 1; ii < path.size(); ++ii) {
+  for (std::size_t ii = 1; ii < path.size(); ++ii) {
     // Nonexistent counts automatically set to 0 initially
     ++edge_counts[get_swap(path[ii - 1], path[ii])];
   }
@@ -155,8 +155,8 @@ RiverFlowPathFinder::~RiverFlowPathFinder() {}
 
 void RiverFlowPathFinder::reset() { m_pimpl->reset(); }
 
-const vector<size_t>& RiverFlowPathFinder::operator()(
-    size_t vertex1, size_t vertex2) {
+const vector<std::size_t>& RiverFlowPathFinder::operator()(
+    std::size_t vertex1, std::size_t vertex2) {
   m_pimpl->path.clear();
   m_pimpl->path.push_back(vertex1);
   if (vertex1 == vertex2) {
@@ -165,10 +165,10 @@ const vector<size_t>& RiverFlowPathFinder::operator()(
 
   // We must build up the path.
   // The number of vertices including the source and target.
-  const size_t final_path_size =
+  const std::size_t final_path_size =
       1 + m_pimpl->distances_calculator(vertex1, vertex2);
 
-  for (size_t infinite_loop_guard = 10 * final_path_size;
+  for (std::size_t infinite_loop_guard = 10 * final_path_size;
        infinite_loop_guard != 0; --infinite_loop_guard) {
     m_pimpl->grow_path(vertex2, final_path_size);
     if (m_pimpl->path.size() == final_path_size) {
@@ -180,7 +180,8 @@ const vector<size_t>& RiverFlowPathFinder::operator()(
   throw std::runtime_error("get path - dropped out of loop");
 }
 
-void RiverFlowPathFinder::register_edge(size_t vertex1, size_t vertex2) {
+void RiverFlowPathFinder::register_edge(
+    std::size_t vertex1, std::size_t vertex2) {
   // Automatically zero if the edge doesn't exist.
   auto& edge_count = m_pimpl->edge_counts[get_swap(vertex1, vertex2)];
   ++edge_count;

--- a/libs/tktokenswap/src/TSAUtils/DistanceFunctions.cpp
+++ b/libs/tktokenswap/src/TSAUtils/DistanceFunctions.cpp
@@ -20,10 +20,10 @@
 namespace tket {
 namespace tsa_internal {
 
-size_t get_total_home_distances(
+std::size_t get_total_home_distances(
     const VertexMapping& vertex_mapping,
     DistancesInterface& distances_calculator) {
-  size_t sum_of_distances = 0;
+  std::size_t sum_of_distances = 0;
   for (const auto& entry : vertex_mapping) {
     sum_of_distances += distances_calculator(entry.first, entry.second);
   }
@@ -31,7 +31,7 @@ size_t get_total_home_distances(
 }
 
 int get_move_decrease(
-    const VertexMapping& vertex_mapping, size_t v1, size_t v2,
+    const VertexMapping& vertex_mapping, std::size_t v1, std::size_t v2,
     DistancesInterface& distances) {
   const auto citer = vertex_mapping.find(v1);
   if (citer == vertex_mapping.cend()) {
@@ -44,7 +44,7 @@ int get_move_decrease(
 }
 
 int get_swap_decrease(
-    const VertexMapping& vertex_mapping, size_t v1, size_t v2,
+    const VertexMapping& vertex_mapping, std::size_t v1, std::size_t v2,
     DistancesInterface& distances) {
   return get_move_decrease(vertex_mapping, v1, v2, distances) +
          get_move_decrease(vertex_mapping, v2, v1, distances);

--- a/libs/tktokenswap/src/TSAUtils/SwapFunctions.cpp
+++ b/libs/tktokenswap/src/TSAUtils/SwapFunctions.cpp
@@ -19,7 +19,7 @@
 
 namespace tket {
 
-Swap get_swap(size_t v1, size_t v2) {
+Swap get_swap(std::size_t v1, std::size_t v2) {
   if (v1 == v2) {
     std::stringstream ss;
     ss << "get_swap : for equal vertices v1 = v2 = v_" << v1;

--- a/libs/tktokenswap/src/TSAUtils/VertexMappingFunctions.cpp
+++ b/libs/tktokenswap/src/TSAUtils/VertexMappingFunctions.cpp
@@ -55,21 +55,21 @@ void check_mapping(const VertexMapping& vertex_mapping) {
 }
 
 void append_swaps_to_interchange_path_ends(
-    const std::vector<size_t>& path, VertexMapping& vertex_mapping,
+    const std::vector<std::size_t>& path, VertexMapping& vertex_mapping,
     SwapList& swap_list) {
   if (path.size() < 2 || path.front() == path.back()) {
     return;
   }
-  for (size_t ii = path.size() - 1; ii > 0; --ii) {
+  for (std::size_t ii = path.size() - 1; ii > 0; --ii) {
     VertexSwapResult(path[ii], path[ii - 1], vertex_mapping, swap_list);
   }
-  for (size_t ii = 2; ii < path.size(); ++ii) {
+  for (std::size_t ii = 2; ii < path.size(); ++ii) {
     VertexSwapResult(path[ii], path[ii - 1], vertex_mapping, swap_list);
   }
 }
 
-size_t get_source_vertex(
-    VertexMapping& source_to_target_map, size_t target_vertex) {
+std::size_t get_source_vertex(
+    VertexMapping& source_to_target_map, std::size_t target_vertex) {
   if (source_to_target_map.count(target_vertex) == 0) {
     // If it IS a genuine permutation mapping (which we assume),
     // then the vertex is as yet unmentioned (and hence unmoved).

--- a/libs/tktokenswap/src/TSAUtils/VertexSwapResult.cpp
+++ b/libs/tktokenswap/src/TSAUtils/VertexSwapResult.cpp
@@ -18,7 +18,8 @@ namespace tket {
 namespace tsa_internal {
 
 VertexSwapResult::VertexSwapResult(
-    size_t v1, size_t v2, VertexMapping& vertex_mapping, SwapList& swap_list)
+    std::size_t v1, std::size_t v2, VertexMapping& vertex_mapping,
+    SwapList& swap_list)
     : VertexSwapResult(v1, v2, vertex_mapping) {
   if (tokens_moved != 0) {
     swap_list.push_back(get_swap(v1, v2));
@@ -30,7 +31,7 @@ VertexSwapResult::VertexSwapResult(
     : VertexSwapResult(swap.first, swap.second, vertex_mapping) {}
 
 VertexSwapResult::VertexSwapResult(
-    size_t v1, size_t v2, VertexMapping& vertex_mapping) {
+    std::size_t v1, std::size_t v2, VertexMapping& vertex_mapping) {
   if (vertex_mapping.count(v1) == 0) {
     if (vertex_mapping.count(v2) == 0) {
       tokens_moved = 0;

--- a/libs/tktokenswap/src/TableLookup/CanonicalRelabelling.cpp
+++ b/libs/tktokenswap/src/TableLookup/CanonicalRelabelling.cpp
@@ -98,7 +98,7 @@ const CanonicalRelabelling::Result& CanonicalRelabelling::operator()(
     const auto& cyc = m_cycles[ii];
     TKET_ASSERT(!cyc.empty());
     TKET_ASSERT(cyc.size() <= 6);
-    for (size_t old_v : cyc) {
+    for (std::size_t old_v : cyc) {
       m_result.new_to_old_vertices.push_back(old_v);
     }
   }

--- a/libs/tktokenswap/src/TableLookup/FilteredSwapSequences.cpp
+++ b/libs/tktokenswap/src/TableLookup/FilteredSwapSequences.cpp
@@ -91,7 +91,7 @@ void FilteredSwapSequences::initialise(
   TKET_ASSERT(codes[0] != 0);
   TrimmedSingleSequenceData datum;
 
-  for (size_t ii = 0; ii < codes.size(); ++ii) {
+  for (std::size_t ii = 0; ii < codes.size(); ++ii) {
     if (ii != 0 && codes[ii] == codes[ii - 1]) {
       // Filter out duplicate entries.
       continue;
@@ -117,7 +117,7 @@ void FilteredSwapSequences::push_back(TrimmedSingleSequenceData datum) {
   // vertices like (4,5). This may or may not be the case, but whatever
   // the truth, there are still enough bits available overall to break
   // the entries up well enough).
-  size_t list_size_to_use = std::numeric_limits<size_t>::max();
+  std::size_t list_size_to_use = std::numeric_limits<std::size_t>::max();
 
   while (bitset_copy != 0) {
     const auto new_bit = get_rightmost_bit(bitset_copy);
@@ -211,8 +211,8 @@ FilteredSwapSequences::get_lookup_result(
   return result;
 }
 
-size_t FilteredSwapSequences::get_total_number_of_entries() const {
-  size_t total = 0;
+std::size_t FilteredSwapSequences::get_total_number_of_entries() const {
+  std::size_t total = 0;
   for (const auto& entry : m_internal_data) {
     total += entry.second.size();
   }

--- a/libs/tktokenswap/src/TableLookup/PartialMappingLookup.cpp
+++ b/libs/tktokenswap/src/TableLookup/PartialMappingLookup.cpp
@@ -24,7 +24,7 @@ namespace tsa_internal {
 
 const ExactMappingLookup::Result& PartialMappingLookup::operator()(
     const VertexMapping& desired_mapping, const vector<Swap>& edges,
-    const std::set<size_t>& vertices_with_tokens_at_start,
+    const std::set<std::size_t>& vertices_with_tokens_at_start,
     unsigned max_number_of_swaps) {
   const auto& exact_mapping_result =
       m_exact_mapping_lookup(desired_mapping, edges, max_number_of_swaps);

--- a/libs/tktokenswap/src/TableLookup/SwapListSegmentOptimiser.cpp
+++ b/libs/tktokenswap/src/TableLookup/SwapListSegmentOptimiser.cpp
@@ -26,7 +26,8 @@ namespace tsa_internal {
 
 const SwapListSegmentOptimiser::Output&
 SwapListSegmentOptimiser::optimise_segment(
-    SwapID initial_id, const std::set<size_t>& vertices_with_tokens_at_start,
+    SwapID initial_id,
+    const std::set<std::size_t>& vertices_with_tokens_at_start,
     VertexMapResizing& map_resizing, SwapList& swap_list) {
   m_best_optimised_swaps.clear();
 
@@ -47,7 +48,7 @@ SwapListSegmentOptimiser::optimise_segment(
     current_map[initial_swap.first] = initial_swap.second;
     current_map[initial_swap.second] = initial_swap.first;
   }
-  size_t current_number_of_swaps = 1;
+  std::size_t current_number_of_swaps = 1;
   VertexMapping current_map_copy;
   for (auto next_id_opt = swap_list.next(initial_id);;) {
     bool too_many_vertices = false;
@@ -82,10 +83,10 @@ SwapListSegmentOptimiser::optimise_segment(
             TKET_ASSERT(
                 m_output.initial_segment_size >= m_best_optimised_swaps.size());
             // GCOVR_EXCL_STOP
-            const size_t current_decrease =
+            const std::size_t current_decrease =
                 m_output.initial_segment_size - m_best_optimised_swaps.size();
             TKET_ASSERT(current_number_of_swaps >= lookup_result.swaps.size());
-            const size_t new_decrease =
+            const std::size_t new_decrease =
                 current_number_of_swaps - lookup_result.swaps.size();
             should_store = new_decrease > current_decrease;
           }
@@ -159,7 +160,7 @@ void SwapListSegmentOptimiser::fill_final_output_and_swaplist(
     m_output.new_segment_last_id =
         overwrite_result.final_overwritten_element_id;
 
-    const size_t remaining_elements_to_erase =
+    const std::size_t remaining_elements_to_erase =
         m_output.initial_segment_size - m_output.final_segment_size;
 
     const auto next_id_opt =

--- a/libs/tktokenswap/src/TableLookup/SwapListTableOptimiser.cpp
+++ b/libs/tktokenswap/src/TableLookup/SwapListTableOptimiser.cpp
@@ -32,7 +32,7 @@ enum class EmptySwapCheckResult {
 // vertices_with_tokens is correct just BEFORE performing the swap.
 // If the swap is empty, erase it and update current_id (to the next swap).
 static EmptySwapCheckResult check_for_empty_swap(
-    const std::set<size_t>& vertices_with_tokens, SwapID& current_id,
+    const std::set<std::size_t>& vertices_with_tokens, SwapID& current_id,
     SwapList& swap_list) {
   const auto swap = swap_list.at(current_id);
   if (vertices_with_tokens.count(swap.first) != 0 ||
@@ -54,7 +54,7 @@ static EmptySwapCheckResult check_for_empty_swap(
 // until EITHER we hit a nonempty swap, OR we run out of swaps,
 // and thus return false.
 static bool erase_empty_swaps_interval(
-    const std::set<size_t>& vertices_with_tokens, SwapID& current_id,
+    const std::set<std::size_t>& vertices_with_tokens, SwapID& current_id,
     SwapList& swap_list) {
   for (auto infinite_loop_guard = 1 + swap_list.size(); infinite_loop_guard > 0;
        --infinite_loop_guard) {
@@ -81,7 +81,7 @@ static bool erase_empty_swaps_interval(
 // Perform the swap (i.e., updating vertices_with_tokens),
 // and advance current_id to the next swap.
 static bool perform_current_nonempty_swap(
-    std::set<size_t>& vertices_with_tokens, SwapID& current_id,
+    std::set<std::size_t>& vertices_with_tokens, SwapID& current_id,
     const SwapList& swap_list) {
   const auto swap = swap_list.at(current_id);
 
@@ -109,7 +109,7 @@ static bool perform_current_nonempty_swap(
 }
 
 void SwapListTableOptimiser::optimise(
-    const std::set<size_t>& vertices_with_tokens_at_start,
+    const std::set<std::size_t>& vertices_with_tokens_at_start,
     VertexMapResizing& map_resizing, SwapList& swap_list,
     SwapListOptimiser& swap_list_optimiser) {
   if (vertices_with_tokens_at_start.empty()) {
@@ -170,7 +170,7 @@ void SwapListTableOptimiser::optimise(
 }
 
 void SwapListTableOptimiser::optimise_in_forward_direction(
-    const std::set<size_t>& vertices_with_tokens_at_start,
+    const std::set<std::size_t>& vertices_with_tokens_at_start,
     VertexMapResizing& map_resizing, SwapList& swap_list,
     SwapListOptimiser& swap_list_optimiser) {
   swap_list_optimiser.optimise_pass_with_frontward_travel(swap_list);
@@ -187,8 +187,8 @@ void SwapListTableOptimiser::optimise_in_forward_direction(
   auto current_id = swap_list.front_id().value();
   auto vertices_with_tokens = vertices_with_tokens_at_start;
 
-  for (size_t infinite_loop_guard = swap_list.size(); infinite_loop_guard != 0;
-       --infinite_loop_guard) {
+  for (std::size_t infinite_loop_guard = swap_list.size();
+       infinite_loop_guard != 0; --infinite_loop_guard) {
     if (!erase_empty_swaps_interval(
             vertices_with_tokens, current_id, swap_list)) {
       return;

--- a/libs/tktokenswap/src/TableLookup/VertexMapResizing.cpp
+++ b/libs/tktokenswap/src/TableLookup/VertexMapResizing.cpp
@@ -26,7 +26,7 @@ namespace tsa_internal {
 VertexMapResizing::VertexMapResizing(NeighboursInterface& neighbours)
     : m_neighbours(neighbours) {}
 
-const vector<size_t>& VertexMapResizing::operator()(size_t vertex) {
+const vector<std::size_t>& VertexMapResizing::operator()(std::size_t vertex) {
   const auto citer = m_cached_neighbours.find(vertex);
   if (citer != m_cached_neighbours.cend()) {
     return citer->second;
@@ -87,17 +87,17 @@ const VertexMapResizing::Result& VertexMapResizing::resize_mapping(
   return m_result;
 }
 
-size_t VertexMapResizing::get_edge_count(
-    const VertexMapping& mapping, size_t vertex) {
+std::size_t VertexMapResizing::get_edge_count(
+    const VertexMapping& mapping, std::size_t vertex) {
   const auto& neighbours = operator()(vertex);
   return std::count_if(
       neighbours.cbegin(), neighbours.cend(),
       // Note that "neighbours" automatically will not contain "vertex" itself.
-      [&mapping](size_t vertex) { return mapping.count(vertex) != 0; });
+      [&mapping](std::size_t vertex) { return mapping.count(vertex) != 0; });
 }
 
 void VertexMapResizing::add_vertex(VertexMapping& mapping) {
-  std::set<size_t> new_vertices;
+  std::set<std::size_t> new_vertices;
 
   // Multipass, maybe a bit inefficient, but doesn't matter.
   // After a few calls, it's just map lookup so not so bad.
@@ -113,8 +113,8 @@ void VertexMapResizing::add_vertex(VertexMapping& mapping) {
   }
 
   // Now find the new vertex which would add the largest number of new edges.
-  size_t maximum_new_edges = 0;
-  size_t best_new_vertex = std::numeric_limits<size_t>::max();
+  std::size_t maximum_new_edges = 0;
+  std::size_t best_new_vertex = std::numeric_limits<std::size_t>::max();
 
   for (auto new_v : new_vertices) {
     const auto edge_count = get_edge_count(mapping, new_v);
@@ -129,12 +129,12 @@ void VertexMapResizing::add_vertex(VertexMapping& mapping) {
 }
 
 void VertexMapResizing::remove_vertex(VertexMapping& mapping) {
-  const auto invalid_number_of_edges = std::numeric_limits<size_t>::max();
+  const auto invalid_number_of_edges = std::numeric_limits<std::size_t>::max();
 
   // We want to leave as many edges as possible,
   // so we remove the minimum number.
-  size_t minimum_edges_removed = invalid_number_of_edges;
-  size_t best_vertex = std::numeric_limits<size_t>::max();
+  std::size_t minimum_edges_removed = invalid_number_of_edges;
+  std::size_t best_vertex = std::numeric_limits<std::size_t>::max();
   for (const auto& existing_vertex_pair : mapping) {
     if (existing_vertex_pair.first != existing_vertex_pair.second) {
       // The vertex is not fixed, so we cannot remove it.

--- a/libs/tktokenswap/src/TableLookup/VertexMapResizing.hpp
+++ b/libs/tktokenswap/src/TableLookup/VertexMapResizing.hpp
@@ -52,7 +52,8 @@ class VertexMapResizing : public NeighboursInterface {
    * @param vertex A vertex in the graph.
    * @return A cached list of neighbours of that vertex, stored internally.
    */
-  virtual const std::vector<size_t>& operator()(size_t vertex) override;
+  virtual const std::vector<std::size_t>& operator()(
+      std::size_t vertex) override;
 
   /** The result of resizing a mapping by deleting fixed vertices if too big,
    * or adding new vertices if too small.
@@ -86,7 +87,7 @@ class VertexMapResizing : public NeighboursInterface {
   Result m_result;
 
   // KEY: a vertex. VALUE: all its neighbours.
-  std::map<size_t, std::vector<size_t>> m_cached_neighbours;
+  std::map<std::size_t, std::vector<std::size_t>> m_cached_neighbours;
   std::set<Swap> m_cached_full_edges;
 
   /** How many edges join the given vertex to other existing vertices?
@@ -96,7 +97,7 @@ class VertexMapResizing : public NeighboursInterface {
    * @return The total number of edges within the LARGER graph joining the
    * vertex to other vertices within the mapping.
    */
-  size_t get_edge_count(const VertexMapping& mapping, size_t vertex);
+  std::size_t get_edge_count(const VertexMapping& mapping, std::size_t vertex);
 
   /** Try to add a single new fixed vertex to the mapping, i.e. a new v with
    * map[v]=v.

--- a/libs/tktokenswap/src/TrivialTSA.cpp
+++ b/libs/tktokenswap/src/TrivialTSA.cpp
@@ -51,7 +51,7 @@ bool TrivialTSA::grow_cycle_forwards(
 
   // If valid, a single cycle contains at most one empty vertex.
   // Thus there are at most N+1 vertices.
-  for (size_t infin_loop_guard = vertex_mapping.size() + 1;
+  for (std::size_t infin_loop_guard = vertex_mapping.size() + 1;
        infin_loop_guard != 0; --infin_loop_guard) {
     const auto v1 = m_abstract_cycles_vertices.at(current_id);
     const auto citer = vertex_mapping.find(v1);
@@ -78,7 +78,7 @@ void TrivialTSA::grow_cycle_backwards(Endpoints& endpoints) {
 
   // In a valid cycle, every vertex but one (the empty vertex)
   // is the target of something, and therefore there are <= N+1 vertices.
-  for (size_t infin_loop_guard = m_reversed_vertex_mapping.size() + 1;
+  for (std::size_t infin_loop_guard = m_reversed_vertex_mapping.size() + 1;
        infin_loop_guard != 0; --infin_loop_guard) {
     const auto v1 = m_abstract_cycles_vertices.at(current_id);
     const auto citer = m_reversed_vertex_mapping.find(v1);
@@ -183,9 +183,10 @@ void TrivialTSA::append_partial_solution(
   TKET_ASSERT(m_options == Options::BREAK_AFTER_PROGRESS);
   // We're only going to do ONE cycle; so find which cycle
   // has the shortest estimated number of swaps
-  size_t best_estimated_concrete_swaps = std::numeric_limits<size_t>::max();
+  std::size_t best_estimated_concrete_swaps =
+      std::numeric_limits<std::size_t>::max();
   Endpoints best_endpoints;
-  size_t start_v_index = std::numeric_limits<size_t>::max();
+  std::size_t start_v_index = std::numeric_limits<std::size_t>::max();
 
   for (const auto& endpoints : m_cycle_endpoints) {
     copy_vertices_to_work_vector(endpoints);
@@ -196,7 +197,8 @@ void TrivialTSA::append_partial_solution(
     const CyclicShiftCostEstimate estimate(m_vertices_work_vector, distances);
     // GCOVR_EXCL_START
     TKET_ASSERT(
-        estimate.estimated_concrete_swaps < std::numeric_limits<size_t>::max());
+        estimate.estimated_concrete_swaps <
+        std::numeric_limits<std::size_t>::max());
     TKET_ASSERT(estimate.start_v_index < m_vertices_work_vector.size());
     // GCOVR_EXCL_STOP
     if (estimate.estimated_concrete_swaps < best_estimated_concrete_swaps) {
@@ -207,7 +209,7 @@ void TrivialTSA::append_partial_solution(
   }
   // GCOVR_EXCL_START
   TKET_ASSERT(
-      best_estimated_concrete_swaps < std::numeric_limits<size_t>::max());
+      best_estimated_concrete_swaps < std::numeric_limits<std::size_t>::max());
   // GCOVR_EXCL_STOP
   const auto swap_size_before = swaps.size();
   const auto decrease = append_partial_solution_with_single_cycle(
@@ -239,7 +241,7 @@ void TrivialTSA::append_partial_solution_with_all_cycles(
     // Break the abstract cycle into abstract swaps...
     // To shift: [a,b,c,d] -> [d,a,b,c], we do abstract swaps in
     // opposite order of the shift direction, i.e.   cd bc ab
-    for (size_t ii = m_vertices_work_vector.size() - 1; ii > 0; --ii) {
+    for (std::size_t ii = m_vertices_work_vector.size() - 1; ii > 0; --ii) {
       // Abstract swap(v1, v2).
       const auto v1 = m_vertices_work_vector[ii];
       const auto v2 = m_vertices_work_vector[ii - 1];
@@ -251,8 +253,8 @@ void TrivialTSA::append_partial_solution_with_all_cycles(
   }
 }
 
-size_t TrivialTSA::append_partial_solution_with_single_cycle(
-    const Endpoints& endpoints, size_t start_v_index, SwapList& swaps,
+std::size_t TrivialTSA::append_partial_solution_with_single_cycle(
+    const Endpoints& endpoints, std::size_t start_v_index, SwapList& swaps,
     VertexMapping& vertex_mapping, DistancesInterface& distances,
     RiverFlowPathFinder& path_finder) {
   copy_vertices_to_work_vector(endpoints);
@@ -265,7 +267,7 @@ size_t TrivialTSA::append_partial_solution_with_single_cycle(
 
   // To shift: [a,b,c,d] -> [d,a,b,c], we do abstract swaps in the opposite
   // order to the shift direction, i.e.   cd bc ab
-  for (size_t ii = m_vertices_work_vector.size() - 1; ii > 0; --ii) {
+  for (std::size_t ii = m_vertices_work_vector.size() - 1; ii > 0; --ii) {
     // Abstract swap(v1, v2).
     const auto v1 = m_vertices_work_vector
         [(ii + start_v_index) % m_vertices_work_vector.size()];
@@ -281,23 +283,23 @@ size_t TrivialTSA::append_partial_solution_with_single_cycle(
     // do concrete swaps xa ab bc cy bc ab xa.
 
     //  xa ab bc cy ...(ascending)
-    for (size_t jj = 1; jj < path.size(); ++jj) {
+    for (std::size_t jj = 1; jj < path.size(); ++jj) {
       current_L_decrease +=
           get_swap_decrease(vertex_mapping, path[jj], path[jj - 1], distances);
 
       VertexSwapResult(path[jj], path[jj - 1], vertex_mapping, swaps);
       if (current_L_decrease > 0) {
-        return static_cast<size_t>(current_L_decrease);
+        return static_cast<std::size_t>(current_L_decrease);
       }
     }
     // Now the reverse: bc ab xa
-    for (size_t kk = path.size() - 2; kk > 0; --kk) {
+    for (std::size_t kk = path.size() - 2; kk > 0; --kk) {
       current_L_decrease +=
           get_swap_decrease(vertex_mapping, path[kk], path[kk - 1], distances);
 
       VertexSwapResult(path[kk], path[kk - 1], vertex_mapping, swaps);
       if (current_L_decrease > 0) {
-        return static_cast<size_t>(current_L_decrease);
+        return static_cast<std::size_t>(current_L_decrease);
       }
     }
   }

--- a/libs/tktokenswap/src/VectorListHybridSkeleton.cpp
+++ b/libs/tktokenswap/src/VectorListHybridSkeleton.cpp
@@ -113,7 +113,7 @@ void VectorListHybridSkeleton::reverse() {
   std::swap(m_front, m_back);
 }
 
-size_t VectorListHybridSkeleton::size() const { return m_size; }
+std::size_t VectorListHybridSkeleton::size() const { return m_size; }
 
 Index VectorListHybridSkeleton::front_index() const { return m_front; }
 
@@ -148,7 +148,7 @@ void VectorListHybridSkeleton::erase(Index index) {
 }
 
 void VectorListHybridSkeleton::erase_interval(
-    Index index, size_t number_of_elements) {
+    Index index, std::size_t number_of_elements) {
   if (number_of_elements == 0) {
     return;
   }
@@ -157,7 +157,7 @@ void VectorListHybridSkeleton::erase_interval(
   // We update only O(1) links in total, not O(N),
   // so slightly faster than a loop of next/erase calls.
   Index last_element_index = index;
-  for (size_t nn = 1; nn < number_of_elements; ++nn) {
+  for (std::size_t nn = 1; nn < number_of_elements; ++nn) {
     last_element_index = m_links.at(last_element_index).next;
 
     // GCOVR_EXCL_START
@@ -277,7 +277,7 @@ Index VectorListHybridSkeleton::get_new_index() {
 
 std::string VectorListHybridSkeleton::debug_str() const {
   std::stringstream ss;
-  const auto to_str = [](size_t ii) -> std::string {
+  const auto to_str = [](std::size_t ii) -> std::string {
     if (ii == INVALID_INDEX) {
       return "NULL";
     }

--- a/libs/tktokenswap/test/src/TSAUtils/test_SwapFunctions.cpp
+++ b/libs/tktokenswap/test/src/TSAUtils/test_SwapFunctions.cpp
@@ -25,8 +25,8 @@ namespace tsa_internal {
 namespace tests {
 
 SCENARIO("Get swaps, with exceptions") {
-  for (size_t ii = 0; ii < 5; ++ii) {
-    for (size_t jj = 0; jj < 5; ++jj) {
+  for (std::size_t ii = 0; ii < 5; ++ii) {
+    for (std::size_t jj = 0; jj < 5; ++jj) {
       try {
         const auto swap = get_swap(ii, jj);
         CHECK(ii != jj);
@@ -42,8 +42,8 @@ SCENARIO("Get swaps, with exceptions") {
 
 SCENARIO("Disjoint swaps") {
   std::vector<Swap> swaps;
-  for (size_t ii = 0; ii < 5; ++ii) {
-    for (size_t jj = ii + 1; jj < 5; ++jj) {
+  for (std::size_t ii = 0; ii < 5; ++ii) {
+    for (std::size_t jj = ii + 1; jj < 5; ++jj) {
       swaps.push_back(get_swap(ii, jj));
     }
   }

--- a/libs/tktokenswap/test/src/TableLookup/NeighboursFromEdges.cpp
+++ b/libs/tktokenswap/test/src/TableLookup/NeighboursFromEdges.cpp
@@ -27,7 +27,8 @@ void NeighboursFromEdges::add_edge(const Swap& edge) {
   m_cached_neighbours[edge.second].insert(edge.first);
 }
 
-const std::vector<size_t>& NeighboursFromEdges::operator()(size_t vertex) {
+const std::vector<std::size_t>& NeighboursFromEdges::operator()(
+    std::size_t vertex) {
   const auto& neighbours_set = m_cached_neighbours[vertex];
   m_neighbours_storage = {neighbours_set.cbegin(), neighbours_set.cend()};
   return m_neighbours_storage;

--- a/libs/tktokenswap/test/src/TableLookup/NeighboursFromEdges.hpp
+++ b/libs/tktokenswap/test/src/TableLookup/NeighboursFromEdges.hpp
@@ -41,13 +41,14 @@ class NeighboursFromEdges : public NeighboursInterface {
    * @param vertex A vertex in the graph
    * @return All other vertices adjecent to the vertex (stored internally).
    */
-  virtual const std::vector<size_t>& operator()(size_t vertex) override;
+  virtual const std::vector<std::size_t>& operator()(
+      std::size_t vertex) override;
 
  private:
   /** The key is the vertex, the value is the list of neighbours. */
-  std::map<size_t, std::set<size_t>> m_cached_neighbours;
+  std::map<std::size_t, std::set<std::size_t>> m_cached_neighbours;
 
-  std::vector<size_t> m_neighbours_storage;
+  std::vector<std::size_t> m_neighbours_storage;
 };
 
 template <class SwapContainer>

--- a/libs/tktokenswap/test/src/TableLookup/SwapSequenceReductionTester.cpp
+++ b/libs/tktokenswap/test/src/TableLookup/SwapSequenceReductionTester.cpp
@@ -43,7 +43,7 @@ static void reduce_sequence(
   for (const auto& swap : swaps) {
     raw_swap_list.push_back(swap);
   }
-  std::set<size_t> vertices_with_tokens;
+  std::set<std::size_t> vertices_with_tokens;
   for (const auto& entry : vertex_mapping) {
     vertices_with_tokens.insert(entry.first);
   }
@@ -76,7 +76,7 @@ static void check_solution(
   REQUIRE(all_tokens_home(problem_vertex_mapping));
 }
 
-static size_t get_reduced_swaps_size_with_checks(
+static std::size_t get_reduced_swaps_size_with_checks(
     const vector<Swap>& swaps, const VertexMapping& problem_vertex_mapping,
     NeighboursFromEdges& neighbours_calculator,
     SwapListOptimiser& general_optimiser,
@@ -90,7 +90,7 @@ static size_t get_reduced_swaps_size_with_checks(
   return raw_swap_list.size();
 }
 
-size_t SwapSequenceReductionTester::get_checked_solution_size(
+std::size_t SwapSequenceReductionTester::get_checked_solution_size(
     const DecodedProblemData& problem_data,
     const SwapSequenceReductionTester::Options& options) {
   NeighboursFromEdges neighbours_calculator(problem_data.swaps);
@@ -100,7 +100,7 @@ size_t SwapSequenceReductionTester::get_checked_solution_size(
 }
 
 // Reduces the sequence of swaps, checks it, and returns the size.
-size_t SwapSequenceReductionTester::get_checked_solution_size(
+std::size_t SwapSequenceReductionTester::get_checked_solution_size(
     const DecodedProblemData& problem_data,
     const DecodedArchitectureData& architecture_data,
     const SwapSequenceReductionTester::Options& options) {
@@ -118,7 +118,7 @@ SequenceReductionStats::SequenceReductionStats()
       total_reduced_swaps(0) {}
 
 void SequenceReductionStats::add_solution(
-    size_t original_swaps, size_t reduced_swaps) {
+    std::size_t original_swaps, std::size_t reduced_swaps) {
   REQUIRE(reduced_swaps <= original_swaps);
   ++problems;
   if (reduced_swaps < original_swaps) {
@@ -131,11 +131,12 @@ void SequenceReductionStats::add_solution(
 
 std::string SequenceReductionStats::str() const {
   std::stringstream ss;
-  const size_t swaps_for_equal_probs =
+  const std::size_t swaps_for_equal_probs =
       total_original_swaps - total_original_swaps_for_reduced_problems;
-  const size_t reduced_swaps_for_reduced_probs =
+  const std::size_t reduced_swaps_for_reduced_probs =
       total_reduced_swaps - swaps_for_equal_probs;
-  const size_t overall_decrease = total_original_swaps - total_reduced_swaps;
+  const std::size_t overall_decrease =
+      total_original_swaps - total_reduced_swaps;
   ss << "[" << problems - reduced_problems << " equal probs ("
      << swaps_for_equal_probs << "); " << reduced_problems << " reduced probs ("
      << reduced_swaps_for_reduced_probs << " vs "

--- a/libs/tktokenswap/test/src/TableLookup/SwapSequenceReductionTester.hpp
+++ b/libs/tktokenswap/test/src/TableLookup/SwapSequenceReductionTester.hpp
@@ -32,11 +32,11 @@ class SwapSequenceReductionTester {
   };
 
   // Reduces the sequence of swaps, checks it, and returns the size.
-  size_t get_checked_solution_size(
+  std::size_t get_checked_solution_size(
       const DecodedProblemData& problem_data,
       const DecodedArchitectureData& architecture_data, const Options& options);
 
-  size_t get_checked_solution_size(
+  std::size_t get_checked_solution_size(
       const DecodedProblemData& problem_data, const Options& options);
 
  private:
@@ -45,21 +45,21 @@ class SwapSequenceReductionTester {
 };
 
 struct SequenceReductionStats {
-  size_t problems;
-  size_t reduced_problems;
-  size_t total_original_swaps;
+  std::size_t problems;
+  std::size_t reduced_problems;
+  std::size_t total_original_swaps;
 
   // This only includes problems where the number of swaps strictly decreased
   // after table reduction.
-  size_t total_original_swaps_for_reduced_problems;
+  std::size_t total_original_swaps_for_reduced_problems;
 
   // This is the sum of "reduced_swaps" passed in, over all problems (including
   // those where there was no decrease).
-  size_t total_reduced_swaps;
+  std::size_t total_reduced_swaps;
 
   SequenceReductionStats();
 
-  void add_solution(size_t original_swaps, size_t reduced_swaps);
+  void add_solution(std::size_t original_swaps, std::size_t reduced_swaps);
 
   std::string str() const;
 };

--- a/libs/tktokenswap/test/src/TableLookup/test_CanonicalRelabelling.cpp
+++ b/libs/tktokenswap/test/src/TableLookup/test_CanonicalRelabelling.cpp
@@ -126,7 +126,7 @@ static void check_that_all_entries_have_the_same_permutation(
 // and see that the relabellings work.
 SCENARIO("Relabelling test for random mappings") {
   const unsigned number_of_vertices = 5;
-  vector<size_t> original_labels;
+  vector<std::size_t> original_labels;
 
   // The generated mappings, together with the relabelling results.
   // The key is the permutation hash.
@@ -146,7 +146,7 @@ SCENARIO("Relabelling test for random mappings") {
     }
     rng.do_shuffle(original_labels);
     {
-      size_t ii = 0;
+      std::size_t ii = 0;
       for (auto& entry : original_map) {
         entry.second = original_labels[ii];
         ++ii;

--- a/libs/tktokenswap/test/src/TableLookup/test_ExactMappingLookup.cpp
+++ b/libs/tktokenswap/test/src/TableLookup/test_ExactMappingLookup.cpp
@@ -28,9 +28,9 @@ namespace tests {
 
 namespace {
 struct ResultChecker {
-  size_t failed_due_to_too_many_vertices = 0;
-  size_t failed_due_to_table_missing_entry = 0;
-  size_t success = 0;
+  std::size_t failed_due_to_too_many_vertices = 0;
+  std::size_t failed_due_to_table_missing_entry = 0;
+  std::size_t success = 0;
 
   void check_failed_result(
       const ExactMappingLookup::Result& lookup_result,
@@ -108,7 +108,7 @@ SCENARIO("Test exact mapping table lookup for wheel") {
   // (although it shouldn't).
   vector<Swap> all_edges;
   vector<Swap> all_edges_sorted;
-  vector<size_t> vertices_used;
+  vector<std::size_t> vertices_used;
   ResultChecker checker;
 
   for (unsigned number_of_spokes = 3; number_of_spokes <= 6;

--- a/libs/tktokenswap/test/src/TestUtils/DebugFunctions.cpp
+++ b/libs/tktokenswap/test/src/TestUtils/DebugFunctions.cpp
@@ -38,7 +38,7 @@ std::string str(const std::vector<Swap>& swaps) {
   return ss.str();
 }
 
-size_t get_swaps_lower_bound(
+std::size_t get_swaps_lower_bound(
     const VertexMapping& vertex_mapping,
     DistancesInterface& distances_calculator) {
   // Each swap decreases the sum by at most 2 (and more likely 1 in many cases,

--- a/libs/tktokenswap/test/src/TestUtils/DebugFunctions.hpp
+++ b/libs/tktokenswap/test/src/TestUtils/DebugFunctions.hpp
@@ -57,7 +57,7 @@ std::string str(const std::vector<Swap>& swaps);
  *    the value seems about as hard as finding an actual solution, and thus
  *    is possibly exponentially hard (seems to be unknown, even for trees).
  */
-size_t get_swaps_lower_bound(
+std::size_t get_swaps_lower_bound(
     const VertexMapping& vertex_mapping, DistancesInterface& distances);
 
 }  // namespace tsa_internal

--- a/libs/tktokenswap/test/src/TestUtils/DecodedProblemData.cpp
+++ b/libs/tktokenswap/test/src/TestUtils/DecodedProblemData.cpp
@@ -59,17 +59,17 @@ static const std::string& encoding_chars() {
   return chars;
 }
 
-static std::map<unsigned char, size_t> get_char_to_vertex_map_local() {
-  std::map<unsigned char, size_t> char_to_vertex_map;
+static std::map<unsigned char, std::size_t> get_char_to_vertex_map_local() {
+  std::map<unsigned char, std::size_t> char_to_vertex_map;
   const auto& chars = encoding_chars();
-  for (size_t ii = 0; ii < chars.size(); ++ii) {
+  for (std::size_t ii = 0; ii < chars.size(); ++ii) {
     char_to_vertex_map[chars[ii]] = ii;
   }
   return char_to_vertex_map;
 }
 
-static const std::map<unsigned char, size_t>& char_to_vertex_map() {
-  static const std::map<unsigned char, size_t> map(
+static const std::map<unsigned char, std::size_t>& char_to_vertex_map() {
+  static const std::map<unsigned char, std::size_t> map(
       get_char_to_vertex_map_local());
   return map;
 }
@@ -95,7 +95,7 @@ DecodedProblemData::DecodedProblemData(
     index += 2;
   }
 
-  std::set<size_t> vertices;
+  std::set<std::size_t> vertices;
   for (auto swap : swaps) {
     vertices.insert(swap.first);
     vertices.insert(swap.second);
@@ -136,8 +136,8 @@ DecodedArchitectureData::DecodedArchitectureData() : number_of_vertices(0) {}
 
 DecodedArchitectureData::DecodedArchitectureData(
     const std::string& solution_edges_string) {
-  vector<vector<size_t>> neighbours(1);
-  std::set<size_t> vertices_seen;
+  vector<vector<std::size_t>> neighbours(1);
+  std::set<std::size_t> vertices_seen;
   for (unsigned char ch : solution_edges_string) {
     if (ch != ':') {
       const auto new_v = char_to_vertex_map().at(ch);
@@ -159,7 +159,7 @@ DecodedArchitectureData::DecodedArchitectureData(
   REQUIRE(!vertices_seen.empty());
   REQUIRE(*vertices_seen.crbegin() <= neighbours.size());
 
-  for (size_t ii = 0; ii < neighbours.size(); ++ii) {
+  for (std::size_t ii = 0; ii < neighbours.size(); ++ii) {
     if (neighbours[ii].empty()) {
       continue;
     }

--- a/libs/tktokenswap/test/src/TestUtils/DecodedProblemData.hpp
+++ b/libs/tktokenswap/test/src/TestUtils/DecodedProblemData.hpp
@@ -35,7 +35,7 @@ struct DecodedProblemData {
   /** The desired source->target mapping for a problem. */
   VertexMapping vertex_mapping;
 
-  size_t number_of_vertices;
+  std::size_t number_of_vertices;
 
   /** Do we require the vertex numbers to be {0,1,2,...,m}, with no gaps? */
   enum class RequireContiguousVertices { YES, NO };
@@ -58,7 +58,7 @@ struct DecodedArchitectureData {
   std::set<Swap> edges;
 
   /** The vertex numbers are contiguous, i.e. 0,1,2,...N for some N. */
-  size_t number_of_vertices;
+  std::size_t number_of_vertices;
 
   /** Simply without filling any data. */
   DecodedArchitectureData();

--- a/libs/tktokenswap/test/src/TestUtils/GetRandomSet.cpp
+++ b/libs/tktokenswap/test/src/TestUtils/GetRandomSet.cpp
@@ -21,11 +21,11 @@ namespace tket {
 namespace tsa_internal {
 namespace tests {
 
-std::set<size_t> get_random_set(
-    RNG& rng, size_t sample_size, size_t population_size) {
+std::set<std::size_t> get_random_set(
+    RNG& rng, std::size_t sample_size, std::size_t population_size) {
   TKET_ASSERT(sample_size <= population_size);
 
-  std::set<size_t> result;
+  std::set<std::size_t> result;
   if (sample_size == 0 || population_size == 0) {
     return result;
   }
@@ -35,7 +35,7 @@ std::set<size_t> get_random_set(
     }
     return result;
   }
-  std::vector<size_t> elems(population_size);
+  std::vector<std::size_t> elems(population_size);
   std::iota(elems.begin(), elems.end(), 0);
   rng.do_shuffle(elems);
   for (const auto& elem : elems) {

--- a/libs/tktokenswap/test/src/TestUtils/GetRandomSet.hpp
+++ b/libs/tktokenswap/test/src/TestUtils/GetRandomSet.hpp
@@ -28,8 +28,8 @@ namespace tests {
  *    of nonnegative integers, starting at 0).
  *  @return A set of numbers. Throws upon invalid parameters.
  */
-std::set<size_t> get_random_set(
-    RNG& rng, size_t sample_size, size_t population_size);
+std::set<std::size_t> get_random_set(
+    RNG& rng, std::size_t sample_size, std::size_t population_size);
 
 }  // namespace tests
 }  // namespace tsa_internal

--- a/libs/tktokenswap/test/src/TestUtils/ProblemGeneration.cpp
+++ b/libs/tktokenswap/test/src/TestUtils/ProblemGeneration.cpp
@@ -44,7 +44,7 @@ VertexMapping TSProblemParameters00::get_problem(
       get_random_set(rng, number_of_tokens, number_of_vertices);
   REQUIRE(tokens.size() == number_of_tokens);
   REQUIRE(targets_set.size() == number_of_tokens);
-  vector<size_t> targets{targets_set.cbegin(), targets_set.cend()};
+  vector<std::size_t> targets{targets_set.cbegin(), targets_set.cend()};
   for (auto token : tokens) {
     vertex_mapping[token] = rng.get_and_remove_element(targets);
   }

--- a/libs/tktokenswap/test/src/TestUtils/TestStatsStructs.cpp
+++ b/libs/tktokenswap/test/src/TestUtils/TestStatsStructs.cpp
@@ -22,14 +22,15 @@ namespace tket {
 namespace tsa_internal {
 namespace tests {
 
-void MinMaxAv::add(size_t result) {
+void MinMaxAv::add(std::size_t result) {
   min = std::min(min, result);
   max = std::max(max, result);
   total += result;
 }
 
 void PartialTsaStatistics::add_problem_result(
-    size_t initial_L, size_t final_L, size_t tokens, size_t swaps) {
+    std::size_t initial_L, std::size_t final_L, std::size_t tokens,
+    std::size_t swaps) {
   REQUIRE(final_L <= initial_L);
   REQUIRE(final_L + 2 * swaps >= initial_L);
   total_number_of_tokens += tokens;
@@ -41,7 +42,7 @@ void PartialTsaStatistics::add_problem_result(
   }
   ++number_of_problems;
   total_of_L += initial_L;
-  const size_t l_decrease = initial_L - final_L;
+  const std::size_t l_decrease = initial_L - final_L;
   total_of_L_decreases += l_decrease;
 
   l_decrease_percentages.add((100 * (initial_L - final_L)) / initial_L);
@@ -53,7 +54,7 @@ void PartialTsaStatistics::add_problem_result(
   }
 }
 
-std::string PartialTsaStatistics::str(size_t number_of_problems) const {
+std::string PartialTsaStatistics::str(std::size_t number_of_problems) const {
   REQUIRE(number_of_problems != 0);
   std::stringstream ss;
   ss << total_number_of_tokens << " tokens; " << total_of_L << " total L; "

--- a/libs/tktokenswap/test/src/TestUtils/TestStatsStructs.hpp
+++ b/libs/tktokenswap/test/src/TestUtils/TestStatsStructs.hpp
@@ -21,19 +21,19 @@ namespace tsa_internal {
 namespace tests {
 
 struct MinMaxAv {
-  size_t min = std::numeric_limits<size_t>::max();
-  size_t max = 0;
-  size_t total = 0;
+  std::size_t min = std::numeric_limits<std::size_t>::max();
+  std::size_t max = 0;
+  std::size_t total = 0;
 
-  void add(size_t result);
+  void add(std::size_t result);
 };
 
 struct PartialTsaStatistics {
-  size_t number_of_problems = 0;
-  size_t total_of_L = 0;
-  size_t total_of_L_decreases = 0;
-  size_t total_number_of_tokens = 0;
-  size_t total_number_of_swaps = 0;
+  std::size_t number_of_problems = 0;
+  std::size_t total_of_L = 0;
+  std::size_t total_of_L_decreases = 0;
+  std::size_t total_number_of_tokens = 0;
+  std::size_t total_number_of_swaps = 0;
 
   MinMaxAv l_decrease_percentages;
 
@@ -44,9 +44,10 @@ struct PartialTsaStatistics {
   MinMaxAv powers;
 
   void add_problem_result(
-      size_t initial_L, size_t final_L, size_t tokens, size_t swaps);
+      std::size_t initial_L, std::size_t final_L, std::size_t tokens,
+      std::size_t swaps);
 
-  std::string str(size_t number_of_problems) const;
+  std::string str(std::size_t number_of_problems) const;
 };
 
 }  // namespace tests

--- a/libs/tktokenswap/test/src/test_SwapListOptimiser.cpp
+++ b/libs/tktokenswap/test/src/test_SwapListOptimiser.cpp
@@ -43,7 +43,7 @@ class SwapCorrectnessTester {
 
   void require_equal_permutations(const SwapList& swap_list) const {
     m_tracker_to_change.reset();
-    size_t num_swaps = 0;
+    std::size_t num_swaps = 0;
     for (auto id = swap_list.front_id(); id; id = swap_list.next(id.value())) {
       m_tracker_to_change.do_vertex_swap(swap_list.at(id.value()));
       ++num_swaps;
@@ -55,7 +55,7 @@ class SwapCorrectnessTester {
   }
 
  private:
-  size_t m_number_of_raw_swaps = 0;
+  std::size_t m_number_of_raw_swaps = 0;
   DynamicTokenTracker m_final_tracker;
   mutable DynamicTokenTracker m_tracker_to_change;
 };
@@ -105,7 +105,7 @@ class SwapTester {
     m_counts[1] += raw_swaps.size();
     m_correctness_tester.reset(raw_swaps);
 
-    for (size_t ii = 0; ii < m_optimisation_functions.size(); ++ii) {
+    for (std::size_t ii = 0; ii < m_optimisation_functions.size(); ++ii) {
       m_swap_list.clear();
       if (ii != 0) {
         for (const auto& swap : raw_swaps) {
@@ -121,7 +121,7 @@ class SwapTester {
   std::string get_final_result() const {
     std::stringstream ss;
     ss << "[ " << m_counts[0] << " tests; swap counts:";
-    for (size_t ii = 1; ii < m_counts.size(); ++ii) {
+    for (std::size_t ii = 1; ii < m_counts.size(); ++ii) {
       ss << " " << m_counts[ii] << " ";
     }
     ss << "]";
@@ -133,12 +133,12 @@ class SwapTester {
       std::function<void(const vector<Swap>&, SwapList&, SwapListOptimiser&)>>
       m_optimisation_functions;
 
-  vector<size_t> m_counts;
+  vector<std::size_t> m_counts;
 
   SwapList m_swap_list;
   SwapListOptimiser m_optimiser;
   SwapCorrectnessTester m_correctness_tester;
-  size_t number_of_tests;
+  std::size_t number_of_tests;
 };
 }  // namespace
 
@@ -146,33 +146,34 @@ SCENARIO("Random swaps are optimised") {
   RNG rng;
   SwapTester tester;
   vector<Swap> raw_swaps;
-  const vector<size_t> num_vertices{5, 10, 20};
+  const vector<std::size_t> num_vertices{5, 10, 20};
 
   // We will multiply the number of possible distinct swaps
   // by these numbers, then divide by 100, to determine how many swaps
   // to generate for the test.
-  const vector<size_t> percentages{50, 100, 200, 500};
+  const vector<std::size_t> percentages{50, 100, 200, 500};
 
   // Not necessarily contiguous.
-  std::set<size_t> vertices_set;
+  std::set<std::size_t> vertices_set;
 
-  for (size_t number_of_vertices : num_vertices) {
-    const size_t possible_swaps =
+  for (std::size_t number_of_vertices : num_vertices) {
+    const std::size_t possible_swaps =
         (number_of_vertices * (number_of_vertices - 1)) / 2;
     for (auto percent : percentages) {
-      const size_t num_swaps = (possible_swaps * percent) / 100;
+      const std::size_t num_swaps = (possible_swaps * percent) / 100;
       vertices_set.clear();
 
-      for (size_t ii = 0; ii < number_of_vertices; ++ii) {
+      for (std::size_t ii = 0; ii < number_of_vertices; ++ii) {
         vertices_set.insert(ii);
       }
-      const vector<size_t> vertices(vertices_set.cbegin(), vertices_set.cend());
+      const vector<std::size_t> vertices(
+          vertices_set.cbegin(), vertices_set.cend());
       for (int test_counter = 0; test_counter < 1; ++test_counter) {
         INFO(
             "test_counter=" << test_counter << ", number_of_vertices="
                             << number_of_vertices << ", percent=" << percent);
 
-        for (size_t jj = 0; jj < num_swaps; ++jj) {
+        for (std::size_t jj = 0; jj < num_swaps; ++jj) {
           const auto v1 = rng.get_element(vertices);
           auto v2 = v1;
           while (v1 == v2) {
@@ -197,16 +198,16 @@ namespace {
 // This might be more realistic.
 struct EdgesGenerator {
   std::set<Swap> swaps_set;
-  size_t approx_num_vertices = 5;
-  size_t approx_num_edges = 10;
-  size_t percentage_to_add_new_vertex = 50;
+  std::size_t approx_num_vertices = 5;
+  std::size_t approx_num_edges = 10;
+  std::size_t percentage_to_add_new_vertex = 50;
 
-  vector<Swap> get_swaps(RNG& rng, size_t& actual_num_vertices) {
+  vector<Swap> get_swaps(RNG& rng, std::size_t& actual_num_vertices) {
     actual_num_vertices = 2;
     swaps_set.clear();
     swaps_set.insert(get_swap(0, 1));
 
-    for (size_t counter = 10 * approx_num_edges; counter > 0; --counter) {
+    for (std::size_t counter = 10 * approx_num_edges; counter > 0; --counter) {
       if (actual_num_vertices >= approx_num_vertices ||
           swaps_set.size() >= approx_num_edges) {
         break;
@@ -246,28 +247,28 @@ struct ManyTestsRunner {
 
   EdgesGenerator swaps_generator;
   vector<Swap> possible_swaps;
-  size_t actual_num_vertices;
+  std::size_t actual_num_vertices;
   vector<Swap> raw_swaps;
 
   void run(
-      RNG& rng, const vector<size_t>& approx_num_vertices,
-      const vector<size_t>& approx_num_edges_percentages,
-      const vector<size_t>& swap_length_percentages,
-      size_t num_tests_per_parameter_list) {
+      RNG& rng, const vector<std::size_t>& approx_num_vertices,
+      const vector<std::size_t>& approx_num_edges_percentages,
+      const vector<std::size_t>& swap_length_percentages,
+      std::size_t num_tests_per_parameter_list) {
     for (auto approx_nv : approx_num_vertices) {
       swaps_generator.approx_num_vertices = approx_nv;
       for (auto approx_nep : approx_num_edges_percentages) {
         swaps_generator.approx_num_edges =
             approx_nv / 2 + (approx_nv * (approx_nv - 1) * approx_nep) / 200;
-        for (size_t num_graphs = 0; num_graphs < 1; ++num_graphs) {
+        for (std::size_t num_graphs = 0; num_graphs < 1; ++num_graphs) {
           possible_swaps = swaps_generator.get_swaps(rng, actual_num_vertices);
           for (auto slp : swap_length_percentages) {
-            const size_t swap_list_length =
+            const std::size_t swap_list_length =
                 1 + (possible_swaps.size() * slp) / 100;
-            for (size_t test_counter = 0;
+            for (std::size_t test_counter = 0;
                  test_counter < num_tests_per_parameter_list; ++test_counter) {
               raw_swaps.clear();
-              for (size_t nn = 0; nn < swap_list_length; ++nn) {
+              for (std::size_t nn = 0; nn < swap_list_length; ++nn) {
                 raw_swaps.push_back(rng.get_element(possible_swaps));
               }
               tester.test(raw_swaps);
@@ -282,18 +283,18 @@ struct ManyTestsRunner {
 
 SCENARIO("More realistic swap sequences") {
   RNG rng;
-  const size_t num_tests_per_parameter_list = 10;
+  const std::size_t num_tests_per_parameter_list = 10;
 
   // How many edges should we aim for, as a rough percentage of
   // the total number n(n-1)/2 of possibilities?
-  const vector<size_t> approx_num_edges_percentages{5, 10, 20, 30, 40, 80};
+  const vector<std::size_t> approx_num_edges_percentages{5, 10, 20, 30, 40, 80};
 
   // How long should the swap length be, as a percentage of the
   // total possible number of swaps?
-  const vector<size_t> swap_length_percentages{50, 100, 200};
+  const vector<std::size_t> swap_length_percentages{50, 100, 200};
 
   {
-    const vector<size_t> approx_num_vertices{5, 8};
+    const vector<std::size_t> approx_num_vertices{5, 8};
     ManyTestsRunner runner;
     runner.run(
         rng, approx_num_vertices, approx_num_edges_percentages,
@@ -303,7 +304,7 @@ SCENARIO("More realistic swap sequences") {
         "[ 360 tests; swap counts: 3160  2380  2104  2104  1396  1406 ]");
   }
   {
-    const vector<size_t> approx_num_vertices{10, 12, 14};
+    const vector<std::size_t> approx_num_vertices{10, 12, 14};
     ManyTestsRunner runner;
     runner.run(
         rng, approx_num_vertices, approx_num_edges_percentages,
@@ -313,7 +314,7 @@ SCENARIO("More realistic swap sequences") {
         "[ 540 tests; swap counts: 10370  9048  7580  7580  5180  5216 ]");
   }
   {
-    const vector<size_t> approx_num_vertices{30, 35, 40};
+    const vector<std::size_t> approx_num_vertices{30, 35, 40};
     ManyTestsRunner runner;
     runner.run(
         rng, approx_num_vertices, approx_num_edges_percentages,
@@ -362,13 +363,13 @@ SCENARIO("Trivial swap list reversed order optimisation; pass comparisons") {
     }
   };
 
-  size_t simple_travel_equals_token_tracking_count = 0;
-  size_t simple_travel_beats_token_tracking_count = 0;
-  size_t simple_travel_beaten_by_token_tracking_count = 0;
-  size_t full_optimise_fully_reduces_palindrome = 0;
-  size_t full_optimise_does_not_destroy_palindrome = 0;
-  size_t token_tracking_pass_fully_reduces_palindrome = 0;
-  size_t token_tracking_pass_does_not_destroy_palindrome = 0;
+  std::size_t simple_travel_equals_token_tracking_count = 0;
+  std::size_t simple_travel_beats_token_tracking_count = 0;
+  std::size_t simple_travel_beaten_by_token_tracking_count = 0;
+  std::size_t full_optimise_fully_reduces_palindrome = 0;
+  std::size_t full_optimise_does_not_destroy_palindrome = 0;
+  std::size_t token_tracking_pass_fully_reduces_palindrome = 0;
+  std::size_t token_tracking_pass_does_not_destroy_palindrome = 0;
 
   RNG rng;
 

--- a/libs/tktokenswap/test/src/test_VectorListHybridSkeleton.cpp
+++ b/libs/tktokenswap/test/src/test_VectorListHybridSkeleton.cpp
@@ -32,14 +32,14 @@ namespace tests {
 // using linked lists
 struct VLHS_tester_reimplementation {
   // Each node will contain the index it was given.
-  mutable std::list<size_t> data;
+  mutable std::list<std::size_t> data;
 
   void clear() { data.clear(); }
-  size_t size() const { return data.size(); }
-  size_t front_index() const { return data.front(); }
-  size_t back_index() const { return data.back(); }
+  std::size_t size() const { return data.size(); }
+  std::size_t front_index() const { return data.front(); }
+  std::size_t back_index() const { return data.back(); }
 
-  std::list<size_t>::iterator find(size_t index) {
+  std::list<std::size_t>::iterator find(std::size_t index) {
     for (auto iter = data.begin(); iter != data.end(); ++iter) {
       if (*iter == index) {
         return iter;
@@ -49,7 +49,7 @@ struct VLHS_tester_reimplementation {
         std::string("index ") + std::to_string(index) + " not found");
   }
 
-  std::list<size_t>::const_iterator find(size_t index) const {
+  std::list<std::size_t>::const_iterator find(std::size_t index) const {
     for (auto citer = data.cbegin(); citer != data.cend(); ++citer) {
       if (*citer == index) {
         return citer;
@@ -59,7 +59,7 @@ struct VLHS_tester_reimplementation {
         std::string("index ") + std::to_string(index) + " not found");
   }
 
-  std::optional<size_t> next(size_t index) const {
+  std::optional<std::size_t> next(std::size_t index) const {
     auto citer = find(index);
     ++citer;
     if (citer == data.cend()) {
@@ -68,7 +68,7 @@ struct VLHS_tester_reimplementation {
     return *citer;
   }
 
-  std::optional<size_t> previous(size_t index) const {
+  std::optional<std::size_t> previous(std::size_t index) const {
     auto citer = find(index);
     --citer;
     if (citer != data.cend()) {
@@ -77,17 +77,17 @@ struct VLHS_tester_reimplementation {
     return *citer;
   }
 
-  void erase(size_t index) {
+  void erase(std::size_t index) {
     auto iter = find(index);
     data.erase(iter);
   }
 
-  void insert_for_empty_list(size_t new_index) {
+  void insert_for_empty_list(std::size_t new_index) {
     REQUIRE(data.empty());
     data.push_front(new_index);
   }
 
-  void insert_after(size_t index, size_t new_index) {
+  void insert_after(std::size_t index, std::size_t new_index) {
     auto iter = find(index);
     // We can only insert BEFORE an iter with STL
     ++iter;
@@ -100,7 +100,7 @@ struct VLHS_tester_reimplementation {
     data.insert(iter, new_index);
   }
 
-  void insert_before(size_t index, size_t new_index) {
+  void insert_before(std::size_t index, std::size_t new_index) {
     auto iter = find(index);
     data.insert(iter, new_index);
   }
@@ -108,24 +108,24 @@ struct VLHS_tester_reimplementation {
 
 // Keep track of which indices have currently not yet been erased
 struct ValidIndices {
-  std::set<size_t> indices;
+  std::set<std::size_t> indices;
 
-  bool contains(size_t index) const { return indices.count(index) != 0; }
-  void check_and_insert_new_index(size_t index) {
+  bool contains(std::size_t index) const { return indices.count(index) != 0; }
+  void check_and_insert_new_index(std::size_t index) {
     REQUIRE(index != VectorListHybridSkeleton::get_invalid_index());
     REQUIRE(indices.count(index) == 0);
     indices.insert(index);
   }
 
-  void check_and_erase_index(size_t index) {
+  void check_and_erase_index(std::size_t index) {
     REQUIRE(indices.count(index) != 0);
     indices.erase(index);
   }
 
-  size_t get_index(RNG& rng) const {
+  std::size_t get_index(RNG& rng) const {
     REQUIRE(!indices.empty());
     auto citer = indices.cbegin();
-    for (size_t ii = rng.get_size_t(indices.size() - 1); ii != 0; --ii) {
+    for (std::size_t ii = rng.get_size_t(indices.size() - 1); ii != 0; --ii) {
       ++citer;
     }
     return *citer;
@@ -133,7 +133,7 @@ struct ValidIndices {
 };
 
 void require_equal_indices(
-    size_t index, const std::optional<size_t>& index_opt) {
+    std::size_t index, const std::optional<std::size_t>& index_opt) {
   if (index == VectorListHybridSkeleton::get_invalid_index()) {
     REQUIRE(!index_opt);
     return;

--- a/libs/tkwsm/include/tkwsm/Common/ReusableStorage.hpp
+++ b/libs/tkwsm/include/tkwsm/Common/ReusableStorage.hpp
@@ -33,7 +33,7 @@ struct ReusableStorageId {
  * collection - rather than being erased, but the caller is responsible
  * for clearing such T objects when making use of them again.
  *
- * Access the objects by a size_t ID, in time O(1).
+ * Access the objects by a std::size_t ID, in time O(1).
  * The IDs are allowed to be reused, and references are allowed to be
  * invalidated if other elements are added or "erased" (released).
  * An ID remains valid (unlike a reference) even as others are added

--- a/libs/tkwsm/src/Searching/ValueOrdering.cpp
+++ b/libs/tkwsm/src/Searching/ValueOrdering.cpp
@@ -87,7 +87,7 @@ void ValueOrdering::fill_entries_for_high_degree_vertices(
     const NeighboursData& target_ndata) {
   // Multipass algorithm; simple and efficient enough.
   // Pass one: find the max degree.
-  size_t max_degree = 0;
+  std::size_t max_degree = 0;
   for (auto tv = possible_values.find_first(); tv < possible_values.size();
        tv = possible_values.find_next(tv)) {
     max_degree = std::max(max_degree, target_ndata.get_degree(tv));
@@ -131,7 +131,7 @@ VertexWSM ValueOrdering::get_random_choice_from_data(RNG& rng) const {
       continue;
     }
     for (auto vertex : entry.vertices) {
-      size_t mass_after_this_vertex = preceding_mass + entry.mass;
+      std::size_t mass_after_this_vertex = preceding_mass + entry.mass;
       if (mass_after_this_vertex >= index) {
         return vertex;
       }

--- a/libs/tkwsm/test/src/GraphTheoretic/test_FilterUtils.cpp
+++ b/libs/tkwsm/test/src/GraphTheoretic/test_FilterUtils.cpp
@@ -57,8 +57,8 @@ SCENARIO("Test random degree sequences for compatibility") {
     degree_counts_map.clear();
     for (unsigned number_of_degrees = 1 + (ii / divisor); number_of_degrees > 0;
          --number_of_degrees) {
-      size_t a0 = rng.get_size_t(max_degree_minus_1);
-      size_t a1 = rng.get_size_t(max_count_minus_1);
+      std::size_t a0 = rng.get_size_t(max_degree_minus_1);
+      std::size_t a1 = rng.get_size_t(max_count_minus_1);
       degree_counts_map[1 + a0] += 1 + a1;
     }
     unsigned size = 0;

--- a/libs/tkwsm/test/src/InitPlacement/test_InitialPlacementProblems.cpp
+++ b/libs/tkwsm/test/src/InitPlacement/test_InitialPlacementProblems.cpp
@@ -326,8 +326,8 @@ SCENARIO("Binary tree with ~100 vertices, ~30 logical qubits") {
   std::vector<WeightWSM> weights{0, 0};
   weights.resize(100);
   for (unsigned nn = 2; nn < weights.size(); ++nn) {
-    size_t a10 = rng.get_size_t(10);
-    size_t a5 = rng.get_size_t(5);
+    std::size_t a10 = rng.get_size_t(10);
+    std::size_t a5 = rng.get_size_t(5);
     weights[nn] = 1 + a5 + 10 * (a10 / 8);
   }
   WeightedBinaryTree tree(weights, 4);

--- a/libs/tkwsm/test/src/SolvingProblems/test_UnweightedProblems.cpp
+++ b/libs/tkwsm/test/src/SolvingProblems/test_UnweightedProblems.cpp
@@ -285,7 +285,7 @@ get_list_of_increasing_graph_sequences() {
     // Check an edge in the middle...
     const auto& middle_graph = final_list[final_list.size() / 2];
     CHECK(middle_graph.size() == 85);
-    size_t counter = middle_graph.size() / 2;
+    std::size_t counter = middle_graph.size() / 2;
     for (const auto& edge_weight_pair : middle_graph) {
       CHECK(edge_weight_pair.second == 1);
       if (counter != 0) {

--- a/pytket/conanfile.py
+++ b/pytket/conanfile.py
@@ -32,7 +32,7 @@ class pytketRecipe(ConanFile):
         cmake.install()
 
     def requirements(self):
-        self.requires("tket/1.2.21@tket/stable")
+        self.requires("tket/1.2.22@tket/stable")
         self.requires("tklog/0.3.3@tket/stable")
         self.requires("tkrng/0.3.3@tket/stable")
         self.requires("tkassert/0.3.3@tket/stable")

--- a/tket/conanfile.py
+++ b/tket/conanfile.py
@@ -23,7 +23,7 @@ from conan.errors import ConanInvalidConfiguration
 
 class TketConan(ConanFile):
     name = "tket"
-    version = "1.2.21"
+    version = "1.2.22"
     package_type = "library"
     license = "Apache 2"
     homepage = "https://github.com/CQCL/tket"

--- a/tket/include/tket/Architecture/ArchitectureMapping.hpp
+++ b/tket/include/tket/Architecture/ArchitectureMapping.hpp
@@ -71,20 +71,20 @@ class ArchitectureMapping {
   /** The number of vertices in the Architecture.
    *  @return The number of vertices
    */
-  size_t number_of_vertices() const;
+  std::size_t number_of_vertices() const;
 
   /** Get the newly created vertex assigned to the node.
    *  Throws if the node is invalid.
    *  @param node The node within the original Architecture object
    *  @return The newly created vertex representing this node
    */
-  size_t get_vertex(const Node& node) const;
+  std::size_t get_vertex(const Node& node) const;
 
   /** Reverse of "get_vertex", throws if the vertex is invalid.
    *  @param vertex The vertex created by this ArchitectureMapping object.
    *  @return The node corresponding to this vertex.
    */
-  const Node& get_node(size_t vertex) const;
+  const Node& get_node(std::size_t vertex) const;
 
   /** Get the edges using the vertices created by this ArchitectureMapping
    *  object. The vertex numbers, of course, do not necessarily match with
@@ -103,7 +103,7 @@ class ArchitectureMapping {
   node_vector_t m_vertex_to_node_mapping;
 
   /// Reverse of m_vertex_to_node_mapping; look up the index of a node.
-  std::map<Node, size_t> m_node_to_vertex_mapping;
+  std::map<Node, std::size_t> m_node_to_vertex_mapping;
 };
 
 }  // namespace tket

--- a/tket/include/tket/Architecture/DistancesFromArchitecture.hpp
+++ b/tket/include/tket/Architecture/DistancesFromArchitecture.hpp
@@ -40,7 +40,8 @@ class DistancesFromArchitecture : public DistancesInterface {
    *  @return distance from v1 to v2 within the Architecture graph, throwing if
    * they are disconnected (so the distance is +infinity).
    */
-  virtual size_t operator()(size_t vertex1, size_t vertex2) override;
+  virtual std::size_t operator()(
+      std::size_t vertex1, std::size_t vertex2) override;
 
   /** May save computation time later; by some method, the caller
    *  has determined a path from v1 to v2, and hence all along the path
@@ -51,14 +52,15 @@ class DistancesFromArchitecture : public DistancesInterface {
    * shortest path from v0 to vn. The caller must not call this without being
    * SURE that it really is a shortest path, or incorrect results may occur.
    */
-  virtual void register_shortest_path(const std::vector<size_t>& path) override;
+  virtual void register_shortest_path(
+      const std::vector<std::size_t>& path) override;
 
   /** The caller has determined that v1, v2 are adjacent, and therefore
    *  the distance from v1 to v2 equals one. Store this.
    *  @param vertex1 First vertex
    *  @param vertex2 Second vertex
    */
-  virtual void register_edge(size_t vertex1, size_t vertex2) override;
+  virtual void register_edge(std::size_t vertex1, std::size_t vertex2) override;
 
  private:
   /** Reference to the original object passed into the constructor;
@@ -69,7 +71,7 @@ class DistancesFromArchitecture : public DistancesInterface {
   /** The key is the vertex pair (v1, v2), but always sorted with v1<v2
    *  to use half the space.
    */
-  std::map<Swap, size_t> m_cached_distances;
+  std::map<Swap, std::size_t> m_cached_distances;
 
   /** The main register_shortest_path wraps around this; we want to avoid
    *  quadratic timings growth by cutting off long paths.
@@ -81,7 +83,7 @@ class DistancesFromArchitecture : public DistancesInterface {
    *  @param end Like end(), an index one past the last index in path to use.
    */
   void register_shortest_path_with_limits(
-      const std::vector<size_t>& path, size_t begin, size_t end);
+      const std::vector<std::size_t>& path, std::size_t begin, std::size_t end);
 };
 
 }  // namespace tket

--- a/tket/include/tket/Architecture/NeighboursFromArchitecture.hpp
+++ b/tket/include/tket/Architecture/NeighboursFromArchitecture.hpp
@@ -38,13 +38,14 @@ class NeighboursFromArchitecture : public NeighboursInterface {
    *  @param vertex A vertex.
    *  @return A sorted list of all adjacent vertices, stored internally.
    */
-  virtual const std::vector<size_t>& operator()(size_t vertex) override;
+  virtual const std::vector<std::size_t>& operator()(
+      std::size_t vertex) override;
 
  private:
   const ArchitectureMapping& m_arch_mapping;
 
   /** The key is the vertex, the value is the list of neighbours. */
-  std::map<size_t, std::vector<size_t>> m_cached_neighbours;
+  std::map<std::size_t, std::vector<std::size_t>> m_cached_neighbours;
 };
 
 }  // namespace tket

--- a/tket/include/tket/Architecture/SubgraphMonomorphisms.hpp
+++ b/tket/include/tket/Architecture/SubgraphMonomorphisms.hpp
@@ -31,7 +31,7 @@ struct SubgraphMonomorphisms {
 
   /** Element[i] is the target vertex number which the pattern vertex number i
    * is mapped to. */
-  typedef std::vector<size_t> Mapping;
+  typedef std::vector<std::size_t> Mapping;
 
   /** Only complete, valid mappings are included; they are all distinct from
    * each other. This should be fully deterministic and platform independent

--- a/tket/include/tket/Graphs/DirectedGraph.hpp
+++ b/tket/include/tket/Graphs/DirectedGraph.hpp
@@ -250,7 +250,7 @@ class DirectedGraphBase : public AbstractGraph<T> {
     if (node1 == node2) {
       return 0;
     }
-    size_t d = get_distances(node1)[to_vertices(node2)];
+    std::size_t d = get_distances(node1)[to_vertices(node2)];
     if (d == 0) {
       throw NodesNotConnected(node1, node2);
     }
@@ -429,7 +429,7 @@ class DirectedGraph : public DirectedGraphBase<T> {
     if (node1 == node2) {
       return 0;
     }
-    size_t d;
+    std::size_t d;
     if (distance_cache.find(node1) != distance_cache.end()) {
       d = distance_cache[node1][this->to_vertices(node2)];
     } else if (distance_cache.find(node2) != distance_cache.end()) {

--- a/tket/include/tket/Graphs/TreeSearch_impl.hpp
+++ b/tket/include/tket/Graphs/TreeSearch_impl.hpp
@@ -49,7 +49,6 @@ template <typename Graph, typename BoostPMap>
 class TreeSearchBase {
  protected:
   using vertex = utils::vertex<Graph>;
-  using size_t = std::size_t;
   using parent_vec = std::vector<vertex>;
   using color_vec = std::vector<boost::default_color_type>;
   using index_pmap_t = BoostPMap;
@@ -92,7 +91,7 @@ class TreeSearchBase {
   /* vector of distances from the root */
   const dist_vec& get_dists() const& { return dists; }
   const dist_vec&& get_dists() const&& { return std::move(dists); }
-  size_t get_dist(const vertex& v) const { return dists[to_index[v]]; }
+  std::size_t get_dist(const vertex& v) const { return dists[to_index[v]]; }
 
   /* Rebase tree search from some new root */
   void change_root(vertex v) {
@@ -133,7 +132,7 @@ class TreeSearchBase {
   }
 
   /* Depth of tree search */
-  size_t max_depth() const {
+  std::size_t max_depth() const {
     auto it = std::max_element(dists.cbegin(), dists.cend());
     if (it == dists.cend()) {
       throw std::invalid_argument(
@@ -146,7 +145,7 @@ class TreeSearchBase {
   /* Vertex of max depth
    * if more than one exist, returns first found */
   vertex max_depth_vertex() const {
-    const size_t target_depth = max_depth();
+    const std::size_t target_depth = max_depth();
     for (vertex v : boost::make_iterator_range(boost::vertices(this->graph))) {
       if (get_dist(v) == target_depth) {
         return v;

--- a/tket/include/tket/Mapping/LexiRoute.hpp
+++ b/tket/include/tket/Mapping/LexiRoute.hpp
@@ -154,7 +154,7 @@ class LexiRoute {
    * @param p1_second Second Node in second interaction to find distance between
    * @return Pair of size_t, being distances on architecture graph
    */
-  const std::pair<size_t, size_t> pair_distances(
+  const std::pair<std::size_t, std::size_t> pair_distances(
       const Node& p0_first, const Node& p0_second, const Node& p1_first,
       const Node& p1_second) const;
 

--- a/tket/include/tket/Mapping/LexicographicalComparison.hpp
+++ b/tket/include/tket/Mapping/LexicographicalComparison.hpp
@@ -23,7 +23,7 @@ namespace tket {
 typedef std::map<Node, Node> interacting_nodes_t;
 typedef std::pair<Node, Node> swap_t;
 typedef std::set<swap_t> swap_set_t;
-typedef std::vector<size_t> lexicographical_distances_t;
+typedef std::vector<std::size_t> lexicographical_distances_t;
 
 class LexicographicalComparisonError : public std::logic_error {
  public:

--- a/tket/include/tket/Utils/EigenConfig.hpp
+++ b/tket/include/tket/Utils/EigenConfig.hpp
@@ -60,9 +60,9 @@ void from_json(const nlohmann::json& j, Matrix<_Scalar, _Rows, _Cols>& matrix) {
   // resize for dynamically-sized matrices
   if (j.size() == 0) return;
   matrix.resize(j.size(), j.at(0).size());
-  for (size_t i = 0; i < j.size(); ++i) {
+  for (std::size_t i = 0; i < j.size(); ++i) {
     const auto& j_row = j.at(i);
-    for (size_t j = 0; j < j_row.size(); ++j) {
+    for (std::size_t j = 0; j < j_row.size(); ++j) {
       matrix(i, j) =
           j_row.at(j).get<typename Matrix<_Scalar, _Rows, _Cols>::Scalar>();
     }

--- a/tket/include/tket/Utils/UnitID.hpp
+++ b/tket/include/tket/Utils/UnitID.hpp
@@ -100,7 +100,7 @@ class UnitID {
   bool operator!=(const UnitID &other) const { return !(*this == other); }
 
   friend std::size_t hash_value(UnitID const &unitid) {
-    size_t seed = 0;
+    std::size_t seed = 0;
     boost::hash_combine(seed, unitid.data_->name_);
     boost::hash_combine(seed, unitid.data_->index_);
     boost::hash_combine(seed, unitid.data_->type_);

--- a/tket/src/Architecture/Architecture.cpp
+++ b/tket/src/Architecture/Architecture.cpp
@@ -103,7 +103,8 @@ std::set<Node> Architecture::get_articulation_points() const {
 }
 
 static bool lexicographical_comparison(
-    const std::vector<size_t>& dist1, const std::vector<size_t>& dist2) {
+    const std::vector<std::size_t>& dist1,
+    const std::vector<std::size_t>& dist2) {
   return std::lexicographical_compare(
       dist1.begin(), dist1.end(), dist2.begin(), dist2.end());
 }
@@ -121,16 +122,16 @@ std::optional<Node> Architecture::find_worst_node(
   if (bad_nodes.empty()) {
     return std::nullopt;
   }
-  auto make_lexicographic = [](std::vector<size_t> distances) {
+  auto make_lexicographic = [](std::vector<std::size_t> distances) {
     unsigned max = distances.size();
-    std::vector<size_t> out(max + 1, size_t(0));
+    std::vector<std::size_t> out(max + 1, std::size_t(0));
     for (const auto& distance : distances) {
       TKET_ASSERT(distance < max);
       out[max - distance]++;
     }
     return out;
   };
-  std::vector<size_t> worst_distances, temp_distances;
+  std::vector<std::size_t> worst_distances, temp_distances;
   Node worst_node = *bad_nodes.begin();
   worst_distances = make_lexicographic(get_distances(worst_node));
   for (Node temp_node : bad_nodes) {
@@ -141,9 +142,9 @@ std::optional<Node> Architecture::find_worst_node(
       worst_node = temp_node;
       worst_distances = temp_distances;
     } else if (distance_comp == -1) {
-      std::vector<size_t> temp_distances_full =
+      std::vector<std::size_t> temp_distances_full =
           make_lexicographic(original_arch.get_distances(temp_node));
-      std::vector<size_t> worst_distances_full =
+      std::vector<std::size_t> worst_distances_full =
           make_lexicographic(original_arch.get_distances(worst_node));
       if (lexicographical_comparison(
               temp_distances_full, worst_distances_full)) {

--- a/tket/src/Architecture/ArchitectureMapping.cpp
+++ b/tket/src/Architecture/ArchitectureMapping.cpp
@@ -28,7 +28,7 @@ ArchitectureMapping::ArchitectureMapping(const Architecture& arch)
     m_vertex_to_node_mapping.emplace_back(Node(uid));
   }
 
-  for (size_t ii = 0; ii < m_vertex_to_node_mapping.size(); ++ii) {
+  for (std::size_t ii = 0; ii < m_vertex_to_node_mapping.size(); ++ii) {
     const auto& node = m_vertex_to_node_mapping[ii];
     {
       const auto citer = m_node_to_vertex_mapping.find(node);
@@ -91,11 +91,11 @@ ArchitectureMapping::ArchitectureMapping(
   }
 }
 
-size_t ArchitectureMapping::number_of_vertices() const {
+std::size_t ArchitectureMapping::number_of_vertices() const {
   return m_vertex_to_node_mapping.size();
 }
 
-const Node& ArchitectureMapping::get_node(size_t vertex) const {
+const Node& ArchitectureMapping::get_node(std::size_t vertex) const {
   const auto num_vertices = number_of_vertices();
   // GCOVR_EXCL_START
   TKET_ASSERT(
@@ -107,7 +107,7 @@ const Node& ArchitectureMapping::get_node(size_t vertex) const {
   return m_vertex_to_node_mapping[vertex];
 }
 
-size_t ArchitectureMapping::get_vertex(const Node& node) const {
+std::size_t ArchitectureMapping::get_vertex(const Node& node) const {
   const auto citer = m_node_to_vertex_mapping.find(node);
   // GCOVR_EXCL_START
   TKET_ASSERT(

--- a/tket/src/Architecture/DistancesFromArchitecture.cpp
+++ b/tket/src/Architecture/DistancesFromArchitecture.cpp
@@ -24,14 +24,14 @@ DistancesFromArchitecture::DistancesFromArchitecture(
     : m_arch_mapping(arch_mapping) {}
 
 void DistancesFromArchitecture::register_shortest_path(
-    const std::vector<size_t>& path) {
+    const std::vector<std::size_t>& path) {
   // To avoid quadratic growth for really long paths,
   // just do various slices.
   if (path.size() <= 5) {
     register_shortest_path_with_limits(path, 0, path.size());
     return;
   }
-  const size_t middle = path.size() / 2;
+  const std::size_t middle = path.size() / 2;
   if (path.size() <= 10) {
     register_shortest_path_with_limits(path, 0, middle);
     register_shortest_path_with_limits(path, middle, path.size());
@@ -46,19 +46,21 @@ void DistancesFromArchitecture::register_shortest_path(
 }
 
 void DistancesFromArchitecture::register_shortest_path_with_limits(
-    const std::vector<size_t>& path, size_t begin, size_t end) {
-  for (size_t ii = begin; ii < end; ++ii) {
-    for (size_t jj = ii + 1; jj < end; ++jj) {
+    const std::vector<std::size_t>& path, std::size_t begin, std::size_t end) {
+  for (std::size_t ii = begin; ii < end; ++ii) {
+    for (std::size_t jj = ii + 1; jj < end; ++jj) {
       m_cached_distances[get_swap(path[ii], path[jj])] = jj - ii;
     }
   }
 }
 
-void DistancesFromArchitecture::register_edge(size_t vertex1, size_t vertex2) {
+void DistancesFromArchitecture::register_edge(
+    std::size_t vertex1, std::size_t vertex2) {
   m_cached_distances[get_swap(vertex1, vertex2)] = 1;
 }
 
-size_t DistancesFromArchitecture::operator()(size_t vertex1, size_t vertex2) {
+std::size_t DistancesFromArchitecture::operator()(
+    std::size_t vertex1, std::size_t vertex2) {
   if (vertex1 == vertex2) {
     return 0;
   }

--- a/tket/src/Architecture/NeighboursFromArchitecture.cpp
+++ b/tket/src/Architecture/NeighboursFromArchitecture.cpp
@@ -24,8 +24,8 @@ NeighboursFromArchitecture::NeighboursFromArchitecture(
     const ArchitectureMapping& arch_mapping)
     : m_arch_mapping(arch_mapping) {}
 
-const std::vector<size_t>& NeighboursFromArchitecture::operator()(
-    size_t vertex) {
+const std::vector<std::size_t>& NeighboursFromArchitecture::operator()(
+    std::size_t vertex) {
   const auto num_vertices = m_arch_mapping.number_of_vertices();
   // GCOVR_EXCL_START
   TKET_ASSERT(

--- a/tket/src/Architecture/SubgraphMonomorphisms.cpp
+++ b/tket/src/Architecture/SubgraphMonomorphisms.cpp
@@ -23,7 +23,7 @@ namespace tket {
 using namespace WeightedSubgraphMonomorphism;
 
 static GraphEdgeWeights get_weight_one_edges(
-    const std::vector<Swap>& edges, size_t number_of_vertices) {
+    const std::vector<Swap>& edges, std::size_t number_of_vertices) {
   GraphEdgeWeights result;
   for (const auto& edge : edges) {
     TKET_ASSERT(edge.first < number_of_vertices);
@@ -35,14 +35,14 @@ static GraphEdgeWeights get_weight_one_edges(
 }
 
 static void add_solver_solutions(
-    const std::vector<SolutionWSM>& solutions, size_t pattern_n_vertices,
-    size_t target_n_vertices, SubgraphMonomorphisms& monomorphisms) {
+    const std::vector<SolutionWSM>& solutions, std::size_t pattern_n_vertices,
+    std::size_t target_n_vertices, SubgraphMonomorphisms& monomorphisms) {
   monomorphisms.mappings.reserve(solutions.size());
 
   // The solver ignores isolated vertices, so we'll fill them in separately.
-  std::set<size_t> used_pattern_vertices;
-  std::set<size_t> used_pattern_vertices_copy;
-  std::set<size_t> used_target_vertices;
+  std::set<std::size_t> used_pattern_vertices;
+  std::set<std::size_t> used_pattern_vertices_copy;
+  std::set<std::size_t> used_target_vertices;
 
   for (const auto& solution : solutions) {
     monomorphisms.mappings.emplace_back();
@@ -72,8 +72,8 @@ static void add_solver_solutions(
     }
 
     // Now, fill in isolated p-vertex values.
-    size_t next_tv = 0;
-    for (size_t pv = 0; pv < pattern_n_vertices; ++pv) {
+    std::size_t next_tv = 0;
+    for (std::size_t pv = 0; pv < pattern_n_vertices; ++pv) {
       // We could save time by saving the isolated PVs,
       // but surely not worth it
       if (used_pattern_vertices.count(pv) != 0) {
@@ -92,10 +92,10 @@ static void add_solver_solutions(
 // of target vertices, and all permutations of k pattern vertices,
 // but don't bother for now - just give one solution.
 static void fill_with_all_isolated_pattern_vertices(
-    SubgraphMonomorphisms& monomorphisms, size_t pattern_n_vertices) {
+    SubgraphMonomorphisms& monomorphisms, std::size_t pattern_n_vertices) {
   monomorphisms.mappings.resize(1);
   monomorphisms.mappings[0].resize(pattern_n_vertices);
-  for (size_t ii = 0; ii < pattern_n_vertices; ++ii) {
+  for (std::size_t ii = 0; ii < pattern_n_vertices; ++ii) {
     monomorphisms.mappings[0][ii] = ii;
   }
 }

--- a/tket/src/Circuit/CommandJson.cpp
+++ b/tket/src/Circuit/CommandJson.cpp
@@ -36,7 +36,7 @@ void to_json(nlohmann::json& j, const Command& com) {
 
   nlohmann::json j_args;
 
-  for (size_t i = 0; i < sig.size(); i++) {
+  for (std::size_t i = 0; i < sig.size(); i++) {
     switch (sig[i]) {
       case EdgeType::WASM: {
         const WasmState& wb = static_cast<const WasmState&>(args[i]);
@@ -75,7 +75,7 @@ void from_json(const nlohmann::json& j, Command& com) {
     JsonError("Number of args does not match signature of op.");
   }
   unit_vector_t args;
-  for (size_t i = 0; i < sig.size(); i++) {
+  for (std::size_t i = 0; i < sig.size(); i++) {
     switch (sig[i]) {
       case EdgeType::WASM: {
         args.push_back(j_args[i].get<WasmState>());

--- a/tket/src/Circuit/DiagonalBox.cpp
+++ b/tket/src/Circuit/DiagonalBox.cpp
@@ -27,7 +27,7 @@ DiagonalBox::DiagonalBox(const Eigen::VectorXcd &diagonal, bool upper_triangle)
     : Box(OpType::DiagonalBox),
       diagonal_(diagonal),
       upper_triangle_(upper_triangle) {
-  size_t length = diagonal.size();
+  std::size_t length = diagonal.size();
   if (length < 2 || (length & (length - 1)) != 0) {
     throw std::invalid_argument(
         "The size of the diagonal operator passed to DiagonalBox is not a "

--- a/tket/src/Circuit/StatePreparation.cpp
+++ b/tket/src/Circuit/StatePreparation.cpp
@@ -26,7 +26,7 @@
 
 namespace tket {
 
-static unsigned compute_log2(size_t length) {
+static unsigned compute_log2(std::size_t length) {
   if (length < 2 || (length & (length - 1)) != 0) {
     throw std::invalid_argument(
         "The length of the statevector is not a power of 2.");

--- a/tket/src/Converters/PhasePoly.cpp
+++ b/tket/src/Converters/PhasePoly.cpp
@@ -302,12 +302,12 @@ SymSet PhasePolyBox::free_symbols() const {
 // Dynamic Eigen matrix requires special treatment to load, to allocate memory
 template <typename T>
 Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> load_dynamic_matrix(
-    const nlohmann::json& j, size_t rows, size_t cols) {
+    const nlohmann::json& j, std::size_t rows, std::size_t cols) {
   Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> mat(rows, cols);
 
-  for (size_t row = 0; row < j.size(); ++row) {
+  for (std::size_t row = 0; row < j.size(); ++row) {
     const auto& j_row = j.at(row);
-    for (size_t col = 0; col < j_row.size(); ++col) {
+    for (std::size_t col = 0; col < j_row.size(); ++col) {
       mat(row, col) = j_row.at(col).get<T>();
     }
   }

--- a/tket/src/Diagonalisation/PauliPartition.cpp
+++ b/tket/src/Diagonalisation/PauliPartition.cpp
@@ -137,11 +137,11 @@ get_partitioned_paulis_for_exhaustive_method(const PauliACGraph& pac_graph) {
 
   for (const auto& entry : data.get_vertex_map()) {
     const QubitPauliString& vertex = entry.first;
-    const size_t id = entry.second;
+    const std::size_t id = entry.second;
     TKET_ASSERT(id < colouring.colours.size());
 
     // "id" is the index of this vertex.
-    const size_t colour = colouring.colours[id];
+    const std::size_t colour = colouring.colours[id];
     TKET_ASSERT(colour < colouring.number_of_colours);
 
     colour_map[colour].push_back(vertex);

--- a/tket/src/Graphs/BruteForceColouring.cpp
+++ b/tket/src/Graphs/BruteForceColouring.cpp
@@ -31,16 +31,18 @@ namespace graphs {
 
 struct BruteForceColouring::Impl {
   struct NodeColouringData {
-    vector<size_t> allowed_colours;
+    vector<std::size_t> allowed_colours;
 
     // The index in "allowed_colours", not the actual colour
-    size_t current_colour_index = 0;
+    std::size_t current_colour_index = 0;
 
     bool is_valid_colour() const {
       return current_colour_index < allowed_colours.size();
     }
 
-    size_t get_colour() const { return allowed_colours[current_colour_index]; }
+    std::size_t get_colour() const {
+      return allowed_colours[current_colour_index];
+    }
   };
 
   // This exactly mirrors the nodes in the ColouringPriority object;
@@ -48,13 +50,14 @@ struct BruteForceColouring::Impl {
   vector<NodeColouringData> colouring_data;
 
   // KEY: is the vertex, VALUE: the colour
-  map<size_t, size_t> colours;
+  map<std::size_t, std::size_t> colours;
 
   // Fills in the colour possibilities,
   // possibly increasing suggested_number_of_colours.
   // Returns false if it failed.
   bool initial_colouring_setup(
-      const ColouringPriority& priority, size_t& suggested_number_of_colours) {
+      const ColouringPriority& priority,
+      std::size_t& suggested_number_of_colours) {
     const auto& initial_clique = priority.get_initial_clique();
 
     suggested_number_of_colours =
@@ -67,7 +70,7 @@ struct BruteForceColouring::Impl {
     }
     colouring_data.resize(nodes.size());
 
-    for (size_t i = 0; i < initial_clique.size(); ++i) {
+    for (std::size_t i = 0; i < initial_clique.size(); ++i) {
       colouring_data[i].allowed_colours.assign(1, i);
       colours[nodes[i].vertex] = i;
     }
@@ -76,12 +79,12 @@ struct BruteForceColouring::Impl {
     // have nonempty colour possibility lists. (It may still be impossible, of
     // course, due to the detailed graph structure).
 
-    set<size_t> forbidden_colours;
+    set<std::size_t> forbidden_colours;
 
-    for (size_t i = initial_clique.size(); i < nodes.size(); ++i) {
+    for (std::size_t i = initial_clique.size(); i < nodes.size(); ++i) {
       forbidden_colours.clear();
 
-      for (size_t node_index : nodes[i].earlier_neighbour_node_indices) {
+      for (std::size_t node_index : nodes[i].earlier_neighbour_node_indices) {
         const auto& earlier_colours =
             colouring_data[node_index].allowed_colours;
 
@@ -97,7 +100,7 @@ struct BruteForceColouring::Impl {
       }
       auto& possible_colours = colouring_data[i].allowed_colours;
       possible_colours.clear();
-      for (size_t col = 0; col < suggested_number_of_colours; ++col) {
+      for (std::size_t col = 0; col < suggested_number_of_colours; ++col) {
         if (forbidden_colours.count(col) == 0) {
           possible_colours.push_back(col);
         }
@@ -112,7 +115,7 @@ struct BruteForceColouring::Impl {
 
   void fill_colour_map(const ColouringPriority& priority) {
     const auto& nodes = priority.get_nodes();
-    for (size_t i = 0; i < nodes.size(); ++i) {
+    for (std::size_t i = 0; i < nodes.size(); ++i) {
       colours[nodes[i].vertex] = colouring_data[i].get_colour();
     }
   }
@@ -122,9 +125,9 @@ struct BruteForceColouring::Impl {
       data.current_colour_index = 0;
     }
     const auto& nodes = priority.get_nodes();
-    const size_t number_of_nodes = nodes.size();
+    const std::size_t number_of_nodes = nodes.size();
 
-    for (size_t current_node_index = 0;;) {
+    for (std::size_t current_node_index = 0;;) {
       const auto& current_node = nodes[current_node_index];
       auto& current_colouring_node = colouring_data[current_node_index];
 
@@ -134,7 +137,7 @@ struct BruteForceColouring::Impl {
         bool colour_is_impossible = false;
 
         // TODO: would a set of colours be faster here?
-        for (size_t earlier_node_index :
+        for (std::size_t earlier_node_index :
              current_node.earlier_neighbour_node_indices) {
           if (colouring_data[earlier_node_index].get_colour() == current_col) {
             colour_is_impossible = true;
@@ -171,13 +174,13 @@ struct BruteForceColouring::Impl {
 BruteForceColouring::~BruteForceColouring() {}
 
 BruteForceColouring::BruteForceColouring(
-    const ColouringPriority& priority, size_t suggested_number_of_colours)
+    const ColouringPriority& priority, std::size_t suggested_number_of_colours)
     : m_pimpl(std::make_unique<BruteForceColouring::Impl>()) {
   const auto number_of_nodes = priority.get_nodes().size();
   if (suggested_number_of_colours >= number_of_nodes) {
     // We've been given permission to use many colours;
     // so just use them all!
-    for (size_t i = 0; i < number_of_nodes; ++i) {
+    for (std::size_t i = 0; i < number_of_nodes; ++i) {
       m_pimpl->colours[priority.get_nodes()[i].vertex] = i;
     }
     return;
@@ -207,8 +210,8 @@ BruteForceColouring::BruteForceColouring(
       // so try again with one more.
       // If we were really fancy we might consider
       // a binary search on the number of colours.
-      for (size_t i = priority.get_initial_clique().size(); i < number_of_nodes;
-           ++i) {
+      for (std::size_t i = priority.get_initial_clique().size();
+           i < number_of_nodes; ++i) {
         m_pimpl->colouring_data[i].allowed_colours.push_back(
             suggested_number_of_colours);
       }
@@ -227,7 +230,7 @@ BruteForceColouring::BruteForceColouring(
   }
 }
 
-const map<size_t, size_t>& BruteForceColouring::get_colours() const {
+const map<std::size_t, std::size_t>& BruteForceColouring::get_colours() const {
   return m_pimpl->colours;
 }
 

--- a/tket/src/Graphs/ColouringPriority.cpp
+++ b/tket/src/Graphs/ColouringPriority.cpp
@@ -31,13 +31,13 @@ namespace graphs {
 
 static void fill_initial_node_sequence(
     ColouringPriority::Nodes& nodes, const AdjacencyData& adjacency_data,
-    const set<size_t>& vertices_in_component,
-    const set<size_t>& initial_clique) {
+    const set<std::size_t>& vertices_in_component,
+    const set<std::size_t>& initial_clique) {
   nodes.reserve(vertices_in_component.size());
   nodes.clear();
 
   try {
-    for (size_t clique_vertex : initial_clique) {
+    for (std::size_t clique_vertex : initial_clique) {
       // GCOVR_EXCL_START
       if (vertices_in_component.count(clique_vertex) == 0) {
         std::stringstream ss;
@@ -51,18 +51,18 @@ static void fill_initial_node_sequence(
     }
     // Now, we do a breadth-first traversal of the remaining vertices,
     // adding all vertices only one step away from the current set.
-    size_t current_nodes_begin = 0;
+    std::size_t current_nodes_begin = 0;
 
-    set<size_t> vertices_seen = initial_clique;
-    set<size_t> vertices_to_add;
+    set<std::size_t> vertices_seen = initial_clique;
+    set<std::size_t> vertices_to_add;
 
-    for (size_t counter = 0; counter < 2 * vertices_in_component.size();
+    for (std::size_t counter = 0; counter < 2 * vertices_in_component.size();
          ++counter) {
-      const size_t current_nodes_end = nodes.size();
+      const std::size_t current_nodes_end = nodes.size();
 
-      for (size_t i = current_nodes_begin; i < current_nodes_end; ++i) {
+      for (std::size_t i = current_nodes_begin; i < current_nodes_end; ++i) {
         const auto& neighbours = adjacency_data.get_neighbours(nodes[i].vertex);
-        for (size_t neighbour : neighbours) {
+        for (std::size_t neighbour : neighbours) {
           if (vertices_seen.count(neighbour) == 0) {
             vertices_to_add.insert(neighbour);
           }
@@ -71,7 +71,7 @@ static void fill_initial_node_sequence(
       if (vertices_to_add.empty()) {
         break;
       }
-      for (size_t neighbour : vertices_to_add) {
+      for (std::size_t neighbour : vertices_to_add) {
         vertices_seen.insert(neighbour);
         nodes.emplace_back();
         nodes.back().vertex = neighbour;
@@ -106,10 +106,10 @@ static void fill_initial_node_sequence(
 // Fills in "earlier_neighbour_node_indices".
 static void fill_node_dependencies(
     ColouringPriority::Nodes& nodes, const AdjacencyData& adjacency_data) {
-  for (size_t node_index = 1; node_index < nodes.size(); ++node_index) {
+  for (std::size_t node_index = 1; node_index < nodes.size(); ++node_index) {
     auto& this_node = nodes[node_index];
 
-    for (size_t other_index = 0; other_index < node_index; ++other_index) {
+    for (std::size_t other_index = 0; other_index < node_index; ++other_index) {
       if (adjacency_data.edge_exists(
               this_node.vertex, nodes[other_index].vertex)) {
         this_node.earlier_neighbour_node_indices.emplace_back(other_index);
@@ -125,9 +125,9 @@ const ColouringPriority::Nodes& ColouringPriority::get_nodes() const {
 // GCOVR_EXCL_START
 // currently used only within a tket assert macro
 string ColouringPriority::print_raw_data(bool relabel_to_simplify) const {
-  map<size_t, size_t> old_vertex_to_new_vertex;
+  map<std::size_t, std::size_t> old_vertex_to_new_vertex;
   if (relabel_to_simplify) {
-    for (size_t i = 0; i < m_nodes.size(); ++i) {
+    for (std::size_t i = 0; i < m_nodes.size(); ++i) {
       old_vertex_to_new_vertex[m_nodes[i].vertex] = i;
     }
   } else {
@@ -136,11 +136,11 @@ string ColouringPriority::print_raw_data(bool relabel_to_simplify) const {
       old_vertex_to_new_vertex[v] = v;
     }
   }
-  map<size_t, set<size_t>> data;
+  map<std::size_t, set<std::size_t>> data;
   for (const auto& node : m_nodes) {
     const auto this_v = old_vertex_to_new_vertex.at(node.vertex);
     const auto& earlier_v_indices = node.earlier_neighbour_node_indices;
-    for (size_t i : earlier_v_indices) {
+    for (std::size_t i : earlier_v_indices) {
       const auto other_v = old_vertex_to_new_vertex.at(m_nodes[i].vertex);
       data[this_v].insert(other_v);
       data[other_v].insert(this_v);
@@ -148,7 +148,7 @@ string ColouringPriority::print_raw_data(bool relabel_to_simplify) const {
   }
   // Compress: remove (i,j) edges if i>j.
   {
-    vector<size_t> v_to_erase;
+    vector<std::size_t> v_to_erase;
     for (auto& entry : data) {
       v_to_erase.clear();
       for (auto v : entry.second) {
@@ -181,7 +181,8 @@ string ColouringPriority::print_raw_data(bool relabel_to_simplify) const {
 
 ColouringPriority::ColouringPriority(
     const AdjacencyData& adjacency_data,
-    const set<size_t>& vertices_in_component, const set<size_t>& initial_clique)
+    const set<std::size_t>& vertices_in_component,
+    const set<std::size_t>& initial_clique)
     : m_initial_clique(initial_clique) {
   fill_initial_node_sequence(
       m_nodes, adjacency_data, vertices_in_component, initial_clique);
@@ -189,7 +190,7 @@ ColouringPriority::ColouringPriority(
   fill_node_dependencies(m_nodes, adjacency_data);
 }
 
-const set<size_t>& ColouringPriority::get_initial_clique() const {
+const set<std::size_t>& ColouringPriority::get_initial_clique() const {
   return m_initial_clique;
 }
 

--- a/tket/src/Graphs/GraphRoutines.cpp
+++ b/tket/src/Graphs/GraphRoutines.cpp
@@ -26,29 +26,30 @@ using std::vector;
 namespace tket {
 namespace graphs {
 
-vector<set<size_t>> GraphRoutines::get_connected_components(
+vector<set<std::size_t>> GraphRoutines::get_connected_components(
     const AdjacencyData& adjacency_data) {
-  set<size_t> vertices_seen;
-  vector<set<size_t>> result;
-  const size_t number_of_vertices = adjacency_data.get_number_of_vertices();
+  set<std::size_t> vertices_seen;
+  vector<set<std::size_t>> result;
+  const std::size_t number_of_vertices =
+      adjacency_data.get_number_of_vertices();
 
-  for (size_t v = 0; v < number_of_vertices; ++v) {
+  for (std::size_t v = 0; v < number_of_vertices; ++v) {
     if (vertices_seen.count(v) != 0) {
       continue;
     }
-    set<size_t> vertices_seen_in_this_component;
+    set<std::size_t> vertices_seen_in_this_component;
     vertices_seen_in_this_component.insert(v);
 
-    std::stack<size_t> vertices_to_examine_next;
+    std::stack<std::size_t> vertices_to_examine_next;
     vertices_to_examine_next.push(v);
 
     while (!vertices_to_examine_next.empty()) {
-      const size_t this_vertex = vertices_to_examine_next.top();
+      const std::size_t this_vertex = vertices_to_examine_next.top();
       vertices_to_examine_next.pop();
       const auto& neighbouring_vertices =
           adjacency_data.get_neighbours(this_vertex);
 
-      for (size_t j : neighbouring_vertices) {
+      for (std::size_t j : neighbouring_vertices) {
         if (vertices_seen_in_this_component.count(j) == 0) {
           vertices_to_examine_next.push(j);
           vertices_seen_in_this_component.insert(j);
@@ -57,7 +58,7 @@ vector<set<size_t>> GraphRoutines::get_connected_components(
     }
     // Now, push back the vertices seen.
     result.emplace_back(vertices_seen_in_this_component);
-    for (size_t k : vertices_seen_in_this_component) {
+    for (std::size_t k : vertices_seen_in_this_component) {
       vertices_seen.insert(k);
     }
   }

--- a/tket/src/Graphs/LargeCliquesResult.cpp
+++ b/tket/src/Graphs/LargeCliquesResult.cpp
@@ -25,15 +25,16 @@ namespace graphs {
 
 LargeCliquesResult::LargeCliquesResult(
     const AdjacencyData& adjacency_data,
-    const set<size_t>& vertices_in_component, size_t internal_size_limit) {
+    const set<std::size_t>& vertices_in_component,
+    std::size_t internal_size_limit) {
   // ...and, before swapping, everything in here will have size one greater than
   // "result".
-  vector<set<size_t>> extended_result;
+  vector<set<std::size_t>> extended_result;
 
   // At each stage, every set will have the same size, containing a clique of
   // that size.
   cliques.reserve(vertices_in_component.size());
-  for (size_t i : vertices_in_component) {
+  for (std::size_t i : vertices_in_component) {
     cliques.emplace_back(set{i});
   }
   bool hit_internal_limit = false;
@@ -42,11 +43,12 @@ LargeCliquesResult::LargeCliquesResult(
   // ... Therefore, within each vertex set, if we only allow adding vertices
   // with LARGER index than the largest already stored, we will automatically
   // discard duplicates.
-  for (size_t counter = 0; counter <= vertices_in_component.size(); ++counter) {
+  for (std::size_t counter = 0; counter <= vertices_in_component.size();
+       ++counter) {
     // Extend the existing results.
     for (const auto& clique : cliques) {
       // Guaranteed to be nonempty.
-      const size_t largest_index = *clique.crbegin();
+      const std::size_t largest_index = *clique.crbegin();
 
       if (extended_result.size() >= internal_size_limit) {
         hit_internal_limit = true;
@@ -55,13 +57,13 @@ LargeCliquesResult::LargeCliquesResult(
       // We only have to check the neighbours of ONE vertex to form a larger
       // clique.
       const auto& neighbours = adjacency_data.get_neighbours(largest_index);
-      for (size_t new_v : neighbours) {
+      for (std::size_t new_v : neighbours) {
         if (new_v <= largest_index) {
           continue;
         }
         // We have a new vertex; does it adjoin EVERY existing vertex?
         bool joins_every_vertex = true;
-        for (size_t existing_v : clique) {
+        for (std::size_t existing_v : clique) {
           if (adjacency_data.get_neighbours(existing_v).count(new_v) == 0) {
             joins_every_vertex = false;
             break;

--- a/tket/src/Mapping/LexiRoute.cpp
+++ b/tket/src/Mapping/LexiRoute.cpp
@@ -713,7 +713,7 @@ std::pair<bool, bool> LexiRoute::check_bridge(
 
 // Returns the distance between n1 and p1 and the distance between n2 and p2,
 // distance ordered (greatest first)
-const std::pair<size_t, size_t> LexiRoute::pair_distances(
+const std::pair<std::size_t, std::size_t> LexiRoute::pair_distances(
     const Node& p0_first, const Node& p0_second, const Node& p1_first,
     const Node& p1_second) const {
   {
@@ -723,8 +723,10 @@ const std::pair<size_t, size_t> LexiRoute::pair_distances(
                        this->architecture_->node_exists(p1_second);
     TKET_ASSERT(valid);
   }
-  size_t curr_dist1 = this->architecture_->get_distance(p0_first, p0_second);
-  size_t curr_dist2 = this->architecture_->get_distance(p1_first, p1_second);
+  std::size_t curr_dist1 =
+      this->architecture_->get_distance(p0_first, p0_second);
+  std::size_t curr_dist2 =
+      this->architecture_->get_distance(p1_first, p1_second);
   return (curr_dist1 > curr_dist2) ? std::make_pair(curr_dist1, curr_dist2)
                                    : std::make_pair(curr_dist2, curr_dist1);
 }
@@ -758,9 +760,9 @@ void LexiRoute::remove_swaps_decreasing(swap_set_t& swaps) {
     // Check should alrady be done with earlier continue
     TKET_ASSERT(pair_second != swap.first);
 
-    const std::pair<size_t, size_t>& curr_dists =
+    const std::pair<std::size_t, std::size_t>& curr_dists =
         this->pair_distances(swap.first, pair_first, swap.second, pair_second);
-    const std::pair<size_t, size_t>& news_dists =
+    const std::pair<std::size_t, std::size_t>& news_dists =
         this->pair_distances(swap.second, pair_first, swap.first, pair_second);
     if (news_dists >= curr_dists) {
       continue;

--- a/tket/src/Placement/LinePlacement.cpp
+++ b/tket/src/Placement/LinePlacement.cpp
@@ -74,7 +74,7 @@ std::map<Qubit, Node> LinePlacement::assign_lines_to_target_graph(
   std::sort(
       line_pattern.begin(), line_pattern.end(),
       [](qubit_vector_t x, qubit_vector_t y) {
-        size_t xsz = x.size(), ysz = y.size();
+        std::size_t xsz = x.size(), ysz = y.size();
         if (xsz > ysz) {
           return true;
         } else if (xsz < ysz) {

--- a/tket/src/Utils/PauliStrings.cpp
+++ b/tket/src/Utils/PauliStrings.cpp
@@ -394,7 +394,7 @@ void QubitPauliString::set(const Qubit &q, Pauli p) {
 }
 
 std::size_t hash_value(const QubitPauliString &qps) {
-  size_t seed = 0;
+  std::size_t seed = 0;
   for (const std::pair<const Qubit, Pauli> &qb_p : qps.map) {
     if (qb_p.second != Pauli::I) {
       boost::hash_combine(seed, qb_p.first);
@@ -526,7 +526,7 @@ std::string QubitPauliTensor::to_str() const {
 }
 
 std::size_t hash_value(const QubitPauliTensor &qpt) {
-  size_t seed = hash_value(qpt.string);
+  std::size_t seed = hash_value(qpt.string);
   boost::hash_combine(seed, qpt.coeff);
   return seed;
 }

--- a/tket/test/src/Gate/test_GateUnitaryMatrix.cpp
+++ b/tket/test/src/Gate/test_GateUnitaryMatrix.cpp
@@ -72,7 +72,7 @@ static Eigen::MatrixXcd get_tket_sim_unitary(
 
 static void write_error_information(
     const std::string& name, const std::vector<double>& current_values,
-    size_t number_of_qubits, const Eigen::MatrixXcd& unitary,
+    std::size_t number_of_qubits, const Eigen::MatrixXcd& unitary,
     std::stringstream& ss) {
   ss << "\nOp type " << name << " acting on " << number_of_qubits
      << " qubits, with " << current_values.size() << " parameters: [";
@@ -112,7 +112,7 @@ static bool calculate_and_compare_unitaries(
 // Returns false if the calculated matrix U is not almost unitary.
 static bool check_is_unitary(
     const std::string& name, const std::vector<double>& current_values,
-    size_t number_of_qubits, const Eigen::MatrixXcd& unitary,
+    std::size_t number_of_qubits, const Eigen::MatrixXcd& unitary,
     std::stringstream& ss) {
   if (is_unitary(unitary)) {
     return true;
@@ -170,7 +170,7 @@ static bool update_parameter_values(
   if (current_values.empty()) {
     return false;
   }
-  for (size_t nn = current_values.size() - 1;;) {
+  for (std::size_t nn = current_values.size() - 1;;) {
     double& value = current_values[nn];
     value = values_map.at(value);
     if (value != values_map.crbegin()->first) {
@@ -187,8 +187,8 @@ static bool update_parameter_values(
 }
 
 static void test_op(
-    OpType op_type, size_t number_of_parameters, size_t number_of_qubits,
-    const ValuesMap& values_map) {
+    OpType op_type, std::size_t number_of_parameters,
+    std::size_t number_of_qubits, const ValuesMap& values_map) {
   const OpDesc desc(op_type);
   const auto name = desc.name();
   INFO(
@@ -217,7 +217,7 @@ static void test_op(
   try {
     for (;;) {
       // Convert the doubles to expressions.
-      for (size_t nn = 0; nn < current_values.size(); ++nn) {
+      for (std::size_t nn = 0; nn < current_values.size(); ++nn) {
         current_values_expr[nn] = Expr(current_values[nn]);
       }
       if (!test_op_with_parameters(

--- a/tket/test/src/Graphs/EdgeSequence.cpp
+++ b/tket/test/src/Graphs/EdgeSequence.cpp
@@ -25,7 +25,7 @@ namespace tests {
 EdgeSequence::EdgeSequence(AdjacencyData& _adj_data, RNG& _rng)
     : adjacency_data(_adj_data), rng(_rng) {}
 
-bool EdgeSequence::add_edge(size_t i, size_t j) {
+bool EdgeSequence::add_edge(std::size_t i, std::size_t j) {
   if (adjacency_data.add_edge(i, j)) {
     edges.emplace_back(i, j);
     return true;

--- a/tket/test/src/Graphs/EdgeSequenceColouringParameters.cpp
+++ b/tket/test/src/Graphs/EdgeSequenceColouringParameters.cpp
@@ -30,7 +30,7 @@ namespace tket {
 namespace graphs {
 namespace tests {
 
-size_t EdgeSequenceColouringParameters::test_colourings(
+std::size_t EdgeSequenceColouringParameters::test_colourings(
     RandomGraphParameters& parameters, EdgeSequence& edge_sequence) {
   const auto number_of_vertices =
       edge_sequence.adjacency_data.get_number_of_vertices();
@@ -43,10 +43,10 @@ size_t EdgeSequenceColouringParameters::test_colourings(
   edge_sequence.edges.clear();
   parameters.add_edges(edge_sequence);
 
-  size_t number_of_colourings = 0;
-  size_t previous_number_of_colours = 0;
+  std::size_t number_of_colourings = 0;
+  std::size_t previous_number_of_colours = 0;
 
-  const size_t known_max_chromatic_number =
+  const std::size_t known_max_chromatic_number =
       std::min(parameters.max_chromatic_number, number_of_vertices);
 
   // TODO: if the tests start getting slow, consider
@@ -62,7 +62,8 @@ size_t EdgeSequenceColouringParameters::test_colourings(
   string prev_graph;
   string prev_colouring;
 
-  for (size_t edge_index = 0; edge_index < max_number_of_edges; ++edge_index) {
+  for (std::size_t edge_index = 0; edge_index < max_number_of_edges;
+       ++edge_index) {
     if (edge_index >= edge_sequence.edges.size() ||
         number_of_colourings >= max_number_of_colourings) {
       return number_of_colourings;

--- a/tket/test/src/Graphs/GraphTestingRoutines.cpp
+++ b/tket/test/src/Graphs/GraphTestingRoutines.cpp
@@ -36,7 +36,7 @@ namespace tests {
 
 void GraphTestingRoutines::require_valid_colouring_without_graph(
     const GraphColouringResult& colouring_result, bool require_no_colour_gaps) {
-  const set<size_t> colours_seen(
+  const set<std::size_t> colours_seen(
       colouring_result.colours.cbegin(), colouring_result.colours.cend());
 
   try {
@@ -66,13 +66,13 @@ void GraphTestingRoutines::require_valid_colouring_without_graph(
 
 void GraphTestingRoutines::require_valid_colouring(
     const GraphColouringResult& colouring_result,
-    const vector<std::pair<size_t, size_t>>& edges,
-    size_t number_of_edges_to_check) {
+    const vector<std::pair<std::size_t, std::size_t>>& edges,
+    std::size_t number_of_edges_to_check) {
   require_valid_colouring_without_graph(colouring_result);
 
   number_of_edges_to_check = std::min(number_of_edges_to_check, edges.size());
 
-  for (size_t edge_index = 0; edge_index < number_of_edges_to_check;
+  for (std::size_t edge_index = 0; edge_index < number_of_edges_to_check;
        ++edge_index) {
     const auto& edge = edges[edge_index];
     try {
@@ -110,9 +110,9 @@ void GraphTestingRoutines::require_valid_suboptimal_colouring(
     if (number_of_vertices != graph_data.get_number_of_vertices()) {
       throw runtime_error("Mismatching number of vertices");
     }
-    for (size_t vertex = 0; vertex < number_of_vertices; ++vertex) {
+    for (std::size_t vertex = 0; vertex < number_of_vertices; ++vertex) {
       const auto& neighbours = graph_data.get_neighbours(vertex);
-      for (size_t other_vertex : neighbours) {
+      for (std::size_t other_vertex : neighbours) {
         if (colouring_result.colours[vertex] ==
             colouring_result.colours[other_vertex]) {
           stringstream ss;

--- a/tket/test/src/Graphs/RandomGraphGeneration.cpp
+++ b/tket/test/src/Graphs/RandomGraphGeneration.cpp
@@ -28,18 +28,18 @@ namespace graphs {
 namespace tests {
 
 bool RandomFibrousGraphParameters::add_edges(EdgeSequence& edge_sequence) {
-  const size_t number_of_vertices =
+  const std::size_t number_of_vertices =
       edge_sequence.adjacency_data.get_number_of_vertices();
 
   REQUIRE(number_of_vertices >= 2);
   REQUIRE(number_of_vertices <= 10000);
 
-  const size_t max_vertex = number_of_vertices - 1;
+  const std::size_t max_vertex = number_of_vertices - 1;
   auto& rng = edge_sequence.rng;
 
-  for (size_t i = 0; i < number_of_strands; ++i) {
-    const size_t start_v = rng.get_size_t(max_vertex);
-    size_t current_v = start_v;
+  for (std::size_t i = 0; i < number_of_strands; ++i) {
+    const std::size_t start_v = rng.get_size_t(max_vertex);
+    std::size_t current_v = start_v;
 
     for (int counter = 0; counter < 1000; ++counter) {
       auto new_v = current_v;
@@ -71,34 +71,35 @@ bool RandomTreeParameters::add_edges(EdgeSequence& edge_sequence) {
   // Easy to prove that all trees can be 2-coloured.
   max_chromatic_number = 2;
 
-  const size_t number_of_vertices =
+  const std::size_t number_of_vertices =
       edge_sequence.adjacency_data.get_number_of_vertices();
 
   REQUIRE(number_of_vertices >= 2);
   REQUIRE(number_of_vertices <= 10000);
 
-  const size_t max_vertex = number_of_vertices - 1;
+  const std::size_t max_vertex = number_of_vertices - 1;
   auto& rng = edge_sequence.rng;
   const auto root_vertex = rng.get_size_t(max_vertex);
 
   // TODO: be fancy and use a single partitioned vector
   // for existing/unused vertices.
-  vector<size_t> unused_vertices;
+  vector<std::size_t> unused_vertices;
   unused_vertices.reserve(max_vertex);
 
-  for (size_t ii = 0; ii < number_of_vertices; ++ii) {
+  for (std::size_t ii = 0; ii < number_of_vertices; ++ii) {
     if (ii != root_vertex) {
       unused_vertices.push_back(ii);
     }
   }
-  vector<size_t> existing_vertices;
+  vector<std::size_t> existing_vertices;
   existing_vertices.push_back(root_vertex);
 
-  for (size_t counter1 = 0; counter1 < approx_number_of_spawns; ++counter1) {
+  for (std::size_t counter1 = 0; counter1 < approx_number_of_spawns;
+       ++counter1) {
     const auto parent = rng.get_element(existing_vertices);
 
-    for (size_t counter2 = 0; counter2 < approx_number_of_children_per_node;
-         ++counter2) {
+    for (std::size_t counter2 = 0;
+         counter2 < approx_number_of_children_per_node; ++counter2) {
       if (unused_vertices.empty()) {
         return false;
       }
@@ -120,26 +121,26 @@ bool RandomTreeParameters::add_edges(EdgeSequence& edge_sequence) {
 }
 
 bool RandomDenseGraphParameters::add_edges(EdgeSequence& edge_sequence) {
-  const size_t number_of_vertices =
+  const std::size_t number_of_vertices =
       edge_sequence.adjacency_data.get_number_of_vertices();
 
   REQUIRE(number_of_vertices >= 2);
   REQUIRE(number_of_vertices <= 10000);
 
-  const size_t max_vertex = number_of_vertices - 1;
+  const std::size_t max_vertex = number_of_vertices - 1;
   auto& rng = edge_sequence.rng;
 
-  size_t approx_max_total_attempts = 100000;
+  std::size_t approx_max_total_attempts = 100000;
   approx_max_total_attempts = std::min(
       approx_max_total_attempts, number_of_vertices * number_of_vertices);
 
-  size_t max_attempts = 10000;
+  std::size_t max_attempts = 10000;
   max_attempts =
       std::min(max_attempts, max_number_of_consecutive_add_edge_attempts);
 
   for (; approx_max_total_attempts > 0; --approx_max_total_attempts) {
     bool edge_added = false;
-    for (size_t counter = 0; counter < max_attempts; ++counter) {
+    for (std::size_t counter = 0; counter < max_attempts; ++counter) {
       const auto ii = rng.get_size_t(max_vertex);
       const auto jj = rng.get_size_t(max_vertex);
       if (ii != jj && edge_sequence.add_edge(ii, jj)) {
@@ -160,19 +161,19 @@ namespace {
 // Once the vertex colours are known, it's trivial to add edges.
 struct VerticesPartition {
   // Each inner vector element[i] lists all vertices with colour i.
-  vector<vector<size_t>> single_colour_vertex_sets;
+  vector<vector<std::size_t>> single_colour_vertex_sets;
 
-  vector<size_t> known_colouring;
+  vector<std::size_t> known_colouring;
 
   VerticesPartition(
-      EdgeSequence& edge_sequence, size_t max_number_of_colours_to_use) {
-    size_t max_colour_used = 0;
+      EdgeSequence& edge_sequence, std::size_t max_number_of_colours_to_use) {
+    std::size_t max_colour_used = 0;
 
     // In each pair: first is the vertex, second is the colour.
-    vector<std::pair<size_t, size_t>> colours(
+    vector<std::pair<std::size_t, std::size_t>> colours(
         edge_sequence.adjacency_data.get_number_of_vertices());
-    for (size_t ii = 0; ii < colours.size(); ++ii) {
-      const size_t colour = ii % max_number_of_colours_to_use;
+    for (std::size_t ii = 0; ii < colours.size(); ++ii) {
+      const std::size_t colour = ii % max_number_of_colours_to_use;
       max_colour_used = std::max(max_colour_used, colour);
       colours[ii].first = ii;
       colours[ii].second = colour;
@@ -198,13 +199,14 @@ bool RandomColouredDenseGraphParameters::add_edges(
       edge_sequence, max_number_of_colours_to_use);
 
   max_chromatic_number = partition.single_colour_vertex_sets.size();
-  const size_t max_colour = max_chromatic_number - 1;
+  const std::size_t max_colour = max_chromatic_number - 1;
 
   known_colouring = GraphColouringResult(partition.known_colouring);
 
   // If there are N vertices, there are O(N^2) possible edges,
   // so if you still haven't found one after ~N^2 steps, time to give up.
-  size_t max_attempts = edge_sequence.adjacency_data.get_number_of_vertices();
+  std::size_t max_attempts =
+      edge_sequence.adjacency_data.get_number_of_vertices();
   max_attempts *= max_attempts;
 
   max_attempts =
@@ -214,7 +216,7 @@ bool RandomColouredDenseGraphParameters::add_edges(
 
   for (;;) {
     bool edge_added = false;
-    for (size_t counter = 0; counter < max_attempts; ++counter) {
+    for (std::size_t counter = 0; counter < max_attempts; ++counter) {
       const auto colour1 = rng.get_size_t(max_colour);
       const auto colour2 = rng.get_size_t(max_colour);
 
@@ -275,12 +277,12 @@ bool RandomColouredKPartiteGraphParameters::add_edges(
   const auto& k = number_of_vertex_sets;
   const auto& m = number_of_vertices_in_each_set;
 
-  for (size_t c0 = 0; c0 < k; ++c0) {
-    for (size_t c1 = c0 + 1; c1 < k; ++c1) {
-      for (size_t r0 = 0; r0 < m; ++r0) {
-        for (size_t r1 = 0; r1 < m; ++r1) {
-          size_t n0 = m * c0 + r0;
-          size_t n1 = m * c1 + r1;
+  for (std::size_t c0 = 0; c0 < k; ++c0) {
+    for (std::size_t c1 = c0 + 1; c1 < k; ++c1) {
+      for (std::size_t r0 = 0; r0 < m; ++r0) {
+        for (std::size_t r1 = 0; r1 < m; ++r1) {
+          std::size_t n0 = m * c0 + r0;
+          std::size_t n1 = m * c1 + r1;
           auto l0 = labels[n0];
           auto l1 = labels[n1];
 
@@ -293,8 +295,8 @@ bool RandomColouredKPartiteGraphParameters::add_edges(
       }
     }
   }
-  for (size_t c = 0; c < k; ++c) {
-    for (size_t r = 0; r < m; ++r) {
+  for (std::size_t c = 0; c < k; ++c) {
+    for (std::size_t r = 0; r < m; ++r) {
       known_colouring.colours[labels[m * c + r]] = c;
     }
   }
@@ -316,10 +318,10 @@ bool CompleteGraph::add_edges(EdgeSequence& edge_sequence) {
   known_colouring.number_of_colours = max_chromatic_number;
   known_colouring.colours.resize(max_chromatic_number);
 
-  for (size_t ii = 0; ii < max_chromatic_number; ++ii) {
+  for (std::size_t ii = 0; ii < max_chromatic_number; ++ii) {
     known_colouring.colours[ii] = ii;
 
-    for (size_t jj = ii + 1; jj < max_chromatic_number; ++jj) {
+    for (std::size_t jj = ii + 1; jj < max_chromatic_number; ++jj) {
       REQUIRE(edge_sequence.add_edge(ii, jj));
     }
   }

--- a/tket/test/src/Graphs/RandomPlanarGraphs.cpp
+++ b/tket/test/src/Graphs/RandomPlanarGraphs.cpp
@@ -23,7 +23,7 @@ namespace tket {
 namespace graphs {
 namespace tests {
 
-void RandomPlanarGraphs::reset(size_t width) {
+void RandomPlanarGraphs::reset(std::size_t width) {
   m_width = 5;
   m_width = std::max(width, m_width);
 
@@ -32,8 +32,8 @@ void RandomPlanarGraphs::reset(size_t width) {
 
   Gate gate;
   // Think of increasing x as EAST, increasing y as NORTH.
-  for (size_t xx = 0; xx < m_width; ++xx) {
-    for (size_t yy = 0; yy < m_width; ++yy) {
+  for (std::size_t xx = 0; xx < m_width; ++xx) {
+    for (std::size_t yy = 0; yy < m_width; ++yy) {
       gate.vertex1 = yy * m_width + xx;
 
       if (xx + 1 != m_width) {
@@ -50,12 +50,12 @@ void RandomPlanarGraphs::reset(size_t width) {
   }
   m_number_of_regions = m_width * m_width;
   m_region_ids.resize(m_number_of_regions);
-  for (size_t ii = 0; ii < m_region_ids.size(); ++ii) {
+  for (std::size_t ii = 0; ii < m_region_ids.size(); ++ii) {
     m_region_ids[ii] = ii;
   }
 }
 
-size_t RandomPlanarGraphs::merge_squares(RNG& rng) {
+std::size_t RandomPlanarGraphs::merge_squares(RNG& rng) {
   if (m_remaining_gates.empty()) {
     return m_number_of_regions;
   }
@@ -69,7 +69,7 @@ size_t RandomPlanarGraphs::merge_squares(RNG& rng) {
   }
   // The two region IDs now must be merged together.
   // Not the most efficient here!
-  for (size_t& region_id : m_region_ids) {
+  for (std::size_t& region_id : m_region_ids) {
     if (region_id == id2) {
       region_id = id1;
     }
@@ -78,7 +78,7 @@ size_t RandomPlanarGraphs::merge_squares(RNG& rng) {
   return m_number_of_regions;
 }
 
-vector<vector<size_t>> RandomPlanarGraphs::get_region_data() const {
+vector<vector<std::size_t>> RandomPlanarGraphs::get_region_data() const {
   m_region_data.resize(m_number_of_regions);
   for (auto& region_list : m_region_data) {
     region_list.clear();
@@ -92,9 +92,9 @@ vector<vector<size_t>> RandomPlanarGraphs::get_region_data() const {
   }
   REQUIRE(m_old_id_to_new_id.size() == m_number_of_regions);
 
-  for (size_t xx = 0; xx < m_width; ++xx) {
-    for (size_t yy = 0; yy < m_width; ++yy) {
-      const size_t square = xx + yy * m_width;
+  for (std::size_t xx = 0; xx < m_width; ++xx) {
+    for (std::size_t yy = 0; yy < m_width; ++yy) {
+      const std::size_t square = xx + yy * m_width;
       if (xx + 1 < m_width) {
         register_touching_regions(square, square + 1);
       }
@@ -107,7 +107,7 @@ vector<vector<size_t>> RandomPlanarGraphs::get_region_data() const {
 }
 
 void RandomPlanarGraphs::register_touching_regions(
-    size_t square1, size_t square2) const {
+    std::size_t square1, std::size_t square2) const {
   const auto id1 = m_old_id_to_new_id.at(m_region_ids.at(square1));
   const auto id2 = m_old_id_to_new_id.at(m_region_ids.at(square2));
   if (id1 != id2) {

--- a/tket/test/src/Graphs/test_GraphColouring.cpp
+++ b/tket/test/src/Graphs/test_GraphColouring.cpp
@@ -37,7 +37,7 @@ SCENARIO("Test many colourings: random trees") {
   EdgeSequenceColouringParameters colouring_parameters;
   EdgeSequence edge_sequence(adjacency_data, rng);
 
-  for (size_t number_of_vertices = 5; number_of_vertices < 100;
+  for (std::size_t number_of_vertices = 5; number_of_vertices < 100;
        number_of_vertices += 20) {
     for (params.approx_number_of_children_per_node = 2;
          params.approx_number_of_children_per_node <= 4;
@@ -62,7 +62,7 @@ SCENARIO("Test many colourings: random dense graphs") {
   EdgeSequenceColouringParameters colouring_parameters;
   EdgeSequence edge_sequence(adjacency_data, rng);
 
-  for (size_t number_of_vertices = 2; number_of_vertices < 15;
+  for (std::size_t number_of_vertices = 2; number_of_vertices < 15;
        number_of_vertices += 5) {
     for (int nn = 0; nn < 10; ++nn) {
       adjacency_data.clear(number_of_vertices);
@@ -79,7 +79,7 @@ SCENARIO("Test many colourings: random dense graphs with known colours") {
   EdgeSequenceColouringParameters colouring_parameters;
   EdgeSequence edge_sequence(adjacency_data, rng);
 
-  for (size_t number_of_vertices = 2; number_of_vertices < 15;
+  for (std::size_t number_of_vertices = 2; number_of_vertices < 15;
        number_of_vertices += 5) {
     for (params.max_number_of_colours_to_use = 1;
          params.max_number_of_colours_to_use < number_of_vertices;
@@ -99,8 +99,8 @@ SCENARIO("Test many colourings: random k-partite graphs") {
   AdjacencyData adjacency_data;
   EdgeSequenceColouringParameters colouring_parameters;
   EdgeSequence edge_sequence(adjacency_data, rng);
-  size_t total_number_of_edges = 0;
-  size_t total_number_of_colourings = 0;
+  std::size_t total_number_of_edges = 0;
+  std::size_t total_number_of_colourings = 0;
 
   for (params.number_of_vertex_sets = 1; params.number_of_vertex_sets < 5;
        ++params.number_of_vertex_sets) {
@@ -129,7 +129,7 @@ SCENARIO("Test many colourings: random fibrous graphs") {
   EdgeSequenceColouringParameters colouring_parameters;
   EdgeSequence edge_sequence(adjacency_data, rng);
 
-  for (size_t number_of_vertices = 5; number_of_vertices < 50;
+  for (std::size_t number_of_vertices = 5; number_of_vertices < 50;
        number_of_vertices += 10) {
     for (params.number_of_strands = 1; params.number_of_strands < 10;
          ++params.number_of_strands) {
@@ -154,7 +154,7 @@ SCENARIO("Test many colourings: trivial graphs") {
     EdgelessGraph params;
 
     // Very cheap to colour, so do lots
-    for (size_t number_of_vertices = 1; number_of_vertices < 1000;
+    for (std::size_t number_of_vertices = 1; number_of_vertices < 1000;
          ++number_of_vertices) {
       adjacency_data.clear(number_of_vertices);
       colouring_parameters.test_colourings(params, edge_sequence);
@@ -163,7 +163,7 @@ SCENARIO("Test many colourings: trivial graphs") {
   INFO("Complete graphs (all edges filled)");
   {
     CompleteGraph params;
-    for (size_t number_of_vertices = 5; number_of_vertices < 10;
+    for (std::size_t number_of_vertices = 5; number_of_vertices < 10;
          number_of_vertices += 4) {
       adjacency_data.clear(number_of_vertices);
       colouring_parameters.test_colourings(params, edge_sequence);
@@ -176,7 +176,7 @@ SCENARIO("Test fixed graph") {
   // Whenever a particular graph colouring fails somehow,
   // you can copy and paste it into here to add to the tests
   {
-    const map<size_t, vector<size_t>> data = {
+    const map<std::size_t, vector<std::size_t>> data = {
         // clang-format off
             { 0, { 2, 4, 5, 6, 7, 9, 12, } },
             { 1, { 6, 9, 10, 12, } },
@@ -192,7 +192,7 @@ SCENARIO("Test fixed graph") {
         // clang-format on
     };
 
-    const vector<size_t> known_colouring{
+    const vector<std::size_t> known_colouring{
         0, 2, 1, 0, 2, 2, 1, 3, 4, 4, 0, 0, 3,
     };
 
@@ -200,7 +200,7 @@ SCENARIO("Test fixed graph") {
         GraphColouringResult(known_colouring), AdjacencyData(data));
   }
   {
-    const map<size_t, vector<size_t>> data = {
+    const map<std::size_t, vector<std::size_t>> data = {
         // clang-format off
             { 0, { 1, 3, } },
             { 1, { 2, 3, 4, } },
@@ -208,13 +208,13 @@ SCENARIO("Test fixed graph") {
             { 3, { 4, } },
         // clang-format on
     };
-    const vector<size_t> known_colouring{0, 1, 2, 2, 0};
+    const vector<std::size_t> known_colouring{0, 1, 2, 2, 0};
 
     GraphTestingRoutines::calculate_and_check_optimal_colouring(
         GraphColouringResult(known_colouring), AdjacencyData(data));
   }
   {
-    const map<size_t, vector<size_t>> data = {
+    const map<std::size_t, vector<std::size_t>> data = {
         // clang-format off
             { 1, { 3, 6, 8, 11, 13, 17, } },
             { 4, { 8, } },
@@ -222,7 +222,7 @@ SCENARIO("Test fixed graph") {
         // clang-format on
     };
 
-    const vector<size_t> known_colouring{
+    const vector<std::size_t> known_colouring{
         0, 0, 0, 1, 0, 0, 1, 0, 1, 0, 0, 1, 0,
         1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,
     };
@@ -231,14 +231,14 @@ SCENARIO("Test fixed graph") {
         GraphColouringResult(known_colouring), AdjacencyData(data));
   }
   {
-    map<size_t, vector<size_t>> data = {
+    map<std::size_t, vector<std::size_t>> data = {
         // clang-format off
             { 2, { 9, 10, } },
             { 10, { 13, } },
             { 14, {} }
         // clang-format on
     };
-    const vector<size_t> known_colouring{
+    const vector<std::size_t> known_colouring{
         0, 0, 0, 0, 0, 1, 0, 0, 0, 1, 1, 0, 0, 0, 0,
     };
 
@@ -248,17 +248,17 @@ SCENARIO("Test fixed graph") {
 }
 
 SCENARIO("Test random planar graphs") {
-  const size_t grid_width = 20;
-  const size_t max_number_of_regions = 50;
+  const std::size_t grid_width = 20;
+  const std::size_t max_number_of_regions = 50;
   RNG rng;
   RandomPlanarGraphs planar_graphs;
-  size_t number_of_colourings = 0;
+  std::size_t number_of_colourings = 0;
 
   for (int nn = 0; nn < 50; ++nn) {
     planar_graphs.reset(grid_width);
-    size_t current_number_of_regions = 10 * grid_width * grid_width;
+    std::size_t current_number_of_regions = 10 * grid_width * grid_width;
 
-    for (size_t paranoid_loop_counter = 10 * grid_width * grid_width;
+    for (std::size_t paranoid_loop_counter = 10 * grid_width * grid_width;
          paranoid_loop_counter > 0; --paranoid_loop_counter) {
       const auto new_number_of_regions = planar_graphs.merge_squares(rng);
       REQUIRE(new_number_of_regions <= current_number_of_regions);
@@ -296,15 +296,15 @@ SCENARIO("Test random planar graphs") {
 // and hence good for testing colouring. (The max clique size is just 2).
 // See https://en.wikipedia.org/wiki/Mycielskian
 static AdjacencyData get_Mycielski_graph(const AdjacencyData& graph) {
-  const size_t original_vertices = graph.get_number_of_vertices();
-  const size_t vertex_w = 2 * original_vertices;
+  const std::size_t original_vertices = graph.get_number_of_vertices();
+  const std::size_t vertex_w = 2 * original_vertices;
 
   AdjacencyData new_graph(2 * original_vertices + 1);
-  for (size_t ii = 0; ii < original_vertices; ++ii) {
+  for (std::size_t ii = 0; ii < original_vertices; ++ii) {
     REQUIRE(new_graph.add_edge(ii, vertex_w));
     const auto& original_neighbours = graph.get_neighbours(ii);
 
-    for (size_t jj : original_neighbours) {
+    for (std::size_t jj : original_neighbours) {
       // Add the original edges
       new_graph.add_edge(ii, jj);
 
@@ -317,12 +317,13 @@ static AdjacencyData get_Mycielski_graph(const AdjacencyData& graph) {
 
 // Pass in an initial seed graph with known chromatic number
 static void test_Mycielski_graph_sequence(
-    AdjacencyData graph, size_t chromatic_number, size_t number_of_graphs) {
+    AdjacencyData graph, std::size_t chromatic_number,
+    std::size_t number_of_graphs) {
   const auto initial_number_of_vertices = graph.get_number_of_vertices();
   const auto initial_number_of_edges = graph.get_number_of_edges();
   const auto initial_chromatic_number = chromatic_number;
 
-  for (size_t counter = 0; counter < number_of_graphs; ++counter) {
+  for (std::size_t counter = 0; counter < number_of_graphs; ++counter) {
     if (counter != 0) {
       graph = get_Mycielski_graph(graph);
       ++chromatic_number;

--- a/tket/test/src/Graphs/test_GraphFindComponents.cpp
+++ b/tket/test/src/Graphs/test_GraphFindComponents.cpp
@@ -29,39 +29,39 @@ namespace tests {
 
 // For testing the connected component function
 struct ComponentsTestData {
-  vector<vector<size_t>> raw_adjacency_data;
-  vector<set<size_t>> components;
+  vector<vector<std::size_t>> raw_adjacency_data;
+  vector<set<std::size_t>> components;
 };
 
 // Used to test the connected component functions:
 // create a graph with known components
 struct ComponentsParameters {
-  size_t max_tree_size = 10;
-  size_t max_number_of_extra_edges_to_add_to_tree = 2;
-  size_t number_of_singletons = 10;
-  size_t number_of_multivertex_components = 10;
+  std::size_t max_tree_size = 10;
+  std::size_t max_number_of_extra_edges_to_add_to_tree = 2;
+  std::size_t number_of_singletons = 10;
+  std::size_t number_of_multivertex_components = 10;
 
   ComponentsTestData get_test_data(RNG& rng) const {
     ComponentsTestData data;
 
     // KEY: the vertex VALUE: the neighbours
     // (simpler to use a map rather than a vector).
-    map<size_t, vector<size_t>> neighbours;
+    map<std::size_t, vector<std::size_t>> neighbours;
 
-    size_t next_vertex = 0;
+    std::size_t next_vertex = 0;
 
     // Singletons - no edges
     for (; next_vertex < number_of_singletons; ++next_vertex) {
-      data.components.emplace_back(set<size_t>{next_vertex});
+      data.components.emplace_back(set<std::size_t>{next_vertex});
     }
 
     // Trees
-    set<size_t> tree_vertices;
+    set<std::size_t> tree_vertices;
 
     // Each vertex is a tree node which may grow some children
-    vector<size_t> tree_vertex_indices_to_grow;
+    vector<std::size_t> tree_vertex_indices_to_grow;
 
-    for (size_t i = 0; i < number_of_multivertex_components; ++i) {
+    for (std::size_t i = 0; i < number_of_multivertex_components; ++i) {
       // The initial seed node.
       tree_vertices.insert(next_vertex);
       tree_vertex_indices_to_grow.push_back(next_vertex);
@@ -69,7 +69,7 @@ struct ComponentsParameters {
 
       // Keep growing a random tree node.
       while (tree_vertices.size() < max_tree_size) {
-        const size_t node = rng.get_element(tree_vertex_indices_to_grow);
+        const std::size_t node = rng.get_element(tree_vertex_indices_to_grow);
         tree_vertex_indices_to_grow.push_back(next_vertex);
         tree_vertices.insert(next_vertex);
         neighbours[node].emplace_back(next_vertex);
@@ -81,16 +81,17 @@ struct ComponentsParameters {
 
       // Should be contiguous vertex indices.
       REQUIRE(!tree_vertices.empty());
-      const size_t min_index = *tree_vertices.cbegin();
-      const size_t max_index = *tree_vertices.crbegin();
+      const std::size_t min_index = *tree_vertices.cbegin();
+      const std::size_t max_index = *tree_vertices.crbegin();
       REQUIRE(tree_vertices.size() == max_index - min_index + 1);
       REQUIRE(max_index + 1 == next_vertex);
       tree_vertices.clear();
 
       // Add a few extra edges to the tree
-      for (size_t i = 0; i < max_number_of_extra_edges_to_add_to_tree; ++i) {
-        const size_t vertex1 = rng.get_size_t(min_index, max_index);
-        const size_t vertex2 = rng.get_size_t(min_index, max_index);
+      for (std::size_t i = 0; i < max_number_of_extra_edges_to_add_to_tree;
+           ++i) {
+        const std::size_t vertex1 = rng.get_size_t(min_index, max_index);
+        const std::size_t vertex2 = rng.get_size_t(min_index, max_index);
         if (vertex1 != vertex2) {
           neighbours[vertex1].emplace_back(vertex2);
         }
@@ -105,7 +106,7 @@ struct ComponentsParameters {
     data.raw_adjacency_data.resize(next_vertex);
     for (const auto& entry : neighbours) {
       auto& new_neighbours = data.raw_adjacency_data[new_indices[entry.first]];
-      for (size_t old_index : entry.second) {
+      for (std::size_t old_index : entry.second) {
         new_neighbours.emplace_back(new_indices[old_index]);
       }
     }
@@ -113,7 +114,7 @@ struct ComponentsParameters {
     for (auto& old_component : data.components) {
       const auto old_index_set = old_component;
       old_component.clear();
-      for (size_t old_index : old_index_set) {
+      for (std::size_t old_index : old_index_set) {
         old_component.insert(new_indices[old_index]);
       }
     }
@@ -152,12 +153,12 @@ SCENARIO("Correctly calculates graph components") {
 
         // KEY: the smallest vertex index in a component.
         // VALUE: the index in the test_data vector of components.
-        map<size_t, size_t> expected_components;
+        map<std::size_t, std::size_t> expected_components;
 
-        for (size_t i = 0; i < test_data.components.size(); ++i) {
+        for (std::size_t i = 0; i < test_data.components.size(); ++i) {
           const auto& single_component_set = test_data.components[i];
           REQUIRE(!single_component_set.empty());
-          const size_t lowest_index = *single_component_set.crbegin();
+          const std::size_t lowest_index = *single_component_set.crbegin();
           REQUIRE(expected_components.count(lowest_index) == 0);
           expected_components[lowest_index] = i;
         }
@@ -165,16 +166,16 @@ SCENARIO("Correctly calculates graph components") {
         // Now check the detailed components.
         for (const auto& calculated_component : calculated_components) {
           REQUIRE(!calculated_component.empty());
-          const size_t lowest_index = *calculated_component.crbegin();
+          const std::size_t lowest_index = *calculated_component.crbegin();
           REQUIRE(expected_components.count(lowest_index) != 0);
           const auto& expected_component_set =
               test_data.components[expected_components[lowest_index]];
 
           // The two sets must be identical.
-          for (size_t exp_index : expected_component_set) {
+          for (std::size_t exp_index : expected_component_set) {
             REQUIRE(calculated_component.count(exp_index) != 0);
           }
-          for (size_t calc_index : calculated_component) {
+          for (std::size_t calc_index : calculated_component) {
             REQUIRE(expected_component_set.count(calc_index) != 0);
           }
         }

--- a/tket/test/src/Graphs/test_GraphFindMaxClique.cpp
+++ b/tket/test/src/Graphs/test_GraphFindMaxClique.cpp
@@ -28,29 +28,29 @@ namespace graphs {
 namespace tests {
 
 struct MaxCliqueTestData {
-  vector<vector<size_t>> raw_adjacency_data;
+  vector<vector<std::size_t>> raw_adjacency_data;
   // It's not 100% guaranteed that there are no other cliques
   // of equal or larger size,
   // since by pure chance adding random edges might produce a larger clique.
-  vector<set<size_t>> cliques;
+  vector<set<std::size_t>> cliques;
 };
 
 // Used to test the maximum size clique function.
 struct MaxCliqueParameters {
-  size_t number_of_vertices = 20;
-  size_t max_clique_size = 4;
-  size_t approx_number_of_cliques = 3;
-  size_t approx_number_of_extra_edges = 5;
+  std::size_t number_of_vertices = 20;
+  std::size_t max_clique_size = 4;
+  std::size_t approx_number_of_cliques = 3;
+  std::size_t approx_number_of_extra_edges = 5;
 
   MaxCliqueTestData get_test_data(RNG& rng) const;
 };
 
 static void attempt_to_add_clique(
     const MaxCliqueParameters& parameters, RNG& rng, MaxCliqueTestData& data,
-    set<size_t>& clique_vertices) {
+    set<std::size_t>& clique_vertices) {
   clique_vertices.clear();
   bool should_add_clique = false;
-  for (size_t i = 0; i < 2 * parameters.max_clique_size; ++i) {
+  for (std::size_t i = 0; i < 2 * parameters.max_clique_size; ++i) {
     clique_vertices.insert(rng.get_size_t(parameters.number_of_vertices - 1));
     if (clique_vertices.size() == parameters.max_clique_size) {
       should_add_clique = true;
@@ -60,8 +60,8 @@ static void attempt_to_add_clique(
   if (should_add_clique) {
     data.cliques.emplace_back(clique_vertices);
     // Add the actual edges to make this a clique.
-    for (size_t i : clique_vertices) {
-      for (size_t j : clique_vertices) {
+    for (std::size_t i : clique_vertices) {
+      for (std::size_t j : clique_vertices) {
         if (i != j) {
           data.raw_adjacency_data[i].push_back(j);
         }
@@ -73,16 +73,18 @@ static void attempt_to_add_clique(
 MaxCliqueTestData MaxCliqueParameters::get_test_data(RNG& rng) const {
   MaxCliqueTestData data;
   data.raw_adjacency_data.resize(number_of_vertices);
-  set<size_t> clique_vertices;
+  set<std::size_t> clique_vertices;
 
-  for (size_t counter = 0; counter < 2 * approx_number_of_cliques; ++counter) {
+  for (std::size_t counter = 0; counter < 2 * approx_number_of_cliques;
+       ++counter) {
     attempt_to_add_clique(*this, rng, data, clique_vertices);
     if (data.cliques.size() >= approx_number_of_cliques) {
       break;
     }
   }
   // Finally, add extra edges.
-  for (size_t counter = 0; counter < approx_number_of_extra_edges; ++counter) {
+  for (std::size_t counter = 0; counter < approx_number_of_extra_edges;
+       ++counter) {
     const auto i = rng.get_size_t(number_of_vertices - 1);
     const auto j = rng.get_size_t(number_of_vertices - 1);
     if (i != j) {
@@ -93,14 +95,15 @@ MaxCliqueTestData MaxCliqueParameters::get_test_data(RNG& rng) const {
 }
 
 static bool is_clique(
-    const set<size_t>& vertices, const AdjacencyData& cleaned_adjacency_data) {
+    const set<std::size_t>& vertices,
+    const AdjacencyData& cleaned_adjacency_data) {
   if (vertices.size() < 2) {
     return true;
   }
   // simplest: just count the edges
-  size_t edge_count = 0;
-  for (size_t i : vertices) {
-    for (size_t j : vertices) {
+  std::size_t edge_count = 0;
+  for (std::size_t i : vertices) {
+    for (std::size_t j : vertices) {
       if (i < j && cleaned_adjacency_data.edge_exists(i, j)) {
         ++edge_count;
       }
@@ -110,12 +113,13 @@ static bool is_clique(
 }
 
 static bool set_is_present(
-    const set<size_t>& vertices, const vector<set<size_t>>& vertex_set_list) {
+    const set<std::size_t>& vertices,
+    const vector<set<std::size_t>>& vertex_set_list) {
   // Note: cliques CAN overlap, e.g.
   // consider two triangles {1,2,3} and {1,2,4}, with no edge between 3,4.
   for (const auto& other_set : vertex_set_list) {
-    size_t vertex_count = 0;
-    for (size_t i : vertices) {
+    std::size_t vertex_count = 0;
+    for (std::size_t i : vertices) {
       vertex_count += other_set.count(i);
     }
     if (vertex_count == vertices.size() && vertex_count == other_set.size()) {
@@ -126,10 +130,10 @@ static bool set_is_present(
 }
 
 // Returns the size of each clique (they should all be equal)
-static size_t check_that_calculated_cliques_are_valid(
-    const vector<set<size_t>>& calculated_clique_data,
+static std::size_t check_that_calculated_cliques_are_valid(
+    const vector<set<std::size_t>>& calculated_clique_data,
     const AdjacencyData& cleaned_adjacency_data) {
-  set<size_t> clique_sizes;
+  set<std::size_t> clique_sizes;
   for (const auto& calc_clique : calculated_clique_data) {
     clique_sizes.insert(calc_clique.size());
     REQUIRE(is_clique(calc_clique, cleaned_adjacency_data));
@@ -137,7 +141,7 @@ static size_t check_that_calculated_cliques_are_valid(
   // There ARE some cliques, and they are all of the same size!
   REQUIRE(clique_sizes.size() == 1);
   //...and of nonzero size...
-  const size_t max_clique_size_in_this_component = *clique_sizes.cbegin();
+  const std::size_t max_clique_size_in_this_component = *clique_sizes.cbegin();
   REQUIRE(max_clique_size_in_this_component > 0);
   return max_clique_size_in_this_component;
 }
@@ -147,11 +151,12 @@ static size_t check_that_calculated_cliques_are_valid(
 // than the calculated clique size,
 // so we do not epect to see the clique (as it's not of MAXIMUM possible size).
 static bool expected_clique_is_present(
-    const set<size_t>& expected_clique_vertices,
-    const vector<set<size_t>>& calculated_clique_data,
-    const set<size_t>& component, size_t max_clique_size_in_this_component) {
-  size_t expected_vertices_present = 0;
-  for (size_t vertex : expected_clique_vertices) {
+    const set<std::size_t>& expected_clique_vertices,
+    const vector<set<std::size_t>>& calculated_clique_data,
+    const set<std::size_t>& component,
+    std::size_t max_clique_size_in_this_component) {
+  std::size_t expected_vertices_present = 0;
+  for (std::size_t vertex : expected_clique_vertices) {
     expected_vertices_present += component.count(vertex);
   }
   if (expected_vertices_present == 0) {
@@ -175,20 +180,20 @@ static bool expected_clique_is_present(
 // the expected/calculated cliques.
 static void test_cliques_in_single_component(
     const MaxCliqueTestData& test_data,
-    const AdjacencyData& cleaned_adjacency_data, const set<size_t>& component,
-    set<size_t>& clique_indices_seen) {
+    const AdjacencyData& cleaned_adjacency_data,
+    const set<std::size_t>& component, set<std::size_t>& clique_indices_seen) {
   const LargeCliquesResult calculated_clique_result(
       cleaned_adjacency_data, component, 1000);
 
   REQUIRE(calculated_clique_result.cliques_are_definitely_max_size);
 
-  const size_t max_calc_clique_size_in_this_component =
+  const std::size_t max_calc_clique_size_in_this_component =
       check_that_calculated_cliques_are_valid(
           calculated_clique_result.cliques, cleaned_adjacency_data);
 
   // Which EXPECTED cliques in this component are present
   // in the list of calculated cliques?
-  for (size_t clique_index = 0; clique_index < test_data.cliques.size();
+  for (std::size_t clique_index = 0; clique_index < test_data.cliques.size();
        ++clique_index) {
     const auto& expected_clique_vertices = test_data.cliques[clique_index];
     if (expected_clique_is_present(
@@ -200,11 +205,11 @@ static void test_cliques_in_single_component(
 }
 
 // Returns the number of cliques seen, just as an extra check.
-static size_t test_max_clique_generated_data(
+static std::size_t test_max_clique_generated_data(
     const MaxCliqueTestData& test_data) {
   // We'll check at the end that every expected clique DID occur.
   // The indices are for the vector of index sets.
-  set<size_t> clique_indices_seen;
+  set<std::size_t> clique_indices_seen;
 
   const AdjacencyData cleaned_adjacency_data(test_data.raw_adjacency_data);
 
@@ -228,7 +233,7 @@ static size_t test_max_clique_generated_data(
 SCENARIO("Correctly calculates max cliques") {
   RNG rng;
   MaxCliqueParameters parameters;
-  size_t cliques_seen = 0;
+  std::size_t cliques_seen = 0;
 
   for (parameters.number_of_vertices = 10; parameters.number_of_vertices < 50;
        parameters.number_of_vertices += 20) {

--- a/tket/test/src/TokenSwapping/TestUtils/BestTsaTester.cpp
+++ b/tket/test/src/TokenSwapping/TestUtils/BestTsaTester.cpp
@@ -37,7 +37,7 @@ namespace {
 // vertex relabelling takes place.
 // Thus we need an extra layer of conversion to get back what we want.
 struct VertexRelabellingManager {
-  std::map<unsigned, size_t> raw_to_internal_map;
+  std::map<unsigned, std::size_t> raw_to_internal_map;
   // The internal indices are, of course, 0,1,2,...,N for some N,
   // and therefore we can use a vector instead of a map.
   vector<unsigned> internal_to_raw_map;
@@ -47,7 +47,7 @@ struct VertexRelabellingManager {
   explicit VertexRelabellingManager(
       const vector<std::pair<unsigned, unsigned>>& raw_edges) {
     for (auto edge : raw_edges) {
-      size_t next_index = raw_to_internal_map.size();
+      std::size_t next_index = raw_to_internal_map.size();
       if (raw_to_internal_map.count(edge.first) == 0) {
         raw_to_internal_map[edge.first] = next_index;
       }
@@ -81,7 +81,7 @@ struct VertexRelabellingManager {
 };
 }  // namespace
 
-size_t BestTsaTester::get_checked_solution_size(
+std::size_t BestTsaTester::get_checked_solution_size(
     const DecodedProblemData& problem_data) {
   m_architecture_work_data.edges.clear();
   for (const auto& swap : problem_data.swaps) {
@@ -91,7 +91,7 @@ size_t BestTsaTester::get_checked_solution_size(
   return get_checked_solution_size(problem_data, m_architecture_work_data);
 }
 
-size_t BestTsaTester::get_checked_solution_size(
+std::size_t BestTsaTester::get_checked_solution_size(
     const DecodedProblemData& problem_data,
     const DecodedArchitectureData& architecture_data) {
   CHECK(problem_data.number_of_vertices >= 4);

--- a/tket/test/src/TokenSwapping/TestUtils/BestTsaTester.hpp
+++ b/tket/test/src/TokenSwapping/TestUtils/BestTsaTester.hpp
@@ -33,7 +33,7 @@ class BestTsaTester {
    * @return The number of swaps returned by our TSA. The calculated swaps are
    * also checked for correctness.
    */
-  size_t get_checked_solution_size(const DecodedProblemData& data);
+  std::size_t get_checked_solution_size(const DecodedProblemData& data);
 
   /** For problems where the architecture is NOT simply given implicitly
    *  by the swap sequence, so we must also pass in the complete set
@@ -45,7 +45,7 @@ class BestTsaTester {
    * @return The number of swaps returned by our TSA. The calculated swaps are
    * also checked for correctness.
    */
-  size_t get_checked_solution_size(
+  std::size_t get_checked_solution_size(
       const DecodedProblemData& problem_data,
       const DecodedArchitectureData& architecture_data);
 

--- a/tket/test/src/TokenSwapping/TestUtils/DebugFunctions.cpp
+++ b/tket/test/src/TokenSwapping/TestUtils/DebugFunctions.cpp
@@ -38,7 +38,7 @@ std::string str(const std::vector<Swap>& swaps) {
   return ss.str();
 }
 
-size_t get_swaps_lower_bound(
+std::size_t get_swaps_lower_bound(
     const VertexMapping& vertex_mapping,
     DistancesInterface& distances_calculator) {
   // Each swap decreases the sum by at most 2 (and more likely 1 in many cases,

--- a/tket/test/src/TokenSwapping/TestUtils/DebugFunctions.hpp
+++ b/tket/test/src/TokenSwapping/TestUtils/DebugFunctions.hpp
@@ -57,7 +57,7 @@ std::string str(const std::vector<Swap>& swaps);
  *    the value seems about as hard as finding an actual solution, and thus
  *    is possibly exponentially hard (seems to be unknown, even for trees).
  */
-size_t get_swaps_lower_bound(
+std::size_t get_swaps_lower_bound(
     const VertexMapping& vertex_mapping, DistancesInterface& distances);
 
 }  // namespace tsa_internal

--- a/tket/test/src/TokenSwapping/TestUtils/DecodedProblemData.cpp
+++ b/tket/test/src/TokenSwapping/TestUtils/DecodedProblemData.cpp
@@ -59,17 +59,17 @@ static const std::string& encoding_chars() {
   return chars;
 }
 
-static std::map<unsigned char, size_t> get_char_to_vertex_map_local() {
-  std::map<unsigned char, size_t> char_to_vertex_map;
+static std::map<unsigned char, std::size_t> get_char_to_vertex_map_local() {
+  std::map<unsigned char, std::size_t> char_to_vertex_map;
   const auto& chars = encoding_chars();
-  for (size_t ii = 0; ii < chars.size(); ++ii) {
+  for (std::size_t ii = 0; ii < chars.size(); ++ii) {
     char_to_vertex_map[chars[ii]] = ii;
   }
   return char_to_vertex_map;
 }
 
-static const std::map<unsigned char, size_t>& char_to_vertex_map() {
-  static const std::map<unsigned char, size_t> map(
+static const std::map<unsigned char, std::size_t>& char_to_vertex_map() {
+  static const std::map<unsigned char, std::size_t> map(
       get_char_to_vertex_map_local());
   return map;
 }
@@ -95,7 +95,7 @@ DecodedProblemData::DecodedProblemData(
     index += 2;
   }
 
-  std::set<size_t> vertices;
+  std::set<std::size_t> vertices;
   for (auto swap : swaps) {
     vertices.insert(swap.first);
     vertices.insert(swap.second);
@@ -136,8 +136,8 @@ DecodedArchitectureData::DecodedArchitectureData() : number_of_vertices(0) {}
 
 DecodedArchitectureData::DecodedArchitectureData(
     const std::string& solution_edges_string) {
-  vector<vector<size_t>> neighbours(1);
-  std::set<size_t> vertices_seen;
+  vector<vector<std::size_t>> neighbours(1);
+  std::set<std::size_t> vertices_seen;
   for (unsigned char ch : solution_edges_string) {
     if (ch != ':') {
       const auto new_v = char_to_vertex_map().at(ch);
@@ -159,7 +159,7 @@ DecodedArchitectureData::DecodedArchitectureData(
   REQUIRE(!vertices_seen.empty());
   REQUIRE(*vertices_seen.crbegin() <= neighbours.size());
 
-  for (size_t ii = 0; ii < neighbours.size(); ++ii) {
+  for (std::size_t ii = 0; ii < neighbours.size(); ++ii) {
     if (neighbours[ii].empty()) {
       continue;
     }

--- a/tket/test/src/TokenSwapping/TestUtils/DecodedProblemData.hpp
+++ b/tket/test/src/TokenSwapping/TestUtils/DecodedProblemData.hpp
@@ -35,7 +35,7 @@ struct DecodedProblemData {
   /** The desired source->target mapping for a problem. */
   VertexMapping vertex_mapping;
 
-  size_t number_of_vertices;
+  std::size_t number_of_vertices;
 
   /** Do we require the vertex numbers to be {0,1,2,...,m}, with no gaps? */
   enum class RequireContiguousVertices { YES, NO };
@@ -58,7 +58,7 @@ struct DecodedArchitectureData {
   std::set<Swap> edges;
 
   /** The vertex numbers are contiguous, i.e. 0,1,2,...N for some N. */
-  size_t number_of_vertices;
+  std::size_t number_of_vertices;
 
   /** Simply without filling any data. */
   DecodedArchitectureData();

--- a/tket/test/src/TokenSwapping/TestUtils/FullTsaTesting.cpp
+++ b/tket/test/src/TokenSwapping/TestUtils/FullTsaTesting.cpp
@@ -31,8 +31,8 @@ namespace tsa_internal {
 namespace tests {
 
 void FullTsaTesting::check_solution(
-    size_t counts_list_index, VertexMapping vertex_mapping, size_t lower_bound,
-    AllowEmptySwaps allow_empty_swaps) {
+    std::size_t counts_list_index, VertexMapping vertex_mapping,
+    std::size_t lower_bound, AllowEmptySwaps allow_empty_swaps) {
   bool empty_swap_occurred = false;
   REQUIRE(m_swap_list.size() >= lower_bound);
   for (auto swap : m_swap_list.to_vector()) {
@@ -55,7 +55,7 @@ void FullTsaTesting::check_solution(
 }
 
 void FullTsaTesting::check_equivalent_good_solution(
-    size_t existing_index, VertexMapping vertex_mapping,
+    std::size_t existing_index, VertexMapping vertex_mapping,
     AllowEmptySwaps allow_empty_swaps) {
   check_solution(
       m_counts_list.size() - 1, vertex_mapping, 0, allow_empty_swaps);
@@ -65,7 +65,7 @@ void FullTsaTesting::check_equivalent_good_solution(
       m_counts_list.back().sorted_swaps);
 }
 
-void FullTsaTesting::test_order(size_t index1, size_t index2) const {
+void FullTsaTesting::test_order(std::size_t index1, std::size_t index2) const {
   INFO("i1=" << index1 << ", i2=" << index2);
   CHECK(
       m_counts_list[index1].sorted_swaps.size() <=
@@ -73,19 +73,19 @@ void FullTsaTesting::test_order(size_t index1, size_t index2) const {
 }
 
 void FullTsaTesting::complete_counts_list_for_single_problem() {
-  size_t smallest_number = m_counts_list[0].sorted_swaps.size();
+  std::size_t smallest_number = m_counts_list[0].sorted_swaps.size();
 
   // Ignore the last index, which is a dummy.
-  for (size_t index = 0; index + 1 < m_counts_list.size(); ++index) {
+  for (std::size_t index = 0; index + 1 < m_counts_list.size(); ++index) {
     auto& counts = m_counts_list[index];
     counts.total_swaps += counts.sorted_swaps.size();
     smallest_number = std::min(smallest_number, counts.sorted_swaps.size());
   }
   // Now, we've got the (joint) winner.
-  size_t best_index = m_counts_list.size();
-  size_t num_winners = 0;
+  std::size_t best_index = m_counts_list.size();
+  std::size_t num_winners = 0;
 
-  for (size_t index = 0; index + 1 < m_counts_list.size(); ++index) {
+  for (std::size_t index = 0; index + 1 < m_counts_list.size(); ++index) {
     auto& counts = m_counts_list[index];
     REQUIRE(counts.sorted_swaps.size() >= smallest_number);
     if (counts.sorted_swaps.size() == smallest_number) {
@@ -126,7 +126,7 @@ void FullTsaTesting::add_problems(
   vector<Swap> raw_calc_swaps;
   VertexMapping problem_copy_to_destroy;
 
-  for (size_t prob_index = 0; prob_index < problems.size(); ++prob_index) {
+  for (std::size_t prob_index = 0; prob_index < problems.size(); ++prob_index) {
     const auto& problem = problems[prob_index];
     const auto lower_bound = get_swaps_lower_bound(problem, distances);
     m_number_of_tokens += problem.size();
@@ -213,15 +213,15 @@ std::string FullTsaTesting::str() const {
      << m_number_of_tokens << " toks; " << m_total_lower_bounds
      << " tot.lb]\n[Total swaps:";
   // The last entry is a "dummy".
-  for (size_t index = 0; index + 1 < m_counts_list.size(); ++index) {
+  for (std::size_t index = 0; index + 1 < m_counts_list.size(); ++index) {
     ss << " " << m_counts_list[index].total_swaps;
   }
   ss << "]\n[Winners: joint:";
-  for (size_t index = 0; index + 1 < m_counts_list.size(); ++index) {
+  for (std::size_t index = 0; index + 1 < m_counts_list.size(); ++index) {
     ss << " " << m_counts_list[index].problems_where_this_was_the_joint_winner;
   }
   ss << "  undisputed:";
-  for (size_t index = 0; index + 1 < m_counts_list.size(); ++index) {
+  for (std::size_t index = 0; index + 1 < m_counts_list.size(); ++index) {
     ss << " " << m_counts_list[index].problems_where_this_was_the_clear_winner;
   }
   ss << "]";

--- a/tket/test/src/TokenSwapping/TestUtils/FullTsaTesting.hpp
+++ b/tket/test/src/TokenSwapping/TestUtils/FullTsaTesting.hpp
@@ -43,9 +43,9 @@ class FullTsaTesting {
   // For various optimisation passes, we check how well they did,
   // and we record when a particular one beats
   struct Counts {
-    size_t total_swaps = 0;
-    size_t problems_where_this_was_the_joint_winner = 0;
-    size_t problems_where_this_was_the_clear_winner = 0;
+    std::size_t total_swaps = 0;
+    std::size_t problems_where_this_was_the_joint_winner = 0;
+    std::size_t problems_where_this_was_the_clear_winner = 0;
 
     // Reset this with each new calculated solution; this checks whether
     // newly calculated solutions really are just a permutation of an existing
@@ -53,9 +53,9 @@ class FullTsaTesting {
     std::vector<Swap> sorted_swaps;
   };
 
-  size_t m_total_lower_bounds = 0;
-  size_t m_number_of_problems = 0;
-  size_t m_number_of_tokens = 0;
+  std::size_t m_total_lower_bounds = 0;
+  std::size_t m_number_of_problems = 0;
+  std::size_t m_number_of_tokens = 0;
   SwapList m_swap_list;
   SwapListOptimiser m_optimiser;
   std::vector<Counts> m_counts_list;
@@ -67,18 +67,18 @@ class FullTsaTesting {
   // Check that the swaps currently stored in m_swap_list are correct,
   // and store the data in m_counts_list (if the index is not too big).
   void check_solution(
-      size_t counts_list_index, VertexMapping vertex_mapping,
-      size_t lower_bound, AllowEmptySwaps allow_empty_swaps);
+      std::size_t counts_list_index, VertexMapping vertex_mapping,
+      std::size_t lower_bound, AllowEmptySwaps allow_empty_swaps);
 
   // Check that the swaps currently stored in m_swap_list are correct.
   // Check also that they are a reordering of those
   // already calculated and stored in m_counts_list, at the given index.
   void check_equivalent_good_solution(
-      size_t existing_index, VertexMapping vertex_mapping,
+      std::size_t existing_index, VertexMapping vertex_mapping,
       AllowEmptySwaps allow_empty_swaps);
 
   // In m_counts_list, the swaps for i1 should be <= the swaps for i2.
-  void test_order(size_t index1, size_t index2) const;
+  void test_order(std::size_t index1, std::size_t index2) const;
 
   void complete_counts_list_for_single_problem();
 };

--- a/tket/test/src/TokenSwapping/TestUtils/GetRandomSet.cpp
+++ b/tket/test/src/TokenSwapping/TestUtils/GetRandomSet.cpp
@@ -21,11 +21,11 @@ namespace tket {
 namespace tsa_internal {
 namespace tests {
 
-std::set<size_t> get_random_set(
-    RNG& rng, size_t sample_size, size_t population_size) {
+std::set<std::size_t> get_random_set(
+    RNG& rng, std::size_t sample_size, std::size_t population_size) {
   TKET_ASSERT(sample_size <= population_size);
 
-  std::set<size_t> result;
+  std::set<std::size_t> result;
   if (sample_size == 0 || population_size == 0) {
     return result;
   }
@@ -35,7 +35,7 @@ std::set<size_t> get_random_set(
     }
     return result;
   }
-  std::vector<size_t> elems(population_size);
+  std::vector<std::size_t> elems(population_size);
   std::iota(elems.begin(), elems.end(), 0);
   rng.do_shuffle(elems);
   for (const auto& elem : elems) {

--- a/tket/test/src/TokenSwapping/TestUtils/GetRandomSet.hpp
+++ b/tket/test/src/TokenSwapping/TestUtils/GetRandomSet.hpp
@@ -28,8 +28,8 @@ namespace tests {
  *    of nonnegative integers, starting at 0).
  *  @return A set of numbers. Throws upon invalid parameters.
  */
-std::set<size_t> get_random_set(
-    RNG& rng, size_t sample_size, size_t population_size);
+std::set<std::size_t> get_random_set(
+    RNG& rng, std::size_t sample_size, std::size_t population_size);
 
 }  // namespace tests
 }  // namespace tsa_internal

--- a/tket/test/src/TokenSwapping/TestUtils/PartialTsaTesting.cpp
+++ b/tket/test/src/TokenSwapping/TestUtils/PartialTsaTesting.cpp
@@ -30,7 +30,7 @@ namespace tsa_internal {
 namespace tests {
 
 // Also checks if an empty token pair swap occurs.
-static size_t get_recalculated_final_L(
+static std::size_t get_recalculated_final_L(
     VertexMapping problem, const SwapList& swap_list,
     DistancesInterface& distances, TokenOption token_option) {
   bool empty_tok_swap = false;
@@ -51,7 +51,7 @@ static size_t get_recalculated_final_L(
 }
 
 static void check_progress(
-    size_t init_L, size_t final_L, RequiredTsaProgress progress) {
+    std::size_t init_L, std::size_t final_L, RequiredTsaProgress progress) {
   REQUIRE(final_L <= init_L);
   switch (progress) {
     case RequiredTsaProgress::FULL:

--- a/tket/test/src/TokenSwapping/TestUtils/ProblemGeneration.cpp
+++ b/tket/test/src/TokenSwapping/TestUtils/ProblemGeneration.cpp
@@ -44,7 +44,7 @@ VertexMapping TSProblemParameters00::get_problem(
       get_random_set(rng, number_of_tokens, number_of_vertices);
   REQUIRE(tokens.size() == number_of_tokens);
   REQUIRE(targets_set.size() == number_of_tokens);
-  vector<size_t> targets{targets_set.cbegin(), targets_set.cend()};
+  vector<std::size_t> targets{targets_set.cbegin(), targets_set.cend()};
   for (auto token : tokens) {
     vertex_mapping[token] = rng.get_and_remove_element(targets);
   }

--- a/tket/test/src/TokenSwapping/TestUtils/TestStatsStructs.cpp
+++ b/tket/test/src/TokenSwapping/TestUtils/TestStatsStructs.cpp
@@ -22,14 +22,15 @@ namespace tket {
 namespace tsa_internal {
 namespace tests {
 
-void MinMaxAv::add(size_t result) {
+void MinMaxAv::add(std::size_t result) {
   min = std::min(min, result);
   max = std::max(max, result);
   total += result;
 }
 
 void PartialTsaStatistics::add_problem_result(
-    size_t initial_L, size_t final_L, size_t tokens, size_t swaps) {
+    std::size_t initial_L, std::size_t final_L, std::size_t tokens,
+    std::size_t swaps) {
   REQUIRE(final_L <= initial_L);
   REQUIRE(final_L + 2 * swaps >= initial_L);
   total_number_of_tokens += tokens;
@@ -41,7 +42,7 @@ void PartialTsaStatistics::add_problem_result(
   }
   ++number_of_problems;
   total_of_L += initial_L;
-  const size_t l_decrease = initial_L - final_L;
+  const std::size_t l_decrease = initial_L - final_L;
   total_of_L_decreases += l_decrease;
 
   l_decrease_percentages.add((100 * (initial_L - final_L)) / initial_L);
@@ -53,7 +54,7 @@ void PartialTsaStatistics::add_problem_result(
   }
 }
 
-std::string PartialTsaStatistics::str(size_t number_of_problems) const {
+std::string PartialTsaStatistics::str(std::size_t number_of_problems) const {
   REQUIRE(number_of_problems != 0);
   std::stringstream ss;
   ss << total_number_of_tokens << " tokens; " << total_of_L << " total L; "

--- a/tket/test/src/TokenSwapping/TestUtils/TestStatsStructs.hpp
+++ b/tket/test/src/TokenSwapping/TestUtils/TestStatsStructs.hpp
@@ -21,19 +21,19 @@ namespace tsa_internal {
 namespace tests {
 
 struct MinMaxAv {
-  size_t min = std::numeric_limits<size_t>::max();
-  size_t max = 0;
-  size_t total = 0;
+  std::size_t min = std::numeric_limits<std::size_t>::max();
+  std::size_t max = 0;
+  std::size_t total = 0;
 
-  void add(size_t result);
+  void add(std::size_t result);
 };
 
 struct PartialTsaStatistics {
-  size_t number_of_problems = 0;
-  size_t total_of_L = 0;
-  size_t total_of_L_decreases = 0;
-  size_t total_number_of_tokens = 0;
-  size_t total_number_of_swaps = 0;
+  std::size_t number_of_problems = 0;
+  std::size_t total_of_L = 0;
+  std::size_t total_of_L_decreases = 0;
+  std::size_t total_number_of_tokens = 0;
+  std::size_t total_number_of_swaps = 0;
 
   MinMaxAv l_decrease_percentages;
 
@@ -44,9 +44,10 @@ struct PartialTsaStatistics {
   MinMaxAv powers;
 
   void add_problem_result(
-      size_t initial_L, size_t final_L, size_t tokens, size_t swaps);
+      std::size_t initial_L, std::size_t final_L, std::size_t tokens,
+      std::size_t swaps);
 
-  std::string str(size_t number_of_problems) const;
+  std::string str(std::size_t number_of_problems) const;
 };
 
 }  // namespace tests

--- a/tket/test/src/TokenSwapping/test_BestTsaFixedSwapSequences.cpp
+++ b/tket/test/src/TokenSwapping/test_BestTsaFixedSwapSequences.cpp
@@ -32,20 +32,20 @@ namespace tests {
 
 namespace {
 struct FixedSeqsStats {
-  size_t equivalent_solns = 0;
-  size_t equivalent_solns_swaps = 0;
-  size_t better_solns = 0;
-  size_t better_solns_swaps = 0;
-  size_t better_solns_known_swaps = 0;
-  size_t better_solns_total_swap_diff = 0;
-  size_t better_solns_percent_decr_total = 0;
-  size_t worse_solns = 0;
-  size_t worse_solns_swaps = 0;
-  size_t worse_solns_known_swaps = 0;
-  size_t worse_solns_total_swap_diff = 0;
-  size_t worse_solns_percent_incr_total = 0;
+  std::size_t equivalent_solns = 0;
+  std::size_t equivalent_solns_swaps = 0;
+  std::size_t better_solns = 0;
+  std::size_t better_solns_swaps = 0;
+  std::size_t better_solns_known_swaps = 0;
+  std::size_t better_solns_total_swap_diff = 0;
+  std::size_t better_solns_percent_decr_total = 0;
+  std::size_t worse_solns = 0;
+  std::size_t worse_solns_swaps = 0;
+  std::size_t worse_solns_known_swaps = 0;
+  std::size_t worse_solns_total_swap_diff = 0;
+  std::size_t worse_solns_percent_incr_total = 0;
 
-  void add(size_t known_size, size_t calc_size) {
+  void add(std::size_t known_size, std::size_t calc_size) {
     if (known_size == calc_size) {
       ++equivalent_solns;
       equivalent_solns_swaps += known_size;
@@ -70,11 +70,11 @@ struct FixedSeqsStats {
 
   std::string str() const {
     std::stringstream ss;
-    size_t good_soln_av_decr = 0;
+    std::size_t good_soln_av_decr = 0;
     if (better_solns > 0) {
       good_soln_av_decr = better_solns_percent_decr_total / better_solns;
     }
-    size_t bad_soln_av_incr = 0;
+    std::size_t bad_soln_av_incr = 0;
     if (worse_solns > 0) {
       bad_soln_av_incr = worse_solns_percent_incr_total / worse_solns;
     }

--- a/tket/test/src/TokenSwapping/test_DistancesFromArchitecture.cpp
+++ b/tket/test/src/TokenSwapping/test_DistancesFromArchitecture.cpp
@@ -31,7 +31,7 @@ SCENARIO("Architecture with disconnected graph") {
   // different connected components.
   const std::vector<std::pair<unsigned, unsigned>> edges{
       {0, 1}, {0, 2}, {1, 3}, {4, 5}};
-  const size_t number_of_vertices = 6;
+  const std::size_t number_of_vertices = 6;
   const Architecture arch(edges);
   // Note: it's a "coincidence" that the vertex numbers are unchanged,
   // because 0,1,2,3,4,5 are first seen in this order.
@@ -39,8 +39,8 @@ SCENARIO("Architecture with disconnected graph") {
   REQUIRE(mapping.number_of_vertices() == number_of_vertices);
   DistancesFromArchitecture dist_calculator(mapping);
   std::stringstream summary;
-  for (size_t v1 = 0; v1 < number_of_vertices; ++v1) {
-    for (size_t v2 = 0; v2 < number_of_vertices; ++v2) {
+  for (std::size_t v1 = 0; v1 < number_of_vertices; ++v1) {
+    for (std::size_t v2 = 0; v2 < number_of_vertices; ++v2) {
       summary << "d(" << v1 << "," << v2 << ")=";
       try {
         const auto distance = dist_calculator(v1, v2);

--- a/tket/test/src/TokenSwapping/test_FullTsa.cpp
+++ b/tket/test/src/TokenSwapping/test_FullTsa.cpp
@@ -70,13 +70,13 @@ SCENARIO("Full TSA: stars") {
       "[Star5: 51528: v6 i1 f100 s1: 100 problems; 270 tokens]",
       "[Star10: 51662: v11 i1 f100 s1: 100 problems; 515 tokens]",
       "[Star20: 51494: v21 i1 f100 s1: 100 problems; 1015 tokens]"};
-  const vector<size_t> num_spokes{3, 5, 10, 20};
+  const vector<std::size_t> num_spokes{3, 5, 10, 20};
   FullTester tester;
   tester.test_name = "Stars";
   std::string arch_name;
   vector<std::pair<unsigned, unsigned>> edges;
 
-  for (size_t index = 0; index < problem_messages.size(); ++index) {
+  for (std::size_t index = 0; index < problem_messages.size(); ++index) {
     arch_name = "Star" + std::to_string(num_spokes[index]);
     edges.clear();
     for (unsigned vv = 1; vv <= num_spokes[index]; ++vv) {
@@ -104,13 +104,13 @@ SCENARIO("Full TSA: wheels") {
       "[Wheel10: 51662: v11 i1 f100 s1: 100 problems; 515 tokens]",
       "[Wheel20: 51494: v21 i1 f100 s1: 100 problems; 1015 tokens]"};
 
-  const vector<size_t> num_spokes{3, 5, 10, 20};
+  const vector<std::size_t> num_spokes{3, 5, 10, 20};
   FullTester tester;
   tester.test_name = "Wheels";
   std::string arch_name;
   vector<std::pair<unsigned, unsigned>> edges;
 
-  for (size_t index = 0; index < problem_messages.size(); ++index) {
+  for (std::size_t index = 0; index < problem_messages.size(); ++index) {
     arch_name = "Wheel" + std::to_string(num_spokes[index]);
     edges.clear();
     for (unsigned vv = 1; vv <= num_spokes[index]; ++vv) {
@@ -142,12 +142,12 @@ SCENARIO("Full TSA: Rings") {
       "[Ring5: 51644: v5 i1 f100 s1: 100 problems; 224 tokens]",
       "[Ring10: 51634: v10 i1 f100 s1: 100 problems; 469 tokens]",
       "[Ring20: 51498: v20 i1 f100 s1: 100 problems; 974 tokens]"};
-  const vector<size_t> num_vertices{3, 5, 10, 20};
+  const vector<std::size_t> num_vertices{3, 5, 10, 20};
   FullTester tester;
   tester.test_name = "Rings";
   std::string arch_name;
 
-  for (size_t index = 0; index < problem_messages.size(); ++index) {
+  for (std::size_t index = 0; index < problem_messages.size(); ++index) {
     const RingArch arch(num_vertices[index]);
     arch_name = "Ring" + std::to_string(num_vertices[index]);
     const ArchitectureMapping arch_mapping(arch);
@@ -181,7 +181,7 @@ SCENARIO("Full TSA: Square Grids") {
   FullTester tester;
   tester.test_name = "Square grids";
 
-  for (size_t index = 0; index < grid_parameters.size(); ++index) {
+  for (std::size_t index = 0; index < grid_parameters.size(); ++index) {
     const auto& parameters = grid_parameters[index];
 
     // NOTE: if we used a SquareGrid architecture object, then results
@@ -230,7 +230,7 @@ SCENARIO("Full TSA: Random trees") {
   tester.test_name = "Trees";
   std::string arch_name;
 
-  for (size_t index = 0; index < problem_messages.size(); ++index) {
+  for (std::size_t index = 0; index < problem_messages.size(); ++index) {
     tree_generator.min_number_of_children = index;
     tree_generator.max_number_of_children = 2 + 2 * index;
     tree_generator.approx_number_of_vertices =

--- a/tket/test/src/TokenSwapping/test_SwapsFromQubitMapping.cpp
+++ b/tket/test/src/TokenSwapping/test_SwapsFromQubitMapping.cpp
@@ -44,8 +44,8 @@ SCENARIO("get_swaps : swaps returned directly from architecture") {
   }
 
   // Key: a node Value: its original position in "nodes"
-  std::map<Node, size_t> original_vertex_indices;
-  for (size_t ii = 0; ii < nodes.size(); ++ii) {
+  std::map<Node, std::size_t> original_vertex_indices;
+  for (std::size_t ii = 0; ii < nodes.size(); ++ii) {
     original_vertex_indices[nodes[ii]] = ii;
   }
   RNG rng_to_generate_swaps;
@@ -55,7 +55,7 @@ SCENARIO("get_swaps : swaps returned directly from architecture") {
 
   problem_ss << " Node mapping:";
   BestTsaWithArch::NodeMapping node_mapping;
-  for (size_t ii = 0; ii < nodes.size(); ++ii) {
+  for (std::size_t ii = 0; ii < nodes.size(); ++ii) {
     problem_ss << "\ni=" << ii << " : " << node_final_positions[ii].repr()
                << " -> " << nodes[ii].repr();
     node_mapping[node_final_positions[ii]] = nodes[ii];

--- a/tket/test/src/TokenSwapping/test_VariousPartialTsa.cpp
+++ b/tket/test/src/TokenSwapping/test_VariousPartialTsa.cpp
@@ -40,7 +40,7 @@ struct Tester {
 
   void run_test(
       const ArchitectureMapping& arch_mapping,
-      const vector<VertexMapping>& problems, size_t index) const {
+      const vector<VertexMapping>& problems, std::size_t index) const {
     trivial_tsa.set(TrivialTSA::Options::FULL_TSA);
     CHECK(
         run_tests(
@@ -168,7 +168,7 @@ SCENARIO("Partial TSA: Rings") {
   std::string arch_name;
   const ProblemGenerator00 generator;
 
-  for (size_t index = 0; index < problem_messages.size(); ++index) {
+  for (std::size_t index = 0; index < problem_messages.size(); ++index) {
     auto num_vertices = index + 3;
     if (num_vertices == 8) {
       num_vertices = 30;
@@ -229,7 +229,7 @@ SCENARIO("Partial TSA: Square grid") {
 
   const ProblemGenerator00 generator;
 
-  for (size_t index = 0; index < grid_parameters.size(); ++index) {
+  for (std::size_t index = 0; index < grid_parameters.size(); ++index) {
     const auto& parameters = grid_parameters[index];
 
     const auto edges =


### PR DESCRIPTION
This is in accordance with the C++ spec (`size_t` is part of the standard library). It's not clear why we get away with `size_t` but some compilers do complain about it.

Touches lots of files I'm afraid but it's all the same change.