### PR TITLE
add job to check all build and test jobs successful

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -577,3 +577,39 @@ jobs:
       run: |
         wget https://cqcl.github.io/tket/pytket/test-coverage/cov.xml -O oldcov.xml
         ./.github/workflows/compare-pytket-coverage oldcov.xml pytket-test-coverage/cov.xml
+
+  check_all_build_and_test_jobs_successful:
+    name: All build and test jobs successful (or skipped)
+    needs:
+      - check_changes
+      - check_docs_tket
+      - check_format_tket
+      - build_test_tket
+      - build_test_tket_windows
+      - publish_pytket_coverage
+      - build_test_pytket_macos
+      - build_test_pytket_ubuntu
+      - build_test_pytket_windows
+      - publish_pytket_coverage
+      - check_pytket_coverage
+    if: always()
+    runs-on: ubuntu-22.04
+    steps:
+      - shell: python
+        name: Check job results
+        run: |
+          results = [
+              "${{ needs.check_changes.result }}",
+              "${{ needs.check_docs_tket.result }}",
+              "${{ needs.check_format_tket.result }}",
+              "${{ needs.build_test_tket.result }}",
+              "${{ needs.build_test_tket_windows.result }}",
+              "${{ needs.publish_pytket_coverage.result }}",
+              "${{ needs.build_test_pytket_macos.result }}",
+              "${{ needs.build_test_pytket_ubuntu.result }}",
+              "${{ needs.build_test_pytket_windows.result }}"
+              "${{ needs.publish_pytket_coverage.result }}",
+              "${{ needs.check_pytket_coverage.result }}",
+          ]
+          if "failure" in results or "cancelled" in results:
+              raise Exception


### PR DESCRIPTION
Fixes #1115, also see comments there

Added a job to build and test workflow whose only job is to check that all other jobs did not explicitly fail or were not canceled (skipped jobs are ok). How this fixes the problem:

- After merging, only use the new job as a required check in the github settings -> No longer need to define a required check for the individual jobs
- No longer have to worry about naming issues that occur with matrix strategy jobs

After merging: In a follow-up PR, should be able to remove the dummy job `build_test_tket_not_required` since it should no longer be required