### PR TITLE
[infra] Build fixes

### DIFF
--- a/libs/tkassert/CMakeLists.txt
+++ b/libs/tkassert/CMakeLists.txt
@@ -63,7 +63,7 @@ ENDIF()
 target_include_directories(tkassert PUBLIC
     $<INSTALL_INTERFACE:include/tkassert>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/tkassert>)
-target_link_libraries(tkassert PRIVATE tklog::tklog)
+target_link_libraries(tkassert PUBLIC tklog::tklog)
 
 target_sources(tkassert
     PRIVATE src/AssertMessage.cpp

--- a/libs/tktokenswap/CMakeLists.txt
+++ b/libs/tktokenswap/CMakeLists.txt
@@ -67,7 +67,7 @@ target_include_directories(tktokenswap PUBLIC
     $<INSTALL_INTERFACE:include/tktokenswap>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/tktokenswap>)
 target_link_libraries(tktokenswap PRIVATE tklog::tklog)
-target_link_libraries(tktokenswap PRIVATE tkassert::tkassert)
+target_link_libraries(tktokenswap PUBLIC tkassert::tkassert)
 target_link_libraries(tktokenswap PRIVATE tkrng::tkrng)
 target_link_libraries(tktokenswap PRIVATE Boost::headers)
 

--- a/libs/tktokenswap/test/src/TableLookup/PermutationTestUtils.cpp
+++ b/libs/tktokenswap/test/src/TableLookup/PermutationTestUtils.cpp
@@ -16,6 +16,7 @@
 
 #include <catch2/catch_test_macros.hpp>
 #include <vector>
+#include <algorithm>
 
 namespace tket {
 namespace tsa_internal {

--- a/libs/tktokenswap/test/src/TestUtils/DecodedProblemData.cpp
+++ b/libs/tktokenswap/test/src/TestUtils/DecodedProblemData.cpp
@@ -17,6 +17,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <tktokenswap/GeneralFunctions.hpp>
 #include <tktokenswap/VertexSwapResult.hpp>
+#include <algorithm>
 
 using std::vector;
 


### PR DESCRIPTION
My gcc 12 toolchain needs the <algorithm> includes for std::is_sorted.

tkassert must be a PUBLIC dependency of tktokenswap because the public header VectorListHybrid.hpp includes tkassert/Assert.hpp.

tklog must be a PUBLIC dependency of tkassert because Assert.hpp includes tklog/TketLog.hpp.