### PR TITLE
Add method to get bytecode from a `WasmFileHandler`

### DIFF
--- a/pytket/docs/changelog.rst
+++ b/pytket/docs/changelog.rst
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+Unreleased
+----------
+
+Features:
+
+* Add ``WasmFileHandler.bytecode()`` method to retrieve the WASM as bytecode.
+
 1.24.0 (January 2024)
 ---------------------
 

--- a/pytket/pytket/wasm/wasm.py
+++ b/pytket/pytket/wasm/wasm.py
@@ -91,7 +91,6 @@ class WasmFileHandler:
         self._unsupported_function = []
 
         if self._check_file:
-
             mod_iter = iter(decode_module(self._wasm_file))
             _, _ = next(mod_iter)
 
@@ -143,7 +142,6 @@ class WasmFileHandler:
                     self._function_types = cur_sec_data.payload.types
 
             for x in function_names:
-
                 # check for only integer type in parameters and return values
                 supported_function = True
                 idx = _func_lookup[x][1]
@@ -213,6 +211,10 @@ class WasmFileHandler:
                 """the content of the wasm file can only be printed if the
 wasm file was checked"""
             )
+
+    def bytecode(self) -> bytes:
+        """The WASM content as bytecode"""
+        return self._wasm_file
 
     def check_function(
         self, function_name: str, number_of_parameters: int, number_of_returns: int

--- a/pytket/tests/classical_test.py
+++ b/pytket/tests/classical_test.py
@@ -178,6 +178,10 @@ def test_wasm_2() -> None:
 def test_wasm_3() -> None:
     w = wasm.WasmFileHandler("testfile.wasm")
 
+    with open("testfile.wasm", "rb") as f:
+        bytecode = f.read()
+    assert w.bytecode() == bytecode
+
     c = Circuit(0, 6)
 
     c.add_wasm("add_one", w, [1], [1], [Bit(0), Bit(1)])


### PR DESCRIPTION
# Description

This provides a stable way to retrieve the WASM bytecode (previously only possible with the `_wasm_file` attribute).

# Related issues

Useful for https://github.com/CQCL/pytket-quantinuum/issues/344 .

# Checklist

- [x] I have performed a self-review of my code.
- [ ] I have commented hard-to-understand parts of my code.
- [x] I have made corresponding changes to the public API documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have updated the changelog with any user-facing changes.
