### PR TITLE
`BarrierOp` and `Circuit._add_conditional_barrier`

### DIFF
--- a/pytket/binders/circuit/Circuit/add_op.cpp
+++ b/pytket/binders/circuit/Circuit/add_op.cpp
@@ -177,6 +177,25 @@ void init_circuit_add_op(py::class_<Circuit, std::shared_ptr<Circuit>> &c) {
           "\n:return: the new :py:class:`Circuit`",
           py::arg("qubits"), py::arg("bits") = no_bits, py::arg("data") = "")
       .def(
+          "_add_conditional_barrier",
+          [](
+              (Circuit *circ, const std::vector<Expr> &params,
+               const std::vector<unsigned> &qubits,
+               std::vector<unsigned> &barrier_bits const std::vector<unsigned>
+                   &condition_bits,
+               unsigned value) {
+                std::vector<UnitID> barrier_args;
+                for (const unsig)
+                  circ->add_conditional_barrier(params, args, bits, value);
+                return circ;
+              },
+              "Append a Conditional Barrier on the given units, conditioned on "
+              "the givne Bit."
+              "\n\n:param data: additional data stored in the barrier"
+              "\n:return: the new :py:class:`Circuit`",
+              py::arg("qubits"), py::arg("bits") = no_bits,
+              py::arg("data") = ""))
+      .def(
           "add_circbox",
           [](Circuit *circ, const CircBox &box,
              const std::vector<unsigned> &args, const py::kwargs &kwargs) {

--- a/pytket/binders/circuit/Circuit/add_op.cpp
+++ b/pytket/binders/circuit/Circuit/add_op.cpp
@@ -179,21 +179,27 @@ void init_circuit_add_op(py::class_<Circuit, std::shared_ptr<Circuit>> &c) {
       .def(
           "_add_conditional_barrier",
           [](
-              (Circuit *circ, const std::vector<Expr> &params,
-               const std::vector<unsigned> &qubits,
-               std::vector<unsigned> &barrier_bits const std::vector<unsigned>
-                   &condition_bits,
-               unsigned value) {
-                std::vector<UnitID> barrier_args;
-                for (const unsig)
-                  circ->add_conditional_barrier(params, args, bits, value);
+              (Circuit *circ, const std::vector<unsigned> &barrier_qubits,
+               const std::vector<unsigned> &barrier_bits,
+               const std::vector<unsigned> &condition_bits, unsigned value,
+               const std::string &data) {
+                circ->add_conditional_barrier(
+                    barrier_qubits, barrier_bits, condition_bits, value, data);
                 return circ;
               },
-              "Append a Conditional Barrier on the given units, conditioned on "
-              "the givne Bit."
-              "\n\n:param data: additional data stored in the barrier"
+              "Append a Conditional Barrier on the given barrier qubits and "
+              "barrier bits, conditioned on the given condition bits."
+              "\n\n:param barrier_qubits: Qubit in Barrier operation."
+              "\n:param barrier_bits: Bit in Barrier operation."
+              "\n:param condition_bits: Bit covering classical control "
+              "condition "
+              "of barrier operation."
+              "\n:param value: Value that classical condition must have to "
+              "hold."
+              "\n: param data: Additional data stored in Barrier operation."
               "\n:return: the new :py:class:`Circuit`",
-              py::arg("qubits"), py::arg("bits") = no_bits,
+              py::arg("barrier_qubits"), py::arg("barrier_bits"),
+              py::arg("condition_bits"), py::arg("value"),
               py::arg("data") = ""))
       .def(
           "add_circbox",
@@ -437,6 +443,29 @@ void init_circuit_add_op(py::class_<Circuit, std::shared_ptr<Circuit>> &c) {
           "\n\n:param data: additional data stored in the barrier"
           "\n:return: the new :py:class:`Circuit`",
           py::arg("units"), py::arg("data") = "")
+
+      .def(
+          "_add_conditional_barrier",
+          [](
+              (Circuit *circ, const unit_vector_t &barrier_args,
+               const unit_vector_t &condition_bits, unsigned value,
+               const std::string &_data) {
+                circ->add_conditional_barrier(
+                    barrier_args, condition_bits, value, data);
+                return circ;
+              },
+              "Append a Conditional Barrier on the given barrier qubits and "
+              "barrier bits, conditioned on the given condition bits."
+              "\n\n:param barrier_args: Qubit and Bit in Barrier operation."
+              "\n:param condition_bits: Bit covering classical control "
+              "condition "
+              "of barrier operation."
+              "\n:param value: Value that classical condition must have to "
+              "hold."
+              "\n: param data: Additional data stored in Barrier operation."
+              "\n:return: the new :py:class:`Circuit`",
+              py::arg("barrier_args"), py::arg("condition_bits"),
+              py::arg("value"), py::arg("data") = ""))
       .def(
           "add_circbox",
           [](Circuit *circ, const CircBox &box, const unit_vector_t &args,

--- a/pytket/binders/circuit/main.cpp
+++ b/pytket/binders/circuit/main.cpp
@@ -602,7 +602,7 @@ PYBIND11_MODULE(circuit, m) {
           ":return: set of symbolic parameters for the command");
 
   py::class_<MetaOp, std::shared_ptr<MetaOp>, Op>(
-      m, "MetaOp", "Meta operation, for example used as barrier")
+      m, "MetaOp", "Meta operation, such as input or output vertices.")
       .def(
           py::init<OpType, op_signature_t, const std::string &>(),
           "Construct MetaOp with optype, signature and additional data string"

--- a/pytket/binders/include/add_gate.hpp
+++ b/pytket/binders/include/add_gate.hpp
@@ -27,9 +27,12 @@ static Circuit *add_gate_method(
     Circuit *circ, const Op_ptr &op, const std::vector<ID> &args,
     const py::kwargs &kwargs) {
   if (op->get_desc().is_meta()) {
+    throw CircuitInvalidity("Cannot add metaop to a circuit.");
+  }
+  if (op->get_desc().is_barrier()) {
     throw CircuitInvalidity(
-        "Cannot add metaop. Please use `add_barrier` to add a "
-        "barrier.");
+        "Please use `add_barrier` to add a "
+        "barrier to a circuit.");
   }
   static const std::set<std::string> allowed_kwargs = {
       "opgroup", "condition", "condition_bits", "condition_value"};

--- a/pytket/pytket/circuit/decompose_classical.py
+++ b/pytket/pytket/circuit/decompose_classical.py
@@ -337,7 +337,7 @@ def _decompose_expressions(circ: Circuit) -> Tuple[Circuit, bool]:
             modified = True
             continue
         if optype == OpType.Barrier:
-            # add_gate doesn't work for metaops like barrier
+            # add_gate doesn't work for metaops 
             newcirc.add_barrier(args)
         else:
             newcirc.add_gate(op, args, **kwargs)

--- a/pytket/tests/qasm_test.py
+++ b/pytket/tests/qasm_test.py
@@ -210,6 +210,7 @@ def test_conditional_gates() -> None:
     circ.Measure(0, 0)
     circ.Measure(1, 1)
     circ.Z(0, condition_bits=[0, 1], condition_value=2)
+    circ._add_conditional_barrier([0,1],[0],[1], 1)
     circ.Measure(0, 0, condition_bits=[0, 1], condition_value=1)
     qasm_out = str(curr_file_path / "qasm_test_files/testout5.qasm")
     circuit_to_qasm(circ, qasm_out)

--- a/tket/CMakeLists.txt
+++ b/tket/CMakeLists.txt
@@ -111,6 +111,7 @@ target_sources(tket
         src/Clifford/ChoiMixTableau.cpp
         src/Clifford/SymplecticTableau.cpp
         src/Clifford/UnitaryTableau.cpp
+        src/Ops/BarrierOp.cpp
         src/Ops/FlowOp.cpp
         src/Ops/MetaOp.cpp
         src/Ops/Op.cpp
@@ -277,6 +278,7 @@ target_sources(tket
         include/tket/Clifford/SymplecticTableau.hpp
         include/tket/Clifford/UnitaryTableau.hpp
         include/tket/Ops/ClassicalOps.hpp
+        include/tket/Ops/BarrierOp.hpp
         include/tket/Ops/FlowOp.hpp
         include/tket/Ops/MetaOp.hpp
         include/tket/Ops/Op.hpp

--- a/tket/include/tket/Circuit/Circuit.hpp
+++ b/tket/include/tket/Circuit/Circuit.hpp
@@ -924,15 +924,15 @@ class Circuit {
   Vertex add_barrier(const unit_vector_t &args, const std::string &_data = "");
 
   Vertex add_conditional_barrier(
-      const std::vector<Expr> &params,
       const std::vector<unsigned> &barrier_qubits,
       const std::vector<unsigned> &barrier_bits,
       const std::vector<unsigned> &condition_bits, unsigned value,
+      const std::string &_data,
       std::optional<std::string> opgroup = std::nullopt);
 
   Vertex add_conditional_barrier(
-      const std::vector<Expr> &params, const unit_vector_t &barrier_uids,
-      const unit_vector_t &condition_bits, unsigned value,
+      const unit_vector_t &barrier_args, const unit_vector_t &condition_bits,
+      unsigned value, const std::string &_data,
       std::optional<std::string> opgroup = std::nullopt);
 
   /**

--- a/tket/include/tket/Circuit/Circuit.hpp
+++ b/tket/include/tket/Circuit/Circuit.hpp
@@ -836,9 +836,9 @@ class Circuit {
   Vertex add_op(
       OpType type, const std::vector<Expr> &params, const std::vector<ID> &args,
       std::optional<std::string> opgroup = std::nullopt) {
-    if (is_metaop_type(type)) {
+    if (is_metaop_type(type) || is_barrier_type(type)) {
       throw CircuitInvalidity(
-          "Cannot add metaop. Please use `add_barrier` to add a "
+          "Cannot add metaop or barrier. Please use `add_barrier` to add a "
           "barrier.");
     }
     return add_op(get_op_ptr(type, params, args.size()), args, opgroup);
@@ -904,6 +904,11 @@ class Circuit {
     if (is_metaop_type(type)) {
       throw CircuitInvalidity("Cannot add a conditional metaop.");
     }
+    if (is_barrier_type(type)) {
+      throw CircuitInvalidity(
+          "Please use '_add_conditional_barrier' to add a conditional barrier "
+          "gate.");
+    }
     Op_ptr cond = std::make_shared<Conditional>(
         get_op_ptr(type, params, (unsigned)args.size()), (unsigned)bits.size(),
         value);
@@ -917,6 +922,18 @@ class Circuit {
       const std::vector<unsigned> &bits = {}, const std::string &_data = "");
 
   Vertex add_barrier(const unit_vector_t &args, const std::string &_data = "");
+
+  Vertex add_conditional_barrier(
+      const std::vector<Expr> &params,
+      const std::vector<unsigned> &barrier_qubits,
+      const std::vector<unsigned> &barrier_bits,
+      const std::vector<unsigned> &condition_bits, unsigned value,
+      std::optional<std::string> opgroup = std::nullopt);
+
+  Vertex add_conditional_barrier(
+      const std::vector<Expr> &params, const unit_vector_t &barrier_uids,
+      const unit_vector_t &condition_bits, unsigned value,
+      std::optional<std::string> opgroup = std::nullopt);
 
   /**
    * Add a postfix to a classical register name if the register exists

--- a/tket/include/tket/Gate/OpPtrFunctions.hpp
+++ b/tket/include/tket/Gate/OpPtrFunctions.hpp
@@ -25,8 +25,8 @@ namespace tket {
  *
  * @param chosen_type operation type
  * @param param operation parameter
- * @param n_qubits number of qubits (only necessary for gates and metaops
- *                 with variable quantum arity)
+ * @param n_qubits number of qubits (only necessary for gates, barrier
+ *  and metaops with variable quantum arity)
  */
 Op_ptr get_op_ptr(OpType chosen_type, const Expr &param, unsigned n_qubits = 0);
 
@@ -35,8 +35,8 @@ Op_ptr get_op_ptr(OpType chosen_type, const Expr &param, unsigned n_qubits = 0);
  *
  * @param chosen_type operation type
  * @param params operation parameters
- * @param n_qubits number of qubits (only necessary for gates and metaops
- *                 with variable quantum arity)
+ * @param n_qubits number of qubits (only necessary for gates, barrier
+ *  and metaops with variable quantum arity)
  */
 Op_ptr get_op_ptr(
     OpType chosen_type, const std::vector<Expr> &params = {},

--- a/tket/include/tket/OpType/OpDesc.hpp
+++ b/tket/include/tket/OpType/OpDesc.hpp
@@ -61,8 +61,11 @@ class OpDesc {
   /** Number of classical bits written to */
   OptUInt n_classical() const;
 
-  /** Whether the 'operation' is actually an input or output or barrier */
+  /** Whether the 'operation' is actually an input or output */
   bool is_meta() const;
+
+  /** Whether the operation is a Barrier */
+  bool is_barrier() const;
 
   /** Whether the operation is a box of some kind */
   bool is_box() const;

--- a/tket/include/tket/OpType/OpDesc.hpp
+++ b/tket/include/tket/OpType/OpDesc.hpp
@@ -114,6 +114,7 @@ class OpDesc {
   const OpType type_;
   const OpTypeInfo info_;
   const bool is_meta_;
+  const bool is_barrier_;
   const bool is_box_;
   const bool is_gate_;
   const bool is_flowop_;

--- a/tket/include/tket/OpType/OpTypeFunctions.hpp
+++ b/tket/include/tket/OpType/OpTypeFunctions.hpp
@@ -48,8 +48,11 @@ const OpTypeSet &all_controlled_gate_types();
 /** Set of all classical gates */
 const OpTypeSet &all_classical_types();
 
-/** Test for initial, final and barrier "ops" */
+/** Test for initial and final "ops" */
 bool is_metaop_type(OpType optype);
+
+/** Test for Barrier "ops" */
+bool is_barrier_type(OpType optype);
 
 /** Test for input or creation quantum "ops" */
 bool is_initial_q_type(OpType optype);

--- a/tket/include/tket/Ops/BarrierOp.hpp
+++ b/tket/include/tket/Ops/BarrierOp.hpp
@@ -22,8 +22,7 @@ namespace tket {
 class BarrierOp : public Op {
  public:
   explicit BarrierOp(
-    op_signature_t signature = {},
-      const std::string &_data = "");
+      op_signature_t signature = {}, const std::string &_data = "");
 
   Op_ptr symbol_substitution(
       const SymEngine::map_basic_basic &sub_map) const override;
@@ -48,9 +47,6 @@ class BarrierOp : public Op {
   nlohmann::json serialize() const override;
 
   static Op_ptr deserialize(const nlohmann::json &j);
-
- protected:
-  BarrierOp();
 
  private:
   op_signature_t

--- a/tket/include/tket/Ops/BarrierOp.hpp
+++ b/tket/include/tket/Ops/BarrierOp.hpp
@@ -1,0 +1,64 @@
+// Copyright 2019-2023 Cambridge Quantum Computing
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "Op.hpp"
+#include "tket/Utils/Json.hpp"
+
+namespace tket {
+
+class BarrierOp : public Op {
+ public:
+  explicit BarrierOp(
+    op_signature_t signature = {},
+      const std::string &_data = "");
+
+  Op_ptr symbol_substitution(
+      const SymEngine::map_basic_basic &sub_map) const override;
+
+  SymSet free_symbols() const override;
+
+  unsigned n_qubits() const override;
+
+  op_signature_t get_signature() const override;
+
+  std::string get_data() const { return data_; }
+
+  bool is_clifford() const override;
+
+  ~BarrierOp() override;
+
+  /**
+   * Equality check between two BarrierOp instances
+   */
+  bool is_equal(const Op &other) const override;
+
+  nlohmann::json serialize() const override;
+
+  static Op_ptr deserialize(const nlohmann::json &j);
+
+ protected:
+  BarrierOp();
+
+ private:
+  op_signature_t
+      signature_; /**< Types of inputs, when not deducible from op type */
+  /**
+   * additional data given by the user, can be passed on to backend
+   */
+  const std::string data_;
+};
+
+}  // namespace tket

--- a/tket/include/tket/Ops/MetaOp.hpp
+++ b/tket/include/tket/Ops/MetaOp.hpp
@@ -49,9 +49,6 @@ class MetaOp : public Op {
 
   static Op_ptr deserialize(const nlohmann::json &j);
 
- protected:
-  MetaOp();
-
  private:
   op_signature_t
       signature_; /**< Types of inputs, when not deducible from op type */

--- a/tket/src/Characterisation/FrameRandomisation.cpp
+++ b/tket/src/Characterisation/FrameRandomisation.cpp
@@ -16,7 +16,7 @@
 
 #include <random>
 
-#include "tket/Ops/MetaOp.hpp"
+#include "tket/Ops/BarrierOp.hpp"
 #include "tket/PauliGraph/ConjugatePauliFunctions.hpp"
 #include "tket/Utils/PauliStrings.hpp"
 
@@ -97,7 +97,7 @@ void add_noop_frames(std::vector<Cycle>& cycles, Circuit& circ) {
       full_cycle.add_vertex_pair({input_noop_vert, output_noop_vert});
     }
     std::vector<EdgeType> sig(barrier_ins.size(), EdgeType::Quantum);
-    Op_ptr o_ptr = std::make_shared<MetaOp>(OpType::Barrier, sig);
+    Op_ptr o_ptr = std::make_shared<BarrierOp>(sig);
     Vertex input_barrier_vert = circ.add_vertex(o_ptr);
     Vertex output_barrier_vert = circ.add_vertex(o_ptr);
     circ.rewire(input_barrier_vert, barrier_ins, sig);

--- a/tket/src/Circuit/OpJson.cpp
+++ b/tket/src/Circuit/OpJson.cpp
@@ -29,7 +29,7 @@ void from_json(const nlohmann::json& j, Op_ptr& op) {
   OpType optype = j.at("type").get<OpType>();
   if (is_metaop_type(optype)) {
     op = MetaOp::deserialize(j);
-  } else if (if_barrier_type(optype)) {
+  } else if (is_barrier_type(optype)) {
     op = BarrierOp::deserialize(j);
   } else if (is_box_type(optype)) {
     op = Box::deserialize(j);

--- a/tket/src/Circuit/OpJson.cpp
+++ b/tket/src/Circuit/OpJson.cpp
@@ -17,6 +17,7 @@
 #include "tket/Gate/Gate.hpp"
 #include "tket/OpType/OpType.hpp"
 #include "tket/OpType/OpTypeFunctions.hpp"
+#include "tket/Ops/BarrierOp.hpp"
 #include "tket/Ops/ClassicalOps.hpp"
 #include "tket/Ops/MetaOp.hpp"
 #include "tket/Ops/OpPtr.hpp"
@@ -28,6 +29,8 @@ void from_json(const nlohmann::json& j, Op_ptr& op) {
   OpType optype = j.at("type").get<OpType>();
   if (is_metaop_type(optype)) {
     op = MetaOp::deserialize(j);
+  } else if (if_barrier_type(optype)) {
+    op = BarrierOp::deserialize(j);
   } else if (is_box_type(optype)) {
     op = Box::deserialize(j);
   } else if (optype == OpType::Conditional) {

--- a/tket/src/Circuit/basic_circ_manip.cpp
+++ b/tket/src/Circuit/basic_circ_manip.cpp
@@ -24,6 +24,7 @@
 
 #include "tket/Circuit/Boxes.hpp"
 #include "tket/Circuit/Circuit.hpp"
+#include "tket/Ops/BarrierOp.hpp"
 #include "tket/Ops/MetaOp.hpp"
 
 namespace tket {
@@ -125,12 +126,11 @@ Vertex Circuit::add_barrier(
   sig.insert(sig.end(), cl_sig.begin(), cl_sig.end());
   std::vector<unsigned> args = qubits;
   args.insert(args.end(), bits.begin(), bits.end());
-  return add_op(std::make_shared<MetaOp>(OpType::Barrier, sig, _data), args);
+  return add_op(std::make_shared<BarrierOp>(sig, _data), args);
 }
 
 Vertex Circuit::add_barrier(
     const unit_vector_t& args, const std::string& _data) {
-  op_signature_t sig;
   for (const UnitID& arg : args) {
     if (arg.type() == UnitType::Qubit) {
       sig.push_back(EdgeType::Quantum);
@@ -138,8 +138,25 @@ Vertex Circuit::add_barrier(
       sig.push_back(EdgeType::Classical);
     }
   }
-  return add_op(std::make_shared<MetaOp>(OpType::Barrier, sig, _data), args);
+  return add_op(std::make_shared<BarrierOp>(sig, _data), args);
 }
+
+Vertex Circuit::add_conditional_barrier(
+    const std::vector<unsigned>& barrier_qubits,
+    const std::vector<unsigned>& barrier_bits,
+    const std::vector<unsigned>& condition_bits, unsigned value,
+    const std::string& _data) {
+  op_signature_t sig(barrier_qubits.size(), EdgeType::Quantum);
+  sig.insert(sig.end(), barrier_bits.size(), EdgeType::Classical);
+
+  return add_op(std::make_shared<Conditional>(
+      std::make_shared<BarrierOp>(sig, _data), (unsigned)condition_bits.size(),
+      value))
+}
+
+Vertex Circuit::add_conditional_barrier(
+    const unit_vector_t& barrier_uids, const unit_vector_t& condition_bits,
+    unsigned value, std::optional<std::string> opgroup = std::nullopt);
 
 std::string Circuit::get_next_c_reg_name(const std::string& reg_name) {
   if (!get_reg_info(reg_name)) {

--- a/tket/src/Circuit/basic_circ_manip.cpp
+++ b/tket/src/Circuit/basic_circ_manip.cpp
@@ -147,7 +147,6 @@ Vertex Circuit::add_conditional_barrier(
     const std::vector<unsigned>& barrier_bits,
     const std::vector<unsigned>& condition_bits, unsigned value,
     const std::string& _data, std::optional<std::string> opgroup) {
-  // TODO: check no overlapping elements between barrier and condition bits
   op_signature_t sig(barrier_qubits.size(), EdgeType::Quantum);
   sig.insert(sig.end(), barrier_bits.size(), EdgeType::Classical);
 
@@ -165,7 +164,6 @@ Vertex Circuit::add_conditional_barrier(
     const unit_vector_t& barrier_args, const unit_vector_t& condition_bits,
     unsigned value, const std::string& _data,
     std::optional<std::string> opgroup) {
-  // TODO: check no overlapping elements between barrier and condition bits
   op_signature_t sig;
   for (const UnitID& arg : barrier_args) {
     if (arg.type() == UnitType::Qubit) {

--- a/tket/src/Converters/PhasePoly.cpp
+++ b/tket/src/Converters/PhasePoly.cpp
@@ -24,7 +24,6 @@
 #include "tket/Circuit/Circuit.hpp"
 #include "tket/Converters/Gauss.hpp"
 #include "tket/OpType/OpType.hpp"
-#include "tket/Ops/MetaOp.hpp"
 #include "tket/Ops/OpJsonFactory.hpp"
 #include "tket/Ops/OpPtr.hpp"
 #include "tket/Utils/GraphHeaders.hpp"

--- a/tket/src/Converters/ZXConverters.cpp
+++ b/tket/src/Converters/ZXConverters.cpp
@@ -311,6 +311,11 @@ BoundaryVertMap circuit_to_zx_recursive(
           }
           op = cond.get_op();
         }
+        if (is_barrier_type(op->get_type())) {
+          throw Unsupported(
+              "Cannot convert conditional barrier operations to a ZX node. \n");
+        }
+
         unsigned port_conditions_size =
             static_cast<unsigned>(port_conditions.size());
         // Convert the underlying op to zx.

--- a/tket/src/Gate/OpPtrFunctions.cpp
+++ b/tket/src/Gate/OpPtrFunctions.cpp
@@ -16,6 +16,7 @@
 
 #include "tket/Gate/Gate.hpp"
 #include "tket/Gate/SymTable.hpp"
+#include "tket/Ops/BarrierOp.hpp"
 #include "tket/Ops/MetaOp.hpp"
 
 namespace tket {
@@ -29,6 +30,8 @@ Op_ptr get_op_ptr(
   if (is_gate_type(chosen_type)) {
     SymTable::register_symbols(expr_free_symbols(params));
     return std::make_shared<const Gate>(chosen_type, params, n_qubits);
+  } else if (is_barrier_type(chosen_type)) {
+    return std::make_shared<const BarrierOp>();
   } else {
     return std::make_shared<const MetaOp>(chosen_type);
   }

--- a/tket/src/Mapping/MappingFrontier.cpp
+++ b/tket/src/Mapping/MappingFrontier.cpp
@@ -1011,28 +1011,24 @@ void MappingFrontier::merge_ancilla(
 bool MappingFrontier::valid_boundary_operation(
     const ArchitecturePtr& architecture, const Op_ptr& op,
     const std::vector<Node>& uids) const {
-  // boxes are never allowed
   OpType ot = op->get_type();
-  if (is_box_type(ot)) {
-    return false;
-  }
 
   if (ot == OpType::Conditional) {
     Op_ptr cond_op_ptr = static_cast<const Conditional&>(*op).get_op();
     // conditional boxes are never allowed, too
-    OpType ot = cond_op_ptr->get_type();
+    ot = cond_op_ptr->get_type();
     while (ot == OpType::Conditional) {
       cond_op_ptr = static_cast<const Conditional&>(*op).get_op();
       ot = cond_op_ptr->get_type();
-      if (is_box_type(ot)) {
-        return false;
-      }
     }
   }
-
-  // Barriers are allways allowed
-  if (ot == OpType::Barrier) {
+  // Barriers are always allowed
+  if (is_barrier_type(ot)) {
     return true;
+  }
+  // boxes are never allowed
+  if (is_box_type(ot)) {
+    return false;
   }
 
   // this currently allows unplaced single qubits gates

--- a/tket/src/Mapping/Verification.cpp
+++ b/tket/src/Mapping/Verification.cpp
@@ -30,12 +30,12 @@ bool respects_connectivity_constraints(
       if (qb_lookup.find(arg) != qb_lookup.end()) qbs.push_back(arg);
     }
     Op_ptr op = com.get_op_ptr();
-    if (op->get_type() == OpType::Barrier) continue;
     if (op->get_type() == OpType::Conditional) {
       std::shared_ptr<const Conditional> cond_ptr =
           std::dynamic_pointer_cast<const Conditional>(op);
       op = cond_ptr->get_op();
     }
+    if (op->get_type() == OpType::Barrier) continue;
     if (op->get_type() == OpType::CircBox) {
       std::shared_ptr<const Box> box_ptr =
           std::dynamic_pointer_cast<const Box>(op);

--- a/tket/src/OpType/OpDesc.cpp
+++ b/tket/src/OpType/OpDesc.cpp
@@ -24,6 +24,7 @@ OpDesc::OpDesc(OpType type)
     : type_(type),
       info_(optypeinfo().at(type)),
       is_meta_(is_metaop_type(type)),
+      is_barrier_(is_barrier_type(type)),
       is_box_(is_box_type(type)),
       is_gate_(is_gate_type(type)),
       is_flowop_(is_flowop_type(type)),
@@ -74,6 +75,8 @@ OptUInt OpDesc::n_classical() const {
 }
 
 bool OpDesc::is_meta() const { return is_meta_; }
+
+bool OpDesc::is_barrier() const { return is_barrier_; }
 
 bool OpDesc::is_box() const { return is_box_; }
 

--- a/tket/src/OpType/OpTypeFunctions.cpp
+++ b/tket/src/OpType/OpTypeFunctions.cpp
@@ -126,11 +126,12 @@ const OpTypeSet& all_controlled_gate_types() {
 
 bool is_metaop_type(OpType optype) {
   static const OpTypeSet metaops = {
-      OpType::Input,    OpType::Output,    OpType::ClInput,
-      OpType::ClOutput, OpType::WASMInput, OpType::WASMOutput,
-      OpType::Barrier,  OpType::Create,    OpType::Discard};
+      OpType::Input,     OpType::Output,     OpType::ClInput, OpType::ClOutput,
+      OpType::WASMInput, OpType::WASMOutput, OpType::Create,  OpType::Discard};
   return find_in_set(optype, metaops);
 }
+
+bool is_barrier_type(OpType optype) { return optype == OpType::Barrier; }
 
 bool is_initial_q_type(OpType optype) {
   return optype == OpType::Input || optype == OpType::Create;

--- a/tket/src/Ops/BarrierOp.cpp
+++ b/tket/src/Ops/BarrierOp.cpp
@@ -23,13 +23,13 @@
 namespace tket {
 
 BarrierOp::BarrierOp(op_signature_t signature, const std::string& _data)
-    : Op(OpType::Barrier), signature_(signature), data_(_data);
+    : Op(OpType::Barrier), signature_(signature), data_(_data) {}
 
 Op_ptr BarrierOp::symbol_substitution(const SymEngine::map_basic_basic&) const {
   return Op_ptr();
 }
 
-SymSet BarrieraOp::free_symbols() const { return {}; }
+SymSet BarrierOp::free_symbols() const { return {}; }
 
 unsigned BarrierOp::n_qubits() const {
   OptUInt n = desc_.n_qubits();
@@ -75,7 +75,5 @@ bool BarrierOp::is_equal(const Op& op_other) const {
   const BarrierOp& other = dynamic_cast<const BarrierOp&>(op_other);
   return (get_signature() == other.get_signature());
 }
-
-BarrierOp::BarrierOp() : Op(OpType::Barrier) {}
 
 }  // namespace tket

--- a/tket/src/Ops/BarrierOp.cpp
+++ b/tket/src/Ops/BarrierOp.cpp
@@ -1,0 +1,81 @@
+// Copyright 2019-2023 Cambridge Quantum Computing
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "tket/Ops/BarrierOp.hpp"
+
+#include <typeinfo>
+
+#include "tket/OpType/EdgeType.hpp"
+#include "tket/OpType/OpType.hpp"
+#include "tket/Utils/Json.hpp"
+
+namespace tket {
+
+BarrierOp::BarrierOp(op_signature_t signature, const std::string& _data)
+    : Op(OpType::Barrier), signature_(signature), data_(_data);
+
+Op_ptr BarrierOp::symbol_substitution(const SymEngine::map_basic_basic&) const {
+  return Op_ptr();
+}
+
+SymSet BarrieraOp::free_symbols() const { return {}; }
+
+unsigned BarrierOp::n_qubits() const {
+  OptUInt n = desc_.n_qubits();
+  if (n == any) {
+    return std::count(signature_.begin(), signature_.end(), EdgeType::Quantum);
+  } else {
+    return n.value();
+  }
+}
+
+op_signature_t BarrierOp::get_signature() const {
+  std::optional<op_signature_t> sig = desc_.signature();
+  if (sig)
+    return *sig;
+  else
+    return signature_;
+}
+
+nlohmann::json BarrierOp::serialize() const {
+  nlohmann::json j;
+  j["type"] = get_type();
+  j["signature"] = get_signature();
+  j["data"] = get_data();
+  return j;
+}
+
+Op_ptr BarrierOp::deserialize(const nlohmann::json& j) {
+  op_signature_t sig = j.at("signature").get<op_signature_t>();
+  std::string data;
+  try {
+    data = j.at("data").get<std::string>();
+  } catch (const nlohmann::json::out_of_range& e) {
+    data = "";
+  }
+  return std::make_shared<BarrierOp>(sig, data);
+}
+
+bool BarrierOp::is_clifford() const { return true; }
+
+BarrierOp::~BarrierOp() {}
+
+bool BarrierOp::is_equal(const Op& op_other) const {
+  const BarrierOp& other = dynamic_cast<const BarrierOp&>(op_other);
+  return (get_signature() == other.get_signature());
+}
+
+BarrierOp::BarrierOp() : Op(OpType::Barrier) {}
+
+}  // namespace tket

--- a/tket/src/Ops/MetaOp.cpp
+++ b/tket/src/Ops/MetaOp.cpp
@@ -79,6 +79,4 @@ bool MetaOp::is_equal(const Op& op_other) const {
   return (get_signature() == other.get_signature());
 }
 
-MetaOp::MetaOp() : Op(OpType::Barrier) {}
-
 }  // namespace tket

--- a/tket/test/src/Circuit/test_Circ.cpp
+++ b/tket/test/src/Circuit/test_Circ.cpp
@@ -3117,6 +3117,174 @@ SCENARIO("check edge type in rewire function") {
     REQUIRE_THROWS_AS(c.rewire(v, ins, types), CircuitInvalidity);
   }
 }
+void check_conditional_circuit(Circuit& c) {
+  // Confirm that the DAG is constructed appropriately by checking
+  // in and out edges of all vertices
+  std::vector<Vertex> vertices = c.all_vertices();
+  // First check Quantum and Classical input and output vertices
+  // have expected number of out edges in interesting cases
+  REQUIRE(c.n_out_edges_of_type(vertices[8], EdgeType::Classical) == 1);
+  REQUIRE(c.n_out_edges_of_type(vertices[8], EdgeType::Boolean) == 1);
+  REQUIRE(c.n_out_edges_of_type(vertices[10], EdgeType::Classical) == 1);
+  REQUIRE(c.n_out_edges_of_type(vertices[10], EdgeType::Boolean) == 2);
+  REQUIRE(c.n_out_edges_of_type(vertices[12], EdgeType::Classical) == 1);
+  REQUIRE(c.n_out_edges_of_type(vertices[12], EdgeType::Boolean) == 2);
+  REQUIRE(c.n_out_edges_of_type(vertices[14], EdgeType::Classical) == 1);
+  REQUIRE(c.n_out_edges_of_type(vertices[14], EdgeType::Boolean) == 2);
+
+  // Conditional gate 0
+  REQUIRE(c.n_in_edges_of_type(vertices[18], EdgeType::Quantum) == 1);
+  REQUIRE(c.n_in_edges_of_type(vertices[18], EdgeType::Classical) == 0);
+  REQUIRE(c.n_in_edges_of_type(vertices[18], EdgeType::Boolean) == 1);
+  REQUIRE(c.n_out_edges_of_type(vertices[18], EdgeType::Quantum) == 1);
+  REQUIRE(c.n_out_edges_of_type(vertices[18], EdgeType::Classical) == 0);
+  REQUIRE(c.n_out_edges_of_type(vertices[18], EdgeType::Boolean) == 0);
+  Op_ptr op_0 = c.get_Op_ptr_from_Vertex(vertices[18]);
+  const Conditional& con_0 = static_cast<const Conditional&>(*op_0);
+  REQUIRE(con_0.get_type() == OpType::Conditional);
+  Op_ptr barrier_0 = con_0.get_op();
+  REQUIRE(barrier_0->get_type() == OpType::Barrier);
+  op_signature_t sig_0 = {EdgeType::Quantum};
+  REQUIRE(barrier_0->get_signature() == sig_0);
+
+  // Conditional gate 1
+  REQUIRE(c.n_in_edges_of_type(vertices[19], EdgeType::Quantum) == 2);
+  REQUIRE(c.n_in_edges_of_type(vertices[19], EdgeType::Classical) == 1);
+  REQUIRE(c.n_in_edges_of_type(vertices[19], EdgeType::Boolean) == 2);
+  REQUIRE(c.n_out_edges_of_type(vertices[19], EdgeType::Quantum) == 2);
+  REQUIRE(c.n_out_edges_of_type(vertices[19], EdgeType::Classical) == 1);
+  REQUIRE(c.n_out_edges_of_type(vertices[19], EdgeType::Boolean) == 0);
+  Op_ptr op_1 = c.get_Op_ptr_from_Vertex(vertices[19]);
+  const Conditional& con_1 = static_cast<const Conditional&>(*op_1);
+  REQUIRE(con_1.get_type() == OpType::Conditional);
+  Op_ptr barrier_1 = con_1.get_op();
+  REQUIRE(barrier_1->get_type() == OpType::Barrier);
+  op_signature_t sig_1 = {
+      EdgeType::Quantum, EdgeType::Quantum, EdgeType::Classical};
+  REQUIRE(barrier_1->get_signature() == sig_1);
+
+  // Conditional gate 2
+  REQUIRE(c.n_in_edges_of_type(vertices[20], EdgeType::Quantum) == 1);
+  REQUIRE(c.n_in_edges_of_type(vertices[20], EdgeType::Classical) == 1);
+  REQUIRE(c.n_in_edges_of_type(vertices[20], EdgeType::Boolean) == 2);
+  REQUIRE(c.n_out_edges_of_type(vertices[20], EdgeType::Quantum) == 1);
+  REQUIRE(c.n_out_edges_of_type(vertices[20], EdgeType::Classical) == 1);
+  REQUIRE(c.n_out_edges_of_type(vertices[20], EdgeType::Boolean) == 0);
+  Op_ptr op_2 = c.get_Op_ptr_from_Vertex(vertices[20]);
+  const Conditional& con_2 = static_cast<const Conditional&>(*op_2);
+  REQUIRE(con_2.get_type() == OpType::Conditional);
+  Op_ptr barrier_2 = con_2.get_op();
+  REQUIRE(barrier_2->get_type() == OpType::Barrier);
+  op_signature_t sig_2 = {EdgeType::Quantum, EdgeType::Classical};
+  REQUIRE(barrier_2->get_signature() == sig_2);
+
+  // Conditional gate 3
+  REQUIRE(c.n_in_edges_of_type(vertices[21], EdgeType::Quantum) == 2);
+  REQUIRE(c.n_in_edges_of_type(vertices[21], EdgeType::Classical) == 3);
+  REQUIRE(c.n_in_edges_of_type(vertices[21], EdgeType::Boolean) == 1);
+  REQUIRE(c.n_out_edges_of_type(vertices[21], EdgeType::Quantum) == 2);
+  REQUIRE(c.n_out_edges_of_type(vertices[21], EdgeType::Classical) == 3);
+  REQUIRE(c.n_out_edges_of_type(vertices[21], EdgeType::Boolean) == 2);
+  Op_ptr op_3 = c.get_Op_ptr_from_Vertex(vertices[21]);
+  const Conditional& con_3 = static_cast<const Conditional&>(*op_3);
+  REQUIRE(con_3.get_type() == OpType::Conditional);
+  Op_ptr barrier_3 = con_3.get_op();
+  REQUIRE(barrier_3->get_type() == OpType::Barrier);
+  op_signature_t sig_3 = {
+      EdgeType::Quantum, EdgeType::Quantum, EdgeType::Classical,
+      EdgeType::Classical, EdgeType::Classical};
+  REQUIRE(barrier_3->get_signature() == sig_3);
+
+  // Conditional gate 4
+  REQUIRE(c.n_in_edges_of_type(vertices[22], EdgeType::Quantum) == 2);
+  REQUIRE(c.n_in_edges_of_type(vertices[22], EdgeType::Classical) == 1);
+  REQUIRE(c.n_in_edges_of_type(vertices[22], EdgeType::Boolean) == 2);
+  REQUIRE(c.n_out_edges_of_type(vertices[22], EdgeType::Quantum) == 2);
+  REQUIRE(c.n_out_edges_of_type(vertices[22], EdgeType::Classical) == 1);
+  REQUIRE(c.n_out_edges_of_type(vertices[22], EdgeType::Boolean) == 0);
+  Op_ptr op_4 = c.get_Op_ptr_from_Vertex(vertices[22]);
+  const Conditional& con_4 = static_cast<const Conditional&>(*op_4);
+  REQUIRE(con_4.get_type() == OpType::Conditional);
+  Op_ptr barrier_4 = con_4.get_op();
+  REQUIRE(barrier_4->get_type() == OpType::Barrier);
+  op_signature_t sig_4 = {
+      EdgeType::Quantum, EdgeType::Quantum, EdgeType::Classical};
+  REQUIRE(barrier_4->get_signature() == sig_4);
+
+  // Conditional gate 5
+  REQUIRE(c.n_in_edges_of_type(vertices[23], EdgeType::Quantum) == 4);
+  REQUIRE(c.n_in_edges_of_type(vertices[23], EdgeType::Classical) == 3);
+  REQUIRE(c.n_in_edges_of_type(vertices[23], EdgeType::Boolean) == 1);
+  REQUIRE(c.n_out_edges_of_type(vertices[23], EdgeType::Quantum) == 4);
+  REQUIRE(c.n_out_edges_of_type(vertices[23], EdgeType::Classical) == 3);
+  REQUIRE(c.n_out_edges_of_type(vertices[23], EdgeType::Boolean) == 0);
+  Op_ptr op_5 = c.get_Op_ptr_from_Vertex(vertices[23]);
+  const Conditional& con_5 = static_cast<const Conditional&>(*op_5);
+  REQUIRE(con_5.get_type() == OpType::Conditional);
+  Op_ptr barrier_5 = con_5.get_op();
+  REQUIRE(barrier_5->get_type() == OpType::Barrier);
+  op_signature_t sig_5 = {EdgeType::Quantum,   EdgeType::Quantum,
+                          EdgeType::Quantum,   EdgeType::Quantum,
+                          EdgeType::Classical, EdgeType::Classical,
+                          EdgeType::Classical};
+  REQUIRE(barrier_5->get_signature() == sig_5);
+
+  // Conditional gate 6
+  REQUIRE(c.n_in_edges_of_type(vertices[25], EdgeType::Quantum) == 4);
+  REQUIRE(c.n_in_edges_of_type(vertices[25], EdgeType::Classical) == 3);
+  REQUIRE(c.n_in_edges_of_type(vertices[25], EdgeType::Boolean) == 1);
+  REQUIRE(c.n_out_edges_of_type(vertices[25], EdgeType::Quantum) == 4);
+  REQUIRE(c.n_out_edges_of_type(vertices[25], EdgeType::Classical) == 3);
+  REQUIRE(c.n_out_edges_of_type(vertices[25], EdgeType::Boolean) == 0);
+  Op_ptr op_6 = c.get_Op_ptr_from_Vertex(vertices[25]);
+  const Conditional& con_6 = static_cast<const Conditional&>(*op_6);
+  REQUIRE(con_6.get_type() == OpType::Conditional);
+  Op_ptr barrier_6 = con_6.get_op();
+  REQUIRE(barrier_6->get_type() == OpType::Barrier);
+  op_signature_t sig_6 = {EdgeType::Quantum,   EdgeType::Quantum,
+                          EdgeType::Quantum,   EdgeType::Quantum,
+                          EdgeType::Classical, EdgeType::Classical,
+                          EdgeType::Classical};
+  REQUIRE(barrier_6->get_signature() == sig_6);
+}
+
+SCENARIO("Check Circuit::add_conditional_barrier.") {
+  GIVEN(
+      "Add various forms of valid conditional barrier using the unsigned "
+      "constructor.") {
+    Circuit c(4, 5);
+    c.add_conditional_barrier({0}, {}, {0}, 0, "");
+    c.add_conditional_barrier({0, 1}, {0}, {1, 2}, 1, "");
+    c.add_conditional_barrier({0}, {0}, {1, 2}, 1, "");
+    c.add_conditional_barrier({1, 3}, {0, 1, 2}, {3}, 0, "test");
+    c.add_conditional_barrier({0, 2}, {0}, {1, 2}, 1, "test1");
+    c.add_conditional_barrier({0, 1, 2, 3}, {0, 1, 2}, {3}, 0, "test1");
+    c.add_measure(3, 4);
+    c.add_conditional_barrier({0, 1, 2, 3}, {0, 1, 2}, {4}, 0, "test2");
+    check_conditional_circuit(c);
+  }
+  GIVEN(
+      "Add various forms of valid conditional barrier using the  unitid "
+      "constructor.") {
+    Circuit c(4, 5);
+    c.add_conditional_barrier({Qubit(0)}, {Bit(0)}, 0, "");
+    c.add_conditional_barrier(
+        {Qubit(0), Qubit(1), Bit(0)}, {Bit(1), Bit(2)}, 1, "");
+    c.add_conditional_barrier({Qubit(0), Bit(0)}, {Bit(1), Bit(2)}, 1, "");
+    c.add_conditional_barrier(
+        {Qubit(1), Qubit(3), Bit(0), Bit(1), Bit(2)}, {Bit(3)}, 0, "test");
+    c.add_conditional_barrier(
+        {Qubit(0), Qubit(2), Bit(0)}, {Bit(1), Bit(2)}, 1, "test1");
+    c.add_conditional_barrier(
+        {Qubit(0), Qubit(1), Qubit(2), Qubit(3), Bit(0), Bit(1), Bit(2)},
+        {Bit(3)}, 0, "test1");
+    c.add_measure(Qubit(3), Bit(4));
+    c.add_conditional_barrier(
+        {Qubit(0), Qubit(1), Qubit(2), Qubit(3), Bit(0), Bit(1), Bit(2)},
+        {Bit(4)}, 0, "test2");
+    check_conditional_circuit(c);
+  }
+}
 
 }  // namespace test_Circ
 }  // namespace tket

--- a/tket/test/src/Circuit/test_ThreeQubitConversion.cpp
+++ b/tket/test/src/Circuit/test_ThreeQubitConversion.cpp
@@ -480,6 +480,7 @@ SCENARIO("Three-qubit squash") {
       c.add_op<unsigned>(OpType::CX, {i % 3, (i + 1) % 3});
       c.add_op<unsigned>(OpType::Rz, 0.25, {(i + 1) % 3});
     }
+    c.add_conditional_barrier({0, 1}, {}, {0}, 1, "");
     c.add_conditional_gate<unsigned>(OpType::X, {}, {0}, {0}, 1);
     for (unsigned i = 11; i < 22; i++) {
       c.add_op<unsigned>(OpType::H, {i % 3});
@@ -489,13 +490,14 @@ SCENARIO("Three-qubit squash") {
     CHECK_FALSE(Transforms::three_qubit_squash().apply(c));
   }
   GIVEN("A circuit with a barrier") {
-    Circuit c(3);
+    Circuit c(3, 1);
     for (unsigned i = 0; i < 11; i++) {
       c.add_op<unsigned>(OpType::H, {i % 3});
       c.add_op<unsigned>(OpType::CX, {i % 3, (i + 1) % 3});
       c.add_op<unsigned>(OpType::Rz, 0.25, {(i + 1) % 3});
     }
     c.add_barrier({0, 1, 2});
+    c.add_conditional_barrier({0, 2, 1}, {}, {0}, 1, "");
     for (unsigned i = 11; i < 22; i++) {
       c.add_op<unsigned>(OpType::H, {i % 3});
       c.add_op<unsigned>(OpType::CX, {i % 3, (i + 1) % 3});

--- a/tket/test/src/Passes/test_SynthesiseTket.cpp
+++ b/tket/test/src/Passes/test_SynthesiseTket.cpp
@@ -27,10 +27,11 @@ SCENARIO("SynthesiseTket with conditionals") {
   c.add_c_register("c", 1);
   c.add_conditional_gate<unsigned>(OpType::CnRy, {0.25}, {0, 1}, {0}, 0);
   c.add_conditional_gate<unsigned>(OpType::Ry, {0.125}, {1}, {0}, 0);
+  c.add_conditional_barrier({0, 1}, {}, {0}, 1, "");
   CompilationUnit cu(c);
   SynthesiseTket()->apply(cu);
   Circuit c1 = cu.get_circ_ref();
-  REQUIRE(c1.n_gates() == 5);
+  REQUIRE(c1.n_gates() == 6);
 }
 
 }  // namespace test_SynthesiseTket

--- a/tket/test/src/Simulation/test_CircuitSimulator.cpp
+++ b/tket/test/src/Simulation/test_CircuitSimulator.cpp
@@ -176,6 +176,13 @@ SCENARIO("Simulate circuit with unsupported operations") {
         tket_sim::get_unitary(circ), Unsupported,
         MessageContains("Unsupported OpType Conditional"));
   }
+  GIVEN("Circuit with conditional barrier") {
+    Circuit circ(2, 2);
+    circ.add_conditional_barrier({0, 1}, {1}, {0}, 1, "");
+    REQUIRE_THROWS_MATCHES(
+        tket_sim::get_unitary(circ), Unsupported,
+        MessageContains("Unsupported OpType Conditional"));
+  }
 }
 
 SCENARIO("Ignored op types don't affect get unitary") {

--- a/tket/test/src/ZX/test_ZXConverters.cpp
+++ b/tket/test/src/ZX/test_ZXConverters.cpp
@@ -266,6 +266,13 @@ SCENARIO("Check converting gates to spiders") {
     REQUIRE(zx.n_wires() == 2);
     REQUIRE_NOTHROW(zx.check_validity());
   }
+  GIVEN("Conditional Barrier") {
+    Circuit circ(2, 2);
+    circ.add_conditional_barrier(
+        std::vector<unsigned>{0, 1}, std::vector<unsigned>{0},
+        std::vector<unsigned>{1}, 1, "");
+    REQUIRE_THROWS_AS(circuit_to_zx(circ), Unsupported);
+  }
   GIVEN("noop") {
     Circuit circ(1);
     circ.add_op<unsigned>(OpType::noop, {0});

--- a/tket/test/src/test_CompilerPass.cpp
+++ b/tket/test/src/test_CompilerPass.cpp
@@ -356,15 +356,16 @@ SCENARIO("Test making (mostly routing) passes using PassGenerators") {
     circ.add_conditional_gate<unsigned>(OpType::Rz, {0.142}, {0}, {0}, 0);
     circ.add_conditional_gate<unsigned>(OpType::Rz, {0.143}, {0}, {0}, 0);
     circ.add_conditional_gate<unsigned>(OpType::Rx, {0.528}, {1}, {0}, 0);
+    circ.add_conditional_barrier({0, 1}, {}, {0}, 1, "");
     CompilationUnit cu(circ);
     squash->apply(cu);
     const Circuit& c = cu.get_circ_ref();
     c.assert_valid();
-    REQUIRE(c.n_gates() == 3);
+    REQUIRE(c.n_gates() == 4);
     std::vector<OpType> expected_optypes{
         OpType::Conditional,  // qubit 0 before CX
         OpType::Conditional,  // qubit 1 before CX
-        OpType::CX};
+        OpType::CX, OpType::Conditional};
     check_command_types(c, expected_optypes);
 
     auto cmds = c.get_commands();

--- a/tket/test/src/test_LexiRoute.cpp
+++ b/tket/test/src/test_LexiRoute.cpp
@@ -459,6 +459,7 @@ SCENARIO("Test LexiRoute::solve and LexiRoute::solve_labelling") {
     circ.add_op<UnitID>(OpType::Measure, {qubits[1], Bit(0)});
     circ.add_op<UnitID>(OpType::CX, {qubits[4], qubits[5]});
     circ.add_op<UnitID>(OpType::Measure, {qubits[3], Bit(0)});
+    circ.add_conditional_barrier({0, 1, 2}, {}, {0}, 1, "");
     // n0 -- n1 -- n2 -- n3 -- n4
     //             |     |
     //             n5    n7
@@ -473,7 +474,7 @@ SCENARIO("Test LexiRoute::solve and LexiRoute::solve_labelling") {
 
     lr.solve(4);
     std::vector<Command> commands = mf->circuit_.get_commands();
-    REQUIRE(commands.size() == 7);
+    REQUIRE(commands.size() == 8);
     Command swap_c = commands[1];
     unit_vector_t uids = {nodes[1], nodes[2]};
     REQUIRE(swap_c.get_args() == uids);

--- a/tket/test/src/test_Rebase.cpp
+++ b/tket/test/src/test_Rebase.cpp
@@ -290,12 +290,14 @@ SCENARIO("Building rebases with rebase_factory") {
     Circuit circ(2, 1);
     circ.add_op<unsigned>(OpType::T, {0});
     circ.add_conditional_gate<unsigned>(OpType::H, {}, {1}, {0}, 1);
+    circ.add_conditional_barrier({0, 1}, {}, {0}, 1, "");
     Transforms::rebase_tket().apply(circ);
     Circuit correct(2, 1);
     correct.add_op<unsigned>(OpType::TK1, {0, 0, 0.25}, {0});
     correct.add_conditional_gate<unsigned>(
         OpType::TK1, {0.5, 0.5, 0.5}, {1}, {0}, 1);
     correct.add_conditional_gate<unsigned>(OpType::Phase, {0.5}, {}, {0}, 1);
+    correct.add_conditional_barrier({0, 1}, {}, {0}, 1, "");
     correct.add_phase(0.125);
     REQUIRE(circ == correct);
   }

--- a/tket/test/src/test_RoutingPasses.cpp
+++ b/tket/test/src/test_RoutingPasses.cpp
@@ -364,6 +364,7 @@ SCENARIO(
     circ.add_conditional_gate<unsigned>(OpType::CX, {}, {2, 1}, {0, 1}, 1);
     circ.add_conditional_gate<unsigned>(OpType::CX, {}, {0, 1}, {0, 1}, 2);
     circ.add_conditional_gate<unsigned>(OpType::CX, {}, {2, 1}, {1, 0}, 3);
+    circ.add_conditional_barrier({1, 2}, {1}, {0}, 1, "");
     circ.add_conditional_gate<unsigned>(OpType::CX, {}, {0, 2}, {0, 1}, 0);
     MappingManager mm(std::make_shared<Architecture>(test_arc));
     REQUIRE(mm.route_circuit(
@@ -382,6 +383,7 @@ SCENARIO(
     Circuit circ(5, 1);
     circ.add_conditional_gate<unsigned>(OpType::CX, {}, {0, 1}, {0}, 1);
     add_2qb_gates(circ, OpType::CX, {{0, 1}, {1, 2}, {1, 3}, {1, 4}, {0, 1}});
+    circ.add_conditional_barrier({0, 1, 2}, {}, {0}, 1, "");
 
     MappingManager mm(std::make_shared<Architecture>(arc));
     REQUIRE(mm.route_circuit(

--- a/tket/test/src/test_Synthesis.cpp
+++ b/tket/test/src/test_Synthesis.cpp
@@ -26,7 +26,7 @@
 #include "tket/Gate/Rotation.hpp"
 #include "tket/OpType/OpType.hpp"
 #include "tket/OpType/OpTypeFunctions.hpp"
-#include "tket/Ops/MetaOp.hpp"
+#include "tket/Ops/BarrierOp.hpp"
 #include "tket/Predicates/CompilationUnit.hpp"
 #include "tket/Predicates/CompilerPass.hpp"
 #include "tket/Predicates/PassLibrary.hpp"
@@ -1754,8 +1754,8 @@ SCENARIO("Test barrier blocks transforms successfully") {
     REQUIRE(circ.depth_by_type(OpType::Barrier) == 1);
     REQUIRE(circ.n_gates() == 3);  // both CXs removed
     Circuit rep(4);
-    const Op_ptr bar = std::make_shared<MetaOp>(
-        OpType::Barrier, op_signature_t(4, EdgeType::Quantum));
+    const Op_ptr bar =
+        std::make_shared<BarrierOp>(op_signature_t(4, EdgeType::Quantum));
     REQUIRE(circ.substitute_all(rep, bar));
     REQUIRE(Transforms::remove_redundancies().apply(circ));
     REQUIRE(verify_n_qubits_for_ops(circ));

--- a/tket/test/src/test_TwoQubitCanonical.cpp
+++ b/tket/test/src/test_TwoQubitCanonical.cpp
@@ -689,8 +689,9 @@ SCENARIO("two_qubit_squash with classical ops") {
         circ.add_conditional_gate<unsigned>(OpType::CX, {}, {0, 1}, {0}, 1);
     circ.add_op<unsigned>(tket::OpType::CX, {0, 1});
     circ.add_op<unsigned>(tket::OpType::CX, {0, 1});
+    circ.add_conditional_barrier({0, 1}, {}, {0}, 1, "");
     REQUIRE(Transforms::two_qubit_squash(OpType::CX).apply(circ));
-    REQUIRE(circ.n_gates() == 1);
+    REQUIRE(circ.n_gates() == 2);
     REQUIRE(circ.get_commands()[0].get_vertex() == v);
   }
   GIVEN("Circuit with conditional gates") {

--- a/tket/test/src/test_json.cpp
+++ b/tket/test/src/test_json.cpp
@@ -225,6 +225,7 @@ SCENARIO("Test Circuit serialization") {
     c.add_conditional_gate<unsigned>(OpType::Ry, {-0.75}, {0}, {0, 1}, 1);
     c.add_conditional_gate<unsigned>(OpType::CX, {}, {0, 1}, {0, 1}, 1);
     c.add_conditional_gate<unsigned>(OpType::Measure, {}, {0, 2}, {0, 1}, 1);
+    c.add_conditional_barrier({0, 1}, {1, 2}, {0}, 0, "");
 
     nlohmann::json j_box = c;
     const Circuit new_c = j_box.get<Circuit>();

--- a/tket/test/src/test_json.cpp
+++ b/tket/test/src/test_json.cpp
@@ -70,10 +70,10 @@ bool check_circuit(const Circuit& c) {
 
 SCENARIO("Test Op serialization") {
   GIVEN("OpType") {
-    const OpTypeSet metaops = {OpType::Input,     OpType::Output,
-                               OpType::ClInput,   OpType::ClOutput,
-                               OpType::WASMInput, OpType::WASMOutput,
-                               OpType::Barrier};
+    const OpTypeSet meta_barrier_ops = {OpType::Input,     OpType::Output,
+                                        OpType::ClInput,   OpType::ClOutput,
+                                        OpType::WASMInput, OpType::WASMOutput,
+                                        OpType::Barrier};
     const OpTypeSet boxes = {
         OpType::CircBox,         OpType::Unitary1qBox,
         OpType::Unitary2qBox,    OpType::Unitary3qBox,
@@ -85,7 +85,7 @@ SCENARIO("Test Op serialization") {
 
     std::set<std::string> type_names;
     for (auto type :
-         boost::join(all_gate_types(), boost::join(metaops, boxes))) {
+         boost::join(all_gate_types(), boost::join(meta_barrier_ops, boxes))) {
       bool success_insert =
           type_names.insert(optypeinfo().at(type).name).second;
       // check all optype names are unique


### PR DESCRIPTION
Adds a new method to the `Circuit` object `_add_conditional_barrier`.
Previously `OpType::Barrier` was classified as a `MetaOp`. However, it seemed a bit at odds with other `MetaOp`, taking a variable number and mix of `UnitID`, and having special case handling for being added to a `Circuit` by a user, while other `MetaOp` can't be.
Given this, this new additional caveat of being to add them as a conditional gate seemed like a step far enough to make them a new child `Op` `BarrierOp`. Happy to undo this work and just have as a special case `MetaOp` if preferred though.

I have made the method "hidden" currently as it is unusual functionality - but obviously we can give it a normal name if we prefer.