### PR TITLE
Use PEP 600 manylinux containers to build pytket

### DIFF
--- a/.github/workflows/build_libs.yml
+++ b/.github/workflows/build_libs.yml
@@ -123,6 +123,6 @@ jobs:
         UPLOAD_PACKAGE=${UPLOAD_PACKAGE}
         JFROG_ARTIFACTORY_TOKEN_3=${{ secrets.JFROG_ARTIFACTORY_TOKEN_3 }}
         JFROG_ARTIFACTORY_USER_3=${{ secrets.JFROG_ARTIFACTORY_USER_3 }}
-        CONAN_PROFILE=linux-x86_64-gcc10-libstdc++
+        CONAN_PROFILE=linux-x86_64-gcc12
         EOF
         docker exec --env-file env-vars linux_build /bin/bash -c "/linuxbuildlib"

--- a/.github/workflows/build_libs.yml
+++ b/.github/workflows/build_libs.yml
@@ -107,7 +107,7 @@ jobs:
     - uses: actions/checkout@v4
     - name: set up container
       run: |
-        docker create --name linux_build -i -v /:/host quay.io/pypa/manylinux2014_x86_64:latest /bin/bash
+        docker create --name linux_build -i -v /:/host quay.io/pypa/manylinux_2_28_x86_64:latest /bin/bash
         docker cp ./libs/${{ matrix.lib }} linux_build:/
         docker cp ./libver linux_build:/
         docker cp ./.github/workflows/linuxbuildlib linux_build:/

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -64,7 +64,7 @@ jobs:
     - name: Install and upload packages
       run: |
         docker start linux_build
-        docker exec -e JFROG_ARTIFACTORY_TOKEN_3="${{ secrets.JFROG_ARTIFACTORY_TOKEN_3 }}" -e JFROG_ARTIFACTORY_USER_3="${{ secrets.JFROG_ARTIFACTORY_USER_3 }}" -e CONAN_PROFILE=linux-x86_64-gcc10-libstdc++ linux_build /bin/bash -c "/tket/.github/workflows/linuxbuildpackages"
+        docker exec -e JFROG_ARTIFACTORY_TOKEN_3="${{ secrets.JFROG_ARTIFACTORY_TOKEN_3 }}" -e JFROG_ARTIFACTORY_USER_3="${{ secrets.JFROG_ARTIFACTORY_USER_3 }}" -e CONAN_PROFILE=linux-x86_64-gcc12 linux_build /bin/bash -c "/tket/.github/workflows/linuxbuildpackages"
 
   build_manylinux_aarch64:
     name: Build on manylinux (aarch64)
@@ -84,7 +84,7 @@ jobs:
       run: |
         export DOCKER_HOST=unix://${HOME}/.docker/run/docker.sock
         docker start linux_build
-        docker exec -e JFROG_ARTIFACTORY_TOKEN_3="${{ secrets.JFROG_ARTIFACTORY_TOKEN_3 }}" -e JFROG_ARTIFACTORY_USER_3="${{ secrets.JFROG_ARTIFACTORY_USER_3 }}" -e CONAN_PROFILE=linux-armv8-gcc10-libstdc++ linux_build /bin/bash -c "/tket/.github/workflows/linuxbuildpackages"
+        docker exec -e JFROG_ARTIFACTORY_TOKEN_3="${{ secrets.JFROG_ARTIFACTORY_TOKEN_3 }}" -e JFROG_ARTIFACTORY_USER_3="${{ secrets.JFROG_ARTIFACTORY_USER_3 }}" -e CONAN_PROFILE=linux-armv8-gcc12 linux_build /bin/bash -c "/tket/.github/workflows/linuxbuildpackages"
 
     - name: Remove container
       if: always()

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -58,7 +58,7 @@ jobs:
 
     - name: Set up container
       run: |
-        docker create --name linux_build -i -v /:/host quay.io/pypa/manylinux2014_x86_64:latest /bin/bash
+        docker create --name linux_build -i -v /:/host quay.io/pypa/manylinux_2_28_x86_64:latest /bin/bash
         docker cp . linux_build:/tket/
 
     - name: Install and upload packages
@@ -77,7 +77,7 @@ jobs:
       run: |
         export DOCKER_HOST=unix://${HOME}/.docker/run/docker.sock
         docker rm --force -v linux_build
-        docker create --name linux_build -i -v /:/host quay.io/pypa/manylinux2014_aarch64:latest /bin/bash
+        docker create --name linux_build -i -v /:/host quay.io/pypa/manylinux_2_28_aarch64:latest /bin/bash
         docker cp . linux_build:/tket/
 
     - name: Install and upload packages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
     - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
     - name: Set up container
       run: |
-        docker create --name linux_build -i -v /:/host quay.io/pypa/manylinux2014_x86_64:latest /bin/bash
+        docker create --name linux_build -i -v /:/host quay.io/pypa/manylinux_2_28_x86_64:latest /bin/bash
         docker cp . linux_build:/tket/
     - name: Run build
       run: |
@@ -49,7 +49,7 @@ jobs:
     - name: Set up container
       run: |
         export DOCKER_HOST=unix://${HOME}/.docker/run/docker.sock
-        docker create --name linux_build -i -v /:/host quay.io/pypa/manylinux2014_aarch64:latest /bin/bash
+        docker create --name linux_build -i -v /:/host quay.io/pypa/manylinux_2_28_aarch64:latest /bin/bash
         docker cp . linux_build:/tket/
     - name: Run build
       run: |
@@ -247,7 +247,7 @@ jobs:
     - name: Set up container
       run: |
         export DOCKER_HOST=unix://${HOME}/.docker/run/docker.sock
-        docker create --name linux_build -i -v /:/host quay.io/pypa/manylinux2014_aarch64:latest /bin/bash
+        docker create --name linux_build -i -v /:/host quay.io/pypa/manylinux_2_28_aarch64:latest /bin/bash
         docker cp . linux_build:/tket/
     - name: Run tests
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Run build
       run: |
         docker start linux_build
-        docker exec -e PY_TAG="cp3${{ matrix.python3-version }}-cp3${{ matrix.python3-version }}" -e CONAN_PROFILE=linux-x86_64-gcc10-libstdc++ linux_build /bin/bash -c "/tket/.github/workflows/linuxbuildwheel"
+        docker exec -e PY_TAG="cp3${{ matrix.python3-version }}-cp3${{ matrix.python3-version }}" -e CONAN_PROFILE=linux-x86_64-gcc12 linux_build /bin/bash -c "/tket/.github/workflows/linuxbuildwheel"
         mkdir wheelhouse
         docker cp linux_build:/tket/pytket/audited/. wheelhouse/
     - uses: actions/upload-artifact@v4
@@ -55,7 +55,7 @@ jobs:
       run: |
         export DOCKER_HOST=unix://${HOME}/.docker/run/docker.sock
         docker start linux_build
-        docker exec -e PY_TAG="cp3${{ matrix.python3-version }}-cp3${{ matrix.python3-version }}" -e CONAN_PROFILE=linux-armv8-gcc10-libstdc++ linux_build /bin/bash -c "/tket/.github/workflows/linuxbuildwheel"
+        docker exec -e PY_TAG="cp3${{ matrix.python3-version }}-cp3${{ matrix.python3-version }}" -e CONAN_PROFILE=linux-armv8-gcc12 linux_build /bin/bash -c "/tket/.github/workflows/linuxbuildwheel"
         mkdir wheelhouse
         docker cp linux_build:/tket/pytket/audited/. wheelhouse/
     - name: Remove container

--- a/conan-profiles/linux-armv8-gcc10-libstdc++
+++ b/conan-profiles/linux-armv8-gcc10-libstdc++
@@ -1,8 +1,0 @@
-[settings]
-arch=armv8
-build_type=Release
-compiler=gcc
-compiler.cppstd=gnu14
-compiler.libcxx=libstdc++
-compiler.version=10
-os=Linux

--- a/conan-profiles/linux-armv8-gcc12
+++ b/conan-profiles/linux-armv8-gcc12
@@ -1,0 +1,8 @@
+[settings]
+arch=armv8
+build_type=Release
+compiler=gcc
+compiler.cppstd=gnu17
+compiler.libcxx=libstdc++11
+compiler.version=12
+os=Linux

--- a/conan-profiles/linux-x86_64-gcc10-libstdc++
+++ b/conan-profiles/linux-x86_64-gcc10-libstdc++
@@ -1,8 +1,0 @@
-[settings]
-arch=x86_64
-build_type=Release
-compiler=gcc
-compiler.cppstd=gnu14
-compiler.libcxx=libstdc++
-compiler.version=10
-os=Linux

--- a/conan-profiles/linux-x86_64-gcc12
+++ b/conan-profiles/linux-x86_64-gcc12
@@ -1,0 +1,8 @@
+[settings]
+arch=x86_64
+build_type=Release
+compiler=gcc
+compiler.cppstd=gnu17
+compiler.libcxx=libstdc++11
+compiler.version=12
+os=Linux

--- a/pytket/conanfile.py
+++ b/pytket/conanfile.py
@@ -32,7 +32,7 @@ class pytketRecipe(ConanFile):
         cmake.install()
 
     def requirements(self):
-        self.requires("tket/1.2.78@tket/stable")
+        self.requires("tket/1.2.79@tket/stable")
         self.requires("tklog/0.3.3@tket/stable")
         self.requires("tkrng/0.3.3@tket/stable")
         self.requires("tkassert/0.3.4@tket/stable")

--- a/tket/conanfile.py
+++ b/tket/conanfile.py
@@ -23,7 +23,7 @@ from conan.errors import ConanInvalidConfiguration
 
 class TketConan(ConanFile):
     name = "tket"
-    version = "1.2.78"
+    version = "1.2.79"
     package_type = "library"
     license = "Apache 2"
     homepage = "https://github.com/CQCL/tket"

--- a/tket/src/Circuit/Boxes.cpp
+++ b/tket/src/Circuit/Boxes.cpp
@@ -328,10 +328,14 @@ std::string CustomGate::get_name(bool) const {
   s << gate_->get_name();
   if (!params_.empty()) {
     s << "(";
-    std::string sep = "";
+    bool initial = true;
     for (const Expr &e : params_) {
-      s << sep << e;
-      sep = ",";
+      if (initial) {
+        s << e;
+      } else {
+        s << "," << e;
+      }
+      initial = false;
     }
     s << ")";
   }

--- a/tket/src/Predicates/CompilationUnit.cpp
+++ b/tket/src/Predicates/CompilationUnit.cpp
@@ -56,27 +56,28 @@ bool CompilationUnit::check_all_predicates() const {
 }
 
 std::string CompilationUnit::to_string() const {
-  std::string str = "~~~CompilationUnit~~~\n<tket::Circuit qubits=" +
-                    std::to_string(circ_.n_qubits()) +
-                    ", gates=" + std::to_string(circ_.n_gates()) + ">\n";
+  std::stringstream s;
+  s << "~~~CompilationUnit~~~" << std::endl
+    << "<tket::Circuit qubits=" << circ_.n_qubits()
+    << ", gates=" << circ_.n_gates() << ">" << std::endl;
 
   if (!target_preds.empty()) {
-    str += "Target Predicates:\n";
+    s << "Target Predicates:" << std::endl;
     for (const TypePredicatePair& pp : target_preds) {
-      str += ("  " + pp.second->to_string() + "\n");
+      s << "  " << pp.second->to_string() << std::endl;
     }
   } else
-    str += "Target Predicates empty\n";
+    s << "Target Predicates empty" << std::endl;
   if (!cache_.empty()) {
-    str += "Cache:\n";
+    s << "Cache:" << std::endl;
     for (const std::pair<const std::type_index, std::pair<PredicatePtr, bool>>&
              tp : cache_) {
-      str += (" " + tp.second.first->to_string() + " :: ");
-      str += tp.second.second ? "True\n" : "False\n";
+      s << " " << tp.second.first->to_string()
+        << " :: " << ((tp.second.second) ? "True" : "False") << std::endl;
     }
   } else
-    str += "Cache empty\n";
-  return str;
+    s << "Cache empty" << std::endl;
+  return s.str();
 }
 
 void CompilationUnit::empty_cache() const { cache_ = {}; }


### PR DESCRIPTION
# Description

See https://peps.python.org/pep-0600/ . Doing this now as it seems necessary for Python 3.12 support.

By default the newer manylinux platforms use gcc 12 and libstdc++11, so update the conan profiles to match that configuration. Fix a couple of build warnings arising from this. 

# Checklist

- [x] I have performed a self-review of my code.
- [ ] I have commented hard-to-understand parts of my code.
- [ ] I have made corresponding changes to the public API documentation.
- [x] I have added tests that prove my fix is effective or that my feature works. (Tested by running the release workflow successfully.)
- [ ] I have updated the changelog with any user-facing changes.
