### PR TITLE
Fix `pytket.zx` dependency issue

### DIFF
--- a/pytket/pytket/zx/tensor_eval.py
+++ b/pytket/pytket/zx/tensor_eval.py
@@ -199,7 +199,7 @@ def _tensor_from_basic_diagram(diag: ZXDiagram) -> np.ndarray:
         tensor_list.append(qt)
     net = qtn.TensorNetwork(tensor_list)
     net.full_simplify_(seq="ADCR")
-    res_ten = net.contract(output_inds=res_indices, optimize="random-greedy")
+    res_ten = net.contract(output_inds=res_indices, optimize="greedy")
     result: np.ndarray
     if type(res_ten) == qtn.Tensor:
         result = res_ten.data


### PR DESCRIPTION
# Description

There was an issue with the `tensor_from_mixed_diagram` function in the `pytket.zx` module. This was due to a new release of the quimb package version 1.7.0.

The 1.7.0 release dropped the `opt_einsum` dependency casuing the error. It seems there is now equivalent functionality in the `cotengra` package under the name of `greedy` instead of `random-greedy`.

Please summarise the changes.

# Related issues

Please mention any github issues addressed by this PR.

See the build failure in https://github.com/CQCL/pytket/issues/279

# Checklist

- [x] I have performed a self-review of my code.
- [ ] I have commented hard-to-understand parts of my code.
- [ ] I have made corresponding changes to the public API documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the changelog with any user-facing changes.
