### PR TITLE
Use github-hosted runners for MacOS arm64 builds

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -375,9 +375,7 @@ jobs:
         conan create recipes/pybind11_json/all --version 0.2.13
     - name: Set up Python (pull request)
       if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-      uses: actions/setup-python@v4
-      with:
-        python-version: "3.9"
+      run: brew install python@3.9
     - name: Set up Python (push)
       if: github.event_name == 'push'
       uses: actions/setup-python@v4
@@ -391,25 +389,25 @@ jobs:
     - name: Build pytket
       run: |
         cd pytket
-        pip install -e .[ZX] -v
+        python${{ matrix.python-version }} -m pip install -e .[ZX] -v
     - name: Run doctests
       run: |
         cd pytket
-        pip install pytest
-        pytest --doctest-modules pytket
+        python${{ matrix.python-version }} -m pip install pytest
+        python${{ matrix.python-version }} -m pytest --doctest-modules pytket
     - name: Test pytket
       run: |
         cd pytket/tests
-        pip install -r requirements.txt
-        pytest --ignore=simulator/
+        python${{ matrix.python-version }} -m pip install -r requirements.txt
+        python${{ matrix.python-version }} -m pytest --ignore=simulator/
     - name: Check type stubs are up-to-date and run mypy
       if: matrix.os == 'macos-12' && (github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch')
       run: |
-        pip install -U mypy
+        python${{ matrix.python-version }} -m pip install -U mypy
         cd pytket
         ./stub_generation/regenerate_stubs
         git diff --quiet pytket/_tket && echo "Stubs are up-to-date" || exit 1  # fail if stubs change after regeneration
-        mypy --config-file=mypy.ini --no-incremental -p pytket -p tests
+        python${{ matrix.python-version }} -m mypy --config-file=mypy.ini --no-incremental -p pytket -p tests
     - name: Upload package
       if: github.event_name == 'push' && github.ref == 'refs/heads/develop' && needs.check_changes.outputs.tket_changed == 'true'
       run: |

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -94,7 +94,7 @@ jobs:
     if: needs.check_changes.outputs.tket_changed == 'true'
     strategy:
       matrix:
-        os: ['ubuntu-22.04', 'macos-12']
+        os: ['ubuntu-22.04', 'macos-12', 'macos-13-xlarge']
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4
@@ -216,60 +216,14 @@ jobs:
           ccache -s  #show stats
           ccache -z  #show stats
 
-  build_test_tket_macos_arm64:
-    name: Build and test tket (macos-arm64)
-    runs-on: ['self-hosted', 'macOS', 'ARM64']
-    needs: check_changes
-    if: needs.check_changes.outputs.tket_changed == 'true' && github.repository == 'CQCL/tket'
-    steps:
-    - uses: actions/checkout@v4
-    - name: Install conan
-      uses: turtlebrowser/get-conan@v1.2
-    - name: Set up conan
-      run: |
-        conan profile detect --force
-        DEFAULT_PROFILE_PATH=`conan profile path default`
-        PROFILE_PATH=./conan-profiles/macos-armv8-clang14
-        diff ${DEFAULT_PROFILE_PATH} ${PROFILE_PATH} || true
-        cp ${PROFILE_PATH} ${DEFAULT_PROFILE_PATH}
-        conan remote add tket-libs https://quantinuumsw.jfrog.io/artifactory/api/conan/tket1-libs --force --index 0
-        conan cache clean
-    - name: ccache
-      uses: hendrikmuhs/ccache-action@v1.2
-      with:
-        key: tket-static-macos-arm64
-    - name: further ccache config
-      run: |
-        ccache --set-config base_dir=${HOME}
-        ccache --set-config compiler_check=content
-        ccache --set-config namespace=WITH_TESTS
-        ccache -p
-    - name: Build tket
-      run: conan create tket --user=tket --channel=test_build -o boost/*:header_only=True -o with_all_tests=True
-    - name: Upload package
-      if: github.event_name == 'push' && github.ref == 'refs/heads/develop'
-      run: |
-        ccache --set-config namespace=WITHOUT_TESTS
-        conan create tket --user=tket --channel=stable -o boost/*:header_only=True
-        conan remote login -p ${{ secrets.JFROG_ARTIFACTORY_TOKEN_3 }} tket-libs ${{ secrets.JFROG_ARTIFACTORY_USER_3 }}
-        conan upload tket/${{ needs.check_changes.outputs.tket_ver }}@tket/stable -r=tket-libs
-
   build_test_tket_not_required:
     name: Build and test (tket)
     needs: check_changes
     if: needs.check_changes.outputs.tket_changed != 'true'
     strategy:
       matrix:
-        os: ['ubuntu-22.04', 'macos-12', 'windows-2022']
+        os: ['ubuntu-22.04', 'macos-12', 'windows-2022', 'macos-13-xlarge']
     runs-on: ${{ matrix.os }}
-    steps:
-      - run: echo "no changes to tket"
-
-  build_test_tket_macos_arm64_not_required:
-    name: Build and test (tket)
-    runs-on: ['self-hosted', 'macOS', 'ARM64']
-    needs: check_changes
-    if: needs.check_changes.outputs.tket_changed != 'true'
     steps:
       - run: echo "no changes to tket"
 
@@ -376,7 +330,10 @@ jobs:
     name: Build and test pytket (macos)
     needs: check_changes
     if: needs.check_changes.outputs.tket_changed == 'true' || needs.check_changes.outputs.pytket_changed == 'true'
-    runs-on: macos-12
+    strategy:
+      matrix:
+        os: ['macos-12', 'macos-13-xlarge']
+    runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4
     - name: Select Python 3.10
@@ -390,7 +347,7 @@ jobs:
       run: |
         conan profile detect
         DEFAULT_PROFILE_PATH=`conan profile path default`
-        PROFILE_PATH=./conan-profiles/macos-12
+        PROFILE_PATH=./conan-profiles/${{ matrix.os }}
         diff ${DEFAULT_PROFILE_PATH} ${PROFILE_PATH} || true
         cp ${PROFILE_PATH} ${DEFAULT_PROFILE_PATH}
         conan remote add tket-libs https://quantinuumsw.jfrog.io/artifactory/api/conan/tket1-libs --index 0
@@ -446,7 +403,7 @@ jobs:
         pip install -r requirements.txt
         pytest --ignore=simulator/
     - name: Check type stubs are up-to-date and run mypy
-      if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+      if: matrix.os == 'macos-12' && (github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch')
       run: |
         pip install -U mypy
         cd pytket
@@ -541,105 +498,6 @@ jobs:
       run: |
         conan remote login -p ${{ secrets.JFROG_ARTIFACTORY_TOKEN_3 }} tket-libs ${{ secrets.JFROG_ARTIFACTORY_USER_3 }}
         conan upload tket/${{ needs.check_changes.outputs.tket_ver }}@tket/stable -r=tket-libs
-
-  build_test_pytket_macos_arm64:
-    name: Build and test pytket (macos-arm64)
-    runs-on: ['self-hosted', 'macOS', 'ARM64']
-    needs: check_changes
-    if: (needs.check_changes.outputs.tket_changed == 'true' || needs.check_changes.outputs.pytket_changed == 'true') && github.repository == 'CQCL/tket'
-    steps:
-    - uses: actions/checkout@v4
-    - name: Install conan
-      uses: turtlebrowser/get-conan@v1.2
-    - name: Set up conan
-      run: |
-        conan profile detect --force
-        DEFAULT_PROFILE_PATH=`conan profile path default`
-        PROFILE_PATH=./conan-profiles/macos-armv8-clang14
-        diff ${DEFAULT_PROFILE_PATH} ${PROFILE_PATH} || true
-        cp ${PROFILE_PATH} ${DEFAULT_PROFILE_PATH}
-        conan remote add tket-libs https://quantinuumsw.jfrog.io/artifactory/api/conan/tket1-libs --force --index 0
-    - name: Remove tket package from cache
-      run: conan remove -c 'tket/*'
-    - name: ccache
-      uses: hendrikmuhs/ccache-action@v1.2
-      with:
-        key: tket-dynamic-macos-arm64
-    - name: further ccache config
-      run: |
-        ccache --set-config base_dir=${HOME}
-        ccache --set-config compiler_check=content
-        ccache -p
-    - name: Build tket
-      if: needs.check_changes.outputs.tket_changed == 'true'
-      run: conan create tket --user tket --channel stable -o boost/*:header_only=True -o tklog/*:shared=True -o tket/*:shared=True -tf ""
-    - name: check that version is consistent
-      if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-      run: ./.github/workflows/check-tket-reqs  ${{ needs.check_changes.outputs.tket_ver }}
-    - name: Uninstall conan
-      run: pip3 uninstall -y conan
-    - name: Build and test pytket (3.9)
-      if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-      run: |
-        eval "$(pyenv init -)"
-        pyenv shell tket-3.9
-        PKG_CONFIG_PATH="$(brew --prefix openblas)"/lib/pkgconfig pip install -U scipy
-        pip install -U conan
-        conan remove -c "pybind11/*"
-        conan remove -c "pytket/*"
-        conan create recipes/pybind11
-        conan create recipes/pybind11_json/all --version 0.2.13
-        cd pytket
-        pip uninstall -y pytket
-        pip install -e .[ZX] -v
-        pytest --doctest-modules pytket
-        cd tests
-        pip install -r requirements.txt
-        pytest --ignore=simulator/
-    - name: Build and test pytket (3.10)
-      if: github.event_name == 'push'
-      run: |
-        eval "$(pyenv init -)"
-        pyenv shell tket-3.10
-        PKG_CONFIG_PATH="$(brew --prefix openblas)"/lib/pkgconfig pip install -U scipy
-        pip install -U conan
-        conan remove -c "pybind11/*"
-        conan remove -c "pytket/*"
-        conan create recipes/pybind11
-        conan create recipes/pybind11_json/all --version 0.2.13
-        cd pytket
-        pip uninstall -y pytket
-        pip install -e .[ZX] -v
-        pytest --doctest-modules pytket
-        cd tests
-        pip install -r requirements.txt
-        pytest --ignore=simulator/
-    - name: Build and test pytket (3.11)
-      if: github.event_name == 'schedule'
-      run: |
-        eval "$(pyenv init -)"
-        pyenv shell tket-3.11
-        PKG_CONFIG_PATH="$(brew --prefix openblas)"/lib/pkgconfig pip install -U scipy
-        pip install -U conan
-        conan remove -c "pybind11/*"
-        conan remove -c "pytket/*"
-        conan create recipes/pybind11
-        conan create recipes/pybind11_json/all --version 0.2.13
-        cd pytket
-        pip uninstall -y pytket
-        pip install -e .[ZX] -v
-        pytest --doctest-modules pytket
-        cd tests
-        pip install -r requirements.txt
-        pytest --ignore=simulator/
-    - name: Install conan
-      uses: turtlebrowser/get-conan@v1.2
-    - name: Upload package
-      if: github.event_name == 'push' && github.ref == 'refs/heads/develop' && needs.check_changes.outputs.tket_changed == 'true'
-      run: |
-        conan remote login -p ${{ secrets.JFROG_ARTIFACTORY_TOKEN_3 }} tket-libs ${{ secrets.JFROG_ARTIFACTORY_USER_3 }}
-        conan upload tket/${{ needs.check_changes.outputs.tket_ver }}@tket/stable -r=tket-libs
-        conan remote logout tket-libs
 
   publish_pytket_coverage:
     name: Publish pytket coverage

--- a/.github/workflows/build_libs.yml
+++ b/.github/workflows/build_libs.yml
@@ -46,7 +46,7 @@ jobs:
     if: ${{ needs.changes.outputs.libs != '[]' && needs.changes.outputs.libs != '' }}
     strategy:
       matrix:
-        os: ['ubuntu-22.04', 'macos-12', 'windows-2022']
+        os: ['ubuntu-22.04', 'macos-12', 'windows-2022', 'macos-13-xlarge']
         lib: ${{ fromJson(needs.changes.outputs.libs) }}
         build_type: ['Release', 'Debug']
     runs-on: ${{ matrix.os }}
@@ -93,41 +93,6 @@ jobs:
     - name: upload package
       if: github.event_name == 'push'
       run: conan upload ${{ env.LIB_LABEL }} -r=tket-libs
-  macos-m1:
-    name: build library (macos-m1)
-    needs: changes
-    if: ${{ needs.changes.outputs.libs != '[]' && needs.changes.outputs.libs != '' }}
-    runs-on: ['self-hosted', 'macOS', 'ARM64']
-    strategy:
-      matrix:
-        lib: ${{ fromJson(needs.changes.outputs.libs) }}
-        build_type: ['Release', 'Debug']
-    steps:
-    - uses: actions/checkout@v4
-    - name: Install conan
-      uses: turtlebrowser/get-conan@v1.2
-    - name: Set up conan
-      run: |
-        conan profile detect --force
-        DEFAULT_PROFILE_PATH=`conan profile path default`
-        PROFILE_PATH=./conan-profiles/macos-armv8-clang14
-        diff ${DEFAULT_PROFILE_PATH} ${PROFILE_PATH} || true
-        cp ${PROFILE_PATH} ${DEFAULT_PROFILE_PATH}
-        conan remote add tket-libs https://quantinuumsw.jfrog.io/artifactory/api/conan/tket1-libs --force --index 0
-    - name: build ${{ matrix.lib }}
-      run: conan create -s build_type=${{ matrix.build_type }} -o boost/*:header_only=True libs/${{ matrix.lib }} --build=missing --user=tket --channel=stable --format json > ${{ matrix.lib }}.json
-    - name: authenticate to repository
-      run: conan remote login -p ${{ secrets.JFROG_ARTIFACTORY_TOKEN_3 }} tket-libs ${{ secrets.JFROG_ARTIFACTORY_USER_3 }}
-    - name: get version
-      run: |
-        lib_label=`./libver ${{ matrix.lib }}.json ${{ matrix.lib }}`
-        echo "LIB_LABEL=${lib_label}" >> $GITHUB_ENV
-    - name: upload package
-      if: github.event_name == 'push'
-      run: conan upload ${{ env.LIB_LABEL }} -r=tket-libs
-    - name: unauthenticate
-      if: always()
-      run: conan remote logout tket-libs
   manylinux:
     name: build library (manylinux)
     needs: changes

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -17,7 +17,7 @@ jobs:
     name: Build
     strategy:
       matrix:
-        os: ['ubuntu-22.04', 'macos-12', 'windows-2022']
+        os: ['ubuntu-22.04', 'macos-12', 'windows-2022', 'macos-13-xlarge']
     runs-on: ${{ matrix.os }}
     steps:
 
@@ -48,35 +48,6 @@ jobs:
     - name: Install and upload packages
       shell: bash
       run: ./.github/workflows/build-external-packages
-
-  build_macos_arm64:
-    name: Build on MacOS ARM64
-    runs-on: ['self-hosted', 'macOS', 'ARM64']
-    steps:
-
-    - uses: actions/checkout@v4
-
-    - name: Install conan
-      uses: turtlebrowser/get-conan@v1.2
-
-    - name: Set up conan
-      run: |
-        conan profile detect --force
-        DEFAULT_PROFILE_PATH=`conan profile path default`
-        PROFILE_PATH=./conan-profiles/macos-armv8-clang14
-        diff ${DEFAULT_PROFILE_PATH} ${PROFILE_PATH} || true
-        cp ${PROFILE_PATH} ${DEFAULT_PROFILE_PATH}
-        conan remote add tket-libs https://quantinuumsw.jfrog.io/artifactory/api/conan/tket1-libs --force --index 0
-
-    - name: authenticate to repository
-      run: conan remote login -p ${{ secrets.JFROG_ARTIFACTORY_TOKEN_3 }} tket-libs ${{ secrets.JFROG_ARTIFACTORY_USER_3 }}
-
-    - name: Install and upload packages
-      shell: bash
-      run: ./.github/workflows/build-external-packages
-
-    - name: unauthenticate
-      run: conan remote logout tket-libs
 
   build_manylinux_x86_64:
     name: Build on manylinux (x86_64)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,7 +115,7 @@ jobs:
 
   build_macos_M1_wheels:
     name: Build macos (M1) wheels
-    runs-on: ['self-hosted', 'macOS', 'ARM64']
+    runs-on: macos-13-xlarge
     strategy:
       matrix:
         python-version: ['3.9', '3.10', '3.11']
@@ -124,40 +124,36 @@ jobs:
       with:
         fetch-depth: '0'
     - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
-    - name: Uninstall conan
-      run: pip3 uninstall -y conan
-    - name: Build wheels
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install conan
+      uses: turtlebrowser/get-conan@v1.2
+    - name: Set up conan
       run: |
-        eval "$(pyenv init -)"
-        pyenv shell tket-${{ matrix.python-version }}
-        python -m pip install -U conan
-        conan profile detect --force
+        conan profile detect
         DEFAULT_PROFILE_PATH=`conan profile path default`
-        PROFILE_PATH=./conan-profiles/macos-armv8-clang14
+        PROFILE_PATH=./conan-profiles/macos-13-xlarge
         diff ${DEFAULT_PROFILE_PATH} ${PROFILE_PATH} || true
         cp ${PROFILE_PATH} ${DEFAULT_PROFILE_PATH}
-        conan remote add tket-libs https://quantinuumsw.jfrog.io/artifactory/api/conan/tket1-libs --force --index 0
-        conan remove -c 'tket/*'
-        conan create tket --user tket --channel stable --build=missing -o boost/*:header_only=True -o tklog/*:shared=True -o tket/*:shared=True -tf ""
-        conan remove -c "pybind11/*"
+        conan remote add tket-libs https://quantinuumsw.jfrog.io/artifactory/api/conan/tket1-libs --index 0
+    - name: Build tket C++
+      run: conan create tket --user tket --channel stable --build=missing -o boost/*:header_only=True -o tklog/*:shared=True -o tket/*:shared=True -tf ""
+    - name: Build wheel
+      run: |
         conan create recipes/pybind11
         conan create recipes/pybind11_json/all --version 0.2.13
         cd pytket
         # Ensure wheels are compatible with MacOS 11.0 and later:
         export WHEEL_PLAT_NAME=macosx_11_0_arm64
-        conan remove -c "pytket/*"
-        python -m pip uninstall -y pytket
-        python -m pip install -U pip build delocate
-        rm -rf dist
+        pip install -U pip build delocate
         python -m build
         delocate-wheel -v -w "$GITHUB_WORKSPACE/wheelhouse/" "dist/pytket-"*".whl"
     - uses: actions/upload-artifact@v3
       with:
         name: MacOS_M1_${{ matrix.python-version }}_wheel
         path: wheelhouse/
-    - name: Remove directory
-      if: always()
-      run: rm -rf wheelhouse
 
   build_Windows_wheels:
     name: Build Windows wheels
@@ -296,32 +292,31 @@ jobs:
   test_macos_M1_wheels:
     name: Test macos (M1) wheels
     needs: build_macos_M1_wheels
-    runs-on: ['self-hosted', 'macOS', 'ARM64']
+    runs-on: macos-13-xlarge
     strategy:
       matrix:
         python-version: ['3.9', '3.10', '3.11']
     steps:
-    - uses: actions/checkout@v4
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
       with:
-        path: tket
+        python-version: ${{ matrix.python-version }}
     - name: Download wheels
       uses: actions/download-artifact@v3
       with:
         name: MacOS_M1_${{ matrix.python-version }}_wheel
         path: wheelhouse/
-    - name: Install wheel and run tests
+    - uses: actions/checkout@v4
+      with:
+        path: tket
+    - name: Install wheel
       run: |
-        eval "$(pyenv init -)"
-        pyenv shell tket-${{ matrix.python-version }}
-        PKG_CONFIG_PATH="$(brew --prefix openblas)"/lib/pkgconfig pip install -U scipy
-        pip uninstall -y pytket
         pip install $GITHUB_WORKSPACE/wheelhouse/pytket-*.whl
-        cd pytket/tests
+    - name: Run tests
+      run: |
+        cd tket/pytket/tests
         pip install -r requirements.txt
         pytest --ignore=simulator/
-    - name: Remove directory
-      if: always()
-      run: rm -rf wheelhouse
 
   test_Windows_wheels:
     name: Test Windows wheels

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,9 +125,13 @@ jobs:
         fetch-depth: '0'
     - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
     - name: Set up Python ${{ matrix.python-version }}
+      if: matrix.python-version != '3.9'
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
+    - name: Set up Python 3.9
+      if: matrix.python-version == '3.9'
+      run: brew install python@3.9
     - name: Install conan
       uses: turtlebrowser/get-conan@v1.2
     - name: Set up conan
@@ -147,8 +151,8 @@ jobs:
         cd pytket
         # Ensure wheels are compatible with MacOS 11.0 and later:
         export WHEEL_PLAT_NAME=macosx_11_0_arm64
-        pip install -U pip build delocate
-        python -m build
+        python${{ matrix.python-version }} -m pip install -U pip build delocate
+        python${{ matrix.python-version }} -m python -m build
         delocate-wheel -v -w "$GITHUB_WORKSPACE/wheelhouse/" "dist/pytket-"*".whl"
     - uses: actions/upload-artifact@v3
       with:
@@ -298,9 +302,13 @@ jobs:
         python-version: ['3.9', '3.10', '3.11']
     steps:
     - name: Set up Python ${{ matrix.python-version }}
+      if: matrix.python-version != '3.9'
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
+    - name: Set up Python 3.9
+      if: matrix.python-version == '3.9'
+      run: brew install python@3.9
     - name: Download wheels
       uses: actions/download-artifact@v3
       with:
@@ -311,12 +319,12 @@ jobs:
         path: tket
     - name: Install wheel
       run: |
-        pip install $GITHUB_WORKSPACE/wheelhouse/pytket-*.whl
+        python${{ matrix.python-version }} -m pip install $GITHUB_WORKSPACE/wheelhouse/pytket-*.whl
     - name: Run tests
       run: |
         cd tket/pytket/tests
-        pip install -r requirements.txt
-        pytest --ignore=simulator/
+        python${{ matrix.python-version }} -m pip install -r requirements.txt
+        python${{ matrix.python-version }} -m pytest --ignore=simulator/
 
   test_Windows_wheels:
     name: Test Windows wheels

--- a/.github/workflows/test_libs.yml
+++ b/.github/workflows/test_libs.yml
@@ -63,7 +63,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ['ubuntu-22.04', 'macos-12', 'windows-2022']
+        os: ['ubuntu-22.04', 'macos-12', 'windows-2022', 'macos-13-xlarge']
         lib: ${{ fromJson(needs.set_libs_matrix.outputs.libs) }}
     runs-on: ${{ matrix.os }}
     steps:
@@ -89,36 +89,6 @@ jobs:
       run: conan create -o boost/*:header_only=True libs/${{ matrix.lib }}/test --build=missing --format json > test-${{ matrix.lib }}.json
     - name: run ${{ matrix.lib }} tests
       shell: bash
-      run: |
-        PKGPATH=`./rootpath test-${{ matrix.lib }}.json test-${{ matrix.lib }}`
-        cd ${PKGPATH}/bin
-        ./test-${{ matrix.lib }}
-  macos-m1:
-    name: test library (macos-m1)
-    needs: set_libs_matrix
-    if: ${{ needs.set_libs_matrix.outputs.libs != '[]' && needs.set_libs_matrix.outputs.libs != '' }}
-    runs-on: ['self-hosted', 'macOS', 'ARM64']
-    strategy:
-      fail-fast: false
-      matrix:
-        lib: ${{ fromJson(needs.set_libs_matrix.outputs.libs) }}
-    steps:
-    - uses: actions/checkout@v4
-    - name: Install conan
-      uses: turtlebrowser/get-conan@v1.2
-    - name: Set up conan
-      run: |
-        conan profile detect --force
-        DEFAULT_PROFILE_PATH=`conan profile path default`
-        PROFILE_PATH=./conan-profiles/macos-armv8-clang14
-        diff ${DEFAULT_PROFILE_PATH} ${PROFILE_PATH} || true
-        cp ${PROFILE_PATH} ${DEFAULT_PROFILE_PATH}
-        conan remote add tket-libs https://quantinuumsw.jfrog.io/artifactory/api/conan/tket1-libs --force --index 0
-    - name: build ${{ matrix.lib }}
-      run: conan create -o boost/*:header_only=True libs/${{ matrix.lib }} --build=missing
-    - name: build ${{ matrix.lib }} tests
-      run: conan create libs/${{ matrix.lib }}/test --build=missing --format json > test-${{ matrix.lib }}.json
-    - name: run ${{ matrix.lib }} tests
       run: |
         PKGPATH=`./rootpath test-${{ matrix.lib }}.json test-${{ matrix.lib }}`
         cd ${PKGPATH}/bin

--- a/.github/workflows/test_libs_all.yml
+++ b/.github/workflows/test_libs_all.yml
@@ -10,7 +10,7 @@ jobs:
     name: test library
     strategy:
       matrix:
-        os: ['ubuntu-22.04', 'macos-12', 'windows-2022']
+        os: ['ubuntu-22.04', 'macos-12', 'windows-2022', 'macos-13-xlarge']
         lib: ['tklog', 'tkassert', 'tkrng', 'tktokenswap', 'tkwsm']
     runs-on: ${{ matrix.os }}
     steps:
@@ -36,34 +36,6 @@ jobs:
       run: conan create libs/${{ matrix.lib }}/test --build=missing -o boost/*:header_only=True --format json > test-${{ matrix.lib }}.json
     - name: run ${{ matrix.lib }} tests
       shell: bash
-      run: |
-        PKGPATH=`./rootpath test-${{ matrix.lib }}.json test-${{ matrix.lib }}`
-        cd ${PKGPATH}/bin
-        ./test-${{ matrix.lib }}
-  macos-m1:
-    name: test library (macos-m1)
-    runs-on: ['self-hosted', 'macOS', 'ARM64']
-    strategy:
-      matrix:
-        lib: ['tklog', 'tkassert', 'tkrng', 'tktokenswap', 'tkwsm']
-    steps:
-    - uses: actions/checkout@v4
-    - name: Install conan
-      uses: turtlebrowser/get-conan@v1.2
-    - name: Set up conan
-      shell: bash
-      run: |
-        conan profile detect --force
-        DEFAULT_PROFILE_PATH=`conan profile path default`
-        PROFILE_PATH=./conan-profiles/macos-armv8-clang14
-        diff ${DEFAULT_PROFILE_PATH} ${PROFILE_PATH} || true
-        cp ${PROFILE_PATH} ${DEFAULT_PROFILE_PATH}
-        conan remote add tket-libs https://quantinuumsw.jfrog.io/artifactory/api/conan/tket1-libs --force --index 0
-    - name: build ${{ matrix.lib }}
-      run: conan create libs/${{ matrix.lib }} --build=missing -o boost/*:header_only=True
-    - name: build ${{ matrix.lib }} tests
-      run: conan create libs/${{ matrix.lib }}/test --build=missing -o boost/*:header_only=True --format json > test-${{ matrix.lib }}.json
-    - name: run ${{ matrix.lib }} tests
       run: |
         PKGPATH=`./rootpath test-${{ matrix.lib }}.json test-${{ matrix.lib }}`
         cd ${PKGPATH}/bin

--- a/conan-profiles/macos-13-xlarge
+++ b/conan-profiles/macos-13-xlarge
@@ -1,0 +1,8 @@
+[settings]
+arch=armv8
+build_type=Release
+compiler=apple-clang
+compiler.cppstd=gnu17
+compiler.libcxx=libc++
+compiler.version=14
+os=Macos

--- a/pytket/conanfile.py
+++ b/pytket/conanfile.py
@@ -32,7 +32,7 @@ class pytketRecipe(ConanFile):
         cmake.install()
 
     def requirements(self):
-        self.requires("tket/1.2.56@tket/stable")
+        self.requires("tket/1.2.57@tket/stable")
         self.requires("tklog/0.3.3@tket/stable")
         self.requires("tkrng/0.3.3@tket/stable")
         self.requires("tkassert/0.3.3@tket/stable")

--- a/tket/conanfile.py
+++ b/tket/conanfile.py
@@ -23,7 +23,7 @@ from conan.errors import ConanInvalidConfiguration
 
 class TketConan(ConanFile):
     name = "tket"
-    version = "1.2.56"
+    version = "1.2.57"
     package_type = "library"
     license = "Apache 2"
     homepage = "https://github.com/CQCL/tket"


### PR DESCRIPTION
Still using the self-hosted arm64 mac for Linux/arm64 builds (using docker), as I haven't yet managed to get docker running on the github-hosted VMs. (Will keep trying.)

One minor annoyance is that `actions/setup-python` can't install Python 3.9 on the arm64 Mac VMs ( https://github.com/actions/setup-python/issues/696 ), so I use brew to install Python 3.9 instead.

Release workflow tested here: https://github.com/CQCL/tket/actions/runs/6404838599 .

(I'll need to modify the names of the "required" checks after this merge: three showing as "required" don't exist anymore.)