### PR TITLE
Link to home page in TOC and update extensions

### DIFF
--- a/pytket/docs/extensions.rst
+++ b/pytket/docs/extensions.rst
@@ -95,6 +95,8 @@ Density Matrix Simulators
 `CirqDensityMatrixSimBackend <https://tket.quantinuum.com/extensions/pytket-cirq/api.html#pytket.extensions.cirq.CirqDensityMatrixSimBackend>`_
 - Backend for Cirq density matrix simulator density_matrix return.
 
+`QulacsBackend`_ - This has a configurable density matrix simulation option. Use ``QulacsBackend(result_type="density_matrix")``.
+
 Clifford Simulators
 -------------------
 
@@ -157,3 +159,4 @@ Other
 .. _AerUnitaryBackend: https://tket.quantinuum.com/extensions/pytket-qiskit/api/api.html#pytket.extensions.qiskit.AerUnitaryBackend
 .. _CirqDensityMatrixSampleBackend: https://tket.quantinuum.com/extensions/pytket-cirq/api/api.html#pytket.extensions.cirq.CirqDensityMatrixSampleBackend
 .. _SimplexBackend: https://tket.quantinuum.com/extensions/pytket-simplex/api.html#pytket.extensions.pysimplex.SimplexBackend
+.. _QulacsBackend: https://tket.quantinuum.com/extensions/pytket-qulacs/api.html#pytket.extensions.qulacs.QulacsBackend

--- a/pytket/docs/extensions.rst
+++ b/pytket/docs/extensions.rst
@@ -95,7 +95,9 @@ Density Matrix Simulators
 `CirqDensityMatrixSimBackend <https://tket.quantinuum.com/extensions/pytket-cirq/api.html#pytket.extensions.cirq.CirqDensityMatrixSimBackend>`_
 - Backend for Cirq density matrix simulator density_matrix return.
 
-`QulacsBackend`_ - This has a configurable density matrix simulation option. Use ``QulacsBackend(result_type="density_matrix")``.
+`QulacsBackend`_ - This has a configurable density matrix simulation option. 
+
+Use ``QulacsBackend(result_type="density_matrix")``.
 
 Clifford Simulators
 -------------------

--- a/pytket/docs/index.rst
+++ b/pytket/docs/index.rst
@@ -75,9 +75,10 @@ Licensed under the `Apache 2 License <http://www.apache.org/licenses/LICENSE-2.0
 .. _Quantinuum: https://www.quantinuum.com/
 
 .. toctree::
-    :caption: Introduction:
+    :caption: Overview:
     :maxdepth: 1
 
+    self
     getting_started.rst
     changelog.rst
     install.rst

--- a/pytket/docs/index.rst
+++ b/pytket/docs/index.rst
@@ -78,16 +78,16 @@ Licensed under the `Apache 2 License <http://www.apache.org/licenses/LICENSE-2.0
     :caption: Overview:
     :maxdepth: 1
 
-    self
+    API docs home <self> 
     getting_started.rst
     changelog.rst
     install.rst
+    TKET website <https://tket.quantinuum.com/>
     faqs.rst
 
 .. toctree::
     :caption: More Documentation:
     
-    TKET website <https://tket.quantinuum.com/>
     Manual <https://tket.quantinuum.com/user-manual/>
     extensions.rst  
     Example notebooks <https://tket.quantinuum.com/examples>


### PR DESCRIPTION
I've added the API docs home to the docs sidebar following -> https://stackoverflow.com/questions/16123951/how-do-i-include-the-homepage-in-the-sphinx-toc

![Screenshot 2023-11-22 at 13 47 57](https://github.com/CQCL/tket/assets/93673602/782a4a20-7eb8-4f75-9e09-79e81ff7b974)

I've also added the qulacs density matrix simulation to the extensions index.
