### PR TITLE
Change docstrings for PauliExpPairBox

### DIFF
--- a/pytket/binders/circuit/boxes.cpp
+++ b/pytket/binders/circuit/boxes.cpp
@@ -267,8 +267,11 @@ void init_boxes(py::module &m) {
           ":return: decomposition method");
   py::class_<PauliExpPairBox, std::shared_ptr<PauliExpPairBox>, Op>(
       m, "PauliExpPairBox",
-      "An operation defined as a pair of exponentials of a tensor of Pauli "
-      "operations and their (possibly symbolic) phase parameters.")
+      "A pair of (not necessarily commuting) Pauli exponentials performed in "
+      "sequence.\nPairing up exponentials for synthesis can reduce gate costs "
+      "of synthesis compared to synthesising individually, with the best "
+      "reductions found when the Pauli tensors act on a large number of the "
+      "same qubits.\nPhase parameters may be symbolic.")
       .def(
           py::init([](const py::tket_custom::SequenceVec<Pauli> &paulis0,
                       Expr t0,

--- a/pytket/binders/circuit/main.cpp
+++ b/pytket/binders/circuit/main.cpp
@@ -314,10 +314,8 @@ PYBIND11_MODULE(circuit, m) {
           ":math:`P` of Pauli operations.")
       .value(
           "PauliExpPairBox", OpType::PauliExpPairBox,
-          "An operation defined as a pair"
-          "of exponentials of the form "
-          ":math:`e^{-\\frac{i\\pi\\alpha}{2} P}` of a tensor "
-          ":math:`P` of Pauli operations.")
+          "A pair of (not necessarily commuting) Pauli exponentials "
+          ":math:`e^{-\\frac{i\\pi\\alpha}{2} P}` performed in sequence.")
       .value(
           "PauliExpCommutingSetBox", OpType::PauliExpCommutingSetBox,
           "An operation defined as a set"

--- a/pytket/pytket/_tket/circuit.pyi
+++ b/pytket/pytket/_tket/circuit.pyi
@@ -3114,7 +3114,7 @@ class OpType:
     
       PauliExpBox : An operation defined as the exponential :math:`e^{-\frac{i\pi\alpha}{2} P}` of a tensor :math:`P` of Pauli operations.
     
-      PauliExpPairBox : An operation defined as a pairof exponentials of the form :math:`e^{-\frac{i\pi\alpha}{2} P}` of a tensor :math:`P` of Pauli operations.
+      PauliExpPairBox : A pair of (not necessarily commuting) Pauli exponentials :math:`e^{-\frac{i\pi\alpha}{2} P}` performed in sequence.
     
       PauliExpCommutingSetBox : An operation defined as a setof commuting exponentials of the form :math:`e^{-\frac{i\pi\alpha}{2} P}` of a tensor :math:`P` of Pauli operations.
     
@@ -3376,7 +3376,9 @@ class PauliExpCommutingSetBox(Op):
         """
 class PauliExpPairBox(Op):
     """
-    An operation defined as a pair of exponentials of a tensor of Pauli operations and their (possibly symbolic) phase parameters.
+    A pair of (not necessarily commuting) Pauli exponentials performed in sequence.
+    Pairing up exponentials for synthesis can reduce gate costs of synthesis compared to synthesising individually, with the best reductions found when the Pauli tensors act on a large number of the same qubits.
+    Phase parameters may be symbolic.
     """
     def __init__(self, paulis0: typing.Sequence[pytket._tket.pauli.Pauli], t0: sympy.Expr | float, paulis1: typing.Sequence[pytket._tket.pauli.Pauli], t1: sympy.Expr | float, cx_config_type: CXConfigType = CXConfigType.Tree) -> None:
         """


### PR DESCRIPTION
# Description

Previous docstrings for PauliExpPairBox did not clarify the lack of commutation requirements. Reworked it to address this and provide some explanation as to why a user might use the box.

# Related issues

# Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have commented hard-to-understand parts of my code.
- [x] I have made corresponding changes to the public API documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the changelog with any user-facing changes.
