### PR TITLE
make tests not a package again

### DIFF
--- a/pytket/tests/assertion_test.py
+++ b/pytket/tests/assertion_test.py
@@ -27,7 +27,7 @@ from pytket.passes import (
 )
 
 from pytket.pauli import PauliStabiliser, Pauli
-from .simulator import TketSimShotBackend
+from simulator import TketSimShotBackend  # type: ignore
 
 
 def test_assertion_init() -> None:

--- a/pytket/tests/backend_test.py
+++ b/pytket/tests/backend_test.py
@@ -34,8 +34,8 @@ from pytket.backends.backendresult import BackendResult
 from pytket.backends.backend_exceptions import InvalidResultType, CircuitNotRunError
 from pytket.backends.status import CircuitStatus, StatusEnum
 
-from .strategies import outcomearrays, backendresults
-from .simulator import TketSimShotBackend, TketSimBackend
+from strategies import outcomearrays, backendresults  # type: ignore
+from simulator import TketSimShotBackend, TketSimBackend   # type: ignore
 
 
 def test_resulthandle() -> None:

--- a/pytket/tests/backendinfo_test.py
+++ b/pytket/tests/backendinfo_test.py
@@ -26,7 +26,7 @@ from pytket.backends.backendinfo import BackendInfo, fully_connected_backendinfo
 from pytket.architecture import SquareGrid, RingArch, FullyConnected
 from pytket.circuit import OpType, Node
 
-import tests.strategies as st
+import strategies as st  # type: ignore
 
 
 def test_nodes() -> None:

--- a/pytket/tests/circuit_test.py
+++ b/pytket/tests/circuit_test.py
@@ -71,8 +71,8 @@ from math import sqrt
 import pytest  # type: ignore
 
 from hypothesis import given, settings
-import tests.strategies as st
-from tests.useful_typedefs import ParamType
+import strategies as st  # type: ignore
+from useful_typedefs import ParamType  # type: ignore
 
 curr_file_path = Path(__file__).resolve().parent
 

--- a/pytket/tests/classical_test.py
+++ b/pytket/tests/classical_test.py
@@ -68,7 +68,7 @@ from pytket.circuit.logic_exp import (
 
 from pytket.passes import DecomposeClassicalExp, FlattenRegisters
 
-from .strategies import reg_name_regex, binary_digits, uint32
+from strategies import reg_name_regex, binary_digits, uint32  # type: ignore
 
 curr_file_path = Path(__file__).resolve().parent
 

--- a/pytket/tests/qubitpaulioperator_test.py
+++ b/pytket/tests/qubitpaulioperator_test.py
@@ -25,7 +25,7 @@ from pytket.utils import QubitPauliOperator
 from pytket.pauli import Pauli, QubitPauliString, pauli_string_mult
 from pytket.circuit import Qubit
 
-import tests.strategies as st
+import strategies as st  # type: ignore
 
 
 def test_QubitPauliOperator_addition() -> None:

--- a/pytket/tests/transform_test.py
+++ b/pytket/tests/transform_test.py
@@ -59,7 +59,7 @@ import numpy as np
 import json
 import pytest
 
-from .useful_typedefs import ParamType
+from useful_typedefs import ParamType  # type: ignore
 
 
 def get_test_circuit() -> Circuit:

--- a/pytket/tests/utils_test.py
+++ b/pytket/tests/utils_test.py
@@ -49,7 +49,7 @@ import pytest  # type: ignore
 import types
 from sympy import symbols  # type: ignore
 from typing import Any, Callable, Tuple, Dict, List
-from .simulator import TketSimShotBackend, TketSimBackend
+from simulator import TketSimShotBackend, TketSimBackend  # type: ignore
 
 
 def test_append_measurements() -> None:


### PR DESCRIPTION
I made `pytket.tests` a package to more easily satisfy `mypy`, but that broke the build wheel and test CI for some reason.
This makes `pytket.tests` not a package again. After reading up [here](https://docs.pytest.org/en/6.2.x/goodpractices.html),
having tests as a package is not good practice anyway (it would be okay if we had the pytket package under `src/pytket` instead of just `pytket`. 