### PR TITLE
Remove docs build warning from `pydata-sphinx-theme` 0.14.2 and upgrade sphinx version

### DIFF
--- a/pytket/docs/conf.py
+++ b/pytket/docs/conf.py
@@ -109,8 +109,6 @@ html_theme_options = {
     },
 }
 
-html_show_sphinx = True
-
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".

--- a/pytket/docs/conf.py
+++ b/pytket/docs/conf.py
@@ -55,7 +55,6 @@ release = "1.21.0"
 extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.autosummary",
-    "sphinx.ext.intersphinx",
     "sphinx.ext.mathjax",
     "sphinx.ext.viewcode",
     "sphinx_copybutton",

--- a/pytket/docs/conf.py
+++ b/pytket/docs/conf.py
@@ -102,6 +102,7 @@ html_theme_options = {
     "repository_url": "https://github.com/CQCL/tket",
     "use_repository_button": True,
     "use_issues_button": True,
+    "navigation_with_keys": True,
     "logo": {
         "image_light": "_static/Quantinuum_logo_black.png",
         "image_dark": "_static/Quantinuum_logo_white.png",

--- a/pytket/docs/conf.py
+++ b/pytket/docs/conf.py
@@ -97,6 +97,7 @@ html_theme = "sphinx_book_theme"
 # further.  For a list of options available for each theme, see the
 # documentation.
 #
+
 html_theme_options = {
     "repository_url": "https://github.com/CQCL/tket",
     "use_repository_button": True,
@@ -107,6 +108,8 @@ html_theme_options = {
         "image_dark": "_static/Quantinuum_logo_white.png",
     },
 }
+
+html_show_sphinx = True
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/pytket/docs/conf.py
+++ b/pytket/docs/conf.py
@@ -87,10 +87,6 @@ language = "en"
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
-# The name of the Pygments (syntax highlighting) style to use.
-pygments_style = "borland"
-
-
 # -- Options for HTML output -------------------------------------------------
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for

--- a/pytket/docs/requirements.txt
+++ b/pytket/docs/requirements.txt
@@ -1,4 +1,4 @@
-sphinx >= 4.5, < 6.2.0
+sphinx >= 4.5
 sphinx_autodoc_annotation >= 1.0
 sphinx_book_theme ~= 1.0.1
 sphinx-copybutton

--- a/pytket/docs/requirements.txt
+++ b/pytket/docs/requirements.txt
@@ -1,4 +1,4 @@
-sphinx >= 4.5
+sphinx >= 4.5, <7
 sphinx_autodoc_annotation >= 1.0
 sphinx_book_theme ~= 1.0.1
 sphinx-copybutton


### PR DESCRIPTION
This fixes a API docs build issue which is caused by the new `pydata-sphinx-theme` [0.14.2 release](https://github.com/pydata/pydata-sphinx-theme/releases/tag/v0.14.2). The pydata-sphinx-theme is the parent theme of the sphinx book theme which we use for the docs.

This release introduced a new warning which caused the docs build to fail. The warning is the following...

________________________________________
#69 39.94 WARNING: The default value for `navigation_with_keys` will change to `False` in the next release. If you wish to preserve the old behavior for your site, set `navigation_with_keys=True` in the `html_theme_options` dict in your `conf.py` file.Be aware that `navigation_with_keys = True` has negative accessibility implications:https://github.com/pydata/pydata-sphinx-theme/issues/1492
________________________________________

I tested this by running the CI with the first commit. The docs build failed
https://github.com/CQCL/tket/actions/runs/6642169421/job/18046321766?pr=1093

The second commit sets the `navigation_with_keys` key to `true` which fixes the docs build
https://github.com/CQCL/tket/actions/runs/6642374353/job/18047022783?pr=1093.

Other changes...

I've removed the restriction on the sphinx version https://github.com/CQCL/tket/issues/836 . This restriction was due to deprecated intersphinx syntax. We are not using intersphinx at the moment in this repository.

I've removed some unused pygments settings as well