### PR TITLE
Don't try to install ZX module with Python 3.12.

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -274,9 +274,15 @@ jobs:
       with:
         python-version: '3.12'
     - name: Build pytket
+      if: github.event_name != 'schedule'
       run: |
         cd pytket
         pip install -e .[ZX] -v
+    - name: Build pytket
+      if: github.event_name == 'schedule' # https://github.com/CQCL/tket/issues/1200
+      run: |
+        cd pytket
+        pip install -e -v
     - name: Run doctests
       run: |
         cd pytket
@@ -381,9 +387,15 @@ jobs:
       with:
         python-version: '3.12'
     - name: Build pytket
+      if: github.event_name != 'schedule'
       run: |
         cd pytket
         python${{ matrix.python-version }} -m pip install -e .[ZX] -v
+    - name: Build pytket
+      if: github.event_name == 'schedule' # https://github.com/CQCL/tket/issues/1200
+      run: |
+        cd pytket
+        python${{ matrix.python-version }} -m pip install -e -v
     - name: Run doctests
       run: |
         cd pytket
@@ -502,9 +514,15 @@ jobs:
       with:
         python-version: '3.12'
     - name: Build pytket
+      if: github.event_name != 'schedule'
       run: |
         cd pytket
         pip install -e .[ZX] -v
+    - name: Build pytket
+      if: github.event_name == 'schedule' # https://github.com/CQCL/tket/issues/1200
+      run: |
+        cd pytket
+        pip install -e -v
     - name: Run doctests
       run: |
         cd pytket


### PR DESCRIPTION
# Description

Don't install pytket with the "ZX" option on Python 3.12 (which is used on the weekly scheduled runs).

# Related issues

Relates to #1200 .

# Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented hard-to-understand parts of my code.
- [ ] I have made corresponding changes to the public API documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the changelog with any user-facing changes.
