### PR TITLE
Add mypy support to nix builds of pytket

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ pytket/tests/qasm_test_files/testout6.qasm
 # IDEs
 .idea
 .vscode
+
+#nix
+result

--- a/nix-support/pytket.nix
+++ b/nix-support/pytket.nix
@@ -55,6 +55,7 @@ in {
       cp -r ${../pytket/pytket} pytket;
       cp ${../pytket/package.md} package.md;
       cp -r ${../schemas} schemas;
+      cp -r ${../pytket/mypy.ini} mypy.ini;
 
       # The usual build depends on setuptools-scm to extract the version.
       # We have already extracted the version within nix, so we can simply
@@ -80,6 +81,7 @@ in {
       } $out/lib/python${super.python3.pythonVersion}/site-packages/pytket/circuit/display/static;
     '';
     checkInputs = with super.python3.pkgs; [
+      mypy
       pytest
       pytest-cov
       pytest-benchmark
@@ -90,6 +92,11 @@ in {
     ] ++ [jsonschema-4180];
     checkPhase = ''
       export HOME=$TMPDIR;
+
+      # run mypy
+      python -m mypy --config-file=mypy.ini --no-incremental -p pytket -p test_root.tests;
+
+      # run tests
       chmod 700 $TMPDIR/test_root/tests/qasm_test_files;
       cd test_root/tests;
       python -m pytest -s .

--- a/pytket/setup.py
+++ b/pytket/setup.py
@@ -142,6 +142,7 @@ class NixBuild(build_ext):
                 libpath = os.path.join(binder, lib)
                 if not os.path.isdir(libpath):
                     shutil.copy(libpath, extdir)
+
         for interface_file in os.listdir("pytket/_tket"):
             if interface_file.endswith(".pyi") or interface_file.endswith(".py"):
                 shutil.copy(os.path.join("pytket/_tket", interface_file), extdir)

--- a/pytket/setup.py
+++ b/pytket/setup.py
@@ -148,7 +148,6 @@ class NixBuild(build_ext):
                 shutil.copy(os.path.join("pytket/_tket", interface_file), extdir)
 
 
-
 plat_name = os.getenv("WHEEL_PLAT_NAME")
 
 

--- a/pytket/setup.py
+++ b/pytket/setup.py
@@ -142,7 +142,6 @@ class NixBuild(build_ext):
                 libpath = os.path.join(binder, lib)
                 if not os.path.isdir(libpath):
                     shutil.copy(libpath, extdir)
-        print(extdir)
         for interface_file in os.listdir("pytket/_tket"):
             if interface_file.endswith(".pyi") or interface_file.endswith(".py"):
                 shutil.copy(os.path.join("pytket/_tket", interface_file), extdir)

--- a/pytket/setup.py
+++ b/pytket/setup.py
@@ -142,6 +142,11 @@ class NixBuild(build_ext):
                 libpath = os.path.join(binder, lib)
                 if not os.path.isdir(libpath):
                     shutil.copy(libpath, extdir)
+        print(extdir)
+        for interface_file in os.listdir("pytket/_tket"):
+            if interface_file.endswith(".pyi") or interface_file.endswith(".py"):
+                shutil.copy(os.path.join("pytket/_tket", interface_file), extdir)
+
 
 
 plat_name = os.getenv("WHEEL_PLAT_NAME")


### PR DESCRIPTION
The previous nix derivations for pytket did not include the .pyi files for the _tket directory. This meant that mypy checks could not establish the type information for the binders. With this PR, those files are included and mypy runs successfully. I have thus added mypy checks to the checkPhase of pytket.

This issue was discovered when running mypy checks on a local pytket-qir clone I'm working on adding nix support to.

I have also .gitignored the 'result' directory, in case someone runs `nix build .#[package]` from within the source directory.