### PR TITLE
Drop support for MacOS 11

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,7 @@ jobs:
 
   build_macos_wheels:
     name: Build macos wheels
-    runs-on: macos-11
+    runs-on: macos-12
     strategy:
       matrix:
         python-version: ['3.9', '3.10', '3.11']
@@ -92,7 +92,7 @@ jobs:
       run: |
         conan profile detect
         DEFAULT_PROFILE_PATH=`conan profile path default`
-        PROFILE_PATH=./conan-profiles/macos-11
+        PROFILE_PATH=./conan-profiles/macos-12
         diff ${DEFAULT_PROFILE_PATH} ${PROFILE_PATH} || true
         cp ${PROFILE_PATH} ${DEFAULT_PROFILE_PATH}
         conan remote add tket-libs https://quantinuumsw.jfrog.io/artifactory/api/conan/tket1-libs --index 0
@@ -103,8 +103,8 @@ jobs:
         conan create recipes/pybind11
         conan create recipes/pybind11_json/all --version 0.2.13
         cd pytket
-        # Ensure wheels are compatible with MacOS 10.14 and later:
-        export WHEEL_PLAT_NAME=macosx_10_14_x86_64
+        # Ensure wheels are compatible with MacOS 12.0 and later:
+        export WHEEL_PLAT_NAME=macosx_12_0_x86_64
         pip install -U pip build delocate
         python -m build
         delocate-wheel -v -w "$GITHUB_WORKSPACE/wheelhouse/" "dist/pytket-"*".whl"
@@ -149,8 +149,8 @@ jobs:
         conan create recipes/pybind11
         conan create recipes/pybind11_json/all --version 0.2.13
         cd pytket
-        # Ensure wheels are compatible with MacOS 11.0 and later:
-        export WHEEL_PLAT_NAME=macosx_11_0_arm64
+        # Ensure wheels are compatible with MacOS 12.0 and later:
+        export WHEEL_PLAT_NAME=macosx_12_0_arm64
         python${{ matrix.python-version }} -m pip install -U pip build delocate
         python${{ matrix.python-version }} -m build
         delocate-wheel -v -w "$GITHUB_WORKSPACE/wheelhouse/" "dist/pytket-"*".whl"
@@ -268,7 +268,7 @@ jobs:
     needs: build_macos_wheels
     strategy:
       matrix:
-        os: ['macos-11', 'macos-12']
+        os: ['macos-12', 'macos-13']
         python-version: ['3.9', '3.10', '3.11']
     runs-on: ${{ matrix.os }}
     steps:

--- a/conan-profiles/macos-11
+++ b/conan-profiles/macos-11
@@ -1,8 +1,0 @@
-[settings]
-arch=x86_64
-build_type=Release
-compiler=apple-clang
-compiler.cppstd=gnu17
-compiler.libcxx=libc++
-compiler.version=13
-os=Macos

--- a/pytket/docs/changelog.rst
+++ b/pytket/docs/changelog.rst
@@ -21,6 +21,10 @@ Fixes:
   length 2.
 * Fix incorrect controlled ``ConjugationBox`` handling.
 
+General:
+
+* Drop support for MacOS 11.
+
 1.21.0 (October 2023)
 ---------------------
 


### PR DESCRIPTION
Release workflow tested [here](https://github.com/CQCL/tket/actions/runs/6891015932).