### PR TITLE
Fix implementations of symbol_substitution() for boxes that cannot contain symbols.

### DIFF
--- a/pytket/conanfile.py
+++ b/pytket/conanfile.py
@@ -32,7 +32,7 @@ class pytketRecipe(ConanFile):
         cmake.install()
 
     def requirements(self):
-        self.requires("tket/1.2.37@tket/stable")
+        self.requires("tket/1.2.38@tket/stable")
         self.requires("tklog/0.3.3@tket/stable")
         self.requires("tkrng/0.3.3@tket/stable")
         self.requires("tkassert/0.3.3@tket/stable")

--- a/pytket/conanfile.py
+++ b/pytket/conanfile.py
@@ -32,7 +32,7 @@ class pytketRecipe(ConanFile):
         cmake.install()
 
     def requirements(self):
-        self.requires("tket/1.2.38@tket/stable")
+        self.requires("tket/1.2.39@tket/stable")
         self.requires("tklog/0.3.3@tket/stable")
         self.requires("tkrng/0.3.3@tket/stable")
         self.requires("tkassert/0.3.3@tket/stable")

--- a/pytket/docs/changelog.rst
+++ b/pytket/docs/changelog.rst
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+Unreleased
+----------
+
+Fixes:
+
+* Correct implementation of `symbol_substitution()` for box types that cannot
+  contain symbols.
+
 0.19.0 (September 2023)
 -----------------------
 

--- a/pytket/tests/circuit_test.py
+++ b/pytket/tests/circuit_test.py
@@ -1239,6 +1239,21 @@ def test_error_wrong_parameters() -> None:
         circ.add_gate(OpType.H, [Bit(0)])
 
 
+def test_symbol_subst() -> None:
+    # https://github.com/CQCL/tket/issues/999
+    d = Circuit(4)
+    rz_op = Op.create(OpType.Rz, 0.3)
+    pauli_x_op = Op.create(OpType.X)
+    pauli_z_op = Op.create(OpType.Z)
+    u = np.asarray([[1.0, 0.0], [0.0, -1.0]])
+    ubox = Unitary1qBox(u)
+    op_map_new = [([_0, _0], [rz_op, pauli_x_op]), ([_1, _1], [ubox, pauli_z_op])]
+    multiplexU2 = MultiplexedTensoredU2Box(op_map_new)
+    d.add_multiplexed_tensored_u2(multiplexU2, [0, 1, 2, 3])
+    d.symbol_substitution({})
+    assert len(d.get_commands()) == 1
+
+
 if __name__ == "__main__":
     test_circuit_gen()
     test_symbolic_ops()

--- a/tket/conanfile.py
+++ b/tket/conanfile.py
@@ -23,7 +23,7 @@ from conan.errors import ConanInvalidConfiguration
 
 class TketConan(ConanFile):
     name = "tket"
-    version = "1.2.38"
+    version = "1.2.39"
     package_type = "library"
     license = "Apache 2"
     homepage = "https://github.com/CQCL/tket"

--- a/tket/conanfile.py
+++ b/tket/conanfile.py
@@ -23,7 +23,7 @@ from conan.errors import ConanInvalidConfiguration
 
 class TketConan(ConanFile):
     name = "tket"
-    version = "1.2.37"
+    version = "1.2.38"
     package_type = "library"
     license = "Apache 2"
     homepage = "https://github.com/CQCL/tket"

--- a/tket/include/tket/Circuit/Boxes.hpp
+++ b/tket/include/tket/Circuit/Boxes.hpp
@@ -200,7 +200,7 @@ class Unitary1qBox : public Box {
 
   Op_ptr symbol_substitution(
       const SymEngine::map_basic_basic &) const override {
-    return Op_ptr();
+    return std::make_shared<Unitary1qBox>(get_matrix());
   }
 
   SymSet free_symbols() const override { return {}; }
@@ -262,7 +262,8 @@ class Unitary2qBox : public Box {
 
   Op_ptr symbol_substitution(
       const SymEngine::map_basic_basic &) const override {
-    return Op_ptr();
+    return std::make_shared<Unitary2qBox>(get_matrix());
+    ;
   }
 
   SymSet free_symbols() const override { return {}; }
@@ -321,7 +322,7 @@ class Unitary3qBox : public Box {
 
   Op_ptr symbol_substitution(
       const SymEngine::map_basic_basic &) const override {
-    return Op_ptr();
+    return std::make_shared<Unitary3qBox>(get_matrix());
   }
 
   SymSet free_symbols() const override { return {}; }
@@ -386,7 +387,7 @@ class ExpBox : public Box {
 
   Op_ptr symbol_substitution(
       const SymEngine::map_basic_basic &) const override {
-    return Op_ptr();
+    return std::make_shared<ExpBox>(A_, t_);
   }
 
   SymSet free_symbols() const override { return {}; }
@@ -575,7 +576,7 @@ class ProjectorAssertionBox : public Box {
 
   Op_ptr symbol_substitution(
       const SymEngine::map_basic_basic &) const override {
-    return Op_ptr();
+    return std::make_shared<ProjectorAssertionBox>(m_);
   }
 
   SymSet free_symbols() const override { return {}; }
@@ -627,7 +628,7 @@ class StabiliserAssertionBox : public Box {
   ~StabiliserAssertionBox() override {}
   Op_ptr symbol_substitution(
       const SymEngine::map_basic_basic &) const override {
-    return Op_ptr();
+    return std::make_shared<StabiliserAssertionBox>(get_stabilisers());
   }
 
   SymSet free_symbols() const override { return {}; }

--- a/tket/include/tket/Circuit/Boxes.hpp
+++ b/tket/include/tket/Circuit/Boxes.hpp
@@ -200,7 +200,7 @@ class Unitary1qBox : public Box {
 
   Op_ptr symbol_substitution(
       const SymEngine::map_basic_basic &) const override {
-    return std::make_shared<Unitary1qBox>(get_matrix());
+    return std::make_shared<Unitary1qBox>(*this);
   }
 
   SymSet free_symbols() const override { return {}; }
@@ -262,8 +262,7 @@ class Unitary2qBox : public Box {
 
   Op_ptr symbol_substitution(
       const SymEngine::map_basic_basic &) const override {
-    return std::make_shared<Unitary2qBox>(get_matrix());
-    ;
+    return std::make_shared<Unitary2qBox>(*this);
   }
 
   SymSet free_symbols() const override { return {}; }
@@ -322,7 +321,7 @@ class Unitary3qBox : public Box {
 
   Op_ptr symbol_substitution(
       const SymEngine::map_basic_basic &) const override {
-    return std::make_shared<Unitary3qBox>(get_matrix());
+    return std::make_shared<Unitary3qBox>(*this);
   }
 
   SymSet free_symbols() const override { return {}; }
@@ -387,7 +386,7 @@ class ExpBox : public Box {
 
   Op_ptr symbol_substitution(
       const SymEngine::map_basic_basic &) const override {
-    return std::make_shared<ExpBox>(A_, t_);
+    return std::make_shared<ExpBox>(*this);
   }
 
   SymSet free_symbols() const override { return {}; }
@@ -576,7 +575,7 @@ class ProjectorAssertionBox : public Box {
 
   Op_ptr symbol_substitution(
       const SymEngine::map_basic_basic &) const override {
-    return std::make_shared<ProjectorAssertionBox>(m_);
+    return std::make_shared<ProjectorAssertionBox>(*this);
   }
 
   SymSet free_symbols() const override { return {}; }
@@ -628,7 +627,7 @@ class StabiliserAssertionBox : public Box {
   ~StabiliserAssertionBox() override {}
   Op_ptr symbol_substitution(
       const SymEngine::map_basic_basic &) const override {
-    return std::make_shared<StabiliserAssertionBox>(get_stabilisers());
+    return std::make_shared<StabiliserAssertionBox>(*this);
   }
 
   SymSet free_symbols() const override { return {}; }

--- a/tket/include/tket/Circuit/ConjugationBox.hpp
+++ b/tket/include/tket/Circuit/ConjugationBox.hpp
@@ -47,7 +47,7 @@ class ConjugationBox : public Box {
 
   Op_ptr symbol_substitution(
       const SymEngine::map_basic_basic &) const override {
-    return std::make_shared<ConjugationBox>(compute_, action_, uncompute_);
+    return std::make_shared<ConjugationBox>(*this);
   }
 
   SymSet free_symbols() const override { return {}; }

--- a/tket/include/tket/Circuit/ConjugationBox.hpp
+++ b/tket/include/tket/Circuit/ConjugationBox.hpp
@@ -47,6 +47,7 @@ class ConjugationBox : public Box {
 
   Op_ptr symbol_substitution(
       const SymEngine::map_basic_basic &) const override {
+    // FIXME https://github.com/CQCL/tket/issues/1007
     return std::make_shared<ConjugationBox>(*this);
   }
 

--- a/tket/include/tket/Circuit/ConjugationBox.hpp
+++ b/tket/include/tket/Circuit/ConjugationBox.hpp
@@ -47,7 +47,7 @@ class ConjugationBox : public Box {
 
   Op_ptr symbol_substitution(
       const SymEngine::map_basic_basic &) const override {
-    return Op_ptr();
+    return std::make_shared<ConjugationBox>(compute_, action_, uncompute_);
   }
 
   SymSet free_symbols() const override { return {}; }

--- a/tket/include/tket/Circuit/DiagonalBox.hpp
+++ b/tket/include/tket/Circuit/DiagonalBox.hpp
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <memory>
+
 #include "Boxes.hpp"
 #include "Circuit.hpp"
 #include "tket/Utils/Json.hpp"
@@ -44,7 +46,7 @@ class DiagonalBox : public Box {
 
   Op_ptr symbol_substitution(
       const SymEngine::map_basic_basic &) const override {
-    return Op_ptr();
+    return std::make_shared<DiagonalBox>(diagonal_, upper_triangle_);
   }
 
   SymSet free_symbols() const override { return {}; }

--- a/tket/include/tket/Circuit/DiagonalBox.hpp
+++ b/tket/include/tket/Circuit/DiagonalBox.hpp
@@ -46,7 +46,7 @@ class DiagonalBox : public Box {
 
   Op_ptr symbol_substitution(
       const SymEngine::map_basic_basic &) const override {
-    return std::make_shared<DiagonalBox>(diagonal_, upper_triangle_);
+    return std::make_shared<DiagonalBox>(*this);
   }
 
   SymSet free_symbols() const override { return {}; }

--- a/tket/include/tket/Circuit/StatePreparation.hpp
+++ b/tket/include/tket/Circuit/StatePreparation.hpp
@@ -48,8 +48,7 @@ class StatePreparationBox : public Box {
 
   Op_ptr symbol_substitution(
       const SymEngine::map_basic_basic &) const override {
-    return std::make_shared<StatePreparationBox>(
-        get_statevector(), is_inverse(), with_initial_reset());
+    return std::make_shared<StatePreparationBox>(*this);
   }
 
   SymSet free_symbols() const override { return {}; }

--- a/tket/include/tket/Circuit/StatePreparation.hpp
+++ b/tket/include/tket/Circuit/StatePreparation.hpp
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <memory>
+
 #include "Boxes.hpp"
 #include "Circuit.hpp"
 #include "tket/Utils/Json.hpp"
@@ -46,7 +48,8 @@ class StatePreparationBox : public Box {
 
   Op_ptr symbol_substitution(
       const SymEngine::map_basic_basic &) const override {
-    return Op_ptr();
+    return std::make_shared<StatePreparationBox>(
+        get_statevector(), is_inverse(), with_initial_reset());
   }
 
   SymSet free_symbols() const override { return {}; }

--- a/tket/include/tket/Circuit/ToffoliBox.hpp
+++ b/tket/include/tket/Circuit/ToffoliBox.hpp
@@ -67,8 +67,7 @@ class ToffoliBox : public Box {
 
   Op_ptr symbol_substitution(
       const SymEngine::map_basic_basic &) const override {
-    return std::make_shared<ToffoliBox>(
-        get_permutation(), get_strat(), get_rotation_axis());
+    return std::make_shared<ToffoliBox>(*this);
   }
 
   SymSet free_symbols() const override { return {}; }

--- a/tket/include/tket/Circuit/ToffoliBox.hpp
+++ b/tket/include/tket/Circuit/ToffoliBox.hpp
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <memory>
+
 #include "Boxes.hpp"
 #include "Circuit.hpp"
 #include "tket/Utils/Json.hpp"
@@ -65,7 +67,8 @@ class ToffoliBox : public Box {
 
   Op_ptr symbol_substitution(
       const SymEngine::map_basic_basic &) const override {
-    return Op_ptr();
+    return std::make_shared<ToffoliBox>(
+        get_permutation(), get_strat(), get_rotation_axis());
   }
 
   SymSet free_symbols() const override { return {}; }

--- a/tket/include/tket/Ops/ClassicalOps.hpp
+++ b/tket/include/tket/Ops/ClassicalOps.hpp
@@ -19,6 +19,8 @@
  * @brief Classical operations
  */
 
+#include <memory>
+
 #include "Op.hpp"
 #include "tket/Utils/Json.hpp"
 
@@ -48,7 +50,7 @@ class ClassicalOp : public Op {
   // Trivial overrides
   Op_ptr symbol_substitution(
       const SymEngine::map_basic_basic &) const override {
-    return Op_ptr();
+    return std::make_shared<ClassicalOp>(type_, n_i_, n_io_, n_o_, name_);
   }
   SymSet free_symbols() const override { return {}; }
   unsigned n_qubits() const override { return 0; }
@@ -76,6 +78,7 @@ class ClassicalOp : public Op {
   bool is_equal(const Op &other) const override;
 
  protected:
+  const OpType type_;
   const unsigned n_i_;
   const unsigned n_io_;
   const unsigned n_o_;

--- a/tket/include/tket/Ops/ClassicalOps.hpp
+++ b/tket/include/tket/Ops/ClassicalOps.hpp
@@ -50,7 +50,7 @@ class ClassicalOp : public Op {
   // Trivial overrides
   Op_ptr symbol_substitution(
       const SymEngine::map_basic_basic &) const override {
-    return std::make_shared<ClassicalOp>(type_, n_i_, n_io_, n_o_, name_);
+    return std::make_shared<ClassicalOp>(*this);
   }
   SymSet free_symbols() const override { return {}; }
   unsigned n_qubits() const override { return 0; }
@@ -78,7 +78,6 @@ class ClassicalOp : public Op {
   bool is_equal(const Op &other) const override;
 
  protected:
-  const OpType type_;
   const unsigned n_i_;
   const unsigned n_io_;
   const unsigned n_o_;

--- a/tket/src/Converters/UnitaryTableauBox.cpp
+++ b/tket/src/Converters/UnitaryTableauBox.cpp
@@ -14,6 +14,7 @@
 
 #include "tket/Converters/UnitaryTableauBox.hpp"
 
+#include "Clifford/UnitaryTableau.hpp"
 #include "tket/Ops/OpJsonFactory.hpp"
 
 namespace tket {
@@ -46,7 +47,7 @@ Op_ptr UnitaryTableauBox::transpose() const {
 
 Op_ptr UnitaryTableauBox::symbol_substitution(
     const SymEngine::map_basic_basic&) const {
-  return Op_ptr();
+  return std::make_shared<UnitaryTableauBox>(get_tableau());
 }
 
 SymSet UnitaryTableauBox::free_symbols() const { return SymSet(); }

--- a/tket/src/Converters/UnitaryTableauBox.cpp
+++ b/tket/src/Converters/UnitaryTableauBox.cpp
@@ -14,7 +14,6 @@
 
 #include "tket/Converters/UnitaryTableauBox.hpp"
 
-#include "Clifford/UnitaryTableau.hpp"
 #include "tket/Ops/OpJsonFactory.hpp"
 
 namespace tket {
@@ -47,7 +46,7 @@ Op_ptr UnitaryTableauBox::transpose() const {
 
 Op_ptr UnitaryTableauBox::symbol_substitution(
     const SymEngine::map_basic_basic&) const {
-  return std::make_shared<UnitaryTableauBox>(get_tableau());
+  return std::make_shared<UnitaryTableauBox>(*this);
 }
 
 SymSet UnitaryTableauBox::free_symbols() const { return SymSet(); }

--- a/tket/src/Ops/ClassicalOps.cpp
+++ b/tket/src/Ops/ClassicalOps.cpp
@@ -152,7 +152,13 @@ static std::shared_ptr<WASMOp> wasm_from_json(const nlohmann::json &j_class) {
 ClassicalOp::ClassicalOp(
     OpType type, unsigned n_i, unsigned n_io, unsigned n_o,
     const std::string &name)
-    : Op(type), n_i_(n_i), n_io_(n_io), n_o_(n_o), name_(name), sig_() {
+    : Op(type),
+      type_(type),
+      n_i_(n_i),
+      n_io_(n_io),
+      n_o_(n_o),
+      name_(name),
+      sig_() {
   for (unsigned i = 0; i < n_i; i++) {
     sig_.push_back(EdgeType::Boolean);
   }

--- a/tket/src/Ops/ClassicalOps.cpp
+++ b/tket/src/Ops/ClassicalOps.cpp
@@ -152,13 +152,7 @@ static std::shared_ptr<WASMOp> wasm_from_json(const nlohmann::json &j_class) {
 ClassicalOp::ClassicalOp(
     OpType type, unsigned n_i, unsigned n_io, unsigned n_o,
     const std::string &name)
-    : Op(type),
-      type_(type),
-      n_i_(n_i),
-      n_io_(n_io),
-      n_o_(n_o),
-      name_(name),
-      sig_() {
+    : Op(type), n_i_(n_i), n_io_(n_io), n_o_(n_o), name_(name), sig_() {
   for (unsigned i = 0; i < n_i; i++) {
     sig_.push_back(EdgeType::Boolean);
   }

--- a/tket/src/Ops/FlowOp.cpp
+++ b/tket/src/Ops/FlowOp.cpp
@@ -28,7 +28,7 @@ FlowOp::FlowOp(OpType type, std::optional<std::string> label)
 }
 
 Op_ptr FlowOp::symbol_substitution(const SymEngine::map_basic_basic&) const {
-  return std::make_shared<FlowOp>(get_type(), get_label());
+  return std::make_shared<FlowOp>(*this);
 }
 
 SymSet FlowOp::free_symbols() const { return {}; }

--- a/tket/src/Ops/FlowOp.cpp
+++ b/tket/src/Ops/FlowOp.cpp
@@ -14,6 +14,8 @@
 
 #include "tket/Ops/FlowOp.hpp"
 
+#include <memory>
+
 #include "tket/OpType/OpTypeInfo.hpp"
 
 namespace tket {
@@ -26,7 +28,7 @@ FlowOp::FlowOp(OpType type, std::optional<std::string> label)
 }
 
 Op_ptr FlowOp::symbol_substitution(const SymEngine::map_basic_basic&) const {
-  return Op_ptr();
+  return std::make_shared<FlowOp>(get_type(), get_label());
 }
 
 SymSet FlowOp::free_symbols() const { return {}; }

--- a/tket/src/Ops/MetaOp.cpp
+++ b/tket/src/Ops/MetaOp.cpp
@@ -29,7 +29,7 @@ MetaOp::MetaOp(OpType type, op_signature_t signature, const std::string& _data)
 }
 
 Op_ptr MetaOp::symbol_substitution(const SymEngine::map_basic_basic&) const {
-  return std::make_shared<MetaOp>(get_type(), get_signature(), get_data());
+  return std::make_shared<MetaOp>(*this);
 }
 
 SymSet MetaOp::free_symbols() const { return {}; }

--- a/tket/src/Ops/MetaOp.cpp
+++ b/tket/src/Ops/MetaOp.cpp
@@ -14,6 +14,7 @@
 
 #include "tket/Ops/MetaOp.hpp"
 
+#include <memory>
 #include <typeinfo>
 
 #include "tket/OpType/EdgeType.hpp"
@@ -28,7 +29,7 @@ MetaOp::MetaOp(OpType type, op_signature_t signature, const std::string& _data)
 }
 
 Op_ptr MetaOp::symbol_substitution(const SymEngine::map_basic_basic&) const {
-  return Op_ptr();
+  return std::make_shared<MetaOp>(get_type(), get_signature(), get_data());
 }
 
 SymSet MetaOp::free_symbols() const { return {}; }


### PR DESCRIPTION
These were just returning a null `Op_ptr`.

Fixes #999 .