### PR TITLE
Pin conan version to 2.0.7.

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -45,6 +45,8 @@ jobs:
             - 'pytket/**'
     - name: Install conan
       uses: turtlebrowser/get-conan@v1.2
+      with:
+        version: 2.0.7
     - name: parse version from conanfile
       id: tket_ver
       run: |
@@ -105,6 +107,8 @@ jobs:
         python-version: '3.10'
     - name: Install conan
       uses: turtlebrowser/get-conan@v1.2
+      with:
+        version: 2.0.7
     - name: Set up conan
       run: |
         conan profile detect
@@ -216,6 +220,8 @@ jobs:
     - uses: actions/checkout@v3
     - name: Install conan
       uses: turtlebrowser/get-conan@v1.2
+      with:
+        version: 2.0.7
     - name: Set up conan
       run: |
         conan profile detect --force
@@ -269,6 +275,8 @@ jobs:
     - uses: actions/checkout@v3
     - name: Install conan
       uses: turtlebrowser/get-conan@v1.2
+      with:
+        version: 2.0.7
     - name: Set up conan
       run: |
         conan profile detect
@@ -369,6 +377,8 @@ jobs:
         python-version: '3.10'
     - name: Install conan
       uses: turtlebrowser/get-conan@v1.2
+      with:
+        version: 2.0.7
     - name: Set up conan
       run: |
         conan profile detect
@@ -451,6 +461,8 @@ jobs:
     - uses: actions/checkout@v3
     - name: Install conan
       uses: turtlebrowser/get-conan@v1.2
+      with:
+        version: 2.0.7
     - name: Set up conan
       run: |
         conan profile detect
@@ -523,6 +535,8 @@ jobs:
     - uses: actions/checkout@v3
     - name: Install conan
       uses: turtlebrowser/get-conan@v1.2
+      with:
+        version: 2.0.7
     - name: Set up conan
       run: |
         conan profile detect --force
@@ -552,7 +566,7 @@ jobs:
         eval "$(pyenv init -)"
         pyenv shell tket-3.9
         PKG_CONFIG_PATH="$(brew --prefix openblas)"/lib/pkgconfig pip install -U scipy
-        pip install -U conan
+        pip install conan==2.0.7
         conan remove -c "pybind11/*"
         conan remove -c "pytket/*"
         conan create recipes/pybind11
@@ -570,7 +584,7 @@ jobs:
         eval "$(pyenv init -)"
         pyenv shell tket-3.10
         PKG_CONFIG_PATH="$(brew --prefix openblas)"/lib/pkgconfig pip install -U scipy
-        pip install -U conan
+        pip install conan==2.0.7
         conan remove -c "pybind11/*"
         conan remove -c "pytket/*"
         conan create recipes/pybind11
@@ -588,7 +602,7 @@ jobs:
         eval "$(pyenv init -)"
         pyenv shell tket-3.11
         PKG_CONFIG_PATH="$(brew --prefix openblas)"/lib/pkgconfig pip install -U scipy
-        pip install -U conan
+        pip install conan==2.0.7
         conan remove -c "pybind11/*"
         conan remove -c "pytket/*"
         conan create recipes/pybind11
@@ -602,6 +616,8 @@ jobs:
         pytest --ignore=simulator/
     - name: Install conan
       uses: turtlebrowser/get-conan@v1.2
+      with:
+        version: 2.0.7
     - name: Upload package
       if: github.event_name == 'push' && github.ref == 'refs/heads/develop' && needs.check_changes.outputs.tket_changed == 'true'
       run: |

--- a/.github/workflows/build_libs.yml
+++ b/.github/workflows/build_libs.yml
@@ -64,6 +64,8 @@ jobs:
         python-version: '3.10'
     - name: Install conan
       uses: turtlebrowser/get-conan@v1.2
+      with:
+        version: 2.0.7
     - name: create profile
       run: conan profile detect
     - name: add remote
@@ -96,6 +98,8 @@ jobs:
     - uses: actions/checkout@v3
     - name: Install conan
       uses: turtlebrowser/get-conan@v1.2
+      with:
+        version: 2.0.7
     - name: create profile
       run: conan profile detect --force
     - name: set remotes

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -42,6 +42,8 @@ jobs:
     - uses: actions/checkout@v3
     - name: Install conan
       uses: turtlebrowser/get-conan@v1.2
+      with:
+        version: 2.0.7
     - name: create profile
       run: conan profile detect
     - name: add remote

--- a/.github/workflows/linuxbuildlib
+++ b/.github/workflows/linuxbuildlib
@@ -20,7 +20,7 @@ set -evu
 export PYBIN=/opt/python/cp39-cp39/bin
 
 ${PYBIN}/pip install --upgrade pip
-${PYBIN}/pip install conan~=2.0
+${PYBIN}/pip install conan==2.0.7
 
 export CONAN_CMD=${PYBIN}/conan
 

--- a/.github/workflows/linuxbuildpackages
+++ b/.github/workflows/linuxbuildpackages
@@ -19,7 +19,7 @@ set -evu
 # Choose a Python to install conan
 export PYBIN=/opt/python/cp310-cp310/bin
 
-${PYBIN}/pip install conan
+${PYBIN}/pip install conan==2.0.7
 
 export CONAN_CMD=${PYBIN}/conan
 

--- a/.github/workflows/linuxbuildwheel
+++ b/.github/workflows/linuxbuildwheel
@@ -22,7 +22,7 @@ export PYBIN=/opt/python/${PY_TAG}/bin
 export PYEX=${PYBIN}/python
 ${PYEX} -m venv env
 . env/bin/activate
-${PYEX} -m pip install -U pip build conan
+${PYEX} -m pip install -U pip build conan==2.0.7
 CONAN_CMD=${PYBIN}/conan
 ${CONAN_CMD} profile detect
 ${CONAN_CMD} remote add tket-libs https://quantinuumsw.jfrog.io/artifactory/api/conan/tket1-libs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,6 +88,8 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install conan
       uses: turtlebrowser/get-conan@v1.2
+      with:
+        version: 2.0.7
     - name: Set up conan
       run: |
         conan profile detect
@@ -126,7 +128,7 @@ jobs:
       run: |
         eval "$(pyenv init -)"
         pyenv shell tket-${{ matrix.python-version }}
-        python -m pip install -U conan
+        python -m pip install conan==2.0.7
         conan profile detect --force
         conan remote add tket-libs https://quantinuumsw.jfrog.io/artifactory/api/conan/tket1-libs --force --index 0
         conan remove -c 'tket/*'
@@ -164,6 +166,8 @@ jobs:
     - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
     - name: Install conan
       uses: turtlebrowser/get-conan@v1.2
+      with:
+        version: 2.0.7
     - name: Set up conan
       run: |
         conan profile detect

--- a/.github/workflows/test_libs.yml
+++ b/.github/workflows/test_libs.yml
@@ -74,6 +74,8 @@ jobs:
         python-version: '3.10'
     - name: Install conan
       uses: turtlebrowser/get-conan@v1.2
+      with:
+        version: 2.0.7
     - name: create profile
       run: conan profile detect
     - name: add remote
@@ -101,6 +103,8 @@ jobs:
     - uses: actions/checkout@v3
     - name: Install conan
       uses: turtlebrowser/get-conan@v1.2
+      with:
+        version: 2.0.7
     - name: create profile
       shell: bash
       run: conan profile detect --force
@@ -127,6 +131,8 @@ jobs:
     - uses: actions/checkout@v3
     - name: Install conan
       uses: turtlebrowser/get-conan@v1.2
+      with:
+        version: 2.0.7
     - name: create profile
       run: conan profile detect
     - name: add remote

--- a/.github/workflows/test_libs_all.yml
+++ b/.github/workflows/test_libs_all.yml
@@ -21,6 +21,8 @@ jobs:
         python-version: '3.10'
     - name: Install conan
       uses: turtlebrowser/get-conan@v1.2
+      with:
+        version: 2.0.7
     - name: create profile
       run: conan profile detect
     - name: add remote
@@ -45,6 +47,8 @@ jobs:
     - uses: actions/checkout@v3
     - name: Install conan
       uses: turtlebrowser/get-conan@v1.2
+      with:
+        version: 2.0.7
     - name: create profile
       shell: bash
       run: conan profile detect --force

--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -37,6 +37,8 @@ jobs:
       run: sudo apt update
     - name: Install conan
       uses: turtlebrowser/get-conan@v1.2
+      with:
+        version: 2.0.7
     - name: Set up conan
       run: |
         conan profile detect

--- a/pytket/pyproject.toml
+++ b/pytket/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools>=45", "wheel", "setuptools_scm>=6.4", "conan>=2.0", "cmake>=3.26"]
+requires = ["setuptools>=45", "wheel", "setuptools_scm>=6.4", "conan==2.0.7", "cmake>=3.26"]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Phew, that's a lot of lines that need changing.

This is a temporary fix because the upgrade to 2.0.8 meant conan couldn't find some expected packages on the artifactory server because they have `fPIC` in their `[options]`. It looks like [this commit](https://github.com/conan-io/conan/pull/14194) may be the cause.

We should upload new versions of the dependencies and then this issue should go away.

