### PR TITLE
Remove `pytket-ionq` backend from index and add sidebar links

### DIFF
--- a/pytket/docs/extensions.rst
+++ b/pytket/docs/extensions.rst
@@ -36,9 +36,6 @@ QPUs
 `IBMQBackend <https://tket.quantinuum.com/extensions/pytket-qiskit/api.html#pytket.extensions.qiskit.IBMQBackend>`_
 - A backend for running circuits on remote IBMQ devices.
 
-`IonQBackend <https://cqcl.github.io/pytket-ionq/api/api.html#pytket.extensions.ionq.IonQBackend>`_
-- A backend for running circuits on remote IONQ devices.
-
 `ForestBackend <https://tket.quantinuum.com/extensions/pytket-pyquil/api.html#pytket.extensions.pyquil.ForestBackend>`_
 - A backend for running circuits on remote Rigetti devices.
 
@@ -132,7 +129,6 @@ Other
    pytket-aqt <https://cqcl.github.io/pytket-aqt/api/index.html>
    pytket-braket <https://tket.quantinuum.com/extensions/pytket-braket>
    pytket-cirq <https://tket.quantinuum.com/extensions/pytket-cirq>
-   pytket-ionq <https://cqcl.github.io/pytket-ionq/api/index.html>
    pytket-iqm <https://tket.quantinuum.com/extensions/pytket-iqm>
    pytket-pennylane <https://tket.quantinuum.com/extensions/pytket-pennylane>
    pytket-projectq <https://tket.quantinuum.com/extensions/pytket-projectq>

--- a/pytket/docs/extensions.rst
+++ b/pytket/docs/extensions.rst
@@ -92,6 +92,10 @@ Density Matrix Simulators
 `CirqDensityMatrixSimBackend <https://tket.quantinuum.com/extensions/pytket-cirq/api.html#pytket.extensions.cirq.CirqDensityMatrixSimBackend>`_
 - Backend for Cirq density matrix simulator density_matrix return.
 
+`QulacsBackend`_ - This has a configurable density matrix simulation option. 
+
+Use ``QulacsBackend(result_type="density_matrix")``.
+
 Clifford Simulators
 -------------------
 
@@ -153,3 +157,4 @@ Other
 .. _AerUnitaryBackend: https://tket.quantinuum.com/extensions/pytket-qiskit/api/api.html#pytket.extensions.qiskit.AerUnitaryBackend
 .. _CirqDensityMatrixSampleBackend: https://tket.quantinuum.com/extensions/pytket-cirq/api/api.html#pytket.extensions.cirq.CirqDensityMatrixSampleBackend
 .. _SimplexBackend: https://tket.quantinuum.com/extensions/pytket-simplex/api.html#pytket.extensions.pysimplex.SimplexBackend
+.. _QulacsBackend: https://tket.quantinuum.com/extensions/pytket-qulacs/api.html#pytket.extensions.qulacs.QulacsBackend

--- a/pytket/docs/index.rst
+++ b/pytket/docs/index.rst
@@ -75,7 +75,7 @@ Licensed under the `Apache 2 License <http://www.apache.org/licenses/LICENSE-2.0
 .. _Quantinuum: https://www.quantinuum.com/
 
 .. toctree::
-    :caption: Introduction:
+    :caption: Overview:
     :maxdepth: 1
 
     getting_started.rst
@@ -84,12 +84,13 @@ Licensed under the `Apache 2 License <http://www.apache.org/licenses/LICENSE-2.0
     faqs.rst
 
 .. toctree::
-    :caption: More Documentation:
+    :caption: pytket documentation:
     
-    TKET website <https://tket.quantinuum.com/>
-    Manual <https://tket.quantinuum.com/user-manual/>
-    extensions.rst  
+    pytket API docs <https://tket.quantinuum.com/api-docs/>
+    extensions.rst
+    Manual <https://tket.quantinuum.com/user-manual>
     Example notebooks <https://tket.quantinuum.com/examples>
+    TKET website <https://tket.quantinuum.com/>
 
 .. toctree::
     :caption: API Reference:


### PR DESCRIPTION
1. Removing pytket-ionq extension form the list of supported Backends. As far as I know its no longer working.
2. Mentioning the new qulacs density matrix simulator in extensions index.
3. Updated the sidebar links to the other documentation pages to be consistent with what we have in the extensions API docs and manual pages.

