### PR TITLE
add render option, remove sleep

### DIFF
--- a/pytket/pytket/circuit/display/__init__.py
+++ b/pytket/pytket/circuit/display/__init__.py
@@ -77,6 +77,7 @@ class CircuitRenderer:
         "recursive": "recursive",
         "condensed": "condensed",
         "dark_theme": "darkTheme",
+        "system_theme": "systemTheme",
         "transparent_bg": "transparentBg",
         "crop_params": "cropParams",
     }
@@ -85,6 +86,7 @@ class CircuitRenderer:
     recursive: Optional[bool] = None
     condensed: Optional[bool] = None
     dark_theme: Optional[bool] = None
+    system_theme: Optional[bool] = None
     transparent_bg: Optional[bool] = None
     crop_params: Optional[bool] = None
 
@@ -106,6 +108,7 @@ class CircuitRenderer:
         :param recursive: bool, display nested circuits inline.
         :param condensed: bool, display circuit on one line only.
         :param dark_theme: bool, use dark mode.
+        :param system_theme: bool, use the system theme mode.
         :param transparent_bg: bool, remove the circuit background.
         :param crop_params: bool, shorten parameter expressions for display.
         """
@@ -161,25 +164,13 @@ class CircuitRenderer:
         if jupyter:
             # If we are in a notebook, we can tell jupyter to display the html.
             # We don't import at the top in case we are not in a notebook environment.
-            import warnings
             from IPython.display import (  # type: ignore
                 HTML,
                 display,
             )  # pylint: disable=C0415
 
-            fp = tempfile.NamedTemporaryFile(
-                mode="w", suffix=".html", delete=False, dir=os.getcwd()
-            )
-            fp.write(html)
-            fp.close()
-            try:
-                with warnings.catch_warnings(record=True):  # supress iframe suggestion
-                    display(HTML(html))  # type: ignore
-                return None
-            finally:
-                # Wait to make sure the file has time to be loaded first.
-                time.sleep(5)
-                os.remove(fp.name)
+            display(HTML(html))
+            return None
         return html
 
     def render_circuit_jupyter(self, circuit: RenderCircuit) -> None:


### PR DESCRIPTION
Revert added file dump for circuits on default render. Not sure how the actual issue it was intended to fix was fixed, but I couldn't reproduce the problem (rendering large circuits having truncated iframe srcdoc).

Also add in system theme option to the renderer defaults.