### PR TITLE
Use `relative_to` in `use_scm_version`.

### DIFF
--- a/pytket/conanfile.py
+++ b/pytket/conanfile.py
@@ -32,7 +32,7 @@ class pytketRecipe(ConanFile):
         cmake.install()
 
     def requirements(self):
-        self.requires("tket/1.2.47@tket/stable")
+        self.requires("tket/1.2.48@tket/stable")
         self.requires("tklog/0.3.3@tket/stable")
         self.requires("tkrng/0.3.3@tket/stable")
         self.requires("tkassert/0.3.3@tket/stable")

--- a/pytket/setup.py
+++ b/pytket/setup.py
@@ -195,7 +195,8 @@ setup(
     zip_safe=False,
     use_scm_version={
         "root": os.path.dirname(setup_dir),
-        "write_to": os.path.join(setup_dir, "pytket", "_version.py"),
+        "relative_to": os.path.join(setup_dir, "pytket"),
+        "write_to": "_version.py",
         "write_to_template": "__version__ = '{version}'",
     },
 )

--- a/tket/conanfile.py
+++ b/tket/conanfile.py
@@ -23,7 +23,7 @@ from conan.errors import ConanInvalidConfiguration
 
 class TketConan(ConanFile):
     name = "tket"
-    version = "1.2.47"
+    version = "1.2.48"
     package_type = "library"
     license = "Apache 2"
     homepage = "https://github.com/CQCL/tket"


### PR DESCRIPTION
Had to bump tket version because the last push to `develop` that bumped it failed to build.