### PR TITLE
Pin conan to 2.0.9 for the `build_test_tket_windows` job

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -147,6 +147,8 @@ jobs:
       - uses: actions/checkout@v3
       - name: Install conan
         uses: turtlebrowser/get-conan@v1.2
+        with:
+          version: '2.0.9'
       - name: Set up conan
         id: conan-setup
         run: |


### PR DESCRIPTION
Short-term fix to get the CI working. See:
* https://github.com/CQCL/tket/actions/runs/6029435290 (conan 2.0.10)
* https://github.com/CQCL/tket/actions/runs/6033500689 (conan 2.0.9)