### PR TITLE
Use ARM-Linux runners from buildjet instead of using docker on the self-hosted Mac

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -68,26 +68,17 @@ jobs:
 
   build_manylinux_aarch64:
     name: Build on manylinux (aarch64)
-    runs-on: ['self-hosted', 'macOS', 'ARM64']
+    runs-on: 'buildjet-8vcpu-ubuntu-2204-arm'
     steps:
 
     - uses: actions/checkout@v4
 
     - name: Set up container
       run: |
-        export DOCKER_HOST=unix://${HOME}/.docker/run/docker.sock
-        docker rm --force -v linux_build
         docker create --name linux_build -i -v /:/host quay.io/pypa/manylinux_2_28_aarch64:latest /bin/bash
         docker cp . linux_build:/tket/
 
     - name: Install and upload packages
       run: |
-        export DOCKER_HOST=unix://${HOME}/.docker/run/docker.sock
         docker start linux_build
         docker exec -e JFROG_ARTIFACTORY_TOKEN_3="${{ secrets.JFROG_ARTIFACTORY_TOKEN_3 }}" -e JFROG_ARTIFACTORY_USER_3="${{ secrets.JFROG_ARTIFACTORY_USER_3 }}" -e CONAN_PROFILE=linux-armv8-gcc12 linux_build /bin/bash -c "/tket/.github/workflows/linuxbuildpackages"
-
-    - name: Remove container
-      if: always()
-      run: |
-        export DOCKER_HOST=unix://${HOME}/.docker/run/docker.sock
-        docker rm --force -v linux_build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,8 @@ jobs:
 
   build_Linux_aarch64_wheels:
     name: Build manylinux aarch64
-    runs-on: ['self-hosted', 'macOS', 'ARM64']
+    # We need the one with 12GB RAM to build pytket.
+    runs-on: 'buildjet-8vcpu-ubuntu-2204-arm'
     strategy:
       matrix:
         python3-version: ['10', '11', '12']
@@ -48,28 +49,18 @@ jobs:
     - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
     - name: Set up container
       run: |
-        export DOCKER_HOST=unix://${HOME}/.docker/run/docker.sock
         docker create --name linux_build -i -v /:/host quay.io/pypa/manylinux_2_28_aarch64:latest /bin/bash
         docker cp . linux_build:/tket/
     - name: Run build
       run: |
-        export DOCKER_HOST=unix://${HOME}/.docker/run/docker.sock
         docker start linux_build
         docker exec -e PY_TAG="cp3${{ matrix.python3-version }}-cp3${{ matrix.python3-version }}" -e CONAN_PROFILE=linux-armv8-gcc12 linux_build /bin/bash -c "/tket/.github/workflows/linuxbuildwheel"
         mkdir wheelhouse
         docker cp linux_build:/tket/pytket/audited/. wheelhouse/
-    - name: Remove container
-      if: always()
-      run: |
-        export DOCKER_HOST=unix://${HOME}/.docker/run/docker.sock
-        docker rm --force -v linux_build
     - uses: actions/upload-artifact@v4
       with:
         name: Linux_aarch64_3.${{ matrix.python3-version }}_wheel
         path: wheelhouse/
-    - name: Remove directory
-      if: always()
-      run: rm -rf wheelhouse
 
   build_macos_wheels:
     name: Build macos wheels
@@ -227,7 +218,7 @@ jobs:
   test_Linux_aarch64_wheels:
     name: Test linux aarch64 wheels
     needs: build_Linux_aarch64_wheels
-    runs-on: ['self-hosted', 'macOS', 'ARM64']
+    runs-on: 'buildjet-4vcpu-ubuntu-2204-arm'
     strategy:
       matrix:
         python3-version: ['10', '11', '12']
@@ -235,29 +226,31 @@ jobs:
     - uses: actions/checkout@v4
       with:
         path: tket
+    - name: Set up Python 3.${{ matrix.python3-version }}
+      # Use deadsnakes/action because Python for Linux/ARM is not available with
+      # actions/setup-python.
+      # Python 3.10 is the default python on Ubuntu 22.04, so this combination
+      # is not available from deadsnakes: use the default python in this case.
+      if: matrix.python3-version != '10'
+      uses: deadsnakes/action@v3.1.0
+      with:
+        python-version: "3.${{ matrix.python3-version }}"
     - name: Download wheel
       uses: actions/download-artifact@v4
       with:
         name: Linux_aarch64_3.${{ matrix.python3-version }}_wheel
         path: wheelhouse/
-    - name: Set up container
+    - name: Install wheel
+      run: pip install wheelhouse/pytket-*.whl
+    - uses: actions/checkout@v4
+      with:
+        path: tket
+    - name: Setup tests
       run: |
-        export DOCKER_HOST=unix://${HOME}/.docker/run/docker.sock
-        docker create --name linux_build -i -v /:/host quay.io/pypa/manylinux_2_28_aarch64:latest /bin/bash
-        docker cp . linux_build:/tket/
+        cd tket/pytket/tests
+        pip install -U -r requirements.txt
     - name: Run tests
-      run: |
-        export DOCKER_HOST=unix://${HOME}/.docker/run/docker.sock
-        docker start linux_build
-        docker exec -e PY_TAG="cp3${{ matrix.python3-version }}-cp3${{ matrix.python3-version }}" linux_build /bin/bash -c "/tket/.github/workflows/linuxtestwheel"
-    - name: Remove container
-      if: always()
-      run: |
-        export DOCKER_HOST=unix://${HOME}/.docker/run/docker.sock
-        docker rm --force -v linux_build
-    - name: Remove directory
-      if: always()
-      run: rm -rf wheelhouse
+      run: cd tket/pytket/tests && pytest --ignore=simulator/
 
   test_macos_wheels:
     name: Test macos wheels


### PR DESCRIPTION
# Description

Now that we have access to the buildjet runners in he tket repo, we can use them to build Linux/ARM use.

# Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented hard-to-understand parts of my code.
- [ ] I have made corresponding changes to the public API documentation.
- [x] I have added tests that prove my fix is effective or that my feature works. (Tested [here](https://github.com/CQCL/tket/actions/runs/7581992662).)
- [ ] I have updated the changelog with any user-facing changes.
