### PR TITLE
Remove docs build warning from `pydata-sphinx-theme` 0.14.2 and upgra…

### DIFF
--- a/pytket/docs/conf.py
+++ b/pytket/docs/conf.py
@@ -55,7 +55,6 @@ release = "1.21.0"
 extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.autosummary",
-    "sphinx.ext.intersphinx",
     "sphinx.ext.mathjax",
     "sphinx.ext.viewcode",
     "sphinx_copybutton",
@@ -87,10 +86,6 @@ language = "en"
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
-# The name of the Pygments (syntax highlighting) style to use.
-pygments_style = "borland"
-
-
 # -- Options for HTML output -------------------------------------------------
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
@@ -102,10 +97,12 @@ html_theme = "sphinx_book_theme"
 # further.  For a list of options available for each theme, see the
 # documentation.
 #
+
 html_theme_options = {
     "repository_url": "https://github.com/CQCL/tket",
     "use_repository_button": True,
     "use_issues_button": True,
+    "navigation_with_keys": True,
     "logo": {
         "image_light": "_static/Quantinuum_logo_black.png",
         "image_dark": "_static/Quantinuum_logo_white.png",

--- a/pytket/docs/requirements.txt
+++ b/pytket/docs/requirements.txt
@@ -1,4 +1,4 @@
-sphinx >= 4.5, < 6.2.0
+sphinx >= 4.5, <7
 sphinx_autodoc_annotation >= 1.0
 sphinx_book_theme ~= 1.0.1
 sphinx-copybutton


### PR DESCRIPTION
We are having some problems with the docs not building on another repo which pulls from main.
I have cherry picked the fix for the build problem, it should work now.

It is not intended to have a release after this is merged.

…de sphinx version (#1093)

* remove unused pygment

* try navigation_with_keys fix

* remove unused intersphinx extension for now

* remove sphinx version restriction

* Show sphinx version in doc footer

* use sphinx <7

* remove show_sphinx flag