### PR TITLE
Fix determination of ccache path on Windows

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -459,17 +459,19 @@ jobs:
         key: tket-dynamic-visual-studio-windows-2022-${{ steps.current_time.outputs.formattedTime }}
         restore-keys: |
           tket-dynamic-visual-studio-windows-2022
-    - name: get ccache version
-      id: ccache-ver
+    - name: get ccache path
+      id: ccache-path
       shell: bash
       run: |
-        ccache_ver=$(choco list -e ccache | grep "ccache" | grep -ioE '[0-9]+\.[0-9]+\.[0-9]+')
-        echo "Found ccache version ${ccache_ver}"
-        echo "ccache_ver=${ccache_ver}" >> $GITHUB_OUTPUT
+        ccache --shimgen-noop > ccache-info.txt || true
+        a=$(cat ccache-info.txt | grep executable)
+        # strip off the initial "  path to executable: "
+        b=${a:22}
+        echo "ccache_path=${b}" >> $GITHUB_OUTPUT
     - name: Build tket
       if: needs.check_changes.outputs.tket_changed == 'true'
       run: |
-        $env:TKET_VSGEN_CCACHE_EXE = 'C:\\ProgramData\\chocolatey\\lib\\ccache\\tools\\ccache-${{ steps.ccache-ver.outputs.ccache_ver }}-windows-x86_64\\ccache.exe' 
+        $env:TKET_VSGEN_CCACHE_EXE = '${{ steps.ccache-path.outputs.ccache_path }}'
         conan build tket --user tket --channel stable -o boost/*:header_only=True -o tklog/*:shared=True -o tket/*:shared=True
         conan export-pkg tket --user tket --channel stable -o boost/*:header_only=True -o tklog/*:shared=True -o tket/*:shared=True -tf `"`"
     - name: Install tket

--- a/pytket/conanfile.py
+++ b/pytket/conanfile.py
@@ -32,7 +32,7 @@ class pytketRecipe(ConanFile):
         cmake.install()
 
     def requirements(self):
-        self.requires("tket/1.2.77@tket/stable")
+        self.requires("tket/1.2.78@tket/stable")
         self.requires("tklog/0.3.3@tket/stable")
         self.requires("tkrng/0.3.3@tket/stable")
         self.requires("tkassert/0.3.4@tket/stable")

--- a/tket/conanfile.py
+++ b/tket/conanfile.py
@@ -23,7 +23,7 @@ from conan.errors import ConanInvalidConfiguration
 
 class TketConan(ConanFile):
     name = "tket"
-    version = "1.2.77"
+    version = "1.2.78"
     package_type = "library"
     license = "Apache 2"
     homepage = "https://github.com/CQCL/tket"


### PR DESCRIPTION
# Description

We were using a hack to get the ccache path, which stopped working because with version 4.9.0 the path for some reason only contained "4.9". Use a different hack which works (for now).

# Related issues

Fixes #1191 .

# Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented hard-to-understand parts of my code.
- [ ] I have made corresponding changes to the public API documentation.
- [x] I have added tests that prove my fix is effective or that my feature works. (Tested by success of PR run.)
- [ ] I have updated the changelog with any user-facing changes.
