### PR TITLE
Use boost 1.84.0 in libs.

### DIFF
--- a/libs/tktokenswap/conanfile.py
+++ b/libs/tktokenswap/conanfile.py
@@ -19,7 +19,7 @@ from conan.errors import ConanInvalidConfiguration
 
 class TktokenswapConan(ConanFile):
     name = "tktokenswap"
-    version = "0.3.6"
+    version = "0.3.7"
     package_type = "library"
     license = "Apache 2"
     url = "https://github.com/CQCL/tket"
@@ -73,4 +73,4 @@ class TktokenswapConan(ConanFile):
         self.requires("tklog/0.3.3@tket/stable")
         self.requires("tkassert/0.3.4@tket/stable", transitive_headers=True)
         self.requires("tkrng/0.3.3@tket/stable")
-        self.requires("boost/1.83.0", transitive_libs=False)
+        self.requires("boost/1.84.0", transitive_libs=False)

--- a/libs/tktokenswap/test/conanfile.py
+++ b/libs/tktokenswap/test/conanfile.py
@@ -59,6 +59,6 @@ class test_tktokenswapRecipe(ConanFile):
         cmake.install()
 
     def requirements(self):
-        self.requires("tktokenswap/0.3.6")
+        self.requires("tktokenswap/0.3.7")
         self.requires("tkrng/0.3.3@tket/stable")
         self.requires("catch2/3.5.2")

--- a/libs/tkwsm/conanfile.py
+++ b/libs/tkwsm/conanfile.py
@@ -19,7 +19,7 @@ from conan.errors import ConanInvalidConfiguration
 
 class TkwsmConan(ConanFile):
     name = "tkwsm"
-    version = "0.3.6"
+    version = "0.3.7"
     package_type = "library"
     license = "Apache 2"
     url = "https://github.com/CQCL/tket"
@@ -72,4 +72,4 @@ class TkwsmConan(ConanFile):
     def requirements(self):
         self.requires("tkassert/0.3.4@tket/stable")
         self.requires("tkrng/0.3.3@tket/stable")
-        self.requires("boost/1.83.0", transitive_headers=True, transitive_libs=False)
+        self.requires("boost/1.84.0", transitive_headers=True, transitive_libs=False)

--- a/libs/tkwsm/test/conanfile.py
+++ b/libs/tkwsm/test/conanfile.py
@@ -59,7 +59,7 @@ class test_tkwsmRecipe(ConanFile):
         cmake.install()
 
     def requirements(self):
-        self.requires("tkwsm/0.3.6")
+        self.requires("tkwsm/0.3.7")
         self.requires("tkassert/0.3.4@tket/stable")
         self.requires("tkrng/0.3.3@tket/stable")
         self.requires("catch2/3.5.2")


### PR DESCRIPTION
# Description

Update tkwsm and tktokenswap to use boost 1.84.0 (follow-up PR will do the same for tket and update its lib dependencies).

# Checklist

- [x] I have performed a self-review of my code.
- [ ] I have commented hard-to-understand parts of my code.
- [ ] I have made corresponding changes to the public API documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the changelog with any user-facing changes.
