### PR TITLE
link to the notebook examples built with jupyterbook

### DIFF
--- a/pytket/docs/backends.rst
+++ b/pytket/docs/backends.rst
@@ -3,7 +3,7 @@ pytket.backends
 
 Contains :py:class:`Backend` abstract class and associated methods. In pytket a :py:class:`Backend` represents an interface between pytket and a quantum device or simulator. Different backends are defined in the various pytket extension modules and inherit from the core pytket :py:class:`Backend` class.
 
-There are several `example notebooks <https://github.com/CQCL/pytket/tree/main/examples#pytket-examples>`_ on pytket :py:class:`Backend`\s. If you are interested in developing your own :py:class:`Backend` or pytket extension then see the `creating backends <https://github.com/CQCL/pytket/blob/main/examples/creating_backends.ipynb>`_ tutorial.
+There are several `example notebooks <https://tket.quantinuum.com/examples>`_ on pytket :py:class:`Backend`\s. If you are interested in developing your own :py:class:`Backend` or pytket extension then see the `creating backends <https://tket.quantinuum.com/examples/creating_backends.html>`_ tutorial.
 
 Notebook tutorials specific to the :py:class:`QuantinuumBackend` can be found `here <https://github.com/CQCL/pytket-quantinuum/tree/develop/examples>`_.
 

--- a/pytket/docs/index.rst
+++ b/pytket/docs/index.rst
@@ -71,7 +71,7 @@ LICENCE
 Licensed under the `Apache 2 License <http://www.apache.org/licenses/LICENSE-2.0>`_.
 
 .. _Getting Started: getting_started.html
-.. _examples: https://github.com/CQCL/pytket/tree/main/examples
+.. _examples: https://tket.quantinuum.com/examples
 .. _Quantinuum: https://www.quantinuum.com/
 
 .. toctree::
@@ -90,7 +90,7 @@ Licensed under the `Apache 2 License <http://www.apache.org/licenses/LICENSE-2.0
     
     Manual <https://cqcl.github.io/pytket/manual/index.html>
     Extensions <https://cqcl.github.io/pytket-extensions/api/index.html>
-    Example notebooks <https://github.com/CQCL/pytket/tree/main/examples>
+    Example notebooks <https://tket.quantinuum.com/examples>
 
 .. toctree::
     :caption: API Reference:

--- a/pytket/docs/passes.rst
+++ b/pytket/docs/passes.rst
@@ -9,7 +9,7 @@ Also there are special purpose passes such as `OptimisePhaseGadgets <https://cqc
 
 Rebase passes can be used to convert a circuit to a desired gateset. See `RebaseCustom <https://cqcl.github.io/tket/pytket/api/passes.html#pytket.passes.RebaseCustom>`_ and `auto_rebase_pass <https://cqcl.github.io/tket/pytket/api/passes.html#module-pytket.passes.auto_rebase>`_.
 
-For more on pytket passes see the `compilation <https://cqcl.github.io/pytket/manual/manual_compiler.html>`_ section of the user manual or the `notebook tutorials <https://github.com/CQCL/pytket/tree/main/examples#pytket-examples>`_
+For more on pytket passes see the `compilation <https://cqcl.github.io/pytket/manual/manual_compiler.html>`_ section of the user manual or the `notebook tutorials <https://tket.quantinuum.com/examples>`_
 
 
 .. automodule:: pytket._tket.passes

--- a/pytket/package.md
+++ b/pytket/package.md
@@ -29,7 +29,7 @@ API reference: https://cqcl.github.io/tket/pytket/api/
 
 To get started using pytket see the [user manual](https://cqcl.github.io/pytket/manual/index.html).
 
-For worked examples using TKET see our [examples repository](https://github.com/CQCL/pytket/tree/main/examples).
+For worked examples using TKET see our [notebook examples](https://tket.quantinuum.com/examples).
 
 ## Support and Discussion
 


### PR DESCRIPTION
Now that the jupyterbook build is more stable I think it makes sense to link to this from the docs.

The new URL is
https://tket.quantinuum.com/examples

The build is tested on the pytket repo but the pages are deployed from the tket-site repositroy as part of the website prototype.