### PR TITLE
Bugfix/slow get statevector

### DIFF
--- a/pytket/conanfile.py
+++ b/pytket/conanfile.py
@@ -32,7 +32,7 @@ class pytketRecipe(ConanFile):
         cmake.install()
 
     def requirements(self):
-        self.requires("tket/1.2.28@tket/stable")
+        self.requires("tket/1.2.29@tket/stable")
         self.requires("tklog/0.3.3@tket/stable")
         self.requires("tkrng/0.3.3@tket/stable")
         self.requires("tkassert/0.3.3@tket/stable")

--- a/pytket/docs/changelog.rst
+++ b/pytket/docs/changelog.rst
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+Unreleased
+----------
+
+Fixes:
+
+* Fix slow ``Circuit.get_statevector()``.
+
+
 1.17.1 (July 2023)
 ------------------
 

--- a/tket/conanfile.py
+++ b/tket/conanfile.py
@@ -23,7 +23,7 @@ from conan.errors import ConanInvalidConfiguration
 
 class TketConan(ConanFile):
     name = "tket"
-    version = "1.2.28"
+    version = "1.2.29"
     package_type = "library"
     license = "Apache 2"
     homepage = "https://github.com/CQCL/tket"

--- a/tket/src/Circuit/Simulation/DecomposeCircuit.cpp
+++ b/tket/src/Circuit/Simulation/DecomposeCircuit.cpp
@@ -54,7 +54,7 @@ static QMap get_qmap_no_checks(
 static bool fill_triplets_directly_from_box(
     GateNode& node, const std::shared_ptr<const Box>& box_ptr,
     double abs_epsilon) {
-  std::optional<Eigen::MatrixXcd> u = box_ptr->get_unitary();
+  std::optional<Eigen::MatrixXcd> u = box_ptr->get_box_unitary();
   if (!u.has_value()) {
     return false;
   }


### PR DESCRIPTION
`box_ptr->get_unitary` always returns a value because it will decompose the box then compute the unitary if the box doesn't implement the `get_box_unitary` method. This unnecessarily compute the unitary of the decomposed box during state vector simulation.