### PR TITLE
Add warning about MacOS and conda to package documentation.

### DIFF
--- a/pytket/package.md
+++ b/pytket/package.md
@@ -18,6 +18,11 @@ To install the pytket extension modules add a hyphen and the extension name to t
 
 For a list of pytket extensions see this page: https://cqcl.github.io/pytket-extensions/api/index.html.
 
+_Warning._ There is a [known issue](https://github.com/CQCL/tket/issues/926)
+with installing pytket in a conda environment on MacOS: you may not be able to
+install versions more recent then 1.11.0. The only known remedy is to use an
+official Python distribution instead.
+
 ## Documentation and Examples
 
 API reference: https://cqcl.github.io/tket/pytket/api/


### PR DESCRIPTION
(This appears on the pypi page. Is there anywhere else we should put this?)