### PR TITLE
Allow restriction of number of threads when building pytket using cmake.

### DIFF
--- a/build-without-conan.md
+++ b/build-without-conan.md
@@ -255,3 +255,7 @@ This needs the shared `tklog` and `tket` libraries to be installed.
 cd ${TKET_DIR}/pytket
 NO_CONAN=1 pip install -v -e .
 ```
+
+(You can use the environment variable `PYTKET_CMAKE_N_THREADS` to restrict the
+number of threads used in the above command; otherwise one thread per CPU is
+used.)

--- a/pytket/setup.py
+++ b/pytket/setup.py
@@ -65,7 +65,12 @@ class CMakeBuild(build_ext):
             ["cmake", f"-DCMAKE_INSTALL_PREFIX={install_dir}", os.pardir], cwd=build_dir
         )
         subprocess.run(
-            ["cmake", "--build", os.curdir, f"-j{multiprocessing.cpu_count()}"],
+            [
+                "cmake",
+                "--build",
+                os.curdir,
+                f"-j{os.getenv('PYTKET_CMAKE_N_THREADS', multiprocessing.cpu_count())}",
+            ],
             cwd=build_dir,
         )
         subprocess.run(["cmake", "--install", os.curdir], cwd=build_dir)


### PR DESCRIPTION
# Description

I sometimes find that building TKET (using cmake) consumes too much memory. One workaround is to restrict the number of threads. This can be done with the `-j` parameter to `cmake`. But the binders are built from within a python script. This PR allows one to set an environment variable that's picked up by that script.

# Checklist

- [x] I have performed a self-review of my code.
- [ ] I have commented hard-to-understand parts of my code.
- [ ] I have made corresponding changes to the public API documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the changelog with any user-facing changes.
