### PR TITLE
remove tket build dummy job

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -219,17 +219,6 @@ jobs:
           ccache -s  #show stats
           ccache -z  #show stats
 
-  build_test_tket_not_required:
-    name: Build and test (tket)
-    needs: check_changes
-    if: needs.check_changes.outputs.tket_or_workflow_changed != 'true'
-    strategy:
-      matrix:
-        os: ['ubuntu-22.04', 'macos-12', 'windows-2022', 'macos-13-xlarge']
-    runs-on: ${{ matrix.os }}
-    steps:
-      - run: echo "no changes to tket"
-
   build_test_pytket_ubuntu:
     name: Build and test pytket (ubuntu)
     needs: check_changes


### PR DESCRIPTION
Removed no longer necessary job `build_test_tket_not_required`

- Shouldn't forget to change the required checks for the build and test workflow to only include the "All jobs succeeded" job. (I don't have the permissions to do this)
