### PR TITLE
Update Noise Aware Placement for Circuits with only single qubit gates

### DIFF
--- a/pytket/conanfile.py
+++ b/pytket/conanfile.py
@@ -32,7 +32,7 @@ class pytketRecipe(ConanFile):
         cmake.install()
 
     def requirements(self):
-        self.requires("tket/1.2.71@tket/stable")
+        self.requires("tket/1.2.72@tket/stable")
         self.requires("tklog/0.3.3@tket/stable")
         self.requires("tkrng/0.3.3@tket/stable")
         self.requires("tkassert/0.3.4@tket/stable")

--- a/pytket/docs/changelog.rst
+++ b/pytket/docs/changelog.rst
@@ -14,12 +14,11 @@ Deprecations:
   
 Fixes:
 
-* Fix `PauliFrameRandomisation.sample_circuits`.
-
-Fixes:
-
 * Ensure that squashing long sequences of gates via unitary multiplication does
   not produce non-unitary results due to rounding errors.
+* Fix `PauliFrameRandomisation.sample_circuits`.
+* For `Circuit` with no 2-qubit gates, `NoiseAwarePlacement` now assigns `Qubit` to `Node` in `Architecture``
+  with lowest reported error rates.
 
 
 1.22.0 (November 2023)

--- a/pytket/docs/changelog.rst
+++ b/pytket/docs/changelog.rst
@@ -17,7 +17,7 @@ Fixes:
 * Ensure that squashing long sequences of gates via unitary multiplication does
   not produce non-unitary results due to rounding errors.
 * Fix `PauliFrameRandomisation.sample_circuits`.
-* For `Circuit` with no 2-qubit gates, `NoiseAwarePlacement` now assigns `Qubit` to `Node` in `Architecture``
+* For `Circuit` with no 2-qubit gates, `NoiseAwarePlacement` now assigns `Qubit` to `Node` in `Architecture`
   with lowest reported error rates.
 
 

--- a/tket/conanfile.py
+++ b/tket/conanfile.py
@@ -23,7 +23,7 @@ from conan.errors import ConanInvalidConfiguration
 
 class TketConan(ConanFile):
     name = "tket"
-    version = "1.2.71"
+    version = "1.2.72"
     package_type = "library"
     license = "Apache 2"
     homepage = "https://github.com/CQCL/tket"

--- a/tket/src/Placement/NoiseAwarePlacement.cpp
+++ b/tket/src/Placement/NoiseAwarePlacement.cpp
@@ -123,6 +123,31 @@ std::vector<std::map<Qubit, Node>> NoiseAwarePlacement::get_all_placement_maps(
     const Circuit& circ_, unsigned matches) const {
   std::vector<WeightedEdge> weighted_pattern_edges =
       this->default_pattern_weighting(circ_);
+
+  if (weighted_pattern_edges.empty()) {
+    // => there are no two-qubit gates in the input circuit
+    // in this case, as this method is "noise-aware", assign
+    // qubits in the circuit to the lowest-error architecture nodes
+    std::vector<std::pair<gate_error_t, Node>> all_node_errors;
+    for (const Node& node : this->architecture_.nodes()) {
+      all_node_errors.push_back(
+          {this->characterisation_.get_error(node), node});
+    }
+    std::sort(
+        all_node_errors.begin(), all_node_errors.end(),
+        [](const auto& lhs, const auto& rhs) {
+          // Compare based on the float values in descending order
+          return lhs.first < rhs.first;
+        });
+    std::vector<Qubit> circ_qubits = circ_.all_qubits();
+    TKET_ASSERT(all_node_errors.size() >= circ_qubits.size());
+    std::map<Qubit, Node> placement_map;
+    for (std::size_t i = 0; i < circ_qubits.size(); i++) {
+      placement_map.insert({circ_qubits[i], all_node_errors[i].second});
+    }
+    return {placement_map};
+  }
+
   std::vector<boost::bimap<Qubit, Node>> placement_maps =
       this->get_all_weighted_subgraph_monomorphisms(
           circ_, weighted_pattern_edges, true);

--- a/tket/src/Placement/NoiseAwarePlacement.cpp
+++ b/tket/src/Placement/NoiseAwarePlacement.cpp
@@ -133,6 +133,9 @@ std::vector<std::map<Qubit, Node>> NoiseAwarePlacement::get_all_placement_maps(
       all_node_errors.push_back(
           {this->characterisation_.get_error(node), node});
     }
+    // make sure all_node_errors goes from best->worst error rates
+    // N.B. `get_error` returns "0", i.e. no error, if the `Node` passed
+    // is not held in the characterisation
     std::sort(
         all_node_errors.begin(), all_node_errors.end(),
         [](const auto& lhs, const auto& rhs) {
@@ -142,6 +145,7 @@ std::vector<std::map<Qubit, Node>> NoiseAwarePlacement::get_all_placement_maps(
     std::vector<Qubit> circ_qubits = circ_.all_qubits();
     TKET_ASSERT(all_node_errors.size() >= circ_qubits.size());
     std::map<Qubit, Node> placement_map;
+    // assign circuit qubits to Node with best error rate
     for (std::size_t i = 0; i < circ_qubits.size(); i++) {
       placement_map.insert({circ_qubits[i], all_node_errors[i].second});
     }


### PR DESCRIPTION
https://github.com/CQCL/tket/issues/922 brings up that qubits without 2-qubit gates aren't placed by `NoiseAwarePlacement`. This is fine for `GraphPlacement` as these qubits will be dynamically assigned during routing, with their allocation unrelated to performance as it assumes "no noise", but for `NoiseAwarePlacement` they could still be assigned to `Node` in the `Architecture` that have smaller error rates.

However, the expectation is that typical circuits won't have qubits without any 2-qubit gates, i.e. this is a special case fix. My proposed solution is:
• If the Circuit has qubits with 2-qubit gates and qubits without 2-qubit gates, don't assign the qubits without 2-qubit gates to any `Node`, as these `Node` may be better used as dynamically assigned later.
• If the Circuit **only** has qubits without 2-qubit gates, then assign them to the `Node` with best reported error-rates.

This changes two previous tests that were seeing how `NoiseAwarePlacement` worked on circuits with no 2-qubit gates. In particular, these tests assumed they would be assigned to the `unplaced` register, while now they are assigned to _any_ `Architecture` `Node`. I have considered this a fine change & minor change in behaviour as this not an impactful change for any realistic circuits.

# Checklist

- [X] I have performed a self-review of my code.
- [X] I have commented hard-to-understand parts of my code.
- [X] I have made corresponding changes to the public API documentation.
- [X] I have added tests that prove my fix is effective or that my feature works.
- [X] I have updated the changelog with any user-facing changes.
