### PR TITLE
Update pytket-qujax link in the documentation

### DIFF
--- a/pytket/docs/extensions.rst
+++ b/pytket/docs/extensions.rst
@@ -145,7 +145,7 @@ Other
    pytket-quantinuum <https://tket.quantinuum.com/extensions/pytket-quantinuum>
    pytket-cutensornet <https://tket.quantinuum.com/extensions/pytket-cutensornet> 
    pytket-qulacs <https://tket.quantinuum.com/extensions/pytket-qulacs>
-   pytket-qujax <https://cqcl.github.io/pytket-qujax/api/index.html>
+   pytket-qujax <https://tket.quantinuum.com/extensions/pytket-qujax>
    pytket-stim <https://tket.quantinuum.com/extensions/pytket-stim>
 
 


### PR DESCRIPTION
I've now built the docs for pytket-qujax on the tket website. I'm updating the link from the index page to point to 
https://tket.quantinuum.com/extensions/pytket-qujax/

The only extensions that are on the index page that do not point to https://tket.quantinuum.com are `pytket-aqt` and `pytket-qsharp`.

There are known issues with pytket-aqt and the source repository has a different file structure which we would have to deal with on the tket-site.

For pytket-qsharp I'm having trouble installing the dotnet SDK in the website but can keep trying if we want to update that link as well.

