### PR TITLE
Update `NoiseAwarePlacement::cost_placement` to cost errors appropriately

### DIFF
--- a/pytket/conanfile.py
+++ b/pytket/conanfile.py
@@ -32,7 +32,7 @@ class pytketRecipe(ConanFile):
         cmake.install()
 
     def requirements(self):
-        self.requires("tket/1.2.27@tket/stable")
+        self.requires("tket/1.2.28@tket/stable")
         self.requires("tklog/0.3.3@tket/stable")
         self.requires("tkrng/0.3.3@tket/stable")
         self.requires("tkassert/0.3.3@tket/stable")

--- a/pytket/tests/placement_test.py
+++ b/pytket/tests/placement_test.py
@@ -245,6 +245,27 @@ def test_big_placement() -> None:
     assert DefaultMappingPass(arc).apply(c)
 
 
+def test_large_error_rate_noise_aware() -> None:
+    nodes = [Node(i) for i in range(3)]
+    arc = Architecture([(nodes[0], nodes[1]), (nodes[1], nodes[2])])
+    nap = NoiseAwarePlacement(
+        arc,
+        {},
+        {
+            (nodes[0], nodes[1]): 0.2,
+            (nodes[1], nodes[0]): 0.5,
+            (nodes[1], nodes[2]): 2,
+            (nodes[2], nodes[1]): 1,
+        },
+    )
+
+    c = Circuit(2).CX(0, 1)
+
+    placement_map = nap.get_placement_map(c)
+    assert placement_map[Qubit(0)] == Node(0)
+    assert placement_map[Qubit(1)] == Node(1)
+
+
 if __name__ == "__main__":
     test_placements()
     test_placements_serialization()
@@ -253,3 +274,4 @@ if __name__ == "__main__":
     test_big_placement()
     test_place_fully_connected()
     test_placement_config()
+    test_large_error_rate_noise_aware()

--- a/tket/conanfile.py
+++ b/tket/conanfile.py
@@ -23,7 +23,7 @@ from conan.errors import ConanInvalidConfiguration
 
 class TketConan(ConanFile):
     name = "tket"
-    version = "1.2.27"
+    version = "1.2.28"
     package_type = "library"
     license = "Apache 2"
     homepage = "https://github.com/CQCL/tket"

--- a/tket/src/Placement/NoiseAwarePlacement.cpp
+++ b/tket/src/Placement/NoiseAwarePlacement.cpp
@@ -77,8 +77,11 @@ double NoiseAwarePlacement::cost_placement(
           this->characterisation_.get_error({node, neighbour});
       gate_error_t bck_error =
           this->characterisation_.get_error({neighbour, node});
-      edge_sum += fwd_edge_weighting * (1.0 - fwd_error);
-      edge_sum += bck_edge_weighting * (1.0 - bck_error);
+
+      if (fwd_error < 1.0 && bck_error < 1.0) {
+        edge_sum += fwd_edge_weighting * (1.0 - fwd_error);
+        edge_sum += bck_edge_weighting * (1.0 - bck_error);
+      }
     }
     // bigger edge sum -> smaller cost
     cost += 1.0 / (edge_sum);


### PR DESCRIPTION
Fixes https://github.com/CQCL/tket/issues/943.

There are some cases where bi-directional edges with different error rates, both >= 1, can be given a "good" cost value, when they actually correspond to bad assignments. This PR updates the cost to only includes edges with < 1 error rate, meaning anything corresponding to complete noise is not considered.