### PR TITLE
Downgrade version in WHEEL_PLAT_NAME for macosx x86_64

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,8 +99,8 @@ jobs:
         conan create recipes/pybind11
         conan create recipes/pybind11_json/all --version 0.2.13
         cd pytket
-        # Ensure wheels are compatible with MacOS 11.0 and later:
-        export WHEEL_PLAT_NAME=macosx_11_0_x86_64
+        # Ensure wheels are compatible with MacOS 10.14 and later:
+        export WHEEL_PLAT_NAME=macosx_10_14_x86_64
         pip install -U pip build delocate
         python -m build
         delocate-wheel -v -w "$GITHUB_WORKSPACE/wheelhouse/" "dist/pytket-"*".whl"

--- a/pytket/docs/changelog.rst
+++ b/pytket/docs/changelog.rst
@@ -4,6 +4,11 @@ Changelog
 1.18.0 (unreleased)
 -------------------
 
+General:
+
+* Fix issue with installing recent pytket versions on macos x86_64 in conda
+  environments.
+
 Minor new features:
 
 * New constructor for ``ToffoliBox`` that allows switching between two decomposition strategies:


### PR DESCRIPTION
This addresses #926 for x86-based Macs (confirmed by Charlie). I don't know why!

Not suggesting we go back to officially supporting MacOS 10.14 (but these wheels are confirmed to work at least on MacOS 11, 12 and 13).