### PR TITLE
Updated Qiskit Documentation

### DIFF
--- a/pytket/docs/getting_started.rst
+++ b/pytket/docs/getting_started.rst
@@ -100,10 +100,10 @@ The following code snippet will show how to compile a circuit to run on an IBM d
     from pytket.extensions.qiskit import IBMQBackend
 
     circ = Circuit(3).X(0).CCX(0, 1, 2)
-    belem_device = IBMQBackend('ibmq_belem')
+    nairobi_device = IBMQBackend('ibmq_nairobi')
 
     # Compile Circuit to use supported gates of IBMQ Belem
-    compiled_circ = belem_device.get_compiled_circuit(circ)
+    compiled_circ = nairobi_device.get_compiled_circuit(circ)
     result = backend.run_circuit(compiled_circ, n_shots=100)
 
 Here the default compilation pass is applied by :py:meth:`IBMQBackend.get_compiled_circuit`. See `this page <https://cqcl.github.io/pytket-qiskit/api/index.html#default-compilation>`_ for more details.

--- a/pytket/docs/getting_started.rst
+++ b/pytket/docs/getting_started.rst
@@ -102,7 +102,7 @@ The following code snippet will show how to compile a circuit to run on an IBM d
     circ = Circuit(3).X(0).CCX(0, 1, 2)
     nairobi_device = IBMQBackend('ibm_nairobi')
 
-    # Compile Circuit to use supported gates of IBMQ Belem
+    # Compile Circuit to use supported gates of IBMQ Nairobi
     compiled_circ = nairobi_device.get_compiled_circuit(circ)
     result = backend.run_circuit(compiled_circ, n_shots=100)
 

--- a/pytket/docs/getting_started.rst
+++ b/pytket/docs/getting_started.rst
@@ -100,7 +100,7 @@ The following code snippet will show how to compile a circuit to run on an IBM d
     from pytket.extensions.qiskit import IBMQBackend
 
     circ = Circuit(3).X(0).CCX(0, 1, 2)
-    nairobi_device = IBMQBackend('ibmq_nairobi')
+    nairobi_device = IBMQBackend('ibm_nairobi')
 
     # Compile Circuit to use supported gates of IBMQ Belem
     compiled_circ = nairobi_device.get_compiled_circuit(circ)


### PR DESCRIPTION
The qiskit documentation mentions `ibmq_belem`. That system has now been retired by IBMQ,The following systems have been retired on September 26th: ibmq_lima, ibmq_belem, ibmq_quito, ibmq_manila, and ibmq_jakarta.

So replaced it with the `ibm_nairobi`  in the documentation.