### PR TITLE
Remove unneeded `conan install` commands.

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -189,7 +189,7 @@ jobs:
           restore-keys: |
             tket-static-${{ matrix.os }}-
       - name: Build tket
-        # On windows use install + build so build directory is consistent across runs (i.e. don't build from conan cache)
+        # On windows use build + export-pkg so build directory is consistent across runs (i.e. don't build from conan cache)
         # Necessary because setting ccache base_dir doesn't currently work on windows
         run: |
           conan build tket --user=tket --channel=stable -o boost/*:header_only=True -o with_all_tests=True -c tools.cmake.cmaketoolchain:generator=Ninja

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -192,14 +192,12 @@ jobs:
         # On windows use install + build so build directory is consistent across runs (i.e. don't build from conan cache)
         # Necessary because setting ccache base_dir doesn't currently work on windows
         run: |
-          conan install tket --user=tket --channel=stable -o boost/*:header_only=True -o with_all_tests=True -c tools.cmake.cmaketoolchain:generator=Ninja
           conan build tket --user=tket --channel=stable -o boost/*:header_only=True -o with_all_tests=True -c tools.cmake.cmaketoolchain:generator=Ninja
           conan export-pkg tket --user=tket --channel=stable -o boost/*:header_only=True -o with_all_tests=True -c tools.cmake.cmaketoolchain:generator=Ninja
       - name: Upload package
         if: github.event_name == 'push' && github.ref == 'refs/heads/develop'
         run: |
           ccache --set-config namespace=WITHOUT_TESTS
-          conan install tket --user=tket --channel=stable -o boost/*:header_only=True
           conan build tket --user=tket --channel=stable -o boost/*:header_only=True
           conan export-pkg tket --user=tket --channel=stable -o boost/*:header_only=True
           conan remote login -p ${{ secrets.JFROG_ARTIFACTORY_TOKEN_3 }} tket-libs ${{ secrets.JFROG_ARTIFACTORY_USER_3 }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -57,8 +57,7 @@ jobs:
         ccache -p
     - name: Build tket
       run: |
-        conan install tket --user=tket --channel=stable -s build_type=Debug --build=missing -o boost/*:header_only=True -o tket/*:profile_coverage=True -o with_test=True -of build/tket
-        conan build tket --user=tket --channel=stable -s build_type=Debug -o boost/*:header_only=True -o tket/*:profile_coverage=True  -o with_test=True -o test-tket/*:with_coverage=True -of build/tket
+        conan build tket --user=tket --channel=stable -s build_type=Debug --build=missing -o boost/*:header_only=True -o tket/*:profile_coverage=True  -o with_test=True -o test-tket/*:with_coverage=True -of build/tket
         conan export-pkg tket --user=tket --channel=stable -s build_type=Debug -o boost/*:header_only=True -o tket/*:profile_coverage=True -o with_test=True -of build/tket -tf ""
     - name: Install runtime test requirements
       if: github.event_name == 'schedule'

--- a/.github/workflows/test_libs.yml
+++ b/.github/workflows/test_libs.yml
@@ -137,7 +137,7 @@ jobs:
         conan export-pkg libs/${{ matrix.lib }} -s build_type=Debug -o boost/*:header_only=True -o ${{ matrix.lib }}/*:profile_coverage=True -of build/${{ matrix.lib }} -tf ""
     - name: build ${{ matrix.lib }} tests
       run: |
-        conan build   libs/${{ matrix.lib }}/test -s build_type=Debug --build=missing -o boost/*:header_only=True -o test-${{ matrix.lib }}/*:with_coverage=True -of build/${{ matrix.lib }}-tests
+        conan build libs/${{ matrix.lib }}/test -s build_type=Debug --build=missing -o boost/*:header_only=True -o test-${{ matrix.lib }}/*:with_coverage=True -of build/${{ matrix.lib }}-tests
     - name: run ${{ matrix.lib }} tests
       working-directory: ./build/${{ matrix.lib }}-tests/build/Debug
       run: ./test-${{ matrix.lib }}

--- a/.github/workflows/test_libs.yml
+++ b/.github/workflows/test_libs.yml
@@ -133,13 +133,11 @@ jobs:
       run: conan remote add tket-libs https://quantinuumsw.jfrog.io/artifactory/api/conan/tket1-libs --index 0
     - name: build ${{ matrix.lib }}
       run: |
-        conan install libs/${{ matrix.lib }} -s build_type=Debug --build=missing -o boost/*:header_only=True -o ${{ matrix.lib }}/*:profile_coverage=True -of build/${{ matrix.lib }}
-        conan build libs/${{ matrix.lib }} -s build_type=Debug -o boost/*:header_only=True -o ${{ matrix.lib }}/*:profile_coverage=True -of build/${{ matrix.lib }}
+        conan build libs/${{ matrix.lib }} -s build_type=Debug --build=missing -o boost/*:header_only=True -o ${{ matrix.lib }}/*:profile_coverage=True -of build/${{ matrix.lib }}
         conan export-pkg libs/${{ matrix.lib }} -s build_type=Debug -o boost/*:header_only=True -o ${{ matrix.lib }}/*:profile_coverage=True -of build/${{ matrix.lib }} -tf ""
     - name: build ${{ matrix.lib }} tests
       run: |
-        conan install libs/${{ matrix.lib }}/test -s build_type=Debug --build=missing -o boost/*:header_only=True -o test-${{ matrix.lib }}/*:with_coverage=True -of build/${{ matrix.lib }}-tests
-        conan build libs/${{ matrix.lib }}/test -s build_type=Debug --build=missing -o boost/*:header_only=True -o test-${{ matrix.lib }}/*:with_coverage=True -of build/${{ matrix.lib }}-tests
+        conan build   libs/${{ matrix.lib }}/test -s build_type=Debug --build=missing -o boost/*:header_only=True -o test-${{ matrix.lib }}/*:with_coverage=True -of build/${{ matrix.lib }}-tests
     - name: run ${{ matrix.lib }} tests
       working-directory: ./build/${{ matrix.lib }}-tests/build/Debug
       run: ./test-${{ matrix.lib }}

--- a/libs/README.md
+++ b/libs/README.md
@@ -60,11 +60,8 @@ If using gcc and with gcovr installed (`pip install gcovr`), a test coverage
 report can be generated using the following sequence of commands:
 
 ```shell
-conan install libs/tkxxx -s build_type=Debug --build=missing -o boost/*:header_only=True -o tkxxx/*:profile_coverage=True -of build/tkxxx
-conan build libs/tkxxx -s build_type=Debug -o boost/*:header_only=True -o tkxxx/*:profile_coverage=True -of build/tkxxx
+conan build libs/tkxxx -s build_type=Debug --build=missing -o boost/*:header_only=True -o tkxxx/*:profile_coverage=True -of build/tkxxx
 conan export-pkg libs/tkxxx -s build_type=Debug -o boost/*:header_only=True -o tkxxx/*:profile_coverage=True -of build/tkxxx -tf ""
-
-conan install libs/tkxxx/test -s build_type=Debug --build=missing -o boost/*:header_only=True -o test-tkxxx/*:with_coverage=True -of build/tkxxx-tests
 conan build libs/tkxxx/test -s build_type=Debug --build=missing -o boost/*:header_only=True -o test-tkxxx/*:with_coverage=True -of build/tkxxx-tests
 cd ./build/tkxxx-tests/build/Debug
 ./test-tkxxx

--- a/tket/README.md
+++ b/tket/README.md
@@ -35,15 +35,7 @@ mkdir -p ~/texmf/tex/latex
 wget http://mirrors.ctan.org/graphics/pgf/contrib/quantikz/tikzlibraryquantikz.code.tex -P ~/texmf/tex/latex
 ```
 
-To install the dependencies for tket to be built and run with unit and proptests run:
-
-```shell
-conan install tket --build=missing -o "boost/*":header_only=True -o with_all_tests=True
-```
-use `with_test` in the place of `with_all_tests` to add only the necessary unit test dependencies or `with_proptest`
-for only proptest dependencies.
-
-To (re-)build and run all tests, use:
+To build tket and its dependencies and run all unit and property tests, use:
 
 ```shell
 conan build tket --build=missing -o "boost/*":header_only=True -o with_all_tests=True
@@ -95,8 +87,7 @@ If using gcc and with gcovr installed (`pip install gcovr`), a test coverage
 report can be generated using the following sequence of commands:
 
 ```shell
-conan install tket --user=tket --channel=stable -s build_type=Debug --build=missing -o "boost/*":header_only=True -o "tket/*":profile_coverage=True -o "test-tket/*":with_coverage=True -o with_test=True -of build/tket
-conan build tket --user=tket --channel=stable -s build_type=Debug -o "boost/*":header_only=True -o "tket/*":profile_coverage=True -o "test-tket/*":with_coverage=True -o with_test=True -of build/tket
+conan build tket --user=tket --channel=stable -s build_type=Debug --build=missing -o "boost/*":header_only=True -o "tket/*":profile_coverage=True -o "test-tket/*":with_coverage=True -o with_test=True -of build/tket
 
 mkdir test-coverage
 gcovr --print-summary --html --html-details -r ./tket --exclude-lines-by-pattern '.*\bTKET_ASSERT\(.*\);' --object-directory ${PWD}/build/tket/build/Debug/CMakeFiles/tket.dir/src -o test-coverage/index.html --decisions


### PR DESCRIPTION
I learned that in conan 2, `conan build` automatically does `conan install` first. Therefore we can delete these `conan install` commands (as long as we add `--build=missing` where needed to the subsequent `conan build` commands).