### PR TITLE
Bugfix/1132 update nix macos compiler

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1697158538,
-        "narHash": "sha256-TR02XPre2EcwU1kT4WXZWJOBi/B8C7P1xoywOUGkdDk=",
+        "lastModified": 1700484102,
+        "narHash": "sha256-yGPHhYBH8KZu70gZvHRBvIzN0Z9dlwXX7u3hFFiGevA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "ee176b5fbb680864dcf80f9ca3f6f134d81331d8",
+        "rev": "48a753219ede79d448cd0aa3bbf29d29fcbab8c9",
         "type": "github"
       },
       "original": {

--- a/nix-support/pytket.nix
+++ b/nix-support/pytket.nix
@@ -74,10 +74,10 @@ in {
       # these directories aren't copied by setup.py, so we do it manually
       cp -r ${
         ../pytket/pytket/circuit/display/js
-      } $out/lib/python3.10/site-packages/pytket/circuit/display/js;
+      } $out/lib/python${super.python3.pythonVersion}/site-packages/pytket/circuit/display/js;
       cp -r ${
         ../pytket/pytket/circuit/display/static
-      } $out/lib/python3.10/site-packages/pytket/circuit/display/static;
+      } $out/lib/python${super.python3.pythonVersion}/site-packages/pytket/circuit/display/static;
     '';
     checkInputs = with super.python3.pkgs; [
       pytest


### PR DESCRIPTION
The solution to bug #1132 was fortunately very simple. Nixpkgs has recently bumped the default darwin clang from 11 to 16, which resolved the C++ compilation issue.

Additionally, nixpkgs has updated python3.10 to python3.11. A change required to build pytket was to encode the python version into a module path rather than hardcoding python3.10, so that's useful for longevity.

nix flake check has been run on my m2 macbook and on my linux machine, and both pass on this branch.