### PR TITLE
Revert "[infra] Pin conan to 2.0.9 for the `build_test_tket_windows` job. (#990)"

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -147,8 +147,6 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install conan
         uses: turtlebrowser/get-conan@v1.2
-        with:
-          version: '2.0.9'
       - name: Set up conan
         id: conan-setup
         run: |


### PR DESCRIPTION
This reverts commit 2aec89c027c0e0e402eb88887ba0bec9e6457969.

Bug was fixed in conan 2.0.11: https://github.com/conan-io/conan/pull/14712 .