### PR TITLE
Revert "[infra] Pin conan version to 2.0.7. (#937)"

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -45,8 +45,6 @@ jobs:
             - 'pytket/**'
     - name: Install conan
       uses: turtlebrowser/get-conan@v1.2
-      with:
-        version: 2.0.7
     - name: parse version from conanfile
       id: tket_ver
       run: |
@@ -107,8 +105,6 @@ jobs:
         python-version: '3.10'
     - name: Install conan
       uses: turtlebrowser/get-conan@v1.2
-      with:
-        version: 2.0.7
     - name: Set up conan
       run: |
         conan profile detect
@@ -220,8 +216,6 @@ jobs:
     - uses: actions/checkout@v3
     - name: Install conan
       uses: turtlebrowser/get-conan@v1.2
-      with:
-        version: 2.0.7
     - name: Set up conan
       run: |
         conan profile detect --force
@@ -275,8 +269,6 @@ jobs:
     - uses: actions/checkout@v3
     - name: Install conan
       uses: turtlebrowser/get-conan@v1.2
-      with:
-        version: 2.0.7
     - name: Set up conan
       run: |
         conan profile detect
@@ -377,8 +369,6 @@ jobs:
         python-version: '3.10'
     - name: Install conan
       uses: turtlebrowser/get-conan@v1.2
-      with:
-        version: 2.0.7
     - name: Set up conan
       run: |
         conan profile detect
@@ -461,8 +451,6 @@ jobs:
     - uses: actions/checkout@v3
     - name: Install conan
       uses: turtlebrowser/get-conan@v1.2
-      with:
-        version: 2.0.7
     - name: Set up conan
       run: |
         conan profile detect
@@ -535,8 +523,6 @@ jobs:
     - uses: actions/checkout@v3
     - name: Install conan
       uses: turtlebrowser/get-conan@v1.2
-      with:
-        version: 2.0.7
     - name: Set up conan
       run: |
         conan profile detect --force
@@ -566,7 +552,7 @@ jobs:
         eval "$(pyenv init -)"
         pyenv shell tket-3.9
         PKG_CONFIG_PATH="$(brew --prefix openblas)"/lib/pkgconfig pip install -U scipy
-        pip install conan==2.0.7
+        pip install -U conan
         conan remove -c "pybind11/*"
         conan remove -c "pytket/*"
         conan create recipes/pybind11
@@ -584,7 +570,7 @@ jobs:
         eval "$(pyenv init -)"
         pyenv shell tket-3.10
         PKG_CONFIG_PATH="$(brew --prefix openblas)"/lib/pkgconfig pip install -U scipy
-        pip install conan==2.0.7
+        pip install -U conan
         conan remove -c "pybind11/*"
         conan remove -c "pytket/*"
         conan create recipes/pybind11
@@ -602,7 +588,7 @@ jobs:
         eval "$(pyenv init -)"
         pyenv shell tket-3.11
         PKG_CONFIG_PATH="$(brew --prefix openblas)"/lib/pkgconfig pip install -U scipy
-        pip install conan==2.0.7
+        pip install -U conan
         conan remove -c "pybind11/*"
         conan remove -c "pytket/*"
         conan create recipes/pybind11
@@ -616,8 +602,6 @@ jobs:
         pytest --ignore=simulator/
     - name: Install conan
       uses: turtlebrowser/get-conan@v1.2
-      with:
-        version: 2.0.7
     - name: Upload package
       if: github.event_name == 'push' && github.ref == 'refs/heads/develop' && needs.check_changes.outputs.tket_changed == 'true'
       run: |

--- a/.github/workflows/build_libs.yml
+++ b/.github/workflows/build_libs.yml
@@ -64,8 +64,6 @@ jobs:
         python-version: '3.10'
     - name: Install conan
       uses: turtlebrowser/get-conan@v1.2
-      with:
-        version: 2.0.7
     - name: create profile
       run: conan profile detect
     - name: add remote
@@ -98,8 +96,6 @@ jobs:
     - uses: actions/checkout@v3
     - name: Install conan
       uses: turtlebrowser/get-conan@v1.2
-      with:
-        version: 2.0.7
     - name: create profile
       run: conan profile detect --force
     - name: set remotes

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -57,7 +57,7 @@ jobs:
         ccache -p
     - name: Build tket
       run: |
-        conan install tket --user=tket --channel=stable -s build_type=Debug -o boost/*:header_only=True -o tket/*:profile_coverage=True -o with_test=True -of build/tket
+        conan install tket --user=tket --channel=stable -s build_type=Debug --build=missing -o boost/*:header_only=True -o tket/*:profile_coverage=True -o with_test=True -of build/tket
         conan build tket --user=tket --channel=stable -s build_type=Debug -o boost/*:header_only=True -o tket/*:profile_coverage=True  -o with_test=True -o test-tket/*:with_coverage=True -of build/tket
         conan export-pkg tket --user=tket --channel=stable -s build_type=Debug -o boost/*:header_only=True -o tket/*:profile_coverage=True -o with_test=True -of build/tket -tf ""
     - name: Install runtime test requirements

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -42,8 +42,6 @@ jobs:
     - uses: actions/checkout@v3
     - name: Install conan
       uses: turtlebrowser/get-conan@v1.2
-      with:
-        version: 2.0.7
     - name: create profile
       run: conan profile detect
     - name: add remote

--- a/.github/workflows/linuxbuildlib
+++ b/.github/workflows/linuxbuildlib
@@ -20,7 +20,7 @@ set -evu
 export PYBIN=/opt/python/cp39-cp39/bin
 
 ${PYBIN}/pip install --upgrade pip
-${PYBIN}/pip install conan==2.0.7
+${PYBIN}/pip install conan~=2.0
 
 export CONAN_CMD=${PYBIN}/conan
 

--- a/.github/workflows/linuxbuildpackages
+++ b/.github/workflows/linuxbuildpackages
@@ -19,7 +19,7 @@ set -evu
 # Choose a Python to install conan
 export PYBIN=/opt/python/cp310-cp310/bin
 
-${PYBIN}/pip install conan==2.0.7
+${PYBIN}/pip install conan
 
 export CONAN_CMD=${PYBIN}/conan
 

--- a/.github/workflows/linuxbuildwheel
+++ b/.github/workflows/linuxbuildwheel
@@ -22,7 +22,7 @@ export PYBIN=/opt/python/${PY_TAG}/bin
 export PYEX=${PYBIN}/python
 ${PYEX} -m venv env
 . env/bin/activate
-${PYEX} -m pip install -U pip build conan==2.0.7
+${PYEX} -m pip install -U pip build conan
 CONAN_CMD=${PYBIN}/conan
 ${CONAN_CMD} profile detect
 ${CONAN_CMD} remote add tket-libs https://quantinuumsw.jfrog.io/artifactory/api/conan/tket1-libs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,8 +88,6 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install conan
       uses: turtlebrowser/get-conan@v1.2
-      with:
-        version: 2.0.7
     - name: Set up conan
       run: |
         conan profile detect
@@ -128,7 +126,7 @@ jobs:
       run: |
         eval "$(pyenv init -)"
         pyenv shell tket-${{ matrix.python-version }}
-        python -m pip install conan==2.0.7
+        python -m pip install -U conan
         conan profile detect --force
         conan remote add tket-libs https://quantinuumsw.jfrog.io/artifactory/api/conan/tket1-libs --force --index 0
         conan remove -c 'tket/*'
@@ -166,8 +164,6 @@ jobs:
     - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
     - name: Install conan
       uses: turtlebrowser/get-conan@v1.2
-      with:
-        version: 2.0.7
     - name: Set up conan
       run: |
         conan profile detect

--- a/.github/workflows/test_libs.yml
+++ b/.github/workflows/test_libs.yml
@@ -74,8 +74,6 @@ jobs:
         python-version: '3.10'
     - name: Install conan
       uses: turtlebrowser/get-conan@v1.2
-      with:
-        version: 2.0.7
     - name: create profile
       run: conan profile detect
     - name: add remote
@@ -103,8 +101,6 @@ jobs:
     - uses: actions/checkout@v3
     - name: Install conan
       uses: turtlebrowser/get-conan@v1.2
-      with:
-        version: 2.0.7
     - name: create profile
       shell: bash
       run: conan profile detect --force
@@ -131,8 +127,6 @@ jobs:
     - uses: actions/checkout@v3
     - name: Install conan
       uses: turtlebrowser/get-conan@v1.2
-      with:
-        version: 2.0.7
     - name: create profile
       run: conan profile detect
     - name: add remote

--- a/.github/workflows/test_libs_all.yml
+++ b/.github/workflows/test_libs_all.yml
@@ -21,8 +21,6 @@ jobs:
         python-version: '3.10'
     - name: Install conan
       uses: turtlebrowser/get-conan@v1.2
-      with:
-        version: 2.0.7
     - name: create profile
       run: conan profile detect
     - name: add remote
@@ -47,8 +45,6 @@ jobs:
     - uses: actions/checkout@v3
     - name: Install conan
       uses: turtlebrowser/get-conan@v1.2
-      with:
-        version: 2.0.7
     - name: create profile
       shell: bash
       run: conan profile detect --force

--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -37,8 +37,6 @@ jobs:
       run: sudo apt update
     - name: Install conan
       uses: turtlebrowser/get-conan@v1.2
-      with:
-        version: 2.0.7
     - name: Set up conan
       run: |
         conan profile detect

--- a/pytket/conanfile.py
+++ b/pytket/conanfile.py
@@ -32,7 +32,7 @@ class pytketRecipe(ConanFile):
         cmake.install()
 
     def requirements(self):
-        self.requires("tket/1.2.26@tket/stable")
+        self.requires("tket/1.2.27@tket/stable")
         self.requires("tklog/0.3.3@tket/stable")
         self.requires("tkrng/0.3.3@tket/stable")
         self.requires("tkassert/0.3.3@tket/stable")

--- a/pytket/pyproject.toml
+++ b/pytket/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools>=45", "wheel", "setuptools_scm>=6.4", "conan==2.0.7", "cmake>=3.26"]
+requires = ["setuptools>=45", "wheel", "setuptools_scm>=6.4", "conan>=2.0", "cmake>=3.26"]
 build-backend = "setuptools.build_meta"

--- a/tket/conanfile.py
+++ b/tket/conanfile.py
@@ -23,7 +23,7 @@ from conan.errors import ConanInvalidConfiguration
 
 class TketConan(ConanFile):
     name = "tket"
-    version = "1.2.26"
+    version = "1.2.27"
     package_type = "library"
     license = "Apache 2"
     homepage = "https://github.com/CQCL/tket"


### PR DESCRIPTION
This reverts commit c5ef1e9826b141c8e0dfc367955ceeba0baa2b79.

I uploaded new packages built with conan 2.0.8.

Also add `--build=missing` flag back to the coverage build. (I am not actually sure why this particular build can't find a matching gmp binary.)