### PR TITLE
Fix Cycle handling in FrameRandomisation

### DIFF
--- a/pytket/conanfile.py
+++ b/pytket/conanfile.py
@@ -32,7 +32,7 @@ class pytketRecipe(ConanFile):
         cmake.install()
 
     def requirements(self):
-        self.requires("tket/1.2.68@tket/stable")
+        self.requires("tket/1.2.69@tket/stable")
         self.requires("tklog/0.3.3@tket/stable")
         self.requires("tkrng/0.3.3@tket/stable")
         self.requires("tkassert/0.3.4@tket/stable")

--- a/pytket/docs/changelog.rst
+++ b/pytket/docs/changelog.rst
@@ -7,8 +7,9 @@ Unreleased
 Deprecations:
 
 * Deprecate ``SynthesiseHQS`` pass.
-* 
+  
 Fixes:
+
 * Fix `PauliFrameRandomisation.sample_circuits`.
 
 1.22.0 (November 2023)

--- a/pytket/docs/changelog.rst
+++ b/pytket/docs/changelog.rst
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+1.23.0 (Unreleased)
+-------------------
+
+Fixes:
+* Fix `PauliFrameRandomisation.sample_circuits`.
+
 1.22.0 (November 2023)
 ----------------------
 

--- a/tket/conanfile.py
+++ b/tket/conanfile.py
@@ -23,7 +23,7 @@ from conan.errors import ConanInvalidConfiguration
 
 class TketConan(ConanFile):
     name = "tket"
-    version = "1.2.68"
+    version = "1.2.69"
     package_type = "library"
     license = "Apache 2"
     homepage = "https://github.com/CQCL/tket"

--- a/tket/include/tket/Characterisation/Cycles.hpp
+++ b/tket/include/tket/Characterisation/Cycles.hpp
@@ -109,7 +109,7 @@ class CycleFinder {
   std::map<Edge, UnitID> cycle_out_edges;
 
   // Stores data structures for tracking created Cycles and associated UnitID's
-  CycleHistory bt;
+  CycleHistory cycle_history;
 
   // Given a new CutFrontier object, creates new cycles from interior vertices
   // and merges them with previous cycles where possible

--- a/tket/src/Characterisation/Cycles.cpp
+++ b/tket/src/Characterisation/Cycles.cpp
@@ -219,7 +219,7 @@ void CycleFinder::order_keys(
             goto new_loop;
           }
 
-  new_loop : {}
+  new_loop: {}
   }
 
   for (const unsigned& key : bad_keys) old_keys.erase(key);

--- a/tket/src/Characterisation/Cycles.cpp
+++ b/tket/src/Characterisation/Cycles.cpp
@@ -170,16 +170,15 @@ std::pair<unsigned, std::set<unsigned>> CycleFinder::make_cycle(
         if (std::find(
                 history_uids.begin(), history_uids.end(), not_present_uid) !=
             history_uids.end()) {
-          // => the not present uid is in this cycle
-          // now we check the overlap
-          //
-          for (const UnitID& a :
-               this->cycle_history.history[candidate_cycle_key]) {
-            for (const UnitID& b : history_uids) {
-              if (a == b) {
-                not_mergeable_keys.insert(candidate_cycle_key);
-              }
-            }
+          std::vector<UnitID> intersection;
+          std::vector<UnitID> candidates =
+              cycle_history.history[candidate_cycle_key];
+          std::set_intersection(
+              candidates.begin(), candidates.end(), history_uids.begin(),
+              history_uids.end(), std::back_inserter(intersection));
+          if (!intersection.empty()) {
+            not_mergeable_keys.insert(candidate_cycle_key);
+            break;
           }
         }
       }

--- a/tket/src/Characterisation/Cycles.cpp
+++ b/tket/src/Characterisation/Cycles.cpp
@@ -147,7 +147,6 @@ void CycleFinder::order_keys(
             bad_keys.insert(*it);
             goto new_loop;
           }
-
   new_loop : {}
   }
 

--- a/tket/src/Characterisation/Cycles.cpp
+++ b/tket/src/Characterisation/Cycles.cpp
@@ -147,7 +147,8 @@ void CycleFinder::order_keys(
             bad_keys.insert(*it);
             goto new_loop;
           }
-  new_loop : {}
+
+  new_loop: {}
   }
 
   for (const unsigned& key : bad_keys) old_keys.erase(key);

--- a/tket/src/Characterisation/Cycles.cpp
+++ b/tket/src/Characterisation/Cycles.cpp
@@ -148,7 +148,7 @@ void CycleFinder::order_keys(
             goto new_loop;
           }
 
-  new_loop: {}
+  new_loop : {}
   }
 
   for (const unsigned& key : bad_keys) old_keys.erase(key);
@@ -256,25 +256,27 @@ std::vector<Cycle> CycleFinder::get_cycles() {
       Edge in_edge = pair.second;
       if (circ.get_edgetype(in_edge) != EdgeType::Classical) {
         Vertex in_vert = circ.source(pair.second);
-
         // if vertex is type from types, then vertex is in slice and need
         // in_edge. else can ignore.
         if (cycle_types_.find(circ.get_OpType_from_Vertex(in_vert)) !=
             cycle_types_.end()) {
           in_edge = circ.get_last_edge(in_vert, pair.second);
         }
-
-        cycle_out_edges.insert({in_edge, pair.first});
-        bt.uid_to_key.insert({pair.first, bt.key});
-        Cycle new_cycle({{in_edge, in_edge}}, {{}});
-        bt.key_to_cycle[bt.key] = new_cycle;
-        bt.history.push_back({pair.first});
-        bt.key++;
+        if (std::find(
+                slice_iter.cut_.slice->begin(), slice_iter.cut_.slice->end(),
+                circ.source(pair.second)) != slice_iter.cut_.slice->end()) {
+          cycle_out_edges.insert({in_edge, pair.first});
+          bt.uid_to_key.insert({pair.first, bt.key});
+          Cycle new_cycle({{in_edge, in_edge}}, {{}});
+          bt.key_to_cycle[bt.key] = new_cycle;
+          bt.history.push_back({pair.first});
+          bt.key++;
+        }
       }
     }
     // extend cycles automatically merges cycles that can be merge due to
     // overlapping multi-qubit gates
-    extend_cycles(slice_iter.cut_);
+    this->extend_cycles(slice_iter.cut_);
     cycle_out_edges = {};
     for (const std::pair<UnitID, Edge>& pair :
          slice_iter.cut_.u_frontier->get<TagKey>()) {
@@ -285,7 +287,7 @@ std::vector<Cycle> CycleFinder::get_cycles() {
     slice_iter.cut_ = circ.next_cut(
         slice_iter.cut_.u_frontier, slice_iter.cut_.b_frontier, skip_func);
     if (!(*slice_iter).empty()) {
-      extend_cycles(slice_iter.cut_);
+      this->extend_cycles(slice_iter.cut_);
     }
   }
 

--- a/tket/src/Characterisation/Cycles.cpp
+++ b/tket/src/Characterisation/Cycles.cpp
@@ -92,16 +92,10 @@ std::pair<unsigned, std::set<unsigned>> CycleFinder::make_cycle(
   // Get UnitID, add to uids for new boundary, keep note of all old boundary
   // keys for merging set new boundary key, add new edges to new boundary update
   // cycle out edges if the edge can't be found
-  // std::cout << "\nMake Cycle for " << circ.index_map()[v] << std::endl;
 
   for (const Edge& e : out_edges) {
     UnitID uid = unitid_from_unit_frontier(cut.u_frontier, e);
     new_boundary_uids.insert(uid);
-    // bool r = this->cycle_history.uid_to_key.find(uid) ==
-    //          this->cycle_history.uid_to_key.end();
-    // std::cout << r << " " << this->cycle_history.uid_to_key[uid] << " "
-    //           << uid.repr() << std::endl;
-
     old_boundary_keys.insert(this->cycle_history.uid_to_key[uid]);
     // boundary key associated with given edge e not included
     // i.e. e's associated in edge isn't a cycle out edge
@@ -135,7 +129,6 @@ std::pair<unsigned, std::set<unsigned>> CycleFinder::make_cycle(
   Cycle new_cycle(
       new_cycle_boundary, {{circ.get_OpType_from_Vertex(v), op_indices, v}});
   this->cycle_history.key_to_cycle[this->cycle_history.key] = {new_cycle};
-
 
   this->cycle_history.history.push_back(
       std::vector<UnitID>(new_boundary_uids.begin(), new_boundary_uids.end()));
@@ -185,7 +178,6 @@ std::pair<unsigned, std::set<unsigned>> CycleFinder::make_cycle(
             for (const UnitID& b : history_uids) {
               if (a == b) {
                 not_mergeable_keys.insert(candidate_cycle_key);
-
               }
             }
           }
@@ -280,28 +272,7 @@ void Cycle::merge(Cycle& new_cycle) {
 
 void CycleFinder::merge_cycles(unsigned new_key, std::set<unsigned>& old_keys) {
   // boundary_keys is a std::set<unsigned> so is ordered
-  // std::cout << "\nMerge cycles" << std::endl;
-  // std::cout << "New key: " << new_key;
-  // for(auto x : this->cycle_history.history[new_key]){
-  //   std::cout << x.repr() << " ";
-  // }
-  // std::cout << std::endl;
-  // std::cout << "\nOld keys: " << std::endl;
-  // for(auto k : old_keys){
-  //   std::cout << k << " ";
-  //   for(auto x : this->cycle_history.history[k]){
-  //     std::cout << x.repr() << " ";
-  //   }
-  //   std::cout << std::endl;
-  // }
-  // std::cout << std::endl;
   order_keys(new_key, old_keys);
-  // std::cout << "New old keys: " << std::endl;
-  // for(auto k : old_keys){
-  //   std::cout << k << " ";
-  // }
-  // std::cout << std::endl;
-
   // all cycles corresponding to keys in boundary_keys should be merged into
   // boundary with smallest value
   std::set<unsigned>::iterator it = old_keys.begin();
@@ -323,13 +294,11 @@ void CycleFinder::merge_cycles(unsigned new_key, std::set<unsigned>& old_keys) {
 }
 
 void CycleFinder::extend_cycles(const CutFrontier& cut) {
-  // std::cout << "\n\nExtend cycles" << std::endl;
   // For each vertex in slice
   // Make a new "cycle"
   // If any in edge to new cycle matches an out edge to a previous cycle,
   // attempt to merge cycles together
   for (const Vertex& v : *cut.slice) {
-    // std::cout << "Trying to extend: " << circ.index_map()[v] << std::endl;
     EdgeVec out_edges = circ.get_out_edges_of_type(v, EdgeType::Quantum);
     // Compare EdgeType::Quantum "in_edges" of vertex in slice to collection of
     // out edges from "active" boundaries If an "in_edge" is not equivalent to
@@ -364,14 +333,6 @@ std::vector<Cycle> CycleFinder::get_cycles() {
             cycle_types_.end()) {
           in_edge = circ.get_last_edge(in_vert, pair.second);
         }
-        // if (std::find(
-        //         slice_iter.cut_.slice->begin(), slice_iter.cut_.slice->end(),
-        //         circ.source(pair.second)) != slice_iter.cut_.slice->end()) {
-
-        //   std::cout <<
-
-        //   }
-        // std::cout << "valid edge! " << pair.first.repr() << std::endl;
         cycle_out_edges.insert({in_edge, pair.first});
         this->cycle_history.uid_to_key.insert(
             {pair.first, this->cycle_history.key});
@@ -379,7 +340,6 @@ std::vector<Cycle> CycleFinder::get_cycles() {
         this->cycle_history.key_to_cycle[this->cycle_history.key] = new_cycle;
         this->cycle_history.history.push_back({pair.first});
         this->cycle_history.key++;
-        // }
       }
     }
     // extend cycles automatically merges cycles that can be merge due to
@@ -416,16 +376,6 @@ std::vector<Cycle> CycleFinder::get_cycles() {
     }
     output_cycles.push_back(entry.second);
   }
-
-  // std::cout << "what was the history?" << std::endl;
-  // for (unsigned i = 0; i < this->cycle_history.history.size(); i++) {
-  //   std::cout << "Cycle: " << i << std::endl;
-  //   for (auto h : this->cycle_history.history[i]) {
-  //     std::cout << h.repr() << " ";
-  //   }
-  //   std::cout << std::endl;
-  // }
-
   return output_cycles;
 }
 }  // namespace tket

--- a/tket/src/Characterisation/Cycles.cpp
+++ b/tket/src/Characterisation/Cycles.cpp
@@ -106,7 +106,6 @@ std::pair<unsigned, std::set<unsigned>> CycleFinder::make_cycle(
     if (cycle_out_edges.find(circ.get_last_edge(v, e)) ==
         cycle_out_edges.end()) {
       not_mergeable_keys.insert(this->cycle_history.uid_to_key[uid]);
-      // not_mergeable_uids.insert(uid);
     }
     this->cycle_history.uid_to_key[uid] = this->cycle_history.key;
     new_cycle_boundary.push_back({circ.get_last_edge(v, e), e});
@@ -117,8 +116,7 @@ std::pair<unsigned, std::set<unsigned>> CycleFinder::make_cycle(
     for (const UnitID& uid : this->cycle_history.history[key]) {
       if (not_mergeable_uids.find(uid) != not_mergeable_uids.end()) {
         not_mergeable_keys.insert(key);
-        // break;
-        continue;
+        break;
       }
     }
   }
@@ -157,7 +155,7 @@ std::pair<unsigned, std::set<unsigned>> CycleFinder::make_cycle(
     // not_present_uids now contains UnitID in the new cycle that are not in the
     // cycle represented by "candidate_cycle_key"
 
-    // We now iterate through all cycles between these UnitID's most recent
+    // We now iterate through all cycles between these UnitIDs' most recent
     // cycles and our target cycle
 
     // If any of these cycles have both a non-present uid and any uid in the

--- a/tket/src/Characterisation/FrameRandomisation.cpp
+++ b/tket/src/Characterisation/FrameRandomisation.cpp
@@ -79,8 +79,17 @@ void add_noop_frames(std::vector<Cycle>& cycles, Circuit& circ) {
         in_edge = (*it).second;
       }
 
+      // boundary in edges can be equal to other boundary out edges
+      // rewiring a vertex into these in edges replace the edge
+      // first see if its been rewired and use new edge if necessary
+      Edge out_edge = boundary.second;
+      it = replacement_rewiring_edges.find(out_edge);
+      if (it != replacement_rewiring_edges.end()) {
+        out_edge = (*it).second;
+      }
+
       circ.rewire(input_noop_vert, {in_edge}, {EdgeType::Quantum});
-      circ.rewire(output_noop_vert, {boundary.second}, {EdgeType::Quantum});
+      circ.rewire(output_noop_vert, {out_edge}, {EdgeType::Quantum});
 
       // Can guarantee both have one output edge only as just rewired
       Edge input_noop_out_edge =
@@ -91,7 +100,7 @@ void add_noop_frames(std::vector<Cycle>& cycles, Circuit& circ) {
       barrier_ins.push_back(input_noop_out_edge);
       barrier_outs.push_back(output_noop_in_edge);
 
-      replacement_rewiring_edges[boundary.second] =
+      replacement_rewiring_edges[out_edge] =
           circ.get_out_edges_of_type(output_noop_vert, EdgeType::Quantum)[0];
       full_cycle.add_vertex_pair({input_noop_vert, output_noop_vert});
     }

--- a/tket/src/Characterisation/FrameRandomisation.cpp
+++ b/tket/src/Characterisation/FrameRandomisation.cpp
@@ -45,8 +45,6 @@ std::string FrameRandomisation::to_string() const {
 // Wires Identity gates into each cycle edge. Identity gates then relabelled
 // with Ops from OpTypeSet to create instances of Frame Randomisation
 void add_noop_frames(std::vector<Cycle>& cycles, Circuit& circ) {
-  IndexMap imap = circ.index_map();
-
   std::map<Edge, Edge> replacement_rewiring_edges;
   for (Cycle& full_cycle : cycles) {
     std::vector<edge_pair_t> cycle = full_cycle.boundary_edges_;

--- a/tket/src/Characterisation/FrameRandomisation.cpp
+++ b/tket/src/Characterisation/FrameRandomisation.cpp
@@ -48,20 +48,7 @@ void add_noop_frames(std::vector<Cycle>& cycles, Circuit& circ) {
   IndexMap imap = circ.index_map();
 
   std::map<Edge, Edge> replacement_rewiring_edges;
-  std::cout << "There are " << cycles.size() << " cycles. " << std::endl;
-  unsigned counter = 0;
   for (Cycle& full_cycle : cycles) {
-    std::cout << "This cycle " <<  counter << " has " << full_cycle.size() << " edges."
-              << std::endl;
-      counter++;
-    std::cout << "Vertices of edges in cycle: ";
-    for (auto com : full_cycle.coms_) {
-      std::cout << imap[com.address] << " ";
-    }
-    std::cout << std::endl;
-  }
-  for (Cycle& full_cycle : cycles) {
-    circ.to_graphviz_file("/Users/silasdilkes/code/tket-public/test.dot");
     std::vector<edge_pair_t> cycle = full_cycle.boundary_edges_;
     // wire "noop" vertices into each cycle edge
     // these are later relabelled with frame gates
@@ -81,14 +68,6 @@ void add_noop_frames(std::vector<Cycle>& cycles, Circuit& circ) {
 
     EdgeVec barrier_ins;
     EdgeVec barrier_outs;
-
-    std::cout << "\n\nCycle has " << cycle.size() << " edges " << std::endl;
-    std::cout << "Indices of vertices in cycle: " << std::endl;
-    for (auto com : full_cycle.coms_) {
-      std::cout << imap[com.address] << " ";
-    }
-    std::cout << std::endl;
-    
     for (const std::pair<Edge, Edge>& boundary : cycle) {
       Vertex input_noop_vert = circ.add_vertex(OpType::noop);
       Vertex output_noop_vert = circ.add_vertex(OpType::noop);
@@ -99,7 +78,6 @@ void add_noop_frames(std::vector<Cycle>& cycles, Circuit& circ) {
       std::map<Edge, Edge>::iterator it =
           replacement_rewiring_edges.find(in_edge);
       if (it != replacement_rewiring_edges.end()) {
-        std::cout << "Replacement in edge!" << std::endl;
         in_edge = (*it).second;
       }
 
@@ -109,10 +87,8 @@ void add_noop_frames(std::vector<Cycle>& cycles, Circuit& circ) {
       Edge out_edge = boundary.second;
       it = replacement_rewiring_edges.find(out_edge);
       if (it != replacement_rewiring_edges.end()) {
-        std::cout << "Replacement out edge!" << std::endl;
         out_edge = (*it).second;
-      } 
-
+      }
 
       circ.rewire(input_noop_vert, {in_edge}, {EdgeType::Quantum});
       circ.rewire(output_noop_vert, {out_edge}, {EdgeType::Quantum});
@@ -126,12 +102,12 @@ void add_noop_frames(std::vector<Cycle>& cycles, Circuit& circ) {
       barrier_ins.push_back(input_noop_out_edge);
       barrier_outs.push_back(output_noop_in_edge);
 
-      // replacement_rewiring_edges[out_edge] =
-          // circ.get_out_edges_of_type(output_noop_vert, EdgeType::Quantum)[0];/
-      replacement_rewiring_edges.insert({out_edge, circ.get_out_edges_of_type(output_noop_vert, EdgeType::Quantum)[0]});
-      // replacement_rewiring_edges[in_edge] =
-          // circ.get_in_edges_of_type(input_noop_vert, EdgeType::Quantum)[0];
-      replacement_rewiring_edges.insert({in_edge, circ.get_in_edges_of_type(input_noop_vert, EdgeType::Quantum)[0]});
+      replacement_rewiring_edges.insert(
+          {out_edge,
+           circ.get_out_edges_of_type(output_noop_vert, EdgeType::Quantum)[0]});
+      replacement_rewiring_edges.insert(
+          {in_edge,
+           circ.get_in_edges_of_type(input_noop_vert, EdgeType::Quantum)[0]});
       full_cycle.add_vertex_pair({input_noop_vert, output_noop_vert});
     }
     std::vector<EdgeType> sig(barrier_ins.size(), EdgeType::Quantum);
@@ -142,7 +118,6 @@ void add_noop_frames(std::vector<Cycle>& cycles, Circuit& circ) {
     circ.rewire(output_barrier_vert, barrier_outs, sig);
   }
   std::vector<Command> commands = circ.get_commands();
-  std::cout << "All cycles finished. " << std::endl;
 }
 
 std::vector<std::vector<OpTypeVector>> get_all_frame_permutations(
@@ -505,14 +480,10 @@ std::vector<Circuit> FrameRandomisation::sample_randomisation_circuits(
   }
   add_noop_frames(all_cycles, circuit_);
   std::vector<unsigned> frame_sizes = get_frame_sizes(all_cycles).first;
-  std::cout << "get sizes done " << std::endl;
   std::vector<std::vector<OpTypeVector>> all_samples =
       get_all_samples(samples, frame_sizes);
-  std::cout << "get samples done " << std::endl;
   std::vector<Circuit> output_circuit_list =
       label_frames(all_samples, all_cycles);
-
-  std::cout << "label frames done " << std::endl;
   return output_circuit_list;
 }
 

--- a/tket/test/CMakeLists.txt
+++ b/tket/test/CMakeLists.txt
@@ -80,100 +80,100 @@ add_executable(test-tket
     src/Gate/GatesData.cpp
     src/Simulation/ComparisonFunctions.cpp
     # test sources:
-    src/Utils/test_CosSinDecomposition.cpp
-    src/Utils/test_HelperFunctions.cpp
-    src/Utils/test_MatrixAnalysis.cpp
-    src/Graphs/test_GraphColouring.cpp
-    src/Graphs/test_GraphFindComponents.cpp
-    src/Graphs/test_GraphFindMaxClique.cpp
-    src/Graphs/test_GraphUtils.cpp
-    src/Graphs/test_DirectedGraph.cpp
-    src/Graphs/test_ArticulationPoints.cpp
-    src/Graphs/test_TreeSearch.cpp
-    src/TokenSwapping/test_ArchitectureMappingEndToEnd.cpp
-    src/TokenSwapping/test_BestTsaFixedSwapSequences.cpp
-    src/TokenSwapping/test_DistancesFromArchitecture.cpp
-    src/TokenSwapping/test_FullTsa.cpp
-    src/TokenSwapping/test_RiverFlowPathFinder.cpp
-    src/TokenSwapping/test_SwapsFromQubitMapping.cpp
-    src/TokenSwapping/test_VariousPartialTsa.cpp
-    src/Architecture/test_SubgraphMonomorphisms.cpp
-    src/test_PauliTensor.cpp
-    src/Ops/test_ClassicalOps.cpp
-    src/Ops/test_Expression.cpp
-    src/Ops/test_Ops.cpp
-    src/OpType/test_OpTypeFunctions.cpp
-    src/Passes/test_SynthesiseTK.cpp
-    src/Passes/test_SynthesiseTket.cpp
-    src/Gate/test_GateUnitaryMatrix.cpp
-    src/Simulation/test_CircuitSimulator.cpp
-    src/Simulation/test_PauliExpBoxUnitaryCalculator.cpp
-    src/Circuit/test_Boxes.cpp
-    src/Circuit/test_PauliExpBoxes.cpp
-    src/Circuit/test_Circ.cpp
-    src/Circuit/test_CircPool.cpp
-    src/Circuit/test_Symbolic.cpp
-    src/Circuit/test_ThreeQubitConversion.cpp
-    src/Circuit/test_Multiplexor.cpp
-    src/Circuit/test_StatePreparation.cpp
-    src/Circuit/test_DiagonalBox.cpp
-    src/Circuit/test_ToffoliBox.cpp
-    src/Circuit/test_ConjugationBox.cpp
-    src/Circuit/test_DummyBox.cpp
-    src/test_UnitaryTableau.cpp
-    src/test_ChoiMixTableau.cpp
-    src/test_Diagonalisation.cpp
-    src/test_PhasePolynomials.cpp
-    src/test_PauliGraph.cpp
-    src/test_Architectures.cpp
-    src/test_ArchitectureAwareSynthesis.cpp
-    src/Placement/test_GraphPlacement.cpp
-    src/Placement/test_LinePlacement.cpp
-    src/Placement/test_NoiseAwarePlacement.cpp
-    src/Placement/test_Placement.cpp
-    src/Placement/test_NeighbourPlacements.cpp
-    src/Transformations/test_RedundancyRemoval.cpp
-    src/test_MappingVerification.cpp
-    src/test_MappingFrontier.cpp
-    src/test_RoutingMethod.cpp
-    src/test_MappingManager.cpp
-    src/test_LexicographicalComparison.cpp
-    src/test_LexiRoute.cpp
-    src/test_AASRoute.cpp
-    src/test_MultiGateReorder.cpp
-    src/test_BoxDecompRoutingMethod.cpp
-    src/test_RoutingPasses.cpp
-    src/test_DeviceCharacterisation.cpp
-    src/test_Clifford.cpp
-    src/test_MeasurementSetup.cpp
-    src/test_Partition.cpp
-    src/test_MeasurementReduction.cpp
-    src/test_PhaseGadget.cpp
-    src/test_Rebase.cpp
-    src/test_PhasedXFrontier.cpp
-    src/test_GlobalisePhasedX.cpp
-    src/test_Synthesis.cpp
-    src/test_TwoQubitCanonical.cpp
-    src/test_ControlDecomp.cpp
-    src/test_Combinators.cpp
-    src/test_Predicates.cpp
-    src/test_CompilerPass.cpp
-    src/test_ContextOpt.cpp
+    # src/Utils/test_CosSinDecomposition.cpp
+    # src/Utils/test_HelperFunctions.cpp
+    # src/Utils/test_MatrixAnalysis.cpp
+    # src/Graphs/test_GraphColouring.cpp
+    # src/Graphs/test_GraphFindComponents.cpp
+    # src/Graphs/test_GraphFindMaxClique.cpp
+    # src/Graphs/test_GraphUtils.cpp
+    # src/Graphs/test_DirectedGraph.cpp
+    # src/Graphs/test_ArticulationPoints.cpp
+    # src/Graphs/test_TreeSearch.cpp
+    # src/TokenSwapping/test_ArchitectureMappingEndToEnd.cpp
+    # src/TokenSwapping/test_BestTsaFixedSwapSequences.cpp
+    # src/TokenSwapping/test_DistancesFromArchitecture.cpp
+    # src/TokenSwapping/test_FullTsa.cpp
+    # src/TokenSwapping/test_RiverFlowPathFinder.cpp
+    # src/TokenSwapping/test_SwapsFromQubitMapping.cpp
+    # src/TokenSwapping/test_VariousPartialTsa.cpp
+    # src/Architecture/test_SubgraphMonomorphisms.cpp
+    # src/test_PauliTensor.cpp
+    # src/Ops/test_ClassicalOps.cpp
+    # src/Ops/test_Expression.cpp
+    # src/Ops/test_Ops.cpp
+    # src/OpType/test_OpTypeFunctions.cpp
+    # src/Passes/test_SynthesiseTK.cpp
+    # src/Passes/test_SynthesiseTket.cpp
+    # src/Gate/test_GateUnitaryMatrix.cpp
+    # src/Simulation/test_CircuitSimulator.cpp
+    # src/Simulation/test_PauliExpBoxUnitaryCalculator.cpp
+    # src/Circuit/test_Boxes.cpp
+    # src/Circuit/test_PauliExpBoxes.cpp
+    # src/Circuit/test_Circ.cpp
+    # src/Circuit/test_CircPool.cpp
+    # src/Circuit/test_Symbolic.cpp
+    # src/Circuit/test_ThreeQubitConversion.cpp
+    # src/Circuit/test_Multiplexor.cpp
+    # src/Circuit/test_StatePreparation.cpp
+    # src/Circuit/test_DiagonalBox.cpp
+    # src/Circuit/test_ToffoliBox.cpp
+    # src/Circuit/test_ConjugationBox.cpp
+    # src/Circuit/test_DummyBox.cpp
+    # src/test_UnitaryTableau.cpp
+    # src/test_ChoiMixTableau.cpp
+    # src/test_Diagonalisation.cpp
+    # src/test_PhasePolynomials.cpp
+    # src/test_PauliGraph.cpp
+    # src/test_Architectures.cpp
+    # src/test_ArchitectureAwareSynthesis.cpp
+    # src/Placement/test_GraphPlacement.cpp
+    # src/Placement/test_LinePlacement.cpp
+    # src/Placement/test_NoiseAwarePlacement.cpp
+    # src/Placement/test_Placement.cpp
+    # src/Placement/test_NeighbourPlacements.cpp
+    # src/Transformations/test_RedundancyRemoval.cpp
+    # src/test_MappingVerification.cpp
+    # src/test_MappingFrontier.cpp
+    # src/test_RoutingMethod.cpp
+    # src/test_MappingManager.cpp
+    # src/test_LexicographicalComparison.cpp
+    # src/test_LexiRoute.cpp
+    # src/test_AASRoute.cpp
+    # src/test_MultiGateReorder.cpp
+    # src/test_BoxDecompRoutingMethod.cpp
+    # src/test_RoutingPasses.cpp
+    # src/test_DeviceCharacterisation.cpp
+    # src/test_Clifford.cpp
+    # src/test_MeasurementSetup.cpp
+    # src/test_Partition.cpp
+    # src/test_MeasurementReduction.cpp
+    # src/test_PhaseGadget.cpp
+    # src/test_Rebase.cpp
+    # src/test_PhasedXFrontier.cpp
+    # src/test_GlobalisePhasedX.cpp
+    # src/test_Synthesis.cpp
+    # src/test_TwoQubitCanonical.cpp
+    # src/test_ControlDecomp.cpp
+    # src/test_Combinators.cpp
+    # src/test_Predicates.cpp
+    # src/test_CompilerPass.cpp
+    # src/test_ContextOpt.cpp
     src/test_FrameRandomisation.cpp
-    src/test_Assertion.cpp
-    src/test_json.cpp
-    src/test_Path.cpp
-    src/test_SteinerTree.cpp
-    src/test_SteinerForest.cpp
-    src/test_wasm.cpp
-    src/test_RoundAngles.cpp
-    src/ZX/test_ZXDiagram.cpp
-    src/ZX/test_ZXAxioms.cpp
-    src/ZX/test_ZXSimp.cpp
-    src/ZX/test_ZXRebase.cpp
-    src/ZX/test_Flow.cpp
-    src/ZX/test_ZXConverters.cpp
-    src/ZX/test_ZXExtraction.cpp
+    # src/test_Assertion.cpp
+    # src/test_json.cpp
+    # src/test_Path.cpp
+    # src/test_SteinerTree.cpp
+    # src/test_SteinerForest.cpp
+    # src/test_wasm.cpp
+    # src/test_RoundAngles.cpp
+    # src/ZX/test_ZXDiagram.cpp
+    # src/ZX/test_ZXAxioms.cpp
+    # src/ZX/test_ZXSimp.cpp
+    # src/ZX/test_ZXRebase.cpp
+    # src/ZX/test_Flow.cpp
+    # src/ZX/test_ZXConverters.cpp
+    # src/ZX/test_ZXExtraction.cpp
     )
 
 if (NOT TARGET gmp::gmp)

--- a/tket/test/CMakeLists.txt
+++ b/tket/test/CMakeLists.txt
@@ -80,100 +80,100 @@ add_executable(test-tket
     src/Gate/GatesData.cpp
     src/Simulation/ComparisonFunctions.cpp
     # test sources:
-    # src/Utils/test_CosSinDecomposition.cpp
-    # src/Utils/test_HelperFunctions.cpp
-    # src/Utils/test_MatrixAnalysis.cpp
-    # src/Graphs/test_GraphColouring.cpp
-    # src/Graphs/test_GraphFindComponents.cpp
-    # src/Graphs/test_GraphFindMaxClique.cpp
-    # src/Graphs/test_GraphUtils.cpp
-    # src/Graphs/test_DirectedGraph.cpp
-    # src/Graphs/test_ArticulationPoints.cpp
-    # src/Graphs/test_TreeSearch.cpp
-    # src/TokenSwapping/test_ArchitectureMappingEndToEnd.cpp
-    # src/TokenSwapping/test_BestTsaFixedSwapSequences.cpp
-    # src/TokenSwapping/test_DistancesFromArchitecture.cpp
-    # src/TokenSwapping/test_FullTsa.cpp
-    # src/TokenSwapping/test_RiverFlowPathFinder.cpp
-    # src/TokenSwapping/test_SwapsFromQubitMapping.cpp
-    # src/TokenSwapping/test_VariousPartialTsa.cpp
-    # src/Architecture/test_SubgraphMonomorphisms.cpp
-    # src/test_PauliTensor.cpp
-    # src/Ops/test_ClassicalOps.cpp
-    # src/Ops/test_Expression.cpp
-    # src/Ops/test_Ops.cpp
-    # src/OpType/test_OpTypeFunctions.cpp
-    # src/Passes/test_SynthesiseTK.cpp
-    # src/Passes/test_SynthesiseTket.cpp
-    # src/Gate/test_GateUnitaryMatrix.cpp
-    # src/Simulation/test_CircuitSimulator.cpp
-    # src/Simulation/test_PauliExpBoxUnitaryCalculator.cpp
-    # src/Circuit/test_Boxes.cpp
-    # src/Circuit/test_PauliExpBoxes.cpp
-    # src/Circuit/test_Circ.cpp
-    # src/Circuit/test_CircPool.cpp
-    # src/Circuit/test_Symbolic.cpp
-    # src/Circuit/test_ThreeQubitConversion.cpp
-    # src/Circuit/test_Multiplexor.cpp
-    # src/Circuit/test_StatePreparation.cpp
-    # src/Circuit/test_DiagonalBox.cpp
-    # src/Circuit/test_ToffoliBox.cpp
-    # src/Circuit/test_ConjugationBox.cpp
-    # src/Circuit/test_DummyBox.cpp
-    # src/test_UnitaryTableau.cpp
-    # src/test_ChoiMixTableau.cpp
-    # src/test_Diagonalisation.cpp
-    # src/test_PhasePolynomials.cpp
-    # src/test_PauliGraph.cpp
-    # src/test_Architectures.cpp
-    # src/test_ArchitectureAwareSynthesis.cpp
-    # src/Placement/test_GraphPlacement.cpp
-    # src/Placement/test_LinePlacement.cpp
-    # src/Placement/test_NoiseAwarePlacement.cpp
-    # src/Placement/test_Placement.cpp
-    # src/Placement/test_NeighbourPlacements.cpp
-    # src/Transformations/test_RedundancyRemoval.cpp
-    # src/test_MappingVerification.cpp
-    # src/test_MappingFrontier.cpp
-    # src/test_RoutingMethod.cpp
-    # src/test_MappingManager.cpp
-    # src/test_LexicographicalComparison.cpp
-    # src/test_LexiRoute.cpp
-    # src/test_AASRoute.cpp
-    # src/test_MultiGateReorder.cpp
-    # src/test_BoxDecompRoutingMethod.cpp
-    # src/test_RoutingPasses.cpp
-    # src/test_DeviceCharacterisation.cpp
-    # src/test_Clifford.cpp
-    # src/test_MeasurementSetup.cpp
-    # src/test_Partition.cpp
-    # src/test_MeasurementReduction.cpp
-    # src/test_PhaseGadget.cpp
-    # src/test_Rebase.cpp
-    # src/test_PhasedXFrontier.cpp
-    # src/test_GlobalisePhasedX.cpp
-    # src/test_Synthesis.cpp
-    # src/test_TwoQubitCanonical.cpp
-    # src/test_ControlDecomp.cpp
-    # src/test_Combinators.cpp
-    # src/test_Predicates.cpp
-    # src/test_CompilerPass.cpp
-    # src/test_ContextOpt.cpp
+    src/Utils/test_CosSinDecomposition.cpp
+    src/Utils/test_HelperFunctions.cpp
+    src/Utils/test_MatrixAnalysis.cpp
+    src/Graphs/test_GraphColouring.cpp
+    src/Graphs/test_GraphFindComponents.cpp
+    src/Graphs/test_GraphFindMaxClique.cpp
+    src/Graphs/test_GraphUtils.cpp
+    src/Graphs/test_DirectedGraph.cpp
+    src/Graphs/test_ArticulationPoints.cpp
+    src/Graphs/test_TreeSearch.cpp
+    src/TokenSwapping/test_ArchitectureMappingEndToEnd.cpp
+    src/TokenSwapping/test_BestTsaFixedSwapSequences.cpp
+    src/TokenSwapping/test_DistancesFromArchitecture.cpp
+    src/TokenSwapping/test_FullTsa.cpp
+    src/TokenSwapping/test_RiverFlowPathFinder.cpp
+    src/TokenSwapping/test_SwapsFromQubitMapping.cpp
+    src/TokenSwapping/test_VariousPartialTsa.cpp
+    src/Architecture/test_SubgraphMonomorphisms.cpp
+    src/test_PauliTensor.cpp
+    src/Ops/test_ClassicalOps.cpp
+    src/Ops/test_Expression.cpp
+    src/Ops/test_Ops.cpp
+    src/OpType/test_OpTypeFunctions.cpp
+    src/Passes/test_SynthesiseTK.cpp
+    src/Passes/test_SynthesiseTket.cpp
+    src/Gate/test_GateUnitaryMatrix.cpp
+    src/Simulation/test_CircuitSimulator.cpp
+    src/Simulation/test_PauliExpBoxUnitaryCalculator.cpp
+    src/Circuit/test_Boxes.cpp
+    src/Circuit/test_PauliExpBoxes.cpp
+    src/Circuit/test_Circ.cpp
+    src/Circuit/test_CircPool.cpp
+    src/Circuit/test_Symbolic.cpp
+    src/Circuit/test_ThreeQubitConversion.cpp
+    src/Circuit/test_Multiplexor.cpp
+    src/Circuit/test_StatePreparation.cpp
+    src/Circuit/test_DiagonalBox.cpp
+    src/Circuit/test_ToffoliBox.cpp
+    src/Circuit/test_ConjugationBox.cpp
+    src/Circuit/test_DummyBox.cpp
+    src/test_UnitaryTableau.cpp
+    src/test_ChoiMixTableau.cpp
+    src/test_Diagonalisation.cpp
+    src/test_PhasePolynomials.cpp
+    src/test_PauliGraph.cpp
+    src/test_Architectures.cpp
+    src/test_ArchitectureAwareSynthesis.cpp
+    src/Placement/test_GraphPlacement.cpp
+    src/Placement/test_LinePlacement.cpp
+    src/Placement/test_NoiseAwarePlacement.cpp
+    src/Placement/test_Placement.cpp
+    src/Placement/test_NeighbourPlacements.cpp
+    src/Transformations/test_RedundancyRemoval.cpp
+    src/test_MappingVerification.cpp
+    src/test_MappingFrontier.cpp
+    src/test_RoutingMethod.cpp
+    src/test_MappingManager.cpp
+    src/test_LexicographicalComparison.cpp
+    src/test_LexiRoute.cpp
+    src/test_AASRoute.cpp
+    src/test_MultiGateReorder.cpp
+    src/test_BoxDecompRoutingMethod.cpp
+    src/test_RoutingPasses.cpp
+    src/test_DeviceCharacterisation.cpp
+    src/test_Clifford.cpp
+    src/test_MeasurementSetup.cpp
+    src/test_Partition.cpp
+    src/test_MeasurementReduction.cpp
+    src/test_PhaseGadget.cpp
+    src/test_Rebase.cpp
+    src/test_PhasedXFrontier.cpp
+    src/test_GlobalisePhasedX.cpp
+    src/test_Synthesis.cpp
+    src/test_TwoQubitCanonical.cpp
+    src/test_ControlDecomp.cpp
+    src/test_Combinators.cpp
+    src/test_Predicates.cpp
+    src/test_CompilerPass.cpp
+    src/test_ContextOpt.cpp
     src/test_FrameRandomisation.cpp
-    # src/test_Assertion.cpp
-    # src/test_json.cpp
-    # src/test_Path.cpp
-    # src/test_SteinerTree.cpp
-    # src/test_SteinerForest.cpp
-    # src/test_wasm.cpp
-    # src/test_RoundAngles.cpp
-    # src/ZX/test_ZXDiagram.cpp
-    # src/ZX/test_ZXAxioms.cpp
-    # src/ZX/test_ZXSimp.cpp
-    # src/ZX/test_ZXRebase.cpp
-    # src/ZX/test_Flow.cpp
-    # src/ZX/test_ZXConverters.cpp
-    # src/ZX/test_ZXExtraction.cpp
+    src/test_Assertion.cpp
+    src/test_json.cpp
+    src/test_Path.cpp
+    src/test_SteinerTree.cpp
+    src/test_SteinerForest.cpp
+    src/test_wasm.cpp
+    src/test_RoundAngles.cpp
+    src/ZX/test_ZXDiagram.cpp
+    src/ZX/test_ZXAxioms.cpp
+    src/ZX/test_ZXSimp.cpp
+    src/ZX/test_ZXRebase.cpp
+    src/ZX/test_Flow.cpp
+    src/ZX/test_ZXConverters.cpp
+    src/ZX/test_ZXExtraction.cpp
     )
 
 if (NOT TARGET gmp::gmp)

--- a/tket/test/src/test_FrameRandomisation.cpp
+++ b/tket/test/src/test_FrameRandomisation.cpp
@@ -384,7 +384,7 @@ SCENARIO("Frame Randomisation non-real DAG") {
   std::vector<Circuit> circs =
       pfr.sample_randomisation_circuits(cu.get_circ_ref(), 1);
   CHECK(circs.size() == 1);
-  TKET_ASSERT(circs[0].get_commands().size() == 107);
+  CHECK(circs[0].get_commands().size() == 107);
 }
 
 }  // namespace test_FrameRandomisation

--- a/tket/test/src/test_FrameRandomisation.cpp
+++ b/tket/test/src/test_FrameRandomisation.cpp
@@ -16,6 +16,8 @@
 
 #include "testutil.hpp"
 #include "tket/Characterisation/FrameRandomisation.hpp"
+#include "tket/Predicates/PassLibrary.hpp"
+#include "tket/Predicates/CompilationUnit.hpp"
 #include "tket/Transformations/Rebase.hpp"
 #include "tket/Transformations/Transform.hpp"
 
@@ -32,331 +34,369 @@ OpTypeVector FrameRandomisationTester::get_out_frame(
 
 namespace test_FrameRandomisation {
 
-SCENARIO(
-    "Test whether get_cycles returns the expected number of cycles with "
-    "the correct operations.") {
-  FrameRandomisation fr({OpType::CX, OpType::H}, {}, {{}});
-  FrameRandomisationTester fr_tester(&fr);
+// SCENARIO(
+//     "Test whether get_cycles returns the expected number of cycles with "
+//     "the correct operations.") {
+//   FrameRandomisation fr({OpType::CX, OpType::H}, {}, {{}});
+//   FrameRandomisationTester fr_tester(&fr);
 
-  const auto add_fixed_sequence_of_ops = [](Circuit& circ) {
-    circ.add_op<unsigned>(OpType::X, {0});
-    circ.add_op<unsigned>(OpType::Y, {1});
-    circ.add_op<unsigned>(OpType::Z, {2});
-    circ.add_op<unsigned>(OpType::H, {0});
-    circ.add_op<unsigned>(OpType::H, {1});
-    circ.add_op<unsigned>(OpType::H, {2});
-    circ.add_op<unsigned>(OpType::CX, {0, 1});
-    circ.add_op<unsigned>(OpType::CX, {0, 2});
-  };
-  const auto get_comparison = [](Edge& e) {
-    return Cycle(
-        {{e, e}, {e, e}, {e, e}}, {
-                                      {OpType::Input, {}, {}},
-                                      {OpType::H, {0}, {}},
-                                      {OpType::Input, {}, {}},
-                                      {OpType::H, {1}, {}},
-                                      {OpType::CX, {0, 1}, {}},
-                                      {OpType::Input, {}, {}},
-                                      {OpType::H, {2}, {}},
-                                      {OpType::CX, {0, 2}, {}},
-                                  });
-  };
-  GIVEN("A circuit with one expected cycle.") {
-    Circuit circ(3);
-    add_fixed_sequence_of_ops(circ);
+//   const auto add_fixed_sequence_of_ops = [](Circuit& circ) {
+//     circ.add_op<unsigned>(OpType::X, {0});
+//     circ.add_op<unsigned>(OpType::Y, {1});
+//     circ.add_op<unsigned>(OpType::Z, {2});
+//     circ.add_op<unsigned>(OpType::H, {0});
+//     circ.add_op<unsigned>(OpType::H, {1});
+//     circ.add_op<unsigned>(OpType::H, {2});
+//     circ.add_op<unsigned>(OpType::CX, {0, 1});
+//     circ.add_op<unsigned>(OpType::CX, {0, 2});
+//   };
+//   const auto get_comparison = [](Edge& e) {
+//     return Cycle(
+//         {{e, e}, {e, e}, {e, e}}, {
+//                                       {OpType::Input, {}, {}},
+//                                       {OpType::H, {0}, {}},
+//                                       {OpType::Input, {}, {}},
+//                                       {OpType::H, {1}, {}},
+//                                       {OpType::CX, {0, 1}, {}},
+//                                       {OpType::Input, {}, {}},
+//                                       {OpType::H, {2}, {}},
+//                                       {OpType::CX, {0, 2}, {}},
+//                                   });
+//   };
+//   GIVEN("A circuit with one expected cycle.") {
+//     Circuit circ(3);
+//     add_fixed_sequence_of_ops(circ);
 
-    Edge e;
-    const auto comparison = get_comparison(e);
-    std::vector<Cycle> cycles = fr_tester.get_cycles(circ);
-    REQUIRE(cycles.size() == 1);
-    REQUIRE(cycles[0] == comparison);
-  }
-  GIVEN("A circuit with two expected cycle.") {
-    Circuit circ(3);
-    add_fixed_sequence_of_ops(circ);
-    add_fixed_sequence_of_ops(circ);
+//     Edge e;
+//     const auto comparison = get_comparison(e);
+//     std::vector<Cycle> cycles = fr_tester.get_cycles(circ);
+//     REQUIRE(cycles.size() == 1);
+//     REQUIRE(cycles[0] == comparison);
+//   }
+//   GIVEN("A circuit with two expected cycle.") {
+//     Circuit circ(3);
+//     add_fixed_sequence_of_ops(circ);
+//     add_fixed_sequence_of_ops(circ);
 
-    Edge e;
-    const auto comparison_0 = get_comparison(e);
-    const Cycle comparison_1(
-        {{e, e}, {e, e}, {e, e}}, {
-                                      {OpType::H, {0}, {}},
-                                      {OpType::H, {1}, {}},
-                                      {OpType::CX, {1, 0}, {}},
-                                      {OpType::H, {2}, {}},
-                                      {OpType::CX, {1, 2}, {}},
-                                  });
+//     Edge e;
+//     const auto comparison_0 = get_comparison(e);
+//     const Cycle comparison_1(
+//         {{e, e}, {e, e}, {e, e}}, {
+//                                       {OpType::H, {0}, {}},
+//                                       {OpType::H, {1}, {}},
+//                                       {OpType::CX, {1, 0}, {}},
+//                                       {OpType::H, {2}, {}},
+//                                       {OpType::CX, {1, 2}, {}},
+//                                   });
 
-    std::vector<Cycle> cycles = fr_tester.get_cycles(circ);
-    REQUIRE(cycles.size() == 2);
-    REQUIRE(cycles[0] == comparison_0);
-    REQUIRE(cycles[1] == comparison_1);
-  }
-  GIVEN("A circuit with 50 cycles.") {
-    Circuit circ(3);
-    for (unsigned i = 0; i < 50; i++) {
-      add_fixed_sequence_of_ops(circ);
-    }
-    std::vector<Cycle> cycles = fr_tester.get_cycles(circ);
-    REQUIRE(cycles.size() == 50);
-  }
-}
+//     std::vector<Cycle> cycles = fr_tester.get_cycles(circ);
+//     REQUIRE(cycles.size() == 2);
+//     REQUIRE(cycles[0] == comparison_0);
+//     REQUIRE(cycles[1] == comparison_1);
+//   }
+//   GIVEN("A circuit with 50 cycles.") {
+//     Circuit circ(3);
+//     for (unsigned i = 0; i < 50; i++) {
+//       add_fixed_sequence_of_ops(circ);
+//     }
+//     std::vector<Cycle> cycles = fr_tester.get_cycles(circ);
+//     REQUIRE(cycles.size() == 50);
+//   }
+// }
 
-SCENARIO("Test that get_out_frame returns the expected result.") {
-  Circuit circ(2);
-  circ.add_op<unsigned>(OpType::CX, {0, 1});
-  std::map<OpType, std::map<OpTypeVector, OpTypeVector>> init;
-  std::map<OpTypeVector, OpTypeVector> entry;
-  entry[{OpType::X, OpType::X}] = {OpType::Y, OpType::Y};
-  entry[{OpType::Y, OpType::Y}] = {OpType::X, OpType::X};
-  init[OpType::CX] = entry;
-  FrameRandomisation fr({OpType::CX, OpType::H}, {OpType::X}, init);
-  FrameRandomisationTester fr_tester(&fr);
+// SCENARIO("Test that get_out_frame returns the expected result.") {
+//   Circuit circ(2);
+//   circ.add_op<unsigned>(OpType::CX, {0, 1});
+//   std::map<OpType, std::map<OpTypeVector, OpTypeVector>> init;
+//   std::map<OpTypeVector, OpTypeVector> entry;
+//   entry[{OpType::X, OpType::X}] = {OpType::Y, OpType::Y};
+//   entry[{OpType::Y, OpType::Y}] = {OpType::X, OpType::X};
+//   init[OpType::CX] = entry;
+//   FrameRandomisation fr({OpType::CX, OpType::H}, {OpType::X}, init);
+//   FrameRandomisationTester fr_tester(&fr);
 
-  Cycle cycle = fr_tester.get_cycles(circ)[0];
-  OpTypeVector out_frame =
-      fr_tester.get_out_frame({OpType::X, OpType::X}, cycle);
-  REQUIRE(out_frame[0] == OpType::Y);
-  REQUIRE(out_frame[1] == OpType::Y);
-  out_frame = fr_tester.get_out_frame({OpType::Y, OpType::Y}, cycle);
-  REQUIRE(out_frame[0] == OpType::X);
-  REQUIRE(out_frame[1] == OpType::X);
-}
+//   Cycle cycle = fr_tester.get_cycles(circ)[0];
+//   OpTypeVector out_frame =
+//       fr_tester.get_out_frame({OpType::X, OpType::X}, cycle);
+//   REQUIRE(out_frame[0] == OpType::Y);
+//   REQUIRE(out_frame[1] == OpType::Y);
+//   out_frame = fr_tester.get_out_frame({OpType::Y, OpType::Y}, cycle);
+//   REQUIRE(out_frame[0] == OpType::X);
+//   REQUIRE(out_frame[1] == OpType::X);
+// }
 
-// KEY: op type
-// VALUE: list of command indices with that type.
-typedef std::map<OpType, std::vector<unsigned>> CircResult;
+// // KEY: op type
+// // VALUE: list of command indices with that type.
+// typedef std::map<OpType, std::vector<unsigned>> CircResult;
 
-// KEY: index in "all_circuits", a list of circuits
-// VALUE: result for that circuit.
-typedef std::map<unsigned, CircResult> AllCircuitsResult;
+// // KEY: index in "all_circuits", a list of circuits
+// // VALUE: result for that circuit.
+// typedef std::map<unsigned, CircResult> AllCircuitsResult;
 
-// KEY: index in "all_circuits"
-// VALUE: the expected parameter value in command[n]
-//          for that circuit (n is constant over all circuits
-//          for which this applies).
-typedef std::map<unsigned, double> ParameterValues;
+// // KEY: index in "all_circuits"
+// // VALUE: the expected parameter value in command[n]
+// //          for that circuit (n is constant over all circuits
+// //          for which this applies).
+// typedef std::map<unsigned, double> ParameterValues;
 
-static void test_parameter_value(
-    unsigned circuit_index, const ParameterValues& values,
-    const std::vector<Command>& commands,
-    unsigned index_for_command_with_parameter) {
-  if (values.empty()) {
-    return;
-  }
-  const double expected_parameter_value = values.at(circuit_index);
-  const auto params =
-      commands[index_for_command_with_parameter].get_op_ptr()->get_params();
-  REQUIRE(params.size() == 1);
-  // Normally it's very naughty to do doubles equality.
-  // But here, no calculations other than possibly inserting
-  // a minus sign are performed, so no roundoff errors occur.
-  REQUIRE(params[0] == expected_parameter_value);
-}
+// static void test_parameter_value(
+//     unsigned circuit_index, const ParameterValues& values,
+//     const std::vector<Command>& commands,
+//     unsigned index_for_command_with_parameter) {
+//   if (values.empty()) {
+//     return;
+//   }
+//   const double expected_parameter_value = values.at(circuit_index);
+//   const auto params =
+//       commands[index_for_command_with_parameter].get_op_ptr()->get_params();
+//   REQUIRE(params.size() == 1);
+//   // Normally it's very naughty to do doubles equality.
+//   // But here, no calculations other than possibly inserting
+//   // a minus sign are performed, so no roundoff errors occur.
+//   REQUIRE(params[0] == expected_parameter_value);
+// }
 
-static void test_command_types(
-    const AllCircuitsResult& result, const std::vector<Circuit>& all_circuits,
-    unsigned number_of_commands, const ParameterValues& values = {},
-    OpType op_with_parameter = OpType::noop,
-    unsigned index_for_command_with_parameter = 9999) {
-  for (const auto& outer_entry : result) {
-    const auto& circuit_index = outer_entry.first;
-    const auto commands = all_circuits[circuit_index].get_commands();
-    REQUIRE(commands.size() == number_of_commands);
-    test_parameter_value(
-        circuit_index, values, commands, index_for_command_with_parameter);
+// static void test_command_types(
+//     const AllCircuitsResult& result, const std::vector<Circuit>&
+//     all_circuits, unsigned number_of_commands, const ParameterValues& values
+//     = {}, OpType op_with_parameter = OpType::noop, unsigned
+//     index_for_command_with_parameter = 9999) {
+//   for (const auto& outer_entry : result) {
+//     const auto& circuit_index = outer_entry.first;
+//     const auto commands = all_circuits[circuit_index].get_commands();
+//     REQUIRE(commands.size() == number_of_commands);
+//     test_parameter_value(
+//         circuit_index, values, commands, index_for_command_with_parameter);
 
-    CircResult op_types_for_this_circ = outer_entry.second;
-    if (!values.empty()) {
-      op_types_for_this_circ[op_with_parameter].push_back(
-          index_for_command_with_parameter);
-    }
-    for (const auto& inner_entry : op_types_for_this_circ) {
-      const OpType& type = inner_entry.first;
-      auto command_indices = inner_entry.second;
-      for (unsigned ii : command_indices) {
-        REQUIRE(commands[ii].get_op_ptr()->get_type() == type);
-      }
-    }
-  }
-}
+//     CircResult op_types_for_this_circ = outer_entry.second;
+//     if (!values.empty()) {
+//       op_types_for_this_circ[op_with_parameter].push_back(
+//           index_for_command_with_parameter);
+//     }
+//     for (const auto& inner_entry : op_types_for_this_circ) {
+//       const OpType& type = inner_entry.first;
+//       auto command_indices = inner_entry.second;
+//       for (unsigned ii : command_indices) {
+//         REQUIRE(commands[ii].get_op_ptr()->get_type() == type);
+//       }
+//     }
+//   }
+// }
 
-SCENARIO("Test that get_all_circuits returns all frames for all cycles.") {
-  std::map<OpType, std::map<OpTypeVector, OpTypeVector>> init;
-  std::map<OpTypeVector, OpTypeVector> entry_cx;
-  std::map<OpTypeVector, OpTypeVector> entry_h;
-  entry_cx[{OpType::X, OpType::X}] = {OpType::Y, OpType::Y};
-  entry_cx[{OpType::Y, OpType::Y}] = {OpType::X, OpType::X};
-  entry_cx[{OpType::X, OpType::Y}] = {OpType::Y, OpType::X};
-  entry_cx[{OpType::Y, OpType::X}] = {OpType::X, OpType::Y};
-  entry_h[{OpType::X}] = {OpType::Y};
-  entry_h[{OpType::Y}] = {OpType::X};
-  init[OpType::CX] = entry_cx;
-  init[OpType::H] = entry_h;
-  FrameRandomisation fr({OpType::CX, OpType::H}, {OpType::X, OpType::Y}, init);
+// SCENARIO("Test that get_all_circuits returns all frames for all cycles.") {
+//   std::map<OpType, std::map<OpTypeVector, OpTypeVector>> init;
+//   std::map<OpTypeVector, OpTypeVector> entry_cx;
+//   std::map<OpTypeVector, OpTypeVector> entry_h;
+//   entry_cx[{OpType::X, OpType::X}] = {OpType::Y, OpType::Y};
+//   entry_cx[{OpType::Y, OpType::Y}] = {OpType::X, OpType::X};
+//   entry_cx[{OpType::X, OpType::Y}] = {OpType::Y, OpType::X};
+//   entry_cx[{OpType::Y, OpType::X}] = {OpType::X, OpType::Y};
+//   entry_h[{OpType::X}] = {OpType::Y};
+//   entry_h[{OpType::Y}] = {OpType::X};
+//   init[OpType::CX] = entry_cx;
+//   init[OpType::H] = entry_h;
+//   FrameRandomisation fr({OpType::CX, OpType::H}, {OpType::X, OpType::Y},
+//   init);
 
-  GIVEN("A two-qubit circuit with one CX gate.") {
-    Circuit circ(2);
-    circ.add_op<unsigned>(OpType::CX, {0, 1});
-    const std::vector<Circuit> two_circuits =
-        fr.sample_randomisation_circuits(circ, 2);
-    REQUIRE(two_circuits.size() == 2);
-    const std::vector<Circuit> all_circuits = fr.get_all_circuits(circ);
-    REQUIRE(all_circuits.size() == 4);
-    REQUIRE(
-        std::find(all_circuits.begin(), all_circuits.end(), two_circuits[0]) !=
-        all_circuits.end());
-    for (const Circuit& circ : all_circuits) {
-      const auto coms = circ.get_commands();
-      REQUIRE(coms.size() == 7);
-      REQUIRE(
-          coms[0].get_op_ptr()->get_type() != coms[5].get_op_ptr()->get_type());
-      REQUIRE(
-          coms[1].get_op_ptr()->get_type() != coms[6].get_op_ptr()->get_type());
-    }
-  }
-  GIVEN("A two-qubit circuit with three cycles.") {
-    Circuit circ(2);
-    const auto add_four_ops = [&circ]() {
-      circ.add_op<unsigned>(OpType::CX, {0, 1});
-      circ.add_op<unsigned>(OpType::H, {1});
-      circ.add_op<unsigned>(OpType::S, {0});
-      circ.add_op<unsigned>(OpType::S, {1});
-    };
-    circ.add_op<unsigned>(OpType::S, {0});
-    add_four_ops();
-    circ.add_op<unsigned>(OpType::H, {0});
-    add_four_ops();
-    add_four_ops();
-    const std::vector<Circuit> all_circuits = fr.get_all_circuits(circ);
-    REQUIRE(all_circuits.size() == 64);
-    const std::vector<unsigned> indices_a{1, 2, 8, 11, 12, 18, 19, 22, 23, 29};
-    const std::vector<unsigned> indices_b{7, 28};
+//   GIVEN("A two-qubit circuit with one CX gate.") {
+//     Circuit circ(2);
+//     circ.add_op<unsigned>(OpType::CX, {0, 1});
+//     const std::vector<Circuit> two_circuits =
+//         fr.sample_randomisation_circuits(circ, 2);
+//     REQUIRE(two_circuits.size() == 2);
+//     const std::vector<Circuit> all_circuits = fr.get_all_circuits(circ);
+//     REQUIRE(all_circuits.size() == 4);
+//     REQUIRE(
+//         std::find(all_circuits.begin(), all_circuits.end(), two_circuits[0])
+//         != all_circuits.end());
+//     for (const Circuit& circ : all_circuits) {
+//       const auto coms = circ.get_commands();
+//       REQUIRE(coms.size() == 7);
+//       REQUIRE(
+//           coms[0].get_op_ptr()->get_type() !=
+//           coms[5].get_op_ptr()->get_type());
+//       REQUIRE(
+//           coms[1].get_op_ptr()->get_type() !=
+//           coms[6].get_op_ptr()->get_type());
+//     }
+//   }
+//   GIVEN("A two-qubit circuit with three cycles.") {
+//     Circuit circ(2);
+//     const auto add_four_ops = [&circ]() {
+//       circ.add_op<unsigned>(OpType::CX, {0, 1});
+//       circ.add_op<unsigned>(OpType::H, {1});
+//       circ.add_op<unsigned>(OpType::S, {0});
+//       circ.add_op<unsigned>(OpType::S, {1});
+//     };
+//     circ.add_op<unsigned>(OpType::S, {0});
+//     add_four_ops();
+//     circ.add_op<unsigned>(OpType::H, {0});
+//     add_four_ops();
+//     add_four_ops();
+//     const std::vector<Circuit> all_circuits = fr.get_all_circuits(circ);
+//     REQUIRE(all_circuits.size() == 64);
+//     const std::vector<unsigned> indices_a{1, 2, 8, 11, 12, 18, 19, 22, 23,
+//     29}; const std::vector<unsigned> indices_b{7, 28};
 
-    const AllCircuitsResult expected_result{
-        {0, {{OpType::X, indices_a}, {OpType::Y, indices_b}}},
-        {63, {{OpType::X, indices_b}, {OpType::Y, indices_a}}},
-    };
-    test_command_types(expected_result, all_circuits, 32);
-  }
-}
+//     const AllCircuitsResult expected_result{
+//         {0, {{OpType::X, indices_a}, {OpType::Y, indices_b}}},
+//         {63, {{OpType::X, indices_b}, {OpType::Y, indices_a}}},
+//     };
+//     test_command_types(expected_result, all_circuits, 32);
+//   }
+// }
 
-SCENARIO(
-    "Test that get_all_circuits returns correct frames for all cycles "
-    "using PauliFrameRandomisation.") {
+// SCENARIO(
+//     "Test that get_all_circuits returns correct frames for all cycles "
+//     "using PauliFrameRandomisation.") {
+//   PauliFrameRandomisation pfr;
+//   GIVEN("A two-qubit circuit with one CX gate.") {
+//     Circuit circ(2);
+//     circ.add_op<unsigned>(OpType::CX, {0, 1});
+//     const std::vector<Circuit> all_circuits = pfr.get_all_circuits(circ);
+//     REQUIRE(all_circuits.size() == 16);
+
+//     const AllCircuitsResult expected_result{
+//         {0, {{OpType::Z, {0, 1, 6}}, {OpType::noop, {5}}}},
+//         {3,
+//          {
+//              {OpType::Z, {0, 5}},
+//              {OpType::noop, {1, 6}},
+//          }},
+//         {7, {{OpType::X, {0, 5, 6}}, {OpType::noop, {1}}}},
+//         {11,
+//          {
+//              {OpType::Y, {0, 5}},
+//              {OpType::noop, {1}},
+//              {OpType::X, {6}},
+//          }},
+//         {15,
+//          {
+//              {OpType::noop, {0, 1, 5, 6}},
+//          }},
+//     };
+//     test_command_types(expected_result, all_circuits, 7);
+//   }
+// }
+
+// SCENARIO(
+//     "Test that get_all_circuits returns correct frames and circuits for "
+//     "all cycles using UniversalFrameRandomisation.") {
+//   UniversalFrameRandomisation ufr;
+//   GIVEN("A two-qubit circuit with one CX and Rz(0.2) gate.") {
+//     Circuit circ(2);
+//     circ.add_op<unsigned>(OpType::Rz, 0.2, {0});
+//     circ.add_op<unsigned>(OpType::CX, {0, 1});
+
+//     const std::vector<Circuit> all_circuits = ufr.get_all_circuits(circ);
+//     REQUIRE(all_circuits.size() == 16);
+
+//     const AllCircuitsResult expected_result{
+//         {0,
+//          {
+//              {OpType::Z, {0, 1, 7}},
+//              {OpType::noop, {6}},
+//          }},
+//         {3,
+//          {
+//              {OpType::Z, {0, 6}},
+//              {OpType::noop, {1, 7}},
+//          }},
+//         {7,
+//          {
+//              {OpType::X, {0, 6, 7}},
+//              {OpType::noop, {1}},
+//          }},
+//         {11,
+//          {
+//              {OpType::X, {7}},
+//              {OpType::Y, {0, 6}},
+//              {OpType::noop, {1}},
+//          }},
+//         {15,
+//          {
+//              {OpType::noop, {0, 1, 6, 7}},
+//          }},
+//     };
+//     const ParameterValues param_values{
+//         {0, 0.2}, {3, 0.2}, {7, -0.2}, {11, -0.2}, {15, 0.2},
+//     };
+//     test_command_types(
+//         expected_result, all_circuits, 8, param_values, OpType::Rz, 3);
+//   }
+//   GIVEN("A circuit that gets rebased ready for UFR") {
+//     Circuit circ(2);
+//     circ.add_op<unsigned>(OpType::CX, {0, 1});
+//     circ.add_op<unsigned>(OpType::Ry, 0.2, {0});
+//     circ.add_op<unsigned>(OpType::CX, {0, 1});
+//     std::vector<Circuit> all_circuits = ufr.get_all_circuits(circ);
+//     REQUIRE(all_circuits.size() == 256);
+//     Transforms::rebase_UFR().apply(circ);
+//     all_circuits = ufr.get_all_circuits(circ);
+//     REQUIRE(all_circuits.size() == 16);
+//   }
+// }
+
+// SCENARIO(
+//     "Test that sample_cycles returns correct number of cycles using "
+//     "PowerCycle.") {
+//   const auto test_sample_cycles_from_power_cycle =
+//       [](unsigned multiplier, const Circuit& circ, unsigned number_of_tests)
+//       {
+//         PowerCycle pc;
+//         for (unsigned nn = 1; nn <= number_of_tests; ++nn) {
+//           const auto sample_cycles = pc.sample_cycles(circ, nn, 1);
+//           REQUIRE(sample_cycles.size() == 1);
+//           const Circuit& cycle_circ = sample_cycles[0];
+//           REQUIRE(cycle_circ.n_gates() == nn * multiplier);
+//         }
+//       };
+//   GIVEN("A one-qubit circuit with one H gate.") {
+//     Circuit circ(1);
+//     circ.add_op<unsigned>(OpType::H, {0});
+//     test_sample_cycles_from_power_cycle(5, circ, 4);
+//   }
+//   GIVEN("A 5-qubit circuit.") {
+//     Circuit circ(5);
+//     add_2qb_gates(circ, OpType::CX, {{0, 1}, {2, 1}, {3, 2}, {3, 4}, {0,
+//     1}}); add_1qb_gates(circ, OpType::S, {3, 2, 4});
+//     test_sample_cycles_from_power_cycle(20, circ, 4);
+//   }
+// }
+
+// SCENARIO("Frame Randomisation Segmentation Fault") {
+//   // https://github.com/CQCL/tket/issues/1015
+//   PauliFrameRandomisation pfr;
+//   Circuit c(4);
+//   c.add_op<unsigned>(OpType::CX, {0, 2});
+//   c.add_op<unsigned>(OpType::Z, {0});
+//   c.add_op<unsigned>(OpType::CX, {0, 3});
+//   c.add_op<unsigned>(OpType::Z, {0});
+//   c.add_op<unsigned>(OpType::CX, {0, 3});
+//   c.add_op<unsigned>(OpType::CX, {0, 1});
+//   std::vector<Circuit> circs = pfr.sample_randomisation_circuits(c, 1);
+
+//   circs[0].to_graphviz_file("/Users/silasdilkes/code/tket-public/whelpf.dot");
+//   CHECK(circs.size() == 1);
+//   // std::cout << circs[0] << std::endl;
+// }
+
+SCENARIO("Frame Randomisation non-real DAG") {
+  // https://github.com/CQCL/tket/issues/1015
   PauliFrameRandomisation pfr;
-  GIVEN("A two-qubit circuit with one CX gate.") {
-    Circuit circ(2);
-    circ.add_op<unsigned>(OpType::CX, {0, 1});
-    const std::vector<Circuit> all_circuits = pfr.get_all_circuits(circ);
-    REQUIRE(all_circuits.size() == 16);
-
-    const AllCircuitsResult expected_result{
-        {0, {{OpType::Z, {0, 1, 6}}, {OpType::noop, {5}}}},
-        {3,
-         {
-             {OpType::Z, {0, 5}},
-             {OpType::noop, {1, 6}},
-         }},
-        {7, {{OpType::X, {0, 5, 6}}, {OpType::noop, {1}}}},
-        {11,
-         {
-             {OpType::Y, {0, 5}},
-             {OpType::noop, {1}},
-             {OpType::X, {6}},
-         }},
-        {15,
-         {
-             {OpType::noop, {0, 1, 5, 6}},
-         }},
-    };
-    test_command_types(expected_result, all_circuits, 7);
-  }
-}
-
-SCENARIO(
-    "Test that get_all_circuits returns correct frames and circuits for "
-    "all cycles using UniversalFrameRandomisation.") {
-  UniversalFrameRandomisation ufr;
-  GIVEN("A two-qubit circuit with one CX and Rz(0.2) gate.") {
-    Circuit circ(2);
-    circ.add_op<unsigned>(OpType::Rz, 0.2, {0});
-    circ.add_op<unsigned>(OpType::CX, {0, 1});
-
-    const std::vector<Circuit> all_circuits = ufr.get_all_circuits(circ);
-    REQUIRE(all_circuits.size() == 16);
-
-    const AllCircuitsResult expected_result{
-        {0,
-         {
-             {OpType::Z, {0, 1, 7}},
-             {OpType::noop, {6}},
-         }},
-        {3,
-         {
-             {OpType::Z, {0, 6}},
-             {OpType::noop, {1, 7}},
-         }},
-        {7,
-         {
-             {OpType::X, {0, 6, 7}},
-             {OpType::noop, {1}},
-         }},
-        {11,
-         {
-             {OpType::X, {7}},
-             {OpType::Y, {0, 6}},
-             {OpType::noop, {1}},
-         }},
-        {15,
-         {
-             {OpType::noop, {0, 1, 6, 7}},
-         }},
-    };
-    const ParameterValues param_values{
-        {0, 0.2}, {3, 0.2}, {7, -0.2}, {11, -0.2}, {15, 0.2},
-    };
-    test_command_types(
-        expected_result, all_circuits, 8, param_values, OpType::Rz, 3);
-  }
-  GIVEN("A circuit that gets rebased ready for UFR") {
-    Circuit circ(2);
-    circ.add_op<unsigned>(OpType::CX, {0, 1});
-    circ.add_op<unsigned>(OpType::Ry, 0.2, {0});
-    circ.add_op<unsigned>(OpType::CX, {0, 1});
-    std::vector<Circuit> all_circuits = ufr.get_all_circuits(circ);
-    REQUIRE(all_circuits.size() == 256);
-    Transforms::rebase_UFR().apply(circ);
-    all_circuits = ufr.get_all_circuits(circ);
-    REQUIRE(all_circuits.size() == 16);
-  }
-}
-
-SCENARIO(
-    "Test that sample_cycles returns correct number of cycles using "
-    "PowerCycle.") {
-  const auto test_sample_cycles_from_power_cycle =
-      [](unsigned multiplier, const Circuit& circ, unsigned number_of_tests) {
-        PowerCycle pc;
-        for (unsigned nn = 1; nn <= number_of_tests; ++nn) {
-          const auto sample_cycles = pc.sample_cycles(circ, nn, 1);
-          REQUIRE(sample_cycles.size() == 1);
-          const Circuit& cycle_circ = sample_cycles[0];
-          REQUIRE(cycle_circ.n_gates() == nn * multiplier);
-        }
-      };
-  GIVEN("A one-qubit circuit with one H gate.") {
-    Circuit circ(1);
-    circ.add_op<unsigned>(OpType::H, {0});
-    test_sample_cycles_from_power_cycle(5, circ, 4);
-  }
-  GIVEN("A 5-qubit circuit.") {
-    Circuit circ(5);
-    add_2qb_gates(circ, OpType::CX, {{0, 1}, {2, 1}, {3, 2}, {3, 4}, {0, 1}});
-    add_1qb_gates(circ, OpType::S, {3, 2, 4});
-    test_sample_cycles_from_power_cycle(20, circ, 4);
-  }
+  Circuit c(4);
+  c.add_op<unsigned>(OpType::CnX, {0, 1, 2, 3});
+  CompilationUnit cu(c);
+  RebaseTket()->apply(cu);
+  std::vector<Circuit> circs = pfr.sample_randomisation_circuits(cu.get_circ_ref(), 1);
+  CHECK(circs.size() == 1);
+  circs[0].to_graphviz_file("/Users/silasdilkes/code/tket-public/wtf.dot");
+  std::cout << "Sampling worked, but???" << std::endl;
+  std::cout << circs[0] << std::endl;
 }
 
 }  // namespace test_FrameRandomisation
 }  // namespace tket
+
+
+

--- a/tket/test/src/test_FrameRandomisation.cpp
+++ b/tket/test/src/test_FrameRandomisation.cpp
@@ -34,357 +34,406 @@ OpTypeVector FrameRandomisationTester::get_out_frame(
 
 namespace test_FrameRandomisation {
 
-SCENARIO(
-    "Test whether get_cycles returns the expected number of cycles with "
-    "the correct operations.") {
-  FrameRandomisation fr({OpType::CX, OpType::H}, {}, {{}});
-  FrameRandomisationTester fr_tester(&fr);
+// SCENARIO(
+//     "Test whether get_cycles returns the expected number of cycles with "
+//     "the correct operations.") {
+//   FrameRandomisation fr({OpType::CX, OpType::H}, {}, {{}});
+//   FrameRandomisationTester fr_tester(&fr);
 
-  const auto add_fixed_sequence_of_ops = [](Circuit& circ) {
-    circ.add_op<unsigned>(OpType::X, {0});
-    circ.add_op<unsigned>(OpType::Y, {1});
-    circ.add_op<unsigned>(OpType::Z, {2});
-    circ.add_op<unsigned>(OpType::H, {0});
-    circ.add_op<unsigned>(OpType::H, {1});
-    circ.add_op<unsigned>(OpType::H, {2});
-    circ.add_op<unsigned>(OpType::CX, {0, 1});
-    circ.add_op<unsigned>(OpType::CX, {0, 2});
-  };
-  const auto get_comparison = [](Edge& e) {
-    return Cycle(
-        {{e, e}, {e, e}, {e, e}}, {
-                                      {OpType::Input, {}, {}},
-                                      {OpType::H, {0}, {}},
-                                      {OpType::Input, {}, {}},
-                                      {OpType::H, {1}, {}},
-                                      {OpType::CX, {0, 1}, {}},
-                                      {OpType::Input, {}, {}},
-                                      {OpType::H, {2}, {}},
-                                      {OpType::CX, {0, 2}, {}},
-                                  });
-  };
-  GIVEN("A circuit with one expected cycle.") {
-    Circuit circ(3);
-    add_fixed_sequence_of_ops(circ);
+//   const auto add_fixed_sequence_of_ops = [](Circuit& circ) {
+//     circ.add_op<unsigned>(OpType::X, {0});
+//     circ.add_op<unsigned>(OpType::Y, {1});
+//     circ.add_op<unsigned>(OpType::Z, {2});
+//     circ.add_op<unsigned>(OpType::H, {0});
+//     circ.add_op<unsigned>(OpType::H, {1});
+//     circ.add_op<unsigned>(OpType::H, {2});
+//     circ.add_op<unsigned>(OpType::CX, {0, 1});
+//     circ.add_op<unsigned>(OpType::CX, {0, 2});
+//   };
+//   const auto get_comparison = [](Edge& e) {
+//     return Cycle(
+//         {{e, e}, {e, e}, {e, e}}, {
+//                                       {OpType::Input, {}, {}},
+//                                       {OpType::H, {0}, {}},
+//                                       {OpType::Input, {}, {}},
+//                                       {OpType::H, {1}, {}},
+//                                       {OpType::CX, {0, 1}, {}},
+//                                       {OpType::Input, {}, {}},
+//                                       {OpType::H, {2}, {}},
+//                                       {OpType::CX, {0, 2}, {}},
+//                                   });
+//   };
+//   GIVEN("A circuit with one expected cycle.") {
+//     Circuit circ(3);
+//     add_fixed_sequence_of_ops(circ);
 
-    Edge e;
-    const auto comparison = get_comparison(e);
-    std::vector<Cycle> cycles = fr_tester.get_cycles(circ);
-    REQUIRE(cycles.size() == 1);
-    REQUIRE(cycles[0] == comparison);
-  }
-  GIVEN("A circuit with two expected cycle.") {
-    Circuit circ(3);
-    add_fixed_sequence_of_ops(circ);
-    add_fixed_sequence_of_ops(circ);
+//     Edge e;
+//     const auto comparison = get_comparison(e);
+//     std::vector<Cycle> cycles = fr_tester.get_cycles(circ);
+//     REQUIRE(cycles.size() == 1);
+//     REQUIRE(cycles[0] == comparison);
+//   }
+//   GIVEN("A circuit with two expected cycle.") {
+//     Circuit circ(3);
+//     add_fixed_sequence_of_ops(circ);
+//     add_fixed_sequence_of_ops(circ);
 
-    Edge e;
-    const auto comparison_0 = get_comparison(e);
-    const Cycle comparison_1(
-        {{e, e}, {e, e}, {e, e}}, {
-                                      {OpType::H, {0}, {}},
-                                      {OpType::H, {1}, {}},
-                                      {OpType::CX, {1, 0}, {}},
-                                      {OpType::H, {2}, {}},
-                                      {OpType::CX, {1, 2}, {}},
-                                  });
+//     Edge e;
+//     const auto comparison_0 = get_comparison(e);
+//     const Cycle comparison_1(
+//         {{e, e}, {e, e}, {e, e}}, {
+//                                       {OpType::H, {0}, {}},
+//                                       {OpType::H, {1}, {}},
+//                                       {OpType::CX, {1, 0}, {}},
+//                                       {OpType::H, {2}, {}},
+//                                       {OpType::CX, {1, 2}, {}},
+//                                   });
 
-    std::vector<Cycle> cycles = fr_tester.get_cycles(circ);
-    REQUIRE(cycles.size() == 2);
-    REQUIRE(cycles[0] == comparison_0);
-    REQUIRE(cycles[1] == comparison_1);
-  }
-  GIVEN("A circuit with 50 cycles.") {
-    Circuit circ(3);
-    for (unsigned i = 0; i < 50; i++) {
-      add_fixed_sequence_of_ops(circ);
-    }
-    std::vector<Cycle> cycles = fr_tester.get_cycles(circ);
-    REQUIRE(cycles.size() == 50);
-  }
-}
+//     std::vector<Cycle> cycles = fr_tester.get_cycles(circ);
+//     REQUIRE(cycles.size() == 2);
+//     REQUIRE(cycles[0] == comparison_0);
+//     REQUIRE(cycles[1] == comparison_1);
+//   }
+//   GIVEN("A circuit with 50 cycles.") {
+//     Circuit circ(3);
+//     for (unsigned i = 0; i < 50; i++) {
+//       add_fixed_sequence_of_ops(circ);
+//     }
+//     std::vector<Cycle> cycles = fr_tester.get_cycles(circ);
+//     REQUIRE(cycles.size() == 50);
+//   }
+// }
 
-SCENARIO("Test that get_out_frame returns the expected result.") {
-  Circuit circ(2);
-  circ.add_op<unsigned>(OpType::CX, {0, 1});
-  std::map<OpType, std::map<OpTypeVector, OpTypeVector>> init;
-  std::map<OpTypeVector, OpTypeVector> entry;
-  entry[{OpType::X, OpType::X}] = {OpType::Y, OpType::Y};
-  entry[{OpType::Y, OpType::Y}] = {OpType::X, OpType::X};
-  init[OpType::CX] = entry;
-  FrameRandomisation fr({OpType::CX, OpType::H}, {OpType::X}, init);
-  FrameRandomisationTester fr_tester(&fr);
+// SCENARIO("Test that get_out_frame returns the expected result.") {
+//   Circuit circ(2);
+//   circ.add_op<unsigned>(OpType::CX, {0, 1});
+//   std::map<OpType, std::map<OpTypeVector, OpTypeVector>> init;
+//   std::map<OpTypeVector, OpTypeVector> entry;
+//   entry[{OpType::X, OpType::X}] = {OpType::Y, OpType::Y};
+//   entry[{OpType::Y, OpType::Y}] = {OpType::X, OpType::X};
+//   init[OpType::CX] = entry;
+//   FrameRandomisation fr({OpType::CX, OpType::H}, {OpType::X}, init);
+//   FrameRandomisationTester fr_tester(&fr);
 
-  Cycle cycle = fr_tester.get_cycles(circ)[0];
-  OpTypeVector out_frame =
-      fr_tester.get_out_frame({OpType::X, OpType::X}, cycle);
-  REQUIRE(out_frame[0] == OpType::Y);
-  REQUIRE(out_frame[1] == OpType::Y);
-  out_frame = fr_tester.get_out_frame({OpType::Y, OpType::Y}, cycle);
-  REQUIRE(out_frame[0] == OpType::X);
-  REQUIRE(out_frame[1] == OpType::X);
-}
+//   Cycle cycle = fr_tester.get_cycles(circ)[0];
+//   OpTypeVector out_frame =
+//       fr_tester.get_out_frame({OpType::X, OpType::X}, cycle);
+//   REQUIRE(out_frame[0] == OpType::Y);
+//   REQUIRE(out_frame[1] == OpType::Y);
+//   out_frame = fr_tester.get_out_frame({OpType::Y, OpType::Y}, cycle);
+//   REQUIRE(out_frame[0] == OpType::X);
+//   REQUIRE(out_frame[1] == OpType::X);
+// }
 
-// KEY: op type
-// VALUE: list of command indices with that type.
-typedef std::map<OpType, std::vector<unsigned>> CircResult;
+// // KEY: op type
+// // VALUE: list of command indices with that type.
+// typedef std::map<OpType, std::vector<unsigned>> CircResult;
 
-// KEY: index in "all_circuits", a list of circuits
-// VALUE: result for that circuit.
-typedef std::map<unsigned, CircResult> AllCircuitsResult;
+// // KEY: index in "all_circuits", a list of circuits
+// // VALUE: result for that circuit.
+// typedef std::map<unsigned, CircResult> AllCircuitsResult;
 
-// KEY: index in "all_circuits"
-// VALUE: the expected parameter value in command[n]
-//          for that circuit (n is constant over all circuits
-//          for which this applies).
-typedef std::map<unsigned, double> ParameterValues;
+// // KEY: index in "all_circuits"
+// // VALUE: the expected parameter value in command[n]
+// //          for that circuit (n is constant over all circuits
+// //          for which this applies).
+// typedef std::map<unsigned, double> ParameterValues;
 
-static void test_parameter_value(
-    unsigned circuit_index, const ParameterValues& values,
-    const std::vector<Command>& commands,
-    unsigned index_for_command_with_parameter) {
-  if (values.empty()) {
-    return;
-  }
-  const double expected_parameter_value = values.at(circuit_index);
-  const auto params =
-      commands[index_for_command_with_parameter].get_op_ptr()->get_params();
-  REQUIRE(params.size() == 1);
-  // Normally it's very naughty to do doubles equality.
-  // But here, no calculations other than possibly inserting
-  // a minus sign are performed, so no roundoff errors occur.
-  REQUIRE(params[0] == expected_parameter_value);
-}
+// static void test_parameter_value(
+//     unsigned circuit_index, const ParameterValues& values,
+//     const std::vector<Command>& commands,
+//     unsigned index_for_command_with_parameter) {
+//   if (values.empty()) {
+//     return;
+//   }
+//   const double expected_parameter_value = values.at(circuit_index);
+//   const auto params =
+//       commands[index_for_command_with_parameter].get_op_ptr()->get_params();
+//   REQUIRE(params.size() == 1);
+//   // Normally it's very naughty to do doubles equality.
+//   // But here, no calculations other than possibly inserting
+//   // a minus sign are performed, so no roundoff errors occur.
+//   REQUIRE(params[0] == expected_parameter_value);
+// }
 
-static void test_command_types(
-    const AllCircuitsResult& result, const std::vector<Circuit>& all_circuits,
-    unsigned number_of_commands, const ParameterValues& values = {},
-    OpType op_with_parameter = OpType::noop,
-    unsigned index_for_command_with_parameter = 9999) {
-  for (const auto& outer_entry : result) {
-    const auto& circuit_index = outer_entry.first;
-    const auto commands = all_circuits[circuit_index].get_commands();
-    REQUIRE(commands.size() == number_of_commands);
-    test_parameter_value(
-        circuit_index, values, commands, index_for_command_with_parameter);
+// static void test_command_types(
+//     const AllCircuitsResult& result, const std::vector<Circuit>& all_circuits,
+//     unsigned number_of_commands, const ParameterValues& values = {},
+//     OpType op_with_parameter = OpType::noop,
+//     unsigned index_for_command_with_parameter = 9999) {
+//   for (const auto& outer_entry : result) {
+//     const auto& circuit_index = outer_entry.first;
+//     const auto commands = all_circuits[circuit_index].get_commands();
+//     REQUIRE(commands.size() == number_of_commands);
+//     test_parameter_value(
+//         circuit_index, values, commands, index_for_command_with_parameter);
 
-    CircResult op_types_for_this_circ = outer_entry.second;
-    if (!values.empty()) {
-      op_types_for_this_circ[op_with_parameter].push_back(
-          index_for_command_with_parameter);
-    }
-    for (const auto& inner_entry : op_types_for_this_circ) {
-      const OpType& type = inner_entry.first;
-      auto command_indices = inner_entry.second;
-      for (unsigned ii : command_indices) {
-        REQUIRE(commands[ii].get_op_ptr()->get_type() == type);
-      }
-    }
-  }
-}
+//     CircResult op_types_for_this_circ = outer_entry.second;
+//     if (!values.empty()) {
+//       op_types_for_this_circ[op_with_parameter].push_back(
+//           index_for_command_with_parameter);
+//     }
+//     for (const auto& inner_entry : op_types_for_this_circ) {
+//       const OpType& type = inner_entry.first;
+//       auto command_indices = inner_entry.second;
+//       for (unsigned ii : command_indices) {
+//         REQUIRE(commands[ii].get_op_ptr()->get_type() == type);
+//       }
+//     }
+//   }
+// }
 
-SCENARIO("Test that get_all_circuits returns all frames for all cycles.") {
-  std::map<OpType, std::map<OpTypeVector, OpTypeVector>> init;
-  std::map<OpTypeVector, OpTypeVector> entry_cx;
-  std::map<OpTypeVector, OpTypeVector> entry_h;
-  entry_cx[{OpType::X, OpType::X}] = {OpType::Y, OpType::Y};
-  entry_cx[{OpType::Y, OpType::Y}] = {OpType::X, OpType::X};
-  entry_cx[{OpType::X, OpType::Y}] = {OpType::Y, OpType::X};
-  entry_cx[{OpType::Y, OpType::X}] = {OpType::X, OpType::Y};
-  entry_h[{OpType::X}] = {OpType::Y};
-  entry_h[{OpType::Y}] = {OpType::X};
-  init[OpType::CX] = entry_cx;
-  init[OpType::H] = entry_h;
-  FrameRandomisation fr({OpType::CX, OpType::H}, {OpType::X, OpType::Y}, init);
+// SCENARIO("Test that get_all_circuits returns all frames for all cycles.") {
+//   std::map<OpType, std::map<OpTypeVector, OpTypeVector>> init;
+//   std::map<OpTypeVector, OpTypeVector> entry_cx;
+//   std::map<OpTypeVector, OpTypeVector> entry_h;
+//   entry_cx[{OpType::X, OpType::X}] = {OpType::Y, OpType::Y};
+//   entry_cx[{OpType::Y, OpType::Y}] = {OpType::X, OpType::X};
+//   entry_cx[{OpType::X, OpType::Y}] = {OpType::Y, OpType::X};
+//   entry_cx[{OpType::Y, OpType::X}] = {OpType::X, OpType::Y};
+//   entry_h[{OpType::X}] = {OpType::Y};
+//   entry_h[{OpType::Y}] = {OpType::X};
+//   init[OpType::CX] = entry_cx;
+//   init[OpType::H] = entry_h;
+//   FrameRandomisation fr({OpType::CX, OpType::H}, {OpType::X, OpType::Y}, init);
 
-  GIVEN("A two-qubit circuit with one CX gate.") {
-    Circuit circ(2);
-    circ.add_op<unsigned>(OpType::CX, {0, 1});
-    const std::vector<Circuit> two_circuits =
-        fr.sample_randomisation_circuits(circ, 2);
-    REQUIRE(two_circuits.size() == 2);
-    const std::vector<Circuit> all_circuits = fr.get_all_circuits(circ);
-    REQUIRE(all_circuits.size() == 4);
-    REQUIRE(
-        std::find(all_circuits.begin(), all_circuits.end(), two_circuits[0]) !=
-        all_circuits.end());
-    for (const Circuit& circ : all_circuits) {
-      const auto coms = circ.get_commands();
-      REQUIRE(coms.size() == 7);
-      REQUIRE(
-          coms[0].get_op_ptr()->get_type() != coms[5].get_op_ptr()->get_type());
-      REQUIRE(
-          coms[1].get_op_ptr()->get_type() != coms[6].get_op_ptr()->get_type());
-    }
-  }
-  GIVEN("A two-qubit circuit with three cycles.") {
-    Circuit circ(2);
-    const auto add_four_ops = [&circ]() {
-      circ.add_op<unsigned>(OpType::CX, {0, 1});
-      circ.add_op<unsigned>(OpType::H, {1});
-      circ.add_op<unsigned>(OpType::S, {0});
-      circ.add_op<unsigned>(OpType::S, {1});
-    };
-    circ.add_op<unsigned>(OpType::S, {0});
-    add_four_ops();
-    circ.add_op<unsigned>(OpType::H, {0});
-    add_four_ops();
-    add_four_ops();
-    const std::vector<Circuit> all_circuits = fr.get_all_circuits(circ);
-    REQUIRE(all_circuits.size() == 64);
-    const std::vector<unsigned> indices_a{1, 2, 8, 11, 12, 18, 19, 22, 23, 29};
-    const std::vector<unsigned> indices_b{7, 28};
+//   GIVEN("A two-qubit circuit with one CX gate.") {
+//     Circuit circ(2);
+//     circ.add_op<unsigned>(OpType::CX, {0, 1});
+//     const std::vector<Circuit> two_circuits =
+//         fr.sample_randomisation_circuits(circ, 2);
+//     REQUIRE(two_circuits.size() == 2);
+//     const std::vector<Circuit> all_circuits = fr.get_all_circuits(circ);
+//     REQUIRE(all_circuits.size() == 4);
+//     REQUIRE(
+//         std::find(all_circuits.begin(), all_circuits.end(), two_circuits[0]) !=
+//         all_circuits.end());
+//     for (const Circuit& circ : all_circuits) {
+//       const auto coms = circ.get_commands();
+//       REQUIRE(coms.size() == 7);
+//       REQUIRE(
+//           coms[0].get_op_ptr()->get_type() != coms[5].get_op_ptr()->get_type());
+//       REQUIRE(
+//           coms[1].get_op_ptr()->get_type() != coms[6].get_op_ptr()->get_type());
+//     }
+//   }
+//   GIVEN("A two-qubit circuit with three cycles.") {
+//     Circuit circ(2);
+//     const auto add_four_ops = [&circ]() {
+//       circ.add_op<unsigned>(OpType::CX, {0, 1});
+//       circ.add_op<unsigned>(OpType::H, {1});
+//       circ.add_op<unsigned>(OpType::S, {0});
+//       circ.add_op<unsigned>(OpType::S, {1});
+//     };
+//     circ.add_op<unsigned>(OpType::S, {0});
+//     add_four_ops();
+//     circ.add_op<unsigned>(OpType::H, {0});
+//     add_four_ops();
+//     add_four_ops();
+//     const std::vector<Circuit> all_circuits = fr.get_all_circuits(circ);
+//     REQUIRE(all_circuits.size() == 64);
+//     const std::vector<unsigned> indices_a{1, 2, 8, 11, 12, 18, 19, 22, 23, 29};
+//     const std::vector<unsigned> indices_b{7, 28};
 
-    const AllCircuitsResult expected_result{
-        {0, {{OpType::X, indices_a}, {OpType::Y, indices_b}}},
-        {63, {{OpType::X, indices_b}, {OpType::Y, indices_a}}},
-    };
-    test_command_types(expected_result, all_circuits, 32);
-  }
-}
+//     const AllCircuitsResult expected_result{
+//         {0, {{OpType::X, indices_a}, {OpType::Y, indices_b}}},
+//         {63, {{OpType::X, indices_b}, {OpType::Y, indices_a}}},
+//     };
+//     test_command_types(expected_result, all_circuits, 32);
+//   }
+// }
 
-SCENARIO(
-    "Test that get_all_circuits returns correct frames for all cycles "
-    "using PauliFrameRandomisation.") {
-  PauliFrameRandomisation pfr;
-  GIVEN("A two-qubit circuit with one CX gate.") {
-    Circuit circ(2);
-    circ.add_op<unsigned>(OpType::CX, {0, 1});
-    const std::vector<Circuit> all_circuits = pfr.get_all_circuits(circ);
-    REQUIRE(all_circuits.size() == 16);
+// SCENARIO(
+//     "Test that get_all_circuits returns correct frames for all cycles "
+//     "using PauliFrameRandomisation.") {
+//   PauliFrameRandomisation pfr;
+//   GIVEN("A two-qubit circuit with one CX gate.") {
+//     Circuit circ(2);
+//     circ.add_op<unsigned>(OpType::CX, {0, 1});
+//     const std::vector<Circuit> all_circuits = pfr.get_all_circuits(circ);
+//     REQUIRE(all_circuits.size() == 16);
 
-    const AllCircuitsResult expected_result{
-        {0, {{OpType::Z, {0, 1, 6}}, {OpType::noop, {5}}}},
-        {3,
-         {
-             {OpType::Z, {0, 5}},
-             {OpType::noop, {1, 6}},
-         }},
-        {7, {{OpType::X, {0, 5, 6}}, {OpType::noop, {1}}}},
-        {11,
-         {
-             {OpType::Y, {0, 5}},
-             {OpType::noop, {1}},
-             {OpType::X, {6}},
-         }},
-        {15,
-         {
-             {OpType::noop, {0, 1, 5, 6}},
-         }},
-    };
-    test_command_types(expected_result, all_circuits, 7);
-  }
-}
+//     const AllCircuitsResult expected_result{
+//         {0, {{OpType::Z, {0, 1, 6}}, {OpType::noop, {5}}}},
+//         {3,
+//          {
+//              {OpType::Z, {0, 5}},
+//              {OpType::noop, {1, 6}},
+//          }},
+//         {7, {{OpType::X, {0, 5, 6}}, {OpType::noop, {1}}}},
+//         {11,
+//          {
+//              {OpType::Y, {0, 5}},
+//              {OpType::noop, {1}},
+//              {OpType::X, {6}},
+//          }},
+//         {15,
+//          {
+//              {OpType::noop, {0, 1, 5, 6}},
+//          }},
+//     };
+//     test_command_types(expected_result, all_circuits, 7);
+//   }
+// }
 
-SCENARIO(
-    "Test that get_all_circuits returns correct frames and circuits for "
-    "all cycles using UniversalFrameRandomisation.") {
-  UniversalFrameRandomisation ufr;
-  GIVEN("A two-qubit circuit with one CX and Rz(0.2) gate.") {
-    Circuit circ(2);
-    circ.add_op<unsigned>(OpType::Rz, 0.2, {0});
-    circ.add_op<unsigned>(OpType::CX, {0, 1});
+// SCENARIO(
+//     "Test that get_all_circuits returns correct frames and circuits for "
+//     "all cycles using UniversalFrameRandomisation.") {
+//   UniversalFrameRandomisation ufr;
+//   GIVEN("A two-qubit circuit with one CX and Rz(0.2) gate.") {
+//     Circuit circ(2);
+//     circ.add_op<unsigned>(OpType::Rz, 0.2, {0});
+//     circ.add_op<unsigned>(OpType::CX, {0, 1});
 
-    const std::vector<Circuit> all_circuits = ufr.get_all_circuits(circ);
-    REQUIRE(all_circuits.size() == 16);
+//     const std::vector<Circuit> all_circuits = ufr.get_all_circuits(circ);
+//     REQUIRE(all_circuits.size() == 16);
 
-    const AllCircuitsResult expected_result{
-        {0,
-         {
-             {OpType::Z, {0, 1, 7}},
-             {OpType::noop, {6}},
-         }},
-        {3,
-         {
-             {OpType::Z, {0, 6}},
-             {OpType::noop, {1, 7}},
-         }},
-        {7,
-         {
-             {OpType::X, {0, 6, 7}},
-             {OpType::noop, {1}},
-         }},
-        {11,
-         {
-             {OpType::X, {7}},
-             {OpType::Y, {0, 6}},
-             {OpType::noop, {1}},
-         }},
-        {15,
-         {
-             {OpType::noop, {0, 1, 6, 7}},
-         }},
-    };
-    const ParameterValues param_values{
-        {0, 0.2}, {3, 0.2}, {7, -0.2}, {11, -0.2}, {15, 0.2},
-    };
-    test_command_types(
-        expected_result, all_circuits, 8, param_values, OpType::Rz, 3);
-  }
-  GIVEN("A circuit that gets rebased ready for UFR") {
-    Circuit circ(2);
-    circ.add_op<unsigned>(OpType::CX, {0, 1});
-    circ.add_op<unsigned>(OpType::Ry, 0.2, {0});
-    circ.add_op<unsigned>(OpType::CX, {0, 1});
-    std::vector<Circuit> all_circuits = ufr.get_all_circuits(circ);
-    REQUIRE(all_circuits.size() == 256);
-    Transforms::rebase_UFR().apply(circ);
-    all_circuits = ufr.get_all_circuits(circ);
-    REQUIRE(all_circuits.size() == 16);
-  }
-}
+//     const AllCircuitsResult expected_result{
+//         {0,
+//          {
+//              {OpType::Z, {0, 1, 7}},
+//              {OpType::noop, {6}},
+//          }},
+//         {3,
+//          {
+//              {OpType::Z, {0, 6}},
+//              {OpType::noop, {1, 7}},
+//          }},
+//         {7,
+//          {
+//              {OpType::X, {0, 6, 7}},
+//              {OpType::noop, {1}},
+//          }},
+//         {11,
+//          {
+//              {OpType::X, {7}},
+//              {OpType::Y, {0, 6}},
+//              {OpType::noop, {1}},
+//          }},
+//         {15,
+//          {
+//              {OpType::noop, {0, 1, 6, 7}},
+//          }},
+//     };
+//     const ParameterValues param_values{
+//         {0, 0.2}, {3, 0.2}, {7, -0.2}, {11, -0.2}, {15, 0.2},
+//     };
+//     test_command_types(
+//         expected_result, all_circuits, 8, param_values, OpType::Rz, 3);
+//   }
+//   GIVEN("A circuit that gets rebased ready for UFR") {
+//     Circuit circ(2);
+//     circ.add_op<unsigned>(OpType::CX, {0, 1});
+//     circ.add_op<unsigned>(OpType::Ry, 0.2, {0});
+//     circ.add_op<unsigned>(OpType::CX, {0, 1});
+//     std::vector<Circuit> all_circuits = ufr.get_all_circuits(circ);
+//     REQUIRE(all_circuits.size() == 256);
+//     Transforms::rebase_UFR().apply(circ);
+//     all_circuits = ufr.get_all_circuits(circ);
+//     REQUIRE(all_circuits.size() == 16);
+//   }
+// }
 
-SCENARIO(
-    "Test that sample_cycles returns correct number of cycles using "
-    "PowerCycle.") {
-  const auto test_sample_cycles_from_power_cycle =
-      [](unsigned multiplier, const Circuit& circ, unsigned number_of_tests) {
-        PowerCycle pc;
-        for (unsigned nn = 1; nn <= number_of_tests; ++nn) {
-          const auto sample_cycles = pc.sample_cycles(circ, nn, 1);
-          REQUIRE(sample_cycles.size() == 1);
-          const Circuit& cycle_circ = sample_cycles[0];
-          REQUIRE(cycle_circ.n_gates() == nn * multiplier);
-        }
-      };
-  GIVEN("A one-qubit circuit with one H gate.") {
-    Circuit circ(1);
-    circ.add_op<unsigned>(OpType::H, {0});
-    test_sample_cycles_from_power_cycle(5, circ, 4);
-  }
-  GIVEN("A 5-qubit circuit.") {
-    Circuit circ(5);
-    add_2qb_gates(circ, OpType::CX, {{0, 1}, {2, 1}, {3, 2}, {3, 4}, {0, 1}});
-    add_1qb_gates(circ, OpType::S, {3, 2, 4});
-    test_sample_cycles_from_power_cycle(20, circ, 4);
-  }
-}
+// SCENARIO(
+//     "Test that sample_cycles returns correct number of cycles using "
+//     "PowerCycle.") {
+//   const auto test_sample_cycles_from_power_cycle =
+//       [](unsigned multiplier, const Circuit& circ, unsigned number_of_tests) {
+//         PowerCycle pc;
+//         for (unsigned nn = 1; nn <= number_of_tests; ++nn) {
+//           const auto sample_cycles = pc.sample_cycles(circ, nn, 1);
+//           REQUIRE(sample_cycles.size() == 1);
+//           const Circuit& cycle_circ = sample_cycles[0];
+//           REQUIRE(cycle_circ.n_gates() == nn * multiplier);
+//         }
+//       };
+//   GIVEN("A one-qubit circuit with one H gate.") {
+//     Circuit circ(1);
+//     circ.add_op<unsigned>(OpType::H, {0});
+//     test_sample_cycles_from_power_cycle(5, circ, 4);
+//   }
+//   GIVEN("A 5-qubit circuit.") {
+//     Circuit circ(5);
+//     add_2qb_gates(circ, OpType::CX, {{0, 1}, {2, 1}, {3, 2}, {3, 4}, {0, 1}});
+//     add_1qb_gates(circ, OpType::S, {3, 2, 4});
+//     test_sample_cycles_from_power_cycle(20, circ, 4);
+//   }
+// }
 
-SCENARIO("Frame Randomisation Segmentation Fault") {
-  // https://github.com/CQCL/tket/issues/1015
-  PauliFrameRandomisation pfr;
-  Circuit c(4);
-  c.add_op<unsigned>(OpType::CX, {0, 2});
-  c.add_op<unsigned>(OpType::Z, {0});
-  c.add_op<unsigned>(OpType::CX, {0, 3});
-  c.add_op<unsigned>(OpType::Z, {0});
-  c.add_op<unsigned>(OpType::CX, {0, 3});
-  c.add_op<unsigned>(OpType::CX, {0, 1});
-  std::vector<Circuit> circs = pfr.sample_randomisation_circuits(c, 1);
-  CHECK(circs.size() == 1);
-}
+// SCENARIO("Frame Randomisation Segmentation Fault") {
+//   // https://github.com/CQCL/tket/issues/1015
+//   PauliFrameRandomisation pfr;
+//   Circuit c(4);
+//   c.add_op<unsigned>(OpType::CX, {0, 2});
+//   c.add_op<unsigned>(OpType::Z, {0});
+//   c.add_op<unsigned>(OpType::CX, {0, 3});
+//   c.add_op<unsigned>(OpType::Z, {0});
+//   c.add_op<unsigned>(OpType::CX, {0, 3});
+//   c.add_op<unsigned>(OpType::CX, {0, 1});
+//   std::vector<Circuit> circs = pfr.sample_randomisation_circuits(c, 1);
+//   CHECK(circs.size() == 1);
+// }
 
 SCENARIO("Frame Randomisation non-real DAG") {
   // https://github.com/CQCL/tket/issues/1015
-  PauliFrameRandomisation pfr;
-  Circuit c(4);
-  c.add_op<unsigned>(OpType::CnX, {0, 1, 2, 3});
-  CompilationUnit cu(c);
-  RebaseTket()->apply(cu);
-  std::vector<Circuit> circs =
-      pfr.sample_randomisation_circuits(cu.get_circ_ref(), 1);
-  CHECK(circs.size() == 1);
-  CHECK(circs[0].get_commands().size() == 107);
+  GIVEN("CnX gate with 3 controls") {
+    PauliFrameRandomisation pfr;
+    Circuit c(4);
+    c.add_op<unsigned>(OpType::CnX, {0, 1, 2, 3});
+    CompilationUnit cu(c);
+    RebaseTket()->apply(cu);
+    std::vector<Circuit> circs =
+        pfr.sample_randomisation_circuits(cu.get_circ_ref(), 1);
+    CHECK(circs.size() == 1);
+    circs[0].to_graphviz_file("/Users/silasdilkes/code/tket-public/bad.dot");
+    CHECK(circs[0].get_commands().size() == 107);
+  }
+  GIVEN("CnX gate with 4 controls") {
+    PauliFrameRandomisation pfr;
+    Circuit c(5);
+    c.add_op<unsigned>(OpType::CnX, {0, 1, 2, 3, 4});
+    CompilationUnit cu(c);
+    RebaseTket()->apply(cu);
+    std::vector<Circuit> circs =
+        pfr.sample_randomisation_circuits(cu.get_circ_ref(), 1);
+    CHECK(circs.size() == 1);
+    std::cout << circs[0].get_commands().size()  << std::endl;
+    CHECK(circs[0].get_commands().size() == 293);
+  }
+  GIVEN("CnX gate with 5 controls") {
+    PauliFrameRandomisation pfr;
+    Circuit c(6);
+    c.add_op<unsigned>(OpType::CnX, {0, 1, 2, 3, 4, 5});
+    CompilationUnit cu(c);
+    RebaseTket()->apply(cu);
+    std::vector<Circuit> circs =
+        pfr.sample_randomisation_circuits(cu.get_circ_ref(), 1);
+    CHECK(circs.size() == 1);
+    CHECK(circs[0].get_commands().size() == 742);
+  }
+  GIVEN("CnX gate with 6 controls") {
+    PauliFrameRandomisation pfr;
+    Circuit c(7);
+    c.add_op<unsigned>(OpType::CnX, {0, 1, 2, 3, 4, 5, 6});
+    CompilationUnit cu(c);
+    RebaseTket()->apply(cu);
+    std::vector<Circuit> circs =
+        pfr.sample_randomisation_circuits(cu.get_circ_ref(), 1);
+    CHECK(circs.size() == 1);
+    CHECK(circs[0].get_commands().size() == 1118);
+  }
+  GIVEN("CnX gate with 7 controls") {
+    PauliFrameRandomisation pfr;
+    Circuit c(8);
+    c.add_op<unsigned>(OpType::CnX, {0, 1, 2, 3, 4, 5, 6, 7});
+    CompilationUnit cu(c);
+    RebaseTket()->apply(cu);
+    std::vector<Circuit> circs =
+        pfr.sample_randomisation_circuits(cu.get_circ_ref(), 1);
+    CHECK(circs.size() == 1);
+    std::cout << circs[0].get_commands().size()  << std::endl;
+    CHECK(circs[0].get_commands().size() == 1570);
+  }
 }
 
 }  // namespace test_FrameRandomisation

--- a/tket/test/src/test_FrameRandomisation.cpp
+++ b/tket/test/src/test_FrameRandomisation.cpp
@@ -157,10 +157,10 @@ namespace test_FrameRandomisation {
 // }
 
 // static void test_command_types(
-//     const AllCircuitsResult& result, const std::vector<Circuit>& all_circuits,
-//     unsigned number_of_commands, const ParameterValues& values = {},
-//     OpType op_with_parameter = OpType::noop,
-//     unsigned index_for_command_with_parameter = 9999) {
+//     const AllCircuitsResult& result, const std::vector<Circuit>&
+//     all_circuits, unsigned number_of_commands, const ParameterValues& values
+//     = {}, OpType op_with_parameter = OpType::noop, unsigned
+//     index_for_command_with_parameter = 9999) {
 //   for (const auto& outer_entry : result) {
 //     const auto& circuit_index = outer_entry.first;
 //     const auto commands = all_circuits[circuit_index].get_commands();
@@ -195,7 +195,8 @@ namespace test_FrameRandomisation {
 //   entry_h[{OpType::Y}] = {OpType::X};
 //   init[OpType::CX] = entry_cx;
 //   init[OpType::H] = entry_h;
-//   FrameRandomisation fr({OpType::CX, OpType::H}, {OpType::X, OpType::Y}, init);
+//   FrameRandomisation fr({OpType::CX, OpType::H}, {OpType::X, OpType::Y},
+//   init);
 
 //   GIVEN("A two-qubit circuit with one CX gate.") {
 //     Circuit circ(2);
@@ -206,15 +207,17 @@ namespace test_FrameRandomisation {
 //     const std::vector<Circuit> all_circuits = fr.get_all_circuits(circ);
 //     REQUIRE(all_circuits.size() == 4);
 //     REQUIRE(
-//         std::find(all_circuits.begin(), all_circuits.end(), two_circuits[0]) !=
-//         all_circuits.end());
+//         std::find(all_circuits.begin(), all_circuits.end(), two_circuits[0])
+//         != all_circuits.end());
 //     for (const Circuit& circ : all_circuits) {
 //       const auto coms = circ.get_commands();
 //       REQUIRE(coms.size() == 7);
 //       REQUIRE(
-//           coms[0].get_op_ptr()->get_type() != coms[5].get_op_ptr()->get_type());
+//           coms[0].get_op_ptr()->get_type() !=
+//           coms[5].get_op_ptr()->get_type());
 //       REQUIRE(
-//           coms[1].get_op_ptr()->get_type() != coms[6].get_op_ptr()->get_type());
+//           coms[1].get_op_ptr()->get_type() !=
+//           coms[6].get_op_ptr()->get_type());
 //     }
 //   }
 //   GIVEN("A two-qubit circuit with three cycles.") {
@@ -232,8 +235,8 @@ namespace test_FrameRandomisation {
 //     add_four_ops();
 //     const std::vector<Circuit> all_circuits = fr.get_all_circuits(circ);
 //     REQUIRE(all_circuits.size() == 64);
-//     const std::vector<unsigned> indices_a{1, 2, 8, 11, 12, 18, 19, 22, 23, 29};
-//     const std::vector<unsigned> indices_b{7, 28};
+//     const std::vector<unsigned> indices_a{1, 2, 8, 11, 12, 18, 19, 22, 23,
+//     29}; const std::vector<unsigned> indices_b{7, 28};
 
 //     const AllCircuitsResult expected_result{
 //         {0, {{OpType::X, indices_a}, {OpType::Y, indices_b}}},
@@ -338,7 +341,8 @@ namespace test_FrameRandomisation {
 //     "Test that sample_cycles returns correct number of cycles using "
 //     "PowerCycle.") {
 //   const auto test_sample_cycles_from_power_cycle =
-//       [](unsigned multiplier, const Circuit& circ, unsigned number_of_tests) {
+//       [](unsigned multiplier, const Circuit& circ, unsigned number_of_tests)
+//       {
 //         PowerCycle pc;
 //         for (unsigned nn = 1; nn <= number_of_tests; ++nn) {
 //           const auto sample_cycles = pc.sample_cycles(circ, nn, 1);
@@ -354,8 +358,8 @@ namespace test_FrameRandomisation {
 //   }
 //   GIVEN("A 5-qubit circuit.") {
 //     Circuit circ(5);
-//     add_2qb_gates(circ, OpType::CX, {{0, 1}, {2, 1}, {3, 2}, {3, 4}, {0, 1}});
-//     add_1qb_gates(circ, OpType::S, {3, 2, 4});
+//     add_2qb_gates(circ, OpType::CX, {{0, 1}, {2, 1}, {3, 2}, {3, 4}, {0,
+//     1}}); add_1qb_gates(circ, OpType::S, {3, 2, 4});
 //     test_sample_cycles_from_power_cycle(20, circ, 4);
 //   }
 // }
@@ -397,7 +401,7 @@ SCENARIO("Frame Randomisation non-real DAG") {
     std::vector<Circuit> circs =
         pfr.sample_randomisation_circuits(cu.get_circ_ref(), 1);
     CHECK(circs.size() == 1);
-    std::cout << circs[0].get_commands().size()  << std::endl;
+    std::cout << circs[0].get_commands().size() << std::endl;
     CHECK(circs[0].get_commands().size() == 293);
   }
   GIVEN("CnX gate with 5 controls") {
@@ -431,7 +435,7 @@ SCENARIO("Frame Randomisation non-real DAG") {
     std::vector<Circuit> circs =
         pfr.sample_randomisation_circuits(cu.get_circ_ref(), 1);
     CHECK(circs.size() == 1);
-    std::cout << circs[0].get_commands().size()  << std::endl;
+    std::cout << circs[0].get_commands().size() << std::endl;
     CHECK(circs[0].get_commands().size() == 1570);
   }
 }

--- a/tket/test/src/test_FrameRandomisation.cpp
+++ b/tket/test/src/test_FrameRandomisation.cpp
@@ -16,8 +16,8 @@
 
 #include "testutil.hpp"
 #include "tket/Characterisation/FrameRandomisation.hpp"
-#include "tket/Predicates/PassLibrary.hpp"
 #include "tket/Predicates/CompilationUnit.hpp"
+#include "tket/Predicates/PassLibrary.hpp"
 #include "tket/Transformations/Rebase.hpp"
 #include "tket/Transformations/Transform.hpp"
 
@@ -34,352 +34,345 @@ OpTypeVector FrameRandomisationTester::get_out_frame(
 
 namespace test_FrameRandomisation {
 
-// SCENARIO(
-//     "Test whether get_cycles returns the expected number of cycles with "
-//     "the correct operations.") {
-//   FrameRandomisation fr({OpType::CX, OpType::H}, {}, {{}});
-//   FrameRandomisationTester fr_tester(&fr);
+SCENARIO(
+    "Test whether get_cycles returns the expected number of cycles with "
+    "the correct operations.") {
+  FrameRandomisation fr({OpType::CX, OpType::H}, {}, {{}});
+  FrameRandomisationTester fr_tester(&fr);
 
-//   const auto add_fixed_sequence_of_ops = [](Circuit& circ) {
-//     circ.add_op<unsigned>(OpType::X, {0});
-//     circ.add_op<unsigned>(OpType::Y, {1});
-//     circ.add_op<unsigned>(OpType::Z, {2});
-//     circ.add_op<unsigned>(OpType::H, {0});
-//     circ.add_op<unsigned>(OpType::H, {1});
-//     circ.add_op<unsigned>(OpType::H, {2});
-//     circ.add_op<unsigned>(OpType::CX, {0, 1});
-//     circ.add_op<unsigned>(OpType::CX, {0, 2});
-//   };
-//   const auto get_comparison = [](Edge& e) {
-//     return Cycle(
-//         {{e, e}, {e, e}, {e, e}}, {
-//                                       {OpType::Input, {}, {}},
-//                                       {OpType::H, {0}, {}},
-//                                       {OpType::Input, {}, {}},
-//                                       {OpType::H, {1}, {}},
-//                                       {OpType::CX, {0, 1}, {}},
-//                                       {OpType::Input, {}, {}},
-//                                       {OpType::H, {2}, {}},
-//                                       {OpType::CX, {0, 2}, {}},
-//                                   });
-//   };
-//   GIVEN("A circuit with one expected cycle.") {
-//     Circuit circ(3);
-//     add_fixed_sequence_of_ops(circ);
+  const auto add_fixed_sequence_of_ops = [](Circuit& circ) {
+    circ.add_op<unsigned>(OpType::X, {0});
+    circ.add_op<unsigned>(OpType::Y, {1});
+    circ.add_op<unsigned>(OpType::Z, {2});
+    circ.add_op<unsigned>(OpType::H, {0});
+    circ.add_op<unsigned>(OpType::H, {1});
+    circ.add_op<unsigned>(OpType::H, {2});
+    circ.add_op<unsigned>(OpType::CX, {0, 1});
+    circ.add_op<unsigned>(OpType::CX, {0, 2});
+  };
+  const auto get_comparison = [](Edge& e) {
+    return Cycle(
+        {{e, e}, {e, e}, {e, e}}, {
+                                      {OpType::Input, {}, {}},
+                                      {OpType::H, {0}, {}},
+                                      {OpType::Input, {}, {}},
+                                      {OpType::H, {1}, {}},
+                                      {OpType::CX, {0, 1}, {}},
+                                      {OpType::Input, {}, {}},
+                                      {OpType::H, {2}, {}},
+                                      {OpType::CX, {0, 2}, {}},
+                                  });
+  };
+  GIVEN("A circuit with one expected cycle.") {
+    Circuit circ(3);
+    add_fixed_sequence_of_ops(circ);
 
-//     Edge e;
-//     const auto comparison = get_comparison(e);
-//     std::vector<Cycle> cycles = fr_tester.get_cycles(circ);
-//     REQUIRE(cycles.size() == 1);
-//     REQUIRE(cycles[0] == comparison);
-//   }
-//   GIVEN("A circuit with two expected cycle.") {
-//     Circuit circ(3);
-//     add_fixed_sequence_of_ops(circ);
-//     add_fixed_sequence_of_ops(circ);
+    Edge e;
+    const auto comparison = get_comparison(e);
+    std::vector<Cycle> cycles = fr_tester.get_cycles(circ);
+    REQUIRE(cycles.size() == 1);
+    REQUIRE(cycles[0] == comparison);
+  }
+  GIVEN("A circuit with two expected cycle.") {
+    Circuit circ(3);
+    add_fixed_sequence_of_ops(circ);
+    add_fixed_sequence_of_ops(circ);
 
-//     Edge e;
-//     const auto comparison_0 = get_comparison(e);
-//     const Cycle comparison_1(
-//         {{e, e}, {e, e}, {e, e}}, {
-//                                       {OpType::H, {0}, {}},
-//                                       {OpType::H, {1}, {}},
-//                                       {OpType::CX, {1, 0}, {}},
-//                                       {OpType::H, {2}, {}},
-//                                       {OpType::CX, {1, 2}, {}},
-//                                   });
+    Edge e;
+    const auto comparison_0 = get_comparison(e);
+    const Cycle comparison_1(
+        {{e, e}, {e, e}, {e, e}}, {
+                                      {OpType::H, {0}, {}},
+                                      {OpType::H, {1}, {}},
+                                      {OpType::CX, {1, 0}, {}},
+                                      {OpType::H, {2}, {}},
+                                      {OpType::CX, {1, 2}, {}},
+                                  });
 
-//     std::vector<Cycle> cycles = fr_tester.get_cycles(circ);
-//     REQUIRE(cycles.size() == 2);
-//     REQUIRE(cycles[0] == comparison_0);
-//     REQUIRE(cycles[1] == comparison_1);
-//   }
-//   GIVEN("A circuit with 50 cycles.") {
-//     Circuit circ(3);
-//     for (unsigned i = 0; i < 50; i++) {
-//       add_fixed_sequence_of_ops(circ);
-//     }
-//     std::vector<Cycle> cycles = fr_tester.get_cycles(circ);
-//     REQUIRE(cycles.size() == 50);
-//   }
-// }
+    std::vector<Cycle> cycles = fr_tester.get_cycles(circ);
+    REQUIRE(cycles.size() == 2);
+    REQUIRE(cycles[0] == comparison_0);
+    REQUIRE(cycles[1] == comparison_1);
+  }
+  GIVEN("A circuit with 50 cycles.") {
+    Circuit circ(3);
+    for (unsigned i = 0; i < 50; i++) {
+      add_fixed_sequence_of_ops(circ);
+    }
+    std::vector<Cycle> cycles = fr_tester.get_cycles(circ);
+    REQUIRE(cycles.size() == 50);
+  }
+}
 
-// SCENARIO("Test that get_out_frame returns the expected result.") {
-//   Circuit circ(2);
-//   circ.add_op<unsigned>(OpType::CX, {0, 1});
-//   std::map<OpType, std::map<OpTypeVector, OpTypeVector>> init;
-//   std::map<OpTypeVector, OpTypeVector> entry;
-//   entry[{OpType::X, OpType::X}] = {OpType::Y, OpType::Y};
-//   entry[{OpType::Y, OpType::Y}] = {OpType::X, OpType::X};
-//   init[OpType::CX] = entry;
-//   FrameRandomisation fr({OpType::CX, OpType::H}, {OpType::X}, init);
-//   FrameRandomisationTester fr_tester(&fr);
+SCENARIO("Test that get_out_frame returns the expected result.") {
+  Circuit circ(2);
+  circ.add_op<unsigned>(OpType::CX, {0, 1});
+  std::map<OpType, std::map<OpTypeVector, OpTypeVector>> init;
+  std::map<OpTypeVector, OpTypeVector> entry;
+  entry[{OpType::X, OpType::X}] = {OpType::Y, OpType::Y};
+  entry[{OpType::Y, OpType::Y}] = {OpType::X, OpType::X};
+  init[OpType::CX] = entry;
+  FrameRandomisation fr({OpType::CX, OpType::H}, {OpType::X}, init);
+  FrameRandomisationTester fr_tester(&fr);
 
-//   Cycle cycle = fr_tester.get_cycles(circ)[0];
-//   OpTypeVector out_frame =
-//       fr_tester.get_out_frame({OpType::X, OpType::X}, cycle);
-//   REQUIRE(out_frame[0] == OpType::Y);
-//   REQUIRE(out_frame[1] == OpType::Y);
-//   out_frame = fr_tester.get_out_frame({OpType::Y, OpType::Y}, cycle);
-//   REQUIRE(out_frame[0] == OpType::X);
-//   REQUIRE(out_frame[1] == OpType::X);
-// }
+  Cycle cycle = fr_tester.get_cycles(circ)[0];
+  OpTypeVector out_frame =
+      fr_tester.get_out_frame({OpType::X, OpType::X}, cycle);
+  REQUIRE(out_frame[0] == OpType::Y);
+  REQUIRE(out_frame[1] == OpType::Y);
+  out_frame = fr_tester.get_out_frame({OpType::Y, OpType::Y}, cycle);
+  REQUIRE(out_frame[0] == OpType::X);
+  REQUIRE(out_frame[1] == OpType::X);
+}
 
-// // KEY: op type
-// // VALUE: list of command indices with that type.
-// typedef std::map<OpType, std::vector<unsigned>> CircResult;
+// KEY: op type
+// VALUE: list of command indices with that type.
+typedef std::map<OpType, std::vector<unsigned>> CircResult;
 
-// // KEY: index in "all_circuits", a list of circuits
-// // VALUE: result for that circuit.
-// typedef std::map<unsigned, CircResult> AllCircuitsResult;
+// KEY: index in "all_circuits", a list of circuits
+// VALUE: result for that circuit.
+typedef std::map<unsigned, CircResult> AllCircuitsResult;
 
-// // KEY: index in "all_circuits"
-// // VALUE: the expected parameter value in command[n]
-// //          for that circuit (n is constant over all circuits
-// //          for which this applies).
-// typedef std::map<unsigned, double> ParameterValues;
+// KEY: index in "all_circuits"
+// VALUE: the expected parameter value in command[n]
+//          for that circuit (n is constant over all circuits
+//          for which this applies).
+typedef std::map<unsigned, double> ParameterValues;
 
-// static void test_parameter_value(
-//     unsigned circuit_index, const ParameterValues& values,
-//     const std::vector<Command>& commands,
-//     unsigned index_for_command_with_parameter) {
-//   if (values.empty()) {
-//     return;
-//   }
-//   const double expected_parameter_value = values.at(circuit_index);
-//   const auto params =
-//       commands[index_for_command_with_parameter].get_op_ptr()->get_params();
-//   REQUIRE(params.size() == 1);
-//   // Normally it's very naughty to do doubles equality.
-//   // But here, no calculations other than possibly inserting
-//   // a minus sign are performed, so no roundoff errors occur.
-//   REQUIRE(params[0] == expected_parameter_value);
-// }
+static void test_parameter_value(
+    unsigned circuit_index, const ParameterValues& values,
+    const std::vector<Command>& commands,
+    unsigned index_for_command_with_parameter) {
+  if (values.empty()) {
+    return;
+  }
+  const double expected_parameter_value = values.at(circuit_index);
+  const auto params =
+      commands[index_for_command_with_parameter].get_op_ptr()->get_params();
+  REQUIRE(params.size() == 1);
+  // Normally it's very naughty to do doubles equality.
+  // But here, no calculations other than possibly inserting
+  // a minus sign are performed, so no roundoff errors occur.
+  REQUIRE(params[0] == expected_parameter_value);
+}
 
-// static void test_command_types(
-//     const AllCircuitsResult& result, const std::vector<Circuit>&
-//     all_circuits, unsigned number_of_commands, const ParameterValues& values
-//     = {}, OpType op_with_parameter = OpType::noop, unsigned
-//     index_for_command_with_parameter = 9999) {
-//   for (const auto& outer_entry : result) {
-//     const auto& circuit_index = outer_entry.first;
-//     const auto commands = all_circuits[circuit_index].get_commands();
-//     REQUIRE(commands.size() == number_of_commands);
-//     test_parameter_value(
-//         circuit_index, values, commands, index_for_command_with_parameter);
+static void test_command_types(
+    const AllCircuitsResult& result, const std::vector<Circuit>& all_circuits,
+    unsigned number_of_commands, const ParameterValues& values = {},
+    OpType op_with_parameter = OpType::noop,
+    unsigned index_for_command_with_parameter = 9999) {
+  for (const auto& outer_entry : result) {
+    const auto& circuit_index = outer_entry.first;
+    const auto commands = all_circuits[circuit_index].get_commands();
+    REQUIRE(commands.size() == number_of_commands);
+    test_parameter_value(
+        circuit_index, values, commands, index_for_command_with_parameter);
 
-//     CircResult op_types_for_this_circ = outer_entry.second;
-//     if (!values.empty()) {
-//       op_types_for_this_circ[op_with_parameter].push_back(
-//           index_for_command_with_parameter);
-//     }
-//     for (const auto& inner_entry : op_types_for_this_circ) {
-//       const OpType& type = inner_entry.first;
-//       auto command_indices = inner_entry.second;
-//       for (unsigned ii : command_indices) {
-//         REQUIRE(commands[ii].get_op_ptr()->get_type() == type);
-//       }
-//     }
-//   }
-// }
+    CircResult op_types_for_this_circ = outer_entry.second;
+    if (!values.empty()) {
+      op_types_for_this_circ[op_with_parameter].push_back(
+          index_for_command_with_parameter);
+    }
+    for (const auto& inner_entry : op_types_for_this_circ) {
+      const OpType& type = inner_entry.first;
+      auto command_indices = inner_entry.second;
+      for (unsigned ii : command_indices) {
+        REQUIRE(commands[ii].get_op_ptr()->get_type() == type);
+      }
+    }
+  }
+}
 
-// SCENARIO("Test that get_all_circuits returns all frames for all cycles.") {
-//   std::map<OpType, std::map<OpTypeVector, OpTypeVector>> init;
-//   std::map<OpTypeVector, OpTypeVector> entry_cx;
-//   std::map<OpTypeVector, OpTypeVector> entry_h;
-//   entry_cx[{OpType::X, OpType::X}] = {OpType::Y, OpType::Y};
-//   entry_cx[{OpType::Y, OpType::Y}] = {OpType::X, OpType::X};
-//   entry_cx[{OpType::X, OpType::Y}] = {OpType::Y, OpType::X};
-//   entry_cx[{OpType::Y, OpType::X}] = {OpType::X, OpType::Y};
-//   entry_h[{OpType::X}] = {OpType::Y};
-//   entry_h[{OpType::Y}] = {OpType::X};
-//   init[OpType::CX] = entry_cx;
-//   init[OpType::H] = entry_h;
-//   FrameRandomisation fr({OpType::CX, OpType::H}, {OpType::X, OpType::Y},
-//   init);
+SCENARIO("Test that get_all_circuits returns all frames for all cycles.") {
+  std::map<OpType, std::map<OpTypeVector, OpTypeVector>> init;
+  std::map<OpTypeVector, OpTypeVector> entry_cx;
+  std::map<OpTypeVector, OpTypeVector> entry_h;
+  entry_cx[{OpType::X, OpType::X}] = {OpType::Y, OpType::Y};
+  entry_cx[{OpType::Y, OpType::Y}] = {OpType::X, OpType::X};
+  entry_cx[{OpType::X, OpType::Y}] = {OpType::Y, OpType::X};
+  entry_cx[{OpType::Y, OpType::X}] = {OpType::X, OpType::Y};
+  entry_h[{OpType::X}] = {OpType::Y};
+  entry_h[{OpType::Y}] = {OpType::X};
+  init[OpType::CX] = entry_cx;
+  init[OpType::H] = entry_h;
+  FrameRandomisation fr({OpType::CX, OpType::H}, {OpType::X, OpType::Y}, init);
 
-//   GIVEN("A two-qubit circuit with one CX gate.") {
-//     Circuit circ(2);
-//     circ.add_op<unsigned>(OpType::CX, {0, 1});
-//     const std::vector<Circuit> two_circuits =
-//         fr.sample_randomisation_circuits(circ, 2);
-//     REQUIRE(two_circuits.size() == 2);
-//     const std::vector<Circuit> all_circuits = fr.get_all_circuits(circ);
-//     REQUIRE(all_circuits.size() == 4);
-//     REQUIRE(
-//         std::find(all_circuits.begin(), all_circuits.end(), two_circuits[0])
-//         != all_circuits.end());
-//     for (const Circuit& circ : all_circuits) {
-//       const auto coms = circ.get_commands();
-//       REQUIRE(coms.size() == 7);
-//       REQUIRE(
-//           coms[0].get_op_ptr()->get_type() !=
-//           coms[5].get_op_ptr()->get_type());
-//       REQUIRE(
-//           coms[1].get_op_ptr()->get_type() !=
-//           coms[6].get_op_ptr()->get_type());
-//     }
-//   }
-//   GIVEN("A two-qubit circuit with three cycles.") {
-//     Circuit circ(2);
-//     const auto add_four_ops = [&circ]() {
-//       circ.add_op<unsigned>(OpType::CX, {0, 1});
-//       circ.add_op<unsigned>(OpType::H, {1});
-//       circ.add_op<unsigned>(OpType::S, {0});
-//       circ.add_op<unsigned>(OpType::S, {1});
-//     };
-//     circ.add_op<unsigned>(OpType::S, {0});
-//     add_four_ops();
-//     circ.add_op<unsigned>(OpType::H, {0});
-//     add_four_ops();
-//     add_four_ops();
-//     const std::vector<Circuit> all_circuits = fr.get_all_circuits(circ);
-//     REQUIRE(all_circuits.size() == 64);
-//     const std::vector<unsigned> indices_a{1, 2, 8, 11, 12, 18, 19, 22, 23,
-//     29}; const std::vector<unsigned> indices_b{7, 28};
+  GIVEN("A two-qubit circuit with one CX gate.") {
+    Circuit circ(2);
+    circ.add_op<unsigned>(OpType::CX, {0, 1});
+    const std::vector<Circuit> two_circuits =
+        fr.sample_randomisation_circuits(circ, 2);
+    REQUIRE(two_circuits.size() == 2);
+    const std::vector<Circuit> all_circuits = fr.get_all_circuits(circ);
+    REQUIRE(all_circuits.size() == 4);
+    REQUIRE(
+        std::find(all_circuits.begin(), all_circuits.end(), two_circuits[0]) !=
+        all_circuits.end());
+    for (const Circuit& circ : all_circuits) {
+      const auto coms = circ.get_commands();
+      REQUIRE(coms.size() == 7);
+      REQUIRE(
+          coms[0].get_op_ptr()->get_type() != coms[5].get_op_ptr()->get_type());
+      REQUIRE(
+          coms[1].get_op_ptr()->get_type() != coms[6].get_op_ptr()->get_type());
+    }
+  }
+  GIVEN("A two-qubit circuit with three cycles.") {
+    Circuit circ(2);
+    const auto add_four_ops = [&circ]() {
+      circ.add_op<unsigned>(OpType::CX, {0, 1});
+      circ.add_op<unsigned>(OpType::H, {1});
+      circ.add_op<unsigned>(OpType::S, {0});
+      circ.add_op<unsigned>(OpType::S, {1});
+    };
+    circ.add_op<unsigned>(OpType::S, {0});
+    add_four_ops();
+    circ.add_op<unsigned>(OpType::H, {0});
+    add_four_ops();
+    add_four_ops();
+    const std::vector<Circuit> all_circuits = fr.get_all_circuits(circ);
+    REQUIRE(all_circuits.size() == 64);
+    const std::vector<unsigned> indices_a{1, 2, 8, 11, 12, 18, 19, 22, 23, 29};
+    const std::vector<unsigned> indices_b{7, 28};
 
-//     const AllCircuitsResult expected_result{
-//         {0, {{OpType::X, indices_a}, {OpType::Y, indices_b}}},
-//         {63, {{OpType::X, indices_b}, {OpType::Y, indices_a}}},
-//     };
-//     test_command_types(expected_result, all_circuits, 32);
-//   }
-// }
+    const AllCircuitsResult expected_result{
+        {0, {{OpType::X, indices_a}, {OpType::Y, indices_b}}},
+        {63, {{OpType::X, indices_b}, {OpType::Y, indices_a}}},
+    };
+    test_command_types(expected_result, all_circuits, 32);
+  }
+}
 
-// SCENARIO(
-//     "Test that get_all_circuits returns correct frames for all cycles "
-//     "using PauliFrameRandomisation.") {
-//   PauliFrameRandomisation pfr;
-//   GIVEN("A two-qubit circuit with one CX gate.") {
-//     Circuit circ(2);
-//     circ.add_op<unsigned>(OpType::CX, {0, 1});
-//     const std::vector<Circuit> all_circuits = pfr.get_all_circuits(circ);
-//     REQUIRE(all_circuits.size() == 16);
+SCENARIO(
+    "Test that get_all_circuits returns correct frames for all cycles "
+    "using PauliFrameRandomisation.") {
+  PauliFrameRandomisation pfr;
+  GIVEN("A two-qubit circuit with one CX gate.") {
+    Circuit circ(2);
+    circ.add_op<unsigned>(OpType::CX, {0, 1});
+    const std::vector<Circuit> all_circuits = pfr.get_all_circuits(circ);
+    REQUIRE(all_circuits.size() == 16);
 
-//     const AllCircuitsResult expected_result{
-//         {0, {{OpType::Z, {0, 1, 6}}, {OpType::noop, {5}}}},
-//         {3,
-//          {
-//              {OpType::Z, {0, 5}},
-//              {OpType::noop, {1, 6}},
-//          }},
-//         {7, {{OpType::X, {0, 5, 6}}, {OpType::noop, {1}}}},
-//         {11,
-//          {
-//              {OpType::Y, {0, 5}},
-//              {OpType::noop, {1}},
-//              {OpType::X, {6}},
-//          }},
-//         {15,
-//          {
-//              {OpType::noop, {0, 1, 5, 6}},
-//          }},
-//     };
-//     test_command_types(expected_result, all_circuits, 7);
-//   }
-// }
+    const AllCircuitsResult expected_result{
+        {0, {{OpType::Z, {0, 1, 6}}, {OpType::noop, {5}}}},
+        {3,
+         {
+             {OpType::Z, {0, 5}},
+             {OpType::noop, {1, 6}},
+         }},
+        {7, {{OpType::X, {0, 5, 6}}, {OpType::noop, {1}}}},
+        {11,
+         {
+             {OpType::Y, {0, 5}},
+             {OpType::noop, {1}},
+             {OpType::X, {6}},
+         }},
+        {15,
+         {
+             {OpType::noop, {0, 1, 5, 6}},
+         }},
+    };
+    test_command_types(expected_result, all_circuits, 7);
+  }
+}
 
-// SCENARIO(
-//     "Test that get_all_circuits returns correct frames and circuits for "
-//     "all cycles using UniversalFrameRandomisation.") {
-//   UniversalFrameRandomisation ufr;
-//   GIVEN("A two-qubit circuit with one CX and Rz(0.2) gate.") {
-//     Circuit circ(2);
-//     circ.add_op<unsigned>(OpType::Rz, 0.2, {0});
-//     circ.add_op<unsigned>(OpType::CX, {0, 1});
+SCENARIO(
+    "Test that get_all_circuits returns correct frames and circuits for "
+    "all cycles using UniversalFrameRandomisation.") {
+  UniversalFrameRandomisation ufr;
+  GIVEN("A two-qubit circuit with one CX and Rz(0.2) gate.") {
+    Circuit circ(2);
+    circ.add_op<unsigned>(OpType::Rz, 0.2, {0});
+    circ.add_op<unsigned>(OpType::CX, {0, 1});
 
-//     const std::vector<Circuit> all_circuits = ufr.get_all_circuits(circ);
-//     REQUIRE(all_circuits.size() == 16);
+    const std::vector<Circuit> all_circuits = ufr.get_all_circuits(circ);
+    REQUIRE(all_circuits.size() == 16);
 
-//     const AllCircuitsResult expected_result{
-//         {0,
-//          {
-//              {OpType::Z, {0, 1, 7}},
-//              {OpType::noop, {6}},
-//          }},
-//         {3,
-//          {
-//              {OpType::Z, {0, 6}},
-//              {OpType::noop, {1, 7}},
-//          }},
-//         {7,
-//          {
-//              {OpType::X, {0, 6, 7}},
-//              {OpType::noop, {1}},
-//          }},
-//         {11,
-//          {
-//              {OpType::X, {7}},
-//              {OpType::Y, {0, 6}},
-//              {OpType::noop, {1}},
-//          }},
-//         {15,
-//          {
-//              {OpType::noop, {0, 1, 6, 7}},
-//          }},
-//     };
-//     const ParameterValues param_values{
-//         {0, 0.2}, {3, 0.2}, {7, -0.2}, {11, -0.2}, {15, 0.2},
-//     };
-//     test_command_types(
-//         expected_result, all_circuits, 8, param_values, OpType::Rz, 3);
-//   }
-//   GIVEN("A circuit that gets rebased ready for UFR") {
-//     Circuit circ(2);
-//     circ.add_op<unsigned>(OpType::CX, {0, 1});
-//     circ.add_op<unsigned>(OpType::Ry, 0.2, {0});
-//     circ.add_op<unsigned>(OpType::CX, {0, 1});
-//     std::vector<Circuit> all_circuits = ufr.get_all_circuits(circ);
-//     REQUIRE(all_circuits.size() == 256);
-//     Transforms::rebase_UFR().apply(circ);
-//     all_circuits = ufr.get_all_circuits(circ);
-//     REQUIRE(all_circuits.size() == 16);
-//   }
-// }
+    const AllCircuitsResult expected_result{
+        {0,
+         {
+             {OpType::Z, {0, 1, 7}},
+             {OpType::noop, {6}},
+         }},
+        {3,
+         {
+             {OpType::Z, {0, 6}},
+             {OpType::noop, {1, 7}},
+         }},
+        {7,
+         {
+             {OpType::X, {0, 6, 7}},
+             {OpType::noop, {1}},
+         }},
+        {11,
+         {
+             {OpType::X, {7}},
+             {OpType::Y, {0, 6}},
+             {OpType::noop, {1}},
+         }},
+        {15,
+         {
+             {OpType::noop, {0, 1, 6, 7}},
+         }},
+    };
+    const ParameterValues param_values{
+        {0, 0.2}, {3, 0.2}, {7, -0.2}, {11, -0.2}, {15, 0.2},
+    };
+    test_command_types(
+        expected_result, all_circuits, 8, param_values, OpType::Rz, 3);
+  }
+  GIVEN("A circuit that gets rebased ready for UFR") {
+    Circuit circ(2);
+    circ.add_op<unsigned>(OpType::CX, {0, 1});
+    circ.add_op<unsigned>(OpType::Ry, 0.2, {0});
+    circ.add_op<unsigned>(OpType::CX, {0, 1});
+    std::vector<Circuit> all_circuits = ufr.get_all_circuits(circ);
+    REQUIRE(all_circuits.size() == 256);
+    Transforms::rebase_UFR().apply(circ);
+    all_circuits = ufr.get_all_circuits(circ);
+    REQUIRE(all_circuits.size() == 16);
+  }
+}
 
-// SCENARIO(
-//     "Test that sample_cycles returns correct number of cycles using "
-//     "PowerCycle.") {
-//   const auto test_sample_cycles_from_power_cycle =
-//       [](unsigned multiplier, const Circuit& circ, unsigned number_of_tests)
-//       {
-//         PowerCycle pc;
-//         for (unsigned nn = 1; nn <= number_of_tests; ++nn) {
-//           const auto sample_cycles = pc.sample_cycles(circ, nn, 1);
-//           REQUIRE(sample_cycles.size() == 1);
-//           const Circuit& cycle_circ = sample_cycles[0];
-//           REQUIRE(cycle_circ.n_gates() == nn * multiplier);
-//         }
-//       };
-//   GIVEN("A one-qubit circuit with one H gate.") {
-//     Circuit circ(1);
-//     circ.add_op<unsigned>(OpType::H, {0});
-//     test_sample_cycles_from_power_cycle(5, circ, 4);
-//   }
-//   GIVEN("A 5-qubit circuit.") {
-//     Circuit circ(5);
-//     add_2qb_gates(circ, OpType::CX, {{0, 1}, {2, 1}, {3, 2}, {3, 4}, {0,
-//     1}}); add_1qb_gates(circ, OpType::S, {3, 2, 4});
-//     test_sample_cycles_from_power_cycle(20, circ, 4);
-//   }
-// }
+SCENARIO(
+    "Test that sample_cycles returns correct number of cycles using "
+    "PowerCycle.") {
+  const auto test_sample_cycles_from_power_cycle =
+      [](unsigned multiplier, const Circuit& circ, unsigned number_of_tests) {
+        PowerCycle pc;
+        for (unsigned nn = 1; nn <= number_of_tests; ++nn) {
+          const auto sample_cycles = pc.sample_cycles(circ, nn, 1);
+          REQUIRE(sample_cycles.size() == 1);
+          const Circuit& cycle_circ = sample_cycles[0];
+          REQUIRE(cycle_circ.n_gates() == nn * multiplier);
+        }
+      };
+  GIVEN("A one-qubit circuit with one H gate.") {
+    Circuit circ(1);
+    circ.add_op<unsigned>(OpType::H, {0});
+    test_sample_cycles_from_power_cycle(5, circ, 4);
+  }
+  GIVEN("A 5-qubit circuit.") {
+    Circuit circ(5);
+    add_2qb_gates(circ, OpType::CX, {{0, 1}, {2, 1}, {3, 2}, {3, 4}, {0, 1}});
+    add_1qb_gates(circ, OpType::S, {3, 2, 4});
+    test_sample_cycles_from_power_cycle(20, circ, 4);
+  }
+}
 
-// SCENARIO("Frame Randomisation Segmentation Fault") {
-//   // https://github.com/CQCL/tket/issues/1015
-//   PauliFrameRandomisation pfr;
-//   Circuit c(4);
-//   c.add_op<unsigned>(OpType::CX, {0, 2});
-//   c.add_op<unsigned>(OpType::Z, {0});
-//   c.add_op<unsigned>(OpType::CX, {0, 3});
-//   c.add_op<unsigned>(OpType::Z, {0});
-//   c.add_op<unsigned>(OpType::CX, {0, 3});
-//   c.add_op<unsigned>(OpType::CX, {0, 1});
-//   std::vector<Circuit> circs = pfr.sample_randomisation_circuits(c, 1);
-
-//   circs[0].to_graphviz_file("/Users/silasdilkes/code/tket-public/whelpf.dot");
-//   CHECK(circs.size() == 1);
-//   // std::cout << circs[0] << std::endl;
-// }
+SCENARIO("Frame Randomisation Segmentation Fault") {
+  // https://github.com/CQCL/tket/issues/1015
+  PauliFrameRandomisation pfr;
+  Circuit c(4);
+  c.add_op<unsigned>(OpType::CX, {0, 2});
+  c.add_op<unsigned>(OpType::Z, {0});
+  c.add_op<unsigned>(OpType::CX, {0, 3});
+  c.add_op<unsigned>(OpType::Z, {0});
+  c.add_op<unsigned>(OpType::CX, {0, 3});
+  c.add_op<unsigned>(OpType::CX, {0, 1});
+  std::vector<Circuit> circs = pfr.sample_randomisation_circuits(c, 1);
+  CHECK(circs.size() == 1);
+}
 
 SCENARIO("Frame Randomisation non-real DAG") {
   // https://github.com/CQCL/tket/issues/1015
@@ -388,15 +381,11 @@ SCENARIO("Frame Randomisation non-real DAG") {
   c.add_op<unsigned>(OpType::CnX, {0, 1, 2, 3});
   CompilationUnit cu(c);
   RebaseTket()->apply(cu);
-  std::vector<Circuit> circs = pfr.sample_randomisation_circuits(cu.get_circ_ref(), 1);
+  std::vector<Circuit> circs =
+      pfr.sample_randomisation_circuits(cu.get_circ_ref(), 1);
   CHECK(circs.size() == 1);
-  circs[0].to_graphviz_file("/Users/silasdilkes/code/tket-public/wtf.dot");
-  std::cout << "Sampling worked, but???" << std::endl;
-  std::cout << circs[0] << std::endl;
+  TKET_ASSERT(circs[0].get_commands().size() == 107);
 }
 
 }  // namespace test_FrameRandomisation
 }  // namespace tket
-
-
-

--- a/tket/test/src/test_FrameRandomisation.cpp
+++ b/tket/test/src/test_FrameRandomisation.cpp
@@ -34,349 +34,345 @@ OpTypeVector FrameRandomisationTester::get_out_frame(
 
 namespace test_FrameRandomisation {
 
-// SCENARIO(
-//     "Test whether get_cycles returns the expected number of cycles with "
-//     "the correct operations.") {
-//   FrameRandomisation fr({OpType::CX, OpType::H}, {}, {{}});
-//   FrameRandomisationTester fr_tester(&fr);
+SCENARIO(
+    "Test whether get_cycles returns the expected number of cycles with "
+    "the correct operations.") {
+  FrameRandomisation fr({OpType::CX, OpType::H}, {}, {{}});
+  FrameRandomisationTester fr_tester(&fr);
 
-//   const auto add_fixed_sequence_of_ops = [](Circuit& circ) {
-//     circ.add_op<unsigned>(OpType::X, {0});
-//     circ.add_op<unsigned>(OpType::Y, {1});
-//     circ.add_op<unsigned>(OpType::Z, {2});
-//     circ.add_op<unsigned>(OpType::H, {0});
-//     circ.add_op<unsigned>(OpType::H, {1});
-//     circ.add_op<unsigned>(OpType::H, {2});
-//     circ.add_op<unsigned>(OpType::CX, {0, 1});
-//     circ.add_op<unsigned>(OpType::CX, {0, 2});
-//   };
-//   const auto get_comparison = [](Edge& e) {
-//     return Cycle(
-//         {{e, e}, {e, e}, {e, e}}, {
-//                                       {OpType::Input, {}, {}},
-//                                       {OpType::H, {0}, {}},
-//                                       {OpType::Input, {}, {}},
-//                                       {OpType::H, {1}, {}},
-//                                       {OpType::CX, {0, 1}, {}},
-//                                       {OpType::Input, {}, {}},
-//                                       {OpType::H, {2}, {}},
-//                                       {OpType::CX, {0, 2}, {}},
-//                                   });
-//   };
-//   GIVEN("A circuit with one expected cycle.") {
-//     Circuit circ(3);
-//     add_fixed_sequence_of_ops(circ);
+  const auto add_fixed_sequence_of_ops = [](Circuit& circ) {
+    circ.add_op<unsigned>(OpType::X, {0});
+    circ.add_op<unsigned>(OpType::Y, {1});
+    circ.add_op<unsigned>(OpType::Z, {2});
+    circ.add_op<unsigned>(OpType::H, {0});
+    circ.add_op<unsigned>(OpType::H, {1});
+    circ.add_op<unsigned>(OpType::H, {2});
+    circ.add_op<unsigned>(OpType::CX, {0, 1});
+    circ.add_op<unsigned>(OpType::CX, {0, 2});
+  };
+  const auto get_comparison = [](Edge& e) {
+    return Cycle(
+        {{e, e}, {e, e}, {e, e}}, {
+                                      {OpType::Input, {}, {}},
+                                      {OpType::H, {0}, {}},
+                                      {OpType::Input, {}, {}},
+                                      {OpType::H, {1}, {}},
+                                      {OpType::CX, {0, 1}, {}},
+                                      {OpType::Input, {}, {}},
+                                      {OpType::H, {2}, {}},
+                                      {OpType::CX, {0, 2}, {}},
+                                  });
+  };
+  GIVEN("A circuit with one expected cycle.") {
+    Circuit circ(3);
+    add_fixed_sequence_of_ops(circ);
 
-//     Edge e;
-//     const auto comparison = get_comparison(e);
-//     std::vector<Cycle> cycles = fr_tester.get_cycles(circ);
-//     REQUIRE(cycles.size() == 1);
-//     REQUIRE(cycles[0] == comparison);
-//   }
-//   GIVEN("A circuit with two expected cycle.") {
-//     Circuit circ(3);
-//     add_fixed_sequence_of_ops(circ);
-//     add_fixed_sequence_of_ops(circ);
+    Edge e;
+    const auto comparison = get_comparison(e);
+    std::vector<Cycle> cycles = fr_tester.get_cycles(circ);
+    REQUIRE(cycles.size() == 1);
+    REQUIRE(cycles[0] == comparison);
+  }
+  GIVEN("A circuit with two expected cycle.") {
+    Circuit circ(3);
+    add_fixed_sequence_of_ops(circ);
+    add_fixed_sequence_of_ops(circ);
 
-//     Edge e;
-//     const auto comparison_0 = get_comparison(e);
-//     const Cycle comparison_1(
-//         {{e, e}, {e, e}, {e, e}}, {
-//                                       {OpType::H, {0}, {}},
-//                                       {OpType::H, {1}, {}},
-//                                       {OpType::CX, {1, 0}, {}},
-//                                       {OpType::H, {2}, {}},
-//                                       {OpType::CX, {1, 2}, {}},
-//                                   });
+    Edge e;
+    const auto comparison_0 = get_comparison(e);
+    const Cycle comparison_1(
+        {{e, e}, {e, e}, {e, e}}, {
+                                      {OpType::H, {0}, {}},
+                                      {OpType::H, {1}, {}},
+                                      {OpType::CX, {1, 0}, {}},
+                                      {OpType::H, {2}, {}},
+                                      {OpType::CX, {1, 2}, {}},
+                                  });
 
-//     std::vector<Cycle> cycles = fr_tester.get_cycles(circ);
-//     REQUIRE(cycles.size() == 2);
-//     REQUIRE(cycles[0] == comparison_0);
-//     REQUIRE(cycles[1] == comparison_1);
-//   }
-//   GIVEN("A circuit with 50 cycles.") {
-//     Circuit circ(3);
-//     for (unsigned i = 0; i < 50; i++) {
-//       add_fixed_sequence_of_ops(circ);
-//     }
-//     std::vector<Cycle> cycles = fr_tester.get_cycles(circ);
-//     REQUIRE(cycles.size() == 50);
-//   }
-// }
+    std::vector<Cycle> cycles = fr_tester.get_cycles(circ);
+    REQUIRE(cycles.size() == 2);
+    REQUIRE(cycles[0] == comparison_0);
+    REQUIRE(cycles[1] == comparison_1);
+  }
+  GIVEN("A circuit with 50 cycles.") {
+    Circuit circ(3);
+    for (unsigned i = 0; i < 50; i++) {
+      add_fixed_sequence_of_ops(circ);
+    }
+    std::vector<Cycle> cycles = fr_tester.get_cycles(circ);
+    REQUIRE(cycles.size() == 50);
+  }
+}
 
-// SCENARIO("Test that get_out_frame returns the expected result.") {
-//   Circuit circ(2);
-//   circ.add_op<unsigned>(OpType::CX, {0, 1});
-//   std::map<OpType, std::map<OpTypeVector, OpTypeVector>> init;
-//   std::map<OpTypeVector, OpTypeVector> entry;
-//   entry[{OpType::X, OpType::X}] = {OpType::Y, OpType::Y};
-//   entry[{OpType::Y, OpType::Y}] = {OpType::X, OpType::X};
-//   init[OpType::CX] = entry;
-//   FrameRandomisation fr({OpType::CX, OpType::H}, {OpType::X}, init);
-//   FrameRandomisationTester fr_tester(&fr);
+SCENARIO("Test that get_out_frame returns the expected result.") {
+  Circuit circ(2);
+  circ.add_op<unsigned>(OpType::CX, {0, 1});
+  std::map<OpType, std::map<OpTypeVector, OpTypeVector>> init;
+  std::map<OpTypeVector, OpTypeVector> entry;
+  entry[{OpType::X, OpType::X}] = {OpType::Y, OpType::Y};
+  entry[{OpType::Y, OpType::Y}] = {OpType::X, OpType::X};
+  init[OpType::CX] = entry;
+  FrameRandomisation fr({OpType::CX, OpType::H}, {OpType::X}, init);
+  FrameRandomisationTester fr_tester(&fr);
 
-//   Cycle cycle = fr_tester.get_cycles(circ)[0];
-//   OpTypeVector out_frame =
-//       fr_tester.get_out_frame({OpType::X, OpType::X}, cycle);
-//   REQUIRE(out_frame[0] == OpType::Y);
-//   REQUIRE(out_frame[1] == OpType::Y);
-//   out_frame = fr_tester.get_out_frame({OpType::Y, OpType::Y}, cycle);
-//   REQUIRE(out_frame[0] == OpType::X);
-//   REQUIRE(out_frame[1] == OpType::X);
-// }
+  Cycle cycle = fr_tester.get_cycles(circ)[0];
+  OpTypeVector out_frame =
+      fr_tester.get_out_frame({OpType::X, OpType::X}, cycle);
+  REQUIRE(out_frame[0] == OpType::Y);
+  REQUIRE(out_frame[1] == OpType::Y);
+  out_frame = fr_tester.get_out_frame({OpType::Y, OpType::Y}, cycle);
+  REQUIRE(out_frame[0] == OpType::X);
+  REQUIRE(out_frame[1] == OpType::X);
+}
 
-// // KEY: op type
-// // VALUE: list of command indices with that type.
-// typedef std::map<OpType, std::vector<unsigned>> CircResult;
+// KEY: op type
+// VALUE: list of command indices with that type.
+typedef std::map<OpType, std::vector<unsigned>> CircResult;
 
-// // KEY: index in "all_circuits", a list of circuits
-// // VALUE: result for that circuit.
-// typedef std::map<unsigned, CircResult> AllCircuitsResult;
+// KEY: index in "all_circuits", a list of circuits
+// VALUE: result for that circuit.
+typedef std::map<unsigned, CircResult> AllCircuitsResult;
 
-// // KEY: index in "all_circuits"
-// // VALUE: the expected parameter value in command[n]
-// //          for that circuit (n is constant over all circuits
-// //          for which this applies).
-// typedef std::map<unsigned, double> ParameterValues;
+// KEY: index in "all_circuits"
+// VALUE: the expected parameter value in command[n]
+//          for that circuit (n is constant over all circuits
+//          for which this applies).
+typedef std::map<unsigned, double> ParameterValues;
 
-// static void test_parameter_value(
-//     unsigned circuit_index, const ParameterValues& values,
-//     const std::vector<Command>& commands,
-//     unsigned index_for_command_with_parameter) {
-//   if (values.empty()) {
-//     return;
-//   }
-//   const double expected_parameter_value = values.at(circuit_index);
-//   const auto params =
-//       commands[index_for_command_with_parameter].get_op_ptr()->get_params();
-//   REQUIRE(params.size() == 1);
-//   // Normally it's very naughty to do doubles equality.
-//   // But here, no calculations other than possibly inserting
-//   // a minus sign are performed, so no roundoff errors occur.
-//   REQUIRE(params[0] == expected_parameter_value);
-// }
+static void test_parameter_value(
+    unsigned circuit_index, const ParameterValues& values,
+    const std::vector<Command>& commands,
+    unsigned index_for_command_with_parameter) {
+  if (values.empty()) {
+    return;
+  }
+  const double expected_parameter_value = values.at(circuit_index);
+  const auto params =
+      commands[index_for_command_with_parameter].get_op_ptr()->get_params();
+  REQUIRE(params.size() == 1);
+  // Normally it's very naughty to do doubles equality.
+  // But here, no calculations other than possibly inserting
+  // a minus sign are performed, so no roundoff errors occur.
+  REQUIRE(params[0] == expected_parameter_value);
+}
 
-// static void test_command_types(
-//     const AllCircuitsResult& result, const std::vector<Circuit>&
-//     all_circuits, unsigned number_of_commands, const ParameterValues& values
-//     = {}, OpType op_with_parameter = OpType::noop, unsigned
-//     index_for_command_with_parameter = 9999) {
-//   for (const auto& outer_entry : result) {
-//     const auto& circuit_index = outer_entry.first;
-//     const auto commands = all_circuits[circuit_index].get_commands();
-//     REQUIRE(commands.size() == number_of_commands);
-//     test_parameter_value(
-//         circuit_index, values, commands, index_for_command_with_parameter);
+static void test_command_types(
+    const AllCircuitsResult& result, const std::vector<Circuit>& all_circuits,
+    unsigned number_of_commands, const ParameterValues& values = {},
+    OpType op_with_parameter = OpType::noop,
+    unsigned index_for_command_with_parameter = 9999) {
+  for (const auto& outer_entry : result) {
+    const auto& circuit_index = outer_entry.first;
+    const auto commands = all_circuits[circuit_index].get_commands();
+    REQUIRE(commands.size() == number_of_commands);
+    test_parameter_value(
+        circuit_index, values, commands, index_for_command_with_parameter);
 
-//     CircResult op_types_for_this_circ = outer_entry.second;
-//     if (!values.empty()) {
-//       op_types_for_this_circ[op_with_parameter].push_back(
-//           index_for_command_with_parameter);
-//     }
-//     for (const auto& inner_entry : op_types_for_this_circ) {
-//       const OpType& type = inner_entry.first;
-//       auto command_indices = inner_entry.second;
-//       for (unsigned ii : command_indices) {
-//         REQUIRE(commands[ii].get_op_ptr()->get_type() == type);
-//       }
-//     }
-//   }
-// }
+    CircResult op_types_for_this_circ = outer_entry.second;
+    if (!values.empty()) {
+      op_types_for_this_circ[op_with_parameter].push_back(
+          index_for_command_with_parameter);
+    }
+    for (const auto& inner_entry : op_types_for_this_circ) {
+      const OpType& type = inner_entry.first;
+      auto command_indices = inner_entry.second;
+      for (unsigned ii : command_indices) {
+        REQUIRE(commands[ii].get_op_ptr()->get_type() == type);
+      }
+    }
+  }
+}
 
-// SCENARIO("Test that get_all_circuits returns all frames for all cycles.") {
-//   std::map<OpType, std::map<OpTypeVector, OpTypeVector>> init;
-//   std::map<OpTypeVector, OpTypeVector> entry_cx;
-//   std::map<OpTypeVector, OpTypeVector> entry_h;
-//   entry_cx[{OpType::X, OpType::X}] = {OpType::Y, OpType::Y};
-//   entry_cx[{OpType::Y, OpType::Y}] = {OpType::X, OpType::X};
-//   entry_cx[{OpType::X, OpType::Y}] = {OpType::Y, OpType::X};
-//   entry_cx[{OpType::Y, OpType::X}] = {OpType::X, OpType::Y};
-//   entry_h[{OpType::X}] = {OpType::Y};
-//   entry_h[{OpType::Y}] = {OpType::X};
-//   init[OpType::CX] = entry_cx;
-//   init[OpType::H] = entry_h;
-//   FrameRandomisation fr({OpType::CX, OpType::H}, {OpType::X, OpType::Y},
-//   init);
+SCENARIO("Test that get_all_circuits returns all frames for all cycles.") {
+  std::map<OpType, std::map<OpTypeVector, OpTypeVector>> init;
+  std::map<OpTypeVector, OpTypeVector> entry_cx;
+  std::map<OpTypeVector, OpTypeVector> entry_h;
+  entry_cx[{OpType::X, OpType::X}] = {OpType::Y, OpType::Y};
+  entry_cx[{OpType::Y, OpType::Y}] = {OpType::X, OpType::X};
+  entry_cx[{OpType::X, OpType::Y}] = {OpType::Y, OpType::X};
+  entry_cx[{OpType::Y, OpType::X}] = {OpType::X, OpType::Y};
+  entry_h[{OpType::X}] = {OpType::Y};
+  entry_h[{OpType::Y}] = {OpType::X};
+  init[OpType::CX] = entry_cx;
+  init[OpType::H] = entry_h;
+  FrameRandomisation fr({OpType::CX, OpType::H}, {OpType::X, OpType::Y}, init);
 
-//   GIVEN("A two-qubit circuit with one CX gate.") {
-//     Circuit circ(2);
-//     circ.add_op<unsigned>(OpType::CX, {0, 1});
-//     const std::vector<Circuit> two_circuits =
-//         fr.sample_randomisation_circuits(circ, 2);
-//     REQUIRE(two_circuits.size() == 2);
-//     const std::vector<Circuit> all_circuits = fr.get_all_circuits(circ);
-//     REQUIRE(all_circuits.size() == 4);
-//     REQUIRE(
-//         std::find(all_circuits.begin(), all_circuits.end(), two_circuits[0])
-//         != all_circuits.end());
-//     for (const Circuit& circ : all_circuits) {
-//       const auto coms = circ.get_commands();
-//       REQUIRE(coms.size() == 7);
-//       REQUIRE(
-//           coms[0].get_op_ptr()->get_type() !=
-//           coms[5].get_op_ptr()->get_type());
-//       REQUIRE(
-//           coms[1].get_op_ptr()->get_type() !=
-//           coms[6].get_op_ptr()->get_type());
-//     }
-//   }
-//   GIVEN("A two-qubit circuit with three cycles.") {
-//     Circuit circ(2);
-//     const auto add_four_ops = [&circ]() {
-//       circ.add_op<unsigned>(OpType::CX, {0, 1});
-//       circ.add_op<unsigned>(OpType::H, {1});
-//       circ.add_op<unsigned>(OpType::S, {0});
-//       circ.add_op<unsigned>(OpType::S, {1});
-//     };
-//     circ.add_op<unsigned>(OpType::S, {0});
-//     add_four_ops();
-//     circ.add_op<unsigned>(OpType::H, {0});
-//     add_four_ops();
-//     add_four_ops();
-//     const std::vector<Circuit> all_circuits = fr.get_all_circuits(circ);
-//     REQUIRE(all_circuits.size() == 64);
-//     const std::vector<unsigned> indices_a{1, 2, 8, 11, 12, 18, 19, 22, 23,
-//     29}; const std::vector<unsigned> indices_b{7, 28};
+  GIVEN("A two-qubit circuit with one CX gate.") {
+    Circuit circ(2);
+    circ.add_op<unsigned>(OpType::CX, {0, 1});
+    const std::vector<Circuit> two_circuits =
+        fr.sample_randomisation_circuits(circ, 2);
+    REQUIRE(two_circuits.size() == 2);
+    const std::vector<Circuit> all_circuits = fr.get_all_circuits(circ);
+    REQUIRE(all_circuits.size() == 4);
+    REQUIRE(
+        std::find(all_circuits.begin(), all_circuits.end(), two_circuits[0]) !=
+        all_circuits.end());
+    for (const Circuit& circ : all_circuits) {
+      const auto coms = circ.get_commands();
+      REQUIRE(coms.size() == 7);
+      REQUIRE(
+          coms[0].get_op_ptr()->get_type() != coms[5].get_op_ptr()->get_type());
+      REQUIRE(
+          coms[1].get_op_ptr()->get_type() != coms[6].get_op_ptr()->get_type());
+    }
+  }
+  GIVEN("A two-qubit circuit with three cycles.") {
+    Circuit circ(2);
+    const auto add_four_ops = [&circ]() {
+      circ.add_op<unsigned>(OpType::CX, {0, 1});
+      circ.add_op<unsigned>(OpType::H, {1});
+      circ.add_op<unsigned>(OpType::S, {0});
+      circ.add_op<unsigned>(OpType::S, {1});
+    };
+    circ.add_op<unsigned>(OpType::S, {0});
+    add_four_ops();
+    circ.add_op<unsigned>(OpType::H, {0});
+    add_four_ops();
+    add_four_ops();
+    const std::vector<Circuit> all_circuits = fr.get_all_circuits(circ);
+    REQUIRE(all_circuits.size() == 64);
+    const std::vector<unsigned> indices_a{1, 2, 8, 11, 12, 18, 19, 22, 23, 29};
+    const std::vector<unsigned> indices_b{7, 28};
 
-//     const AllCircuitsResult expected_result{
-//         {0, {{OpType::X, indices_a}, {OpType::Y, indices_b}}},
-//         {63, {{OpType::X, indices_b}, {OpType::Y, indices_a}}},
-//     };
-//     test_command_types(expected_result, all_circuits, 32);
-//   }
-// }
+    const AllCircuitsResult expected_result{
+        {0, {{OpType::X, indices_a}, {OpType::Y, indices_b}}},
+        {63, {{OpType::X, indices_b}, {OpType::Y, indices_a}}},
+    };
+    test_command_types(expected_result, all_circuits, 32);
+  }
+}
 
-// SCENARIO(
-//     "Test that get_all_circuits returns correct frames for all cycles "
-//     "using PauliFrameRandomisation.") {
-//   PauliFrameRandomisation pfr;
-//   GIVEN("A two-qubit circuit with one CX gate.") {
-//     Circuit circ(2);
-//     circ.add_op<unsigned>(OpType::CX, {0, 1});
-//     const std::vector<Circuit> all_circuits = pfr.get_all_circuits(circ);
-//     REQUIRE(all_circuits.size() == 16);
+SCENARIO(
+    "Test that get_all_circuits returns correct frames for all cycles "
+    "using PauliFrameRandomisation.") {
+  PauliFrameRandomisation pfr;
+  GIVEN("A two-qubit circuit with one CX gate.") {
+    Circuit circ(2);
+    circ.add_op<unsigned>(OpType::CX, {0, 1});
+    const std::vector<Circuit> all_circuits = pfr.get_all_circuits(circ);
+    REQUIRE(all_circuits.size() == 16);
 
-//     const AllCircuitsResult expected_result{
-//         {0, {{OpType::Z, {0, 1, 6}}, {OpType::noop, {5}}}},
-//         {3,
-//          {
-//              {OpType::Z, {0, 5}},
-//              {OpType::noop, {1, 6}},
-//          }},
-//         {7, {{OpType::X, {0, 5, 6}}, {OpType::noop, {1}}}},
-//         {11,
-//          {
-//              {OpType::Y, {0, 5}},
-//              {OpType::noop, {1}},
-//              {OpType::X, {6}},
-//          }},
-//         {15,
-//          {
-//              {OpType::noop, {0, 1, 5, 6}},
-//          }},
-//     };
-//     test_command_types(expected_result, all_circuits, 7);
-//   }
-// }
+    const AllCircuitsResult expected_result{
+        {0, {{OpType::Z, {0, 1, 6}}, {OpType::noop, {5}}}},
+        {3,
+         {
+             {OpType::Z, {0, 5}},
+             {OpType::noop, {1, 6}},
+         }},
+        {7, {{OpType::X, {0, 5, 6}}, {OpType::noop, {1}}}},
+        {11,
+         {
+             {OpType::Y, {0, 5}},
+             {OpType::noop, {1}},
+             {OpType::X, {6}},
+         }},
+        {15,
+         {
+             {OpType::noop, {0, 1, 5, 6}},
+         }},
+    };
+    test_command_types(expected_result, all_circuits, 7);
+  }
+}
 
-// SCENARIO(
-//     "Test that get_all_circuits returns correct frames and circuits for "
-//     "all cycles using UniversalFrameRandomisation.") {
-//   UniversalFrameRandomisation ufr;
-//   GIVEN("A two-qubit circuit with one CX and Rz(0.2) gate.") {
-//     Circuit circ(2);
-//     circ.add_op<unsigned>(OpType::Rz, 0.2, {0});
-//     circ.add_op<unsigned>(OpType::CX, {0, 1});
+SCENARIO(
+    "Test that get_all_circuits returns correct frames and circuits for "
+    "all cycles using UniversalFrameRandomisation.") {
+  UniversalFrameRandomisation ufr;
+  GIVEN("A two-qubit circuit with one CX and Rz(0.2) gate.") {
+    Circuit circ(2);
+    circ.add_op<unsigned>(OpType::Rz, 0.2, {0});
+    circ.add_op<unsigned>(OpType::CX, {0, 1});
 
-//     const std::vector<Circuit> all_circuits = ufr.get_all_circuits(circ);
-//     REQUIRE(all_circuits.size() == 16);
+    const std::vector<Circuit> all_circuits = ufr.get_all_circuits(circ);
+    REQUIRE(all_circuits.size() == 16);
 
-//     const AllCircuitsResult expected_result{
-//         {0,
-//          {
-//              {OpType::Z, {0, 1, 7}},
-//              {OpType::noop, {6}},
-//          }},
-//         {3,
-//          {
-//              {OpType::Z, {0, 6}},
-//              {OpType::noop, {1, 7}},
-//          }},
-//         {7,
-//          {
-//              {OpType::X, {0, 6, 7}},
-//              {OpType::noop, {1}},
-//          }},
-//         {11,
-//          {
-//              {OpType::X, {7}},
-//              {OpType::Y, {0, 6}},
-//              {OpType::noop, {1}},
-//          }},
-//         {15,
-//          {
-//              {OpType::noop, {0, 1, 6, 7}},
-//          }},
-//     };
-//     const ParameterValues param_values{
-//         {0, 0.2}, {3, 0.2}, {7, -0.2}, {11, -0.2}, {15, 0.2},
-//     };
-//     test_command_types(
-//         expected_result, all_circuits, 8, param_values, OpType::Rz, 3);
-//   }
-//   GIVEN("A circuit that gets rebased ready for UFR") {
-//     Circuit circ(2);
-//     circ.add_op<unsigned>(OpType::CX, {0, 1});
-//     circ.add_op<unsigned>(OpType::Ry, 0.2, {0});
-//     circ.add_op<unsigned>(OpType::CX, {0, 1});
-//     std::vector<Circuit> all_circuits = ufr.get_all_circuits(circ);
-//     REQUIRE(all_circuits.size() == 256);
-//     Transforms::rebase_UFR().apply(circ);
-//     all_circuits = ufr.get_all_circuits(circ);
-//     REQUIRE(all_circuits.size() == 16);
-//   }
-// }
+    const AllCircuitsResult expected_result{
+        {0,
+         {
+             {OpType::Z, {0, 1, 7}},
+             {OpType::noop, {6}},
+         }},
+        {3,
+         {
+             {OpType::Z, {0, 6}},
+             {OpType::noop, {1, 7}},
+         }},
+        {7,
+         {
+             {OpType::X, {0, 6, 7}},
+             {OpType::noop, {1}},
+         }},
+        {11,
+         {
+             {OpType::X, {7}},
+             {OpType::Y, {0, 6}},
+             {OpType::noop, {1}},
+         }},
+        {15,
+         {
+             {OpType::noop, {0, 1, 6, 7}},
+         }},
+    };
+    const ParameterValues param_values{
+        {0, 0.2}, {3, 0.2}, {7, -0.2}, {11, -0.2}, {15, 0.2},
+    };
+    test_command_types(
+        expected_result, all_circuits, 8, param_values, OpType::Rz, 3);
+  }
+  GIVEN("A circuit that gets rebased ready for UFR") {
+    Circuit circ(2);
+    circ.add_op<unsigned>(OpType::CX, {0, 1});
+    circ.add_op<unsigned>(OpType::Ry, 0.2, {0});
+    circ.add_op<unsigned>(OpType::CX, {0, 1});
+    std::vector<Circuit> all_circuits = ufr.get_all_circuits(circ);
+    REQUIRE(all_circuits.size() == 256);
+    Transforms::rebase_UFR().apply(circ);
+    all_circuits = ufr.get_all_circuits(circ);
+    REQUIRE(all_circuits.size() == 16);
+  }
+}
 
-// SCENARIO(
-//     "Test that sample_cycles returns correct number of cycles using "
-//     "PowerCycle.") {
-//   const auto test_sample_cycles_from_power_cycle =
-//       [](unsigned multiplier, const Circuit& circ, unsigned number_of_tests)
-//       {
-//         PowerCycle pc;
-//         for (unsigned nn = 1; nn <= number_of_tests; ++nn) {
-//           const auto sample_cycles = pc.sample_cycles(circ, nn, 1);
-//           REQUIRE(sample_cycles.size() == 1);
-//           const Circuit& cycle_circ = sample_cycles[0];
-//           REQUIRE(cycle_circ.n_gates() == nn * multiplier);
-//         }
-//       };
-//   GIVEN("A one-qubit circuit with one H gate.") {
-//     Circuit circ(1);
-//     circ.add_op<unsigned>(OpType::H, {0});
-//     test_sample_cycles_from_power_cycle(5, circ, 4);
-//   }
-//   GIVEN("A 5-qubit circuit.") {
-//     Circuit circ(5);
-//     add_2qb_gates(circ, OpType::CX, {{0, 1}, {2, 1}, {3, 2}, {3, 4}, {0,
-//     1}}); add_1qb_gates(circ, OpType::S, {3, 2, 4});
-//     test_sample_cycles_from_power_cycle(20, circ, 4);
-//   }
-// }
+SCENARIO(
+    "Test that sample_cycles returns correct number of cycles using "
+    "PowerCycle.") {
+  const auto test_sample_cycles_from_power_cycle =
+      [](unsigned multiplier, const Circuit& circ, unsigned number_of_tests) {
+        PowerCycle pc;
+        for (unsigned nn = 1; nn <= number_of_tests; ++nn) {
+          const auto sample_cycles = pc.sample_cycles(circ, nn, 1);
+          REQUIRE(sample_cycles.size() == 1);
+          const Circuit& cycle_circ = sample_cycles[0];
+          REQUIRE(cycle_circ.n_gates() == nn * multiplier);
+        }
+      };
+  GIVEN("A one-qubit circuit with one H gate.") {
+    Circuit circ(1);
+    circ.add_op<unsigned>(OpType::H, {0});
+    test_sample_cycles_from_power_cycle(5, circ, 4);
+  }
+  GIVEN("A 5-qubit circuit.") {
+    Circuit circ(5);
+    add_2qb_gates(circ, OpType::CX, {{0, 1}, {2, 1}, {3, 2}, {3, 4}, {0, 1}});
+    add_1qb_gates(circ, OpType::S, {3, 2, 4});
+    test_sample_cycles_from_power_cycle(20, circ, 4);
+  }
+}
 
-// SCENARIO("Frame Randomisation Segmentation Fault") {
-//   // https://github.com/CQCL/tket/issues/1015
-//   PauliFrameRandomisation pfr;
-//   Circuit c(4);
-//   c.add_op<unsigned>(OpType::CX, {0, 2});
-//   c.add_op<unsigned>(OpType::Z, {0});
-//   c.add_op<unsigned>(OpType::CX, {0, 3});
-//   c.add_op<unsigned>(OpType::Z, {0});
-//   c.add_op<unsigned>(OpType::CX, {0, 3});
-//   c.add_op<unsigned>(OpType::CX, {0, 1});
-//   std::vector<Circuit> circs = pfr.sample_randomisation_circuits(c, 1);
-//   CHECK(circs.size() == 1);
-// }
+SCENARIO("Frame Randomisation Segmentation Fault") {
+  // https://github.com/CQCL/tket/issues/1015
+  PauliFrameRandomisation pfr;
+  Circuit c(4);
+  c.add_op<unsigned>(OpType::CX, {0, 2});
+  c.add_op<unsigned>(OpType::Z, {0});
+  c.add_op<unsigned>(OpType::CX, {0, 3});
+  c.add_op<unsigned>(OpType::Z, {0});
+  c.add_op<unsigned>(OpType::CX, {0, 3});
+  c.add_op<unsigned>(OpType::CX, {0, 1});
+  std::vector<Circuit> circs = pfr.sample_randomisation_circuits(c, 1);
+  CHECK(circs.size() == 1);
+}
 
 SCENARIO("Frame Randomisation non-real DAG") {
   // https://github.com/CQCL/tket/issues/1015
@@ -389,7 +385,6 @@ SCENARIO("Frame Randomisation non-real DAG") {
     std::vector<Circuit> circs =
         pfr.sample_randomisation_circuits(cu.get_circ_ref(), 1);
     CHECK(circs.size() == 1);
-    circs[0].to_graphviz_file("/Users/silasdilkes/code/tket-public/bad.dot");
     CHECK(circs[0].get_commands().size() == 107);
   }
   GIVEN("CnX gate with 4 controls") {
@@ -401,7 +396,6 @@ SCENARIO("Frame Randomisation non-real DAG") {
     std::vector<Circuit> circs =
         pfr.sample_randomisation_circuits(cu.get_circ_ref(), 1);
     CHECK(circs.size() == 1);
-    std::cout << circs[0].get_commands().size() << std::endl;
     CHECK(circs[0].get_commands().size() == 293);
   }
   GIVEN("CnX gate with 5 controls") {
@@ -435,7 +429,6 @@ SCENARIO("Frame Randomisation non-real DAG") {
     std::vector<Circuit> circs =
         pfr.sample_randomisation_circuits(cu.get_circ_ref(), 1);
     CHECK(circs.size() == 1);
-    std::cout << circs[0].get_commands().size() << std::endl;
     CHECK(circs[0].get_commands().size() == 1570);
   }
 }


### PR DESCRIPTION
Fixes https://github.com/CQCL/tket/issues/1015.


FrameRandomisations works by first finding a set of subcircuits (or "cycles") of the given set of OpType and then wiring an OpType::noop vertex in the in and out edges of each of these cycles. To add the "frames" for randomisation, these OpType::noop vertices have their type changed.

"Cycles" are found in causal order and "noop frames" are added in causal order. 

The first fix is for finding cycles. The cycle finding works by iterating through the circuit slice-by-slice, adding vertices to cycles if they have the permitted `OpType`. However, the original code had an incorrect assumption that all `Edge` held in a `Slice` object were connected to vertices held in the slice. This is not true and could lead to incorrect cycle objects. This is fixed by confirming that vertices are in a slice before adding to a cycle.

In some cases, a single edge can be the in edge of one cycle and the out edge of another cycle. Given frames are added in causal order, the code had a hardcoded, but not documented, assumption that while adding new noop frames, an encountered in edge to a cycle may have already had a noop vertex added for a previous cycle, and so no longer be valid. To work around this, there is a std::map that provides a look up for which edge should instead have a noop vertex wired into it.

The segmentation fault occurred because it is possible to have two cycles in causal order where the in edge of a cycle encountered first was also the out edge of a cycle encountered later. The second fix is to update the logic for updating in edges to also update out edges.

