### PR TITLE
Make `SquashRzPhasedX` always squash symbols.

### DIFF
--- a/pytket/conanfile.py
+++ b/pytket/conanfile.py
@@ -32,7 +32,7 @@ class pytketRecipe(ConanFile):
         cmake.install()
 
     def requirements(self):
-        self.requires("tket/1.2.51@tket/stable")
+        self.requires("tket/1.2.52@tket/stable")
         self.requires("tklog/0.3.3@tket/stable")
         self.requires("tkrng/0.3.3@tket/stable")
         self.requires("tkassert/0.3.3@tket/stable")

--- a/pytket/docs/changelog.rst
+++ b/pytket/docs/changelog.rst
@@ -13,6 +13,7 @@ Minor new features:
 * More efficient decomposition for quantum controlled ``ConjugationBox``es.
 * ``PauliExpBox``, ``PauliExpPairBox``, and ``PauliExpCommutingSetBox`` are now
   decomposed into a single ``ConjugationBox``.
+* Make ``SquashRzPhasedX`` pass always squash symbols.
 
 Fixes:
 

--- a/tket/conanfile.py
+++ b/tket/conanfile.py
@@ -23,7 +23,7 @@ from conan.errors import ConanInvalidConfiguration
 
 class TketConan(ConanFile):
     name = "tket"
-    version = "1.2.51"
+    version = "1.2.52"
     package_type = "library"
     license = "Apache 2"
     homepage = "https://github.com/CQCL/tket"

--- a/tket/include/tket/Transformations/BasicOptimisation.hpp
+++ b/tket/include/tket/Transformations/BasicOptimisation.hpp
@@ -140,9 +140,13 @@ Transform normalise_TK2();
 
 /**
  * @brief Squash single qubit gates into PhasedX and Rz gates.
+ *
  * Commute Rzs to the back if possible.
+ *
+ * @param always_squash_symbols whether to squash symbols regardless of
+ *        complexity increase
  */
-Transform squash_1qb_to_Rz_PhasedX();
+Transform squash_1qb_to_Rz_PhasedX(bool always_squash_symbols = false);
 
 /**
  * Generate a transform that rounds all angles to the nearest \f$ \pi / 2^n \f$.

--- a/tket/src/Predicates/PassLibrary.cpp
+++ b/tket/src/Predicates/PassLibrary.cpp
@@ -434,7 +434,7 @@ const PassPtr &ZZPhaseToRz() {
 
 const PassPtr &SquashRzPhasedX() {
   static const PassPtr pp([]() {
-    Transform t = Transforms::squash_1qb_to_Rz_PhasedX();
+    Transform t = Transforms::squash_1qb_to_Rz_PhasedX(true);
     PredicatePtrMap s_ps;
     PredicateClassGuarantees g_postcons{
         {typeid(GateSetPredicate), Guarantee::Clear}};

--- a/tket/src/Transformations/RzPhasedXSquash.cpp
+++ b/tket/src/Transformations/RzPhasedXSquash.cpp
@@ -97,6 +97,7 @@ Transform squash_1qb_to_Rz_PhasedX() {
   return Transform([](Circuit &circ) {
     bool reverse = false;
     bool success = decompose_ZX().apply(circ);
+    success = remove_redundancies().apply(circ) || success;
     auto squasher = std::make_unique<RzPhasedXSquasher>(reverse);
     return SingleQubitSquash(std::move(squasher), circ, reverse).squash() ||
            success;

--- a/tket/src/Transformations/RzPhasedXSquash.cpp
+++ b/tket/src/Transformations/RzPhasedXSquash.cpp
@@ -93,13 +93,15 @@ std::pair<Circuit, Gate_ptr> RzPhasedXSquasher::flush(
   return {replacement, rz3_gate};
 }
 
-Transform squash_1qb_to_Rz_PhasedX() {
-  return Transform([](Circuit &circ) {
+Transform squash_1qb_to_Rz_PhasedX(bool always_squash_symbols) {
+  return Transform([always_squash_symbols](Circuit &circ) {
     bool reverse = false;
     bool success = decompose_ZX().apply(circ);
     success = remove_redundancies().apply(circ) || success;
     auto squasher = std::make_unique<RzPhasedXSquasher>(reverse);
-    return SingleQubitSquash(std::move(squasher), circ, reverse).squash() ||
+    return SingleQubitSquash(
+               std::move(squasher), circ, reverse, always_squash_symbols)
+               .squash() ||
            success;
   });
 }

--- a/tket/test/src/test_Synthesis.cpp
+++ b/tket/test/src/test_Synthesis.cpp
@@ -2490,7 +2490,7 @@ SCENARIO("Test squash Rz PhasedX") {
     circ.add_op<unsigned>(OpType::PhasedX, {alpha, beta}, {0});
     circ.add_op<unsigned>(OpType::Rz, 0.5, {0});
     circ.add_op<unsigned>(OpType::PhasedX, {0.5, 0.5}, {0});
-    Transforms::squash_1qb_to_Rz_PhasedX().apply(circ);
+    Transforms::squash_1qb_to_Rz_PhasedX(true).apply(circ);
     OpTypeSet allowed = {OpType::Rz, OpType::PhasedX};
     for (const Command &cmd : circ) {
       OpType optype = cmd.get_op_ptr()->get_type();

--- a/tket/test/src/test_Synthesis.cpp
+++ b/tket/test/src/test_Synthesis.cpp
@@ -16,6 +16,7 @@
 #include <numeric>
 #include <optional>
 #include <stdexcept>
+#include <tket/Circuit/Circuit.hpp>
 
 #include "CircuitsForTesting.hpp"
 #include "Simulation/ComparisonFunctions.hpp"
@@ -2476,6 +2477,25 @@ SCENARIO("Test squash Rz PhasedX") {
     const Eigen::MatrixXcd u = tket_sim::get_unitary(circ);
     const Eigen::MatrixXcd v = tket_sim::get_unitary(circ2);
     REQUIRE(u.isApprox(v, ERR_EPS));
+  }
+
+  GIVEN("Another symbolic circuit") {
+    // https://github.com/CQCL/tket/issues/1052
+    Sym a = SymEngine::symbol("alpha");
+    Expr alpha(a);
+    Sym b = SymEngine::symbol("beta");
+    Expr beta(b);
+
+    Circuit circ(1);
+    circ.add_op<unsigned>(OpType::PhasedX, {alpha, beta}, {0});
+    circ.add_op<unsigned>(OpType::Rz, 0.5, {0});
+    circ.add_op<unsigned>(OpType::PhasedX, {0.5, 0.5}, {0});
+    Transforms::squash_1qb_to_Rz_PhasedX().apply(circ);
+    OpTypeSet allowed = {OpType::Rz, OpType::PhasedX};
+    for (const Command &cmd : circ) {
+      OpType optype = cmd.get_op_ptr()->get_type();
+      CHECK(allowed.contains(optype));
+    }
   }
 }
 


### PR DESCRIPTION
Fixes #1052 .