### PR TITLE
Don't reuse "stale" Pauli stabilizers when generating Pauli graphs

### DIFF
--- a/pytket/conanfile.py
+++ b/pytket/conanfile.py
@@ -32,7 +32,7 @@ class pytketRecipe(ConanFile):
         cmake.install()
 
     def requirements(self):
-        self.requires("tket/1.2.89@tket/stable")
+        self.requires("tket/1.2.90@tket/stable")
         self.requires("tklog/0.3.3@tket/stable")
         self.requires("tkrng/0.3.3@tket/stable")
         self.requires("tkassert/0.3.4@tket/stable")

--- a/pytket/conanfile.py
+++ b/pytket/conanfile.py
@@ -32,7 +32,7 @@ class pytketRecipe(ConanFile):
         cmake.install()
 
     def requirements(self):
-        self.requires("tket/1.2.88@tket/stable")
+        self.requires("tket/1.2.89@tket/stable")
         self.requires("tklog/0.3.3@tket/stable")
         self.requires("tkrng/0.3.3@tket/stable")
         self.requires("tkassert/0.3.4@tket/stable")

--- a/pytket/docs/changelog.rst
+++ b/pytket/docs/changelog.rst
@@ -8,6 +8,11 @@ Features:
 
 * Add ``WasmFileHandler.bytecode()`` method to retrieve the WASM as bytecode.
 
+Fixes:
+
+* Fix bug in ``PauliExponentials()`` pass affecting circuits containing
+  ``PhasedX`` gates containing Clifford angles.
+
 1.24.0 (January 2024)
 ---------------------
 

--- a/tket/conanfile.py
+++ b/tket/conanfile.py
@@ -23,7 +23,7 @@ from conan.errors import ConanInvalidConfiguration
 
 class TketConan(ConanFile):
     name = "tket"
-    version = "1.2.88"
+    version = "1.2.89"
     package_type = "library"
     license = "Apache 2"
     homepage = "https://github.com/CQCL/tket"

--- a/tket/conanfile.py
+++ b/tket/conanfile.py
@@ -23,7 +23,7 @@ from conan.errors import ConanInvalidConfiguration
 
 class TketConan(ConanFile):
     name = "tket"
-    version = "1.2.89"
+    version = "1.2.90"
     package_type = "library"
     license = "Apache 2"
     homepage = "https://github.com/CQCL/tket"

--- a/tket/src/PauliGraph/PauliGraph.cpp
+++ b/tket/src/PauliGraph/PauliGraph.cpp
@@ -163,8 +163,6 @@ void PauliGraph::apply_gate_at_end(
     case OpType::PhasedX: {
       Expr alpha = gate.get_params().at(0);
       Expr beta = gate.get_params().at(1);
-      SpPauliStabiliser zpauli = cliff_.get_zrow(qbs.at(0));
-      SpPauliStabiliser xpauli = cliff_.get_xrow(qbs.at(0));
       std::optional<unsigned> cliff_alpha = equiv_Clifford(alpha);
       std::optional<unsigned> cliff_beta = equiv_Clifford(beta);
       // Rz(-b)
@@ -173,6 +171,7 @@ void PauliGraph::apply_gate_at_end(
           cliff_.apply_gate_at_end(OpType::Sdg, qbs);
         }
       } else {
+        SpPauliStabiliser zpauli = cliff_.get_zrow(qbs.at(0));
         apply_pauli_gadget_at_end(zpauli, -beta);
       }
       // Rx(a)
@@ -181,6 +180,7 @@ void PauliGraph::apply_gate_at_end(
           cliff_.apply_gate_at_end(OpType::V, qbs);
         }
       } else {
+        SpPauliStabiliser xpauli = cliff_.get_xrow(qbs.at(0));
         apply_pauli_gadget_at_end(xpauli, alpha);
       }
       // Rz(b)
@@ -189,6 +189,7 @@ void PauliGraph::apply_gate_at_end(
           cliff_.apply_gate_at_end(OpType::S, qbs);
         }
       } else {
+        SpPauliStabiliser zpauli = cliff_.get_zrow(qbs.at(0));
         apply_pauli_gadget_at_end(zpauli, beta);
       }
       break;

--- a/tket/test/src/test_CompilerPass.cpp
+++ b/tket/test/src/test_CompilerPass.cpp
@@ -2026,5 +2026,17 @@ SCENARIO(
     REQUIRE(cu.get_circ_ref().n_gates() == 1);
   }
 }
+
+SCENARIO("PauliExponentials") {
+  GIVEN("A PhasedX gate") {
+    // https://github.com/CQCL/tket/issues/1244
+    Circuit c(1);
+    c.add_op<unsigned>(OpType::PhasedX, {0.5, 0.6}, {0});
+    CompilationUnit cu(c);
+    CHECK(gen_pauli_exponentials(Transforms::PauliSynthStrat::Individual)
+              ->apply(cu));
+    REQUIRE(test_unitary_comparison(c, cu.get_circ_ref(), true));
+  }
+}
 }  // namespace test_CompilerPass
 }  // namespace tket

--- a/tket/test/src/test_CompilerPass.cpp
+++ b/tket/test/src/test_CompilerPass.cpp
@@ -2032,6 +2032,7 @@ SCENARIO("PauliExponentials") {
     // https://github.com/CQCL/tket/issues/1244
     Circuit c(1);
     c.add_op<unsigned>(OpType::PhasedX, {0.5, 0.6}, {0});
+    c.add_op<unsigned>(OpType::PhasedX, {0.6, 0.5}, {0});
     CompilationUnit cu(c);
     CHECK(gen_pauli_exponentials(Transforms::PauliSynthStrat::Individual)
               ->apply(cu));


### PR DESCRIPTION
# Description

Fixes a bug in applying `PhasedX` gates as sequences of `Rz` and `Rx` gates.

# Related issues

Fixes #1244 .

# Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented hard-to-understand parts of my code.
- [ ] I have made corresponding changes to the public API documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have updated the changelog with any user-facing changes.
