### PR TITLE
Revert "Don't try to install ZX module with Python 3.12. (#1203)"

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -274,15 +274,9 @@ jobs:
       with:
         python-version: '3.12'
     - name: Build pytket
-      if: github.event_name != 'schedule'
       run: |
         cd pytket
         pip install -e .[ZX] -v
-    - name: Build pytket
-      if: github.event_name == 'schedule' # https://github.com/CQCL/tket/issues/1200
-      run: |
-        cd pytket
-        pip install -e . -v
     - name: Run doctests
       run: |
         cd pytket
@@ -387,15 +381,9 @@ jobs:
       with:
         python-version: '3.12'
     - name: Build pytket
-      if: github.event_name != 'schedule'
       run: |
         cd pytket
         python${{ matrix.python-version }} -m pip install -e .[ZX] -v
-    - name: Build pytket
-      if: github.event_name == 'schedule' # https://github.com/CQCL/tket/issues/1200
-      run: |
-        cd pytket
-        python${{ matrix.python-version }} -m pip install -e . -v
     - name: Run doctests
       run: |
         cd pytket
@@ -514,15 +502,9 @@ jobs:
       with:
         python-version: '3.12'
     - name: Build pytket
-      if: github.event_name != 'schedule'
       run: |
         cd pytket
         pip install -e .[ZX] -v
-    - name: Build pytket
-      if: github.event_name == 'schedule' # https://github.com/CQCL/tket/issues/1200
-      run: |
-        cd pytket
-        pip install -e . -v
     - name: Run doctests
       run: |
         cd pytket

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -274,9 +274,15 @@ jobs:
       with:
         python-version: '3.12'
     - name: Build pytket
+      if: github.event_name != 'schedule'
       run: |
         cd pytket
         pip install -e .[ZX] -v
+    - name: Build pytket
+      if: github.event_name == 'schedule' # https://github.com/CQCL/tket/issues/1242
+      run: |
+        cd pytket
+        pip install -e . -v
     - name: Run doctests
       run: |
         cd pytket

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -383,26 +383,26 @@ jobs:
     - name: Build pytket
       run: |
         cd pytket
-        python${{ matrix.python-version }} -m pip install -e .[ZX] -v
+        python -m pip install -e .[ZX] -v
     - name: Run doctests
       run: |
         cd pytket
-        python${{ matrix.python-version }} -m pip install pytest
-        python${{ matrix.python-version }} -m pytest --doctest-modules pytket
+        python -m pip install pytest
+        python -m pytest --doctest-modules pytket
     - name: Test pytket
       run: |
         cd pytket/tests
-        python${{ matrix.python-version }} -m pip install -r requirements.txt
-        python${{ matrix.python-version }} -m pytest --ignore=simulator/
+        python -m pip install -r requirements.txt
+        python -m pytest --ignore=simulator/
     - name: Check type stubs are up-to-date and run mypy
       if: matrix.os == 'macos-13-xlarge' && (github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch')
       run: |
-        python${{ matrix.python-version }} -m pip install -U mypy
-        python${{ matrix.python-version }} -m pip install pybind11-stubgen==2.3.6 # https://github.com/CQCL/tket/issues/1135
+        python -m pip install -U mypy
+        python -m pip install pybind11-stubgen==2.3.6 # https://github.com/CQCL/tket/issues/1135
         cd pytket
         ./stub_generation/regenerate_stubs
         git diff --quiet pytket/_tket && echo "Stubs are up-to-date" || exit 1  # fail if stubs change after regeneration
-        python${{ matrix.python-version }} -m mypy --config-file=mypy.ini --no-incremental -p pytket -p tests
+        python -m mypy --config-file=mypy.ini --no-incremental -p pytket -p tests
     - name: Upload package
       if: github.event_name == 'push' && github.ref == 'refs/heads/develop' && needs.check_changes.outputs.tket_changed == 'true'
       run: |


### PR DESCRIPTION
# Description

This reverts commit c257befc4afddda515eef55a46a0b96994b1038f now that numba is available for python 3.12.

There is still an [issue](https://github.com/CQCL/tket/issues/1242) on Ubuntu, so keep skipping ZX for that platform on the python 3.12 run.

Also remove references in the workflow to `matrix.python-version` which doesn't exist (and apparently resolves to the empty string).

Tested [here](https://github.com/CQCL/tket/actions/runs/7755286684/job/21150352628).

# Related issues

Closes #1200 .

# Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented hard-to-understand parts of my code.
- [ ] I have made corresponding changes to the public API documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the changelog with any user-facing changes.
