### PR TITLE
Give higher priority to `ZZPhase` when using `auto_rebase_pass()`

### DIFF
--- a/pytket/docs/changelog.rst
+++ b/pytket/docs/changelog.rst
@@ -7,7 +7,8 @@ Changelog
 Minor new features:
 
 * New constructor for ``ToffoliBox`` that allows switching between two decomposition strategies:
-  ``ToffoliBoxSynthStrat.Matching`` and ``ToffoliBoxSynthStrat.Cycle``. 
+  ``ToffoliBoxSynthStrat.Matching`` and ``ToffoliBoxSynthStrat.Cycle``.
+* Prefer ``ZZPhase`` to ``CX`` or ``ZZMax`` when using ``auto_rebase_pass()``.
 
 1.17.0 (July 2023)
 ------------------

--- a/pytket/pytket/passes/auto_rebase.py
+++ b/pytket/pytket/passes/auto_rebase.py
@@ -39,9 +39,9 @@ def _TK2_using_TK2(a: Param, b: Param, c: Param) -> Circuit:
 
 _TK2_CIRCS: Dict[OpType, Callable[[Param, Param, Param], "Circuit"]] = {
     OpType.TK2: _TK2_using_TK2,
+    OpType.ZZPhase: _library._TK2_using_ZZPhase,
     OpType.CX: _library._TK2_using_CX,
     OpType.ZZMax: _library._TK2_using_ZZMax,
-    OpType.ZZPhase: _library._TK2_using_ZZPhase,
 }
 
 


### PR DESCRIPTION
This simple change ensures that when `ZZMax` and `ZZPhase` are both available the rebase pass chooses `ZZPhase`, which is generally a better choice.