### PR TITLE
Only check pytket coverage for PRs to develop.

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -557,7 +557,7 @@ jobs:
   check_pytket_coverage:
     name: Check pytket line and branch coverage
     needs: build_test_pytket_ubuntu
-    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+    if: (github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'develop') || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/compare-pytket-coverage
+++ b/.github/workflows/compare-pytket-coverage
@@ -69,9 +69,9 @@ def compare(old_cov_file, new_cov_file):
     print(f"Branch coverage: {new_branch_rate}")
     print()
 
-    if new_line_rate < old_line_rate:
+    if new_line_rate + 0.01 < old_line_rate:
         sys.exit("Line coverage has decreased!")
-    if new_branch_rate < old_branch_rate:
+    if new_branch_rate + 0.01 < old_branch_rate:
         sys.exit("Branch coverage has decreased!")
 
 


### PR DESCRIPTION
# Description

Only do the pytket coverage check for PRs to `develop`. Since we are comparing with the results of the latest push to `develop`, this is not meaningful for PRs to other branches (e.g. `main`, which may be behind `develop`).

Also add a tolerance for random variation.

# Checklist

- [x] I have performed a self-review of my code.