### PR TITLE
Update `with_TK2` to use set decompositions before deriving them

### DIFF
--- a/pytket/conanfile.py
+++ b/pytket/conanfile.py
@@ -32,7 +32,7 @@ class pytketRecipe(ConanFile):
         cmake.install()
 
     def requirements(self):
-        self.requires("tket/1.2.31@tket/stable")
+        self.requires("tket/1.2.32@tket/stable")
         self.requires("tklog/0.3.3@tket/stable")
         self.requires("tkrng/0.3.3@tket/stable")
         self.requires("tkassert/0.3.3@tket/stable")

--- a/tket/conanfile.py
+++ b/tket/conanfile.py
@@ -23,7 +23,7 @@ from conan.errors import ConanInvalidConfiguration
 
 class TketConan(ConanFile):
     name = "tket"
-    version = "1.2.31"
+    version = "1.2.32"
     package_type = "library"
     license = "Apache 2"
     homepage = "https://github.com/CQCL/tket"

--- a/tket/src/Circuit/CircPool.cpp
+++ b/tket/src/Circuit/CircPool.cpp
@@ -839,11 +839,11 @@ Circuit YYPhase_using_TK2(const Expr &alpha) {
 
 Circuit YYPhase_using_CX(const Expr &alpha) {
   Circuit c(2);
-  c.add_op<unsigned>(OpType::U3, {0, -0.5, 0}, {0});
+  c.add_op<unsigned>(OpType::Sdg, {0});
   c.add_op<unsigned>(OpType::CX, {1, 0});
-  c.add_op<unsigned>(OpType::U3, {0, alpha, 0}, {1});
+  c.add_op<unsigned>(OpType::Ry, alpha, {1});
   c.add_op<unsigned>(OpType::CX, {1, 0});
-  c.add_op<unsigned>(OpType::U3, {0, 0.5, 0}, {0});
+  c.add_op<unsigned>(OpType::S, {0});
   return c;
 }
 

--- a/tket/src/Circuit/CircPool.cpp
+++ b/tket/src/Circuit/CircPool.cpp
@@ -839,11 +839,11 @@ Circuit YYPhase_using_TK2(const Expr &alpha) {
 
 Circuit YYPhase_using_CX(const Expr &alpha) {
   Circuit c(2);
-  c.add_op<unsigned>(OpType::U3, {0,-0.5,0}, {0});
+  c.add_op<unsigned>(OpType::U3, {0, -0.5, 0}, {0});
   c.add_op<unsigned>(OpType::CX, {1, 0});
-  c.add_op<unsigned>(OpType::U3, {0, 0.5, 0}, {1});
+  c.add_op<unsigned>(OpType::U3, {0, alpha, 0}, {1});
   c.add_op<unsigned>(OpType::CX, {1, 0});
-  c.add_op<unsigned>(OpType::U3, {0, 0.5,0}, {0});
+  c.add_op<unsigned>(OpType::U3, {0, 0.5, 0}, {0});
   return c;
 }
 

--- a/tket/src/Circuit/CircPool.cpp
+++ b/tket/src/Circuit/CircPool.cpp
@@ -839,13 +839,11 @@ Circuit YYPhase_using_TK2(const Expr &alpha) {
 
 Circuit YYPhase_using_CX(const Expr &alpha) {
   Circuit c(2);
-  c.add_op<unsigned>(OpType::U3, {0.5, -0.5, 0.5}, {0});
-  c.add_op<unsigned>(OpType::U3, {0.5, -0.5, 0.5}, {1});
-  c.add_op<unsigned>(OpType::CX, {0, 1});
-  c.add_op<unsigned>(OpType::Rz, alpha, {1});
-  c.add_op<unsigned>(OpType::CX, {0, 1});
-  c.add_op<unsigned>(OpType::U3, {-0.5, -0.5, 0.5}, {0});
-  c.add_op<unsigned>(OpType::U3, {-0.5, -0.5, 0.5}, {1});
+  c.add_op<unsigned>(OpType::U3, {0,-0.5,0}, {0});
+  c.add_op<unsigned>(OpType::CX, {1, 0});
+  c.add_op<unsigned>(OpType::U3, {0, 0.5, 0}, {1});
+  c.add_op<unsigned>(OpType::CX, {1, 0});
+  c.add_op<unsigned>(OpType::U3, {0, 0.5,0}, {0});
   return c;
 }
 

--- a/tket/src/Circuit/CircUtils.cpp
+++ b/tket/src/Circuit/CircUtils.cpp
@@ -429,6 +429,7 @@ Circuit with_TK2(Gate_ptr op) {
     case OpType::XXPhase:
       return CircPool::XXPhase_using_TK2(params[0]);
     case OpType::YYPhase:
+      return CircPool::YYPhase_using_TK2(params[0]);
     case OpType::ZZPhase:
       return CircPool::ZZPhase_using_TK2(params[0]);
     case OpType::ZZMax:


### PR DESCRIPTION
`with_TK2` has a switch statement for implementing some predefined primitives using known decompositions. However, this is placed after another statement that works out a construction for a given gate in terms of `TK2` and `TK1` from scratch.

This gives inefficient constructions. As an example, `YYPhase` and `ZZPhase` return TK2 gates with a rotation in the x basis and single qubit basis changes with TK1 gates, instead of just updating a different angle.

This PR updates this method to use the switch statement with known decompositions first, before deriving a decomposition.