### PR TITLE
Bugfix/slow cliffordsimp

### DIFF
--- a/pytket/conanfile.py
+++ b/pytket/conanfile.py
@@ -32,7 +32,7 @@ class pytketRecipe(ConanFile):
         cmake.install()
 
     def requirements(self):
-        self.requires("tket/1.2.41@tket/stable")
+        self.requires("tket/1.2.42@tket/stable")
         self.requires("tklog/0.3.3@tket/stable")
         self.requires("tkrng/0.3.3@tket/stable")
         self.requires("tkassert/0.3.3@tket/stable")

--- a/pytket/docs/changelog.rst
+++ b/pytket/docs/changelog.rst
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+Unreleased
+----------
+
+Fixes:
+
+* Fix ``CliffordSimp`` slow runtime issue.
+
 1.20.0 (September 2023)
 -----------------------
 

--- a/tket/conanfile.py
+++ b/tket/conanfile.py
@@ -23,7 +23,7 @@ from conan.errors import ConanInvalidConfiguration
 
 class TketConan(ConanFile):
     name = "tket"
-    version = "1.2.41"
+    version = "1.2.42"
     package_type = "library"
     license = "Apache 2"
     homepage = "https://github.com/CQCL/tket"

--- a/tket/src/Transformations/CliffordReductionPass.cpp
+++ b/tket/src/Transformations/CliffordReductionPass.cpp
@@ -410,8 +410,12 @@ Subcircuit CliffordReductionPass::substitute(
   // edges.
   EdgeList future_edges;
   VertexSet v_frontier;
+  // keep track of visited vertices
+  VertexSet visited;
   for (unsigned qi = 0; qi < q_width; ++qi) {
-    v_frontier.insert(circ.target(out_edges[qi]));
+    Vertex target = circ.target(out_edges[qi]);
+    visited.insert(target);
+    v_frontier.insert(target);
   }
   while (!v_frontier.empty()) {
     EdgeSet out_edges;
@@ -424,7 +428,12 @@ Subcircuit CliffordReductionPass::substitute(
     future_edges.insert(future_edges.end(), out_edges.begin(), out_edges.end());
     VertexSet new_v_frontier;
     for (auto e : out_edges) {
-      new_v_frontier.insert(circ.target(e));
+      Vertex target = circ.target(e);
+      auto it = visited.insert(target);
+      if (it.second) {
+        // add vertex to the next frontier if the vertex has not been visited
+        new_v_frontier.insert(target);
+      }
     }
     v_frontier = std::move(new_v_frontier);
   }


### PR DESCRIPTION
Fixes #1018 

I initially thought that the `CliffordSimp` could enter an infinite loop. However, it turned out that a particular gate in the test circuit triggered a series of merging actions of 2-qubit Clifford gates. As the merging points moved closer to the front of the circuit, the time taken for each merge increased and eventually became extremely slow.

After each merging, the algorithm would traverse the causal future of that merging point and remove any potential interactions in this causal cone. The issue was that the code had a bug in it, which caused the traversal to blow up when the cone got larger.
