### PR TITLE
Methods for adding a `CircBox` registerwise

### DIFF
--- a/pytket/CMakeLists.txt
+++ b/pytket/CMakeLists.txt
@@ -102,6 +102,7 @@ set(HEADER_FILES
         binders/include/add_gate.hpp
         binders/include/binder_json.hpp
         binders/include/binder_utils.hpp
+        binders/include/circuit_registers.hpp
         binders/include/deleted_hash.hpp
         binders/include/py_operators.hpp
         binders/include/typecast.hpp

--- a/pytket/binders/circuit/Circuit/add_op.cpp
+++ b/pytket/binders/circuit/Circuit/add_op.cpp
@@ -557,11 +557,13 @@ void init_circuit_add_op(py::class_<Circuit, std::shared_ptr<Circuit>> &c) {
           "together."
           "\n\n:param circbox: The box to append"
           "\n:param qregs: Sequence of :py:class:`QubitRegister` from the "
-          "outer :py:class:`Circuit`, in order of corresponding registers in "
-          "the :py:class:`CircBox`"
+          "outer :py:class:`Circuit`, the order corresponding to the "
+          "lexicographic order of corresponding registers in the "
+          ":py:class:`CircBox`"
           "\n:param cregs: Sequence of :py:class:`BitRegister` from the "
-          "outer :py:class:`Circuit`, in order of corresponding registers in "
-          "the :py:class:`CircBox`"
+          "outer :py:class:`Circuit`, the order corresponding to the "
+          "lexicographic order of corresponding registers in the "
+          ":py:class:`CircBox`"
           "\n:return: the new :py:class:`Circuit`",
           py::arg("circbox"), py::arg("qregs"), py::arg("cregs"))
       .def(

--- a/pytket/binders/circuit/Circuit/add_op.cpp
+++ b/pytket/binders/circuit/Circuit/add_op.cpp
@@ -219,9 +219,13 @@ void init_circuit_add_op(py::class_<Circuit, std::shared_ptr<Circuit>> &c) {
             return add_box_method(
                 circ, std::make_shared<CircBox>(box), args, kwargs);
           },
-          "Append a :py:class:`CircBox` to the circuit.\n\n:param "
-          "circbox: The box to append\n:param args: Indices of the "
-          "qubits/bits to append the box to"
+          "Append a :py:class:`CircBox` to the circuit."
+          "\n\nThe qubits and bits of the :py:class:`CircBox` are wired into "
+          "the circuit in lexicographic order. Bits follow qubits in the order "
+          "of arguments."
+          "\n\n:param circbox: The box to append"
+          "\n:param args: Indices of the (default-register) qubits/bits to "
+          "append the box to"
           "\n:return: the new :py:class:`Circuit`",
           py::arg("circbox"), py::arg("args"))
       .def(
@@ -517,9 +521,12 @@ void init_circuit_add_op(py::class_<Circuit, std::shared_ptr<Circuit>> &c) {
             return add_box_method(
                 circ, std::make_shared<CircBox>(box), args, kwargs);
           },
-          "Append a :py:class:`CircBox` to the circuit.\n\n:param "
-          "circbox: The box to append\n:param args: The qubits/bits "
-          "to append the box to"
+          "Append a :py:class:`CircBox` to the circuit."
+          "\n\nThe qubits and bits of the :py:class:`CircBox` are wired into "
+          "the circuit in lexicographic order. Bits follow qubits in the order "
+          "of arguments."
+          "\n\n:param circbox: The box to append"
+          "\n:param args: The qubits/bits to append the box to"
           "\n:return: the new :py:class:`Circuit`",
           py::arg("circbox"), py::arg("args"))
       .def(

--- a/pytket/binders/circuit/Circuit/add_op.cpp
+++ b/pytket/binders/circuit/Circuit/add_op.cpp
@@ -589,7 +589,7 @@ void init_circuit_add_op(py::class_<Circuit, std::shared_ptr<Circuit>> &c) {
             // Get box circuit:
             std::shared_ptr<Circuit> box_circ = box.to_circuit();
 
-            // Get units of box:
+            // Get units of box (in lexicographic order):
             const qubit_vector_t box_qubits = box_circ->all_qubits();
             const bit_vector_t box_bits = box_circ->all_bits();
 
@@ -633,7 +633,10 @@ void init_circuit_add_op(py::class_<Circuit, std::shared_ptr<Circuit>> &c) {
               }
             }
 
-            // Populate the arguments (qubits then bits):
+            // Populate the arguments (qubits then bits). Note that they are in
+            // lexicographic order; when the box is inserted into the circuit
+            // (in Circuit::substitute_box_vertex()) the units are also
+            // connected in lexicographic order.
             std::vector<UnitID> args;
             for (const Qubit &qb : box_qubits) {
               args.push_back(Qubit(qregmap.at(qb.reg_name()), qb.index()[0]));

--- a/pytket/binders/circuit/Circuit/main.cpp
+++ b/pytket/binders/circuit/Circuit/main.cpp
@@ -24,6 +24,7 @@
 #include "UnitRegister.hpp"
 #include "binder_json.hpp"
 #include "boost/graph/iteration_macros.hpp"
+#include "circuit_registers.hpp"
 #include "deleted_hash.hpp"
 #include "py_operators.hpp"
 #include "tket/Circuit/Boxes.hpp"
@@ -56,43 +57,6 @@ UnitID to_cpp_unitid(const PyUnitID &py_unitid) {
     return get<Qubit>(py_unitid);
   }
   return get<Bit>(py_unitid);
-}
-
-template <typename T>
-std::vector<T> get_unit_registers(Circuit &circ) {
-  static_assert(
-      std::is_same<T, QubitRegister>::value ||
-          std::is_same<T, BitRegister>::value,
-      "T must be either QubitRegister or BitRegister");
-  using T2 = typename std::conditional<
-      std::is_same<T, QubitRegister>::value, Qubit, Bit>::type;
-  std::vector<T2> unitids;
-  if constexpr (std::is_same<T, QubitRegister>::value) {
-    unitids = circ.all_qubits();
-  } else if constexpr (std::is_same<T, BitRegister>::value) {
-    unitids = circ.all_bits();
-  }
-  // map from register name to unsigned indices
-  std::map<std::string, std::set<unsigned>> unit_map;
-  std::vector<T> regs;
-  for (const T2 &unitid : unitids) {
-    // UnitRegisters only describe registers with 1-d indices
-    if (unitid.reg_dim() > 1) continue;
-    auto it = unit_map.find(unitid.reg_name());
-    if (it == unit_map.end()) {
-      unit_map.insert({unitid.reg_name(), {unitid.index()[0]}});
-    } else {
-      it->second.insert(unitid.index()[0]);
-    }
-  }
-  regs.reserve(unit_map.size());
-  for (auto const &it : unit_map) {
-    // only return registers that are indexed consecutively from zero
-    if (*it.second.rbegin() == it.second.size() - 1) {
-      regs.emplace_back(it.first, it.second.size());
-    }
-  }
-  return regs;
 }
 
 void init_circuit_add_op(py::class_<Circuit, std::shared_ptr<Circuit>> &c);

--- a/pytket/binders/circuit/Circuit/main.cpp
+++ b/pytket/binders/circuit/Circuit/main.cpp
@@ -291,10 +291,8 @@ void def_circuit(py::class_<Circuit, std::shared_ptr<Circuit>> &pyCircuit) {
       .def_property_readonly(
           "c_registers", &get_unit_registers<BitRegister>,
           "Get all classical registers.\n\n"
-          "This property is only valid if the bits in the circuit are "
-          "organized into registers (i.e. all bit indices are single numbers "
-          "and all sets of bits with the same string identifier consist of "
-          "bits indexed consecutively from zero).\n\n"
+          "The list only includes registers that are singly-indexed "
+          "contiguously from zero.\n\n"
           ":return: List of :py:class:`BitRegister`")
       .def(
           "get_q_register",
@@ -313,10 +311,8 @@ void def_circuit(py::class_<Circuit, std::shared_ptr<Circuit>> &pyCircuit) {
       .def_property_readonly(
           "q_registers", &get_unit_registers<QubitRegister>,
           "Get all quantum registers.\n\n"
-          "This property is only valid if the qubits in the circuit are "
-          "organized into registers (i.e. all qubit indices are single numbers "
-          "and all sets of qubits with the same string identifier consist of "
-          "qubits indexed consecutively from zero).\n\n"
+          "The list only includes registers that are singly-indexed "
+          "contiguously from zero.\n\n"
           ":return: List of :py:class:`QubitRegister`")
       .def(
           "add_qubit", &Circuit::add_qubit,

--- a/pytket/binders/include/circuit_registers.hpp
+++ b/pytket/binders/include/circuit_registers.hpp
@@ -1,0 +1,59 @@
+// Copyright 2019-2024 Cambridge Quantum Computing
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "UnitRegister.hpp"
+#include "tket/Circuit/Circuit.hpp"
+
+namespace tket {
+
+template <typename T>
+std::vector<T> get_unit_registers(Circuit &circ) {
+  static_assert(
+      std::is_same<T, QubitRegister>::value ||
+          std::is_same<T, BitRegister>::value,
+      "T must be either QubitRegister or BitRegister");
+  using T2 = typename std::conditional<
+      std::is_same<T, QubitRegister>::value, Qubit, Bit>::type;
+  std::vector<T2> unitids;
+  if constexpr (std::is_same<T, QubitRegister>::value) {
+    unitids = circ.all_qubits();
+  } else if constexpr (std::is_same<T, BitRegister>::value) {
+    unitids = circ.all_bits();
+  }
+  // map from register name to unsigned indices
+  std::map<std::string, std::set<unsigned>> unit_map;
+  std::vector<T> regs;
+  for (const T2 &unitid : unitids) {
+    // UnitRegisters only describe registers with 1-d indices
+    if (unitid.reg_dim() > 1) continue;
+    auto it = unit_map.find(unitid.reg_name());
+    if (it == unit_map.end()) {
+      unit_map.insert({unitid.reg_name(), {unitid.index()[0]}});
+    } else {
+      it->second.insert(unitid.index()[0]);
+    }
+  }
+  regs.reserve(unit_map.size());
+  for (auto const &it : unit_map) {
+    // only return registers that are indexed consecutively from zero
+    if (*it.second.rbegin() == it.second.size() - 1) {
+      regs.emplace_back(it.first, it.second.size());
+    }
+  }
+  return regs;
+}
+
+}  // namespace tket

--- a/pytket/conanfile.py
+++ b/pytket/conanfile.py
@@ -32,7 +32,7 @@ class pytketRecipe(ConanFile):
         cmake.install()
 
     def requirements(self):
-        self.requires("tket/1.2.91@tket/stable")
+        self.requires("tket/1.2.92@tket/stable")
         self.requires("tklog/0.3.3@tket/stable")
         self.requires("tkrng/0.3.3@tket/stable")
         self.requires("tkassert/0.3.4@tket/stable")

--- a/pytket/conanfile.py
+++ b/pytket/conanfile.py
@@ -32,7 +32,7 @@ class pytketRecipe(ConanFile):
         cmake.install()
 
     def requirements(self):
-        self.requires("tket/1.2.90@tket/stable")
+        self.requires("tket/1.2.91@tket/stable")
         self.requires("tklog/0.3.3@tket/stable")
         self.requires("tkrng/0.3.3@tket/stable")
         self.requires("tkassert/0.3.4@tket/stable")

--- a/pytket/docs/changelog.rst
+++ b/pytket/docs/changelog.rst
@@ -1,6 +1,17 @@
 Changelog
 =========
 
+Unreleased
+----------
+
+Features:
+
+* Allow ``CircBox`` containing non-default registers.
+* Add new methods ``Circuit.add_circbox_regwise()`` and
+  ``Circuit.add_circbox_with_regmap()`` for adding a ``CircBox`` to a circuit
+  providing either an ordered sequence of registers or a mapping of registers
+  from the box to the containing circuit.
+
 1.25.0 (February 2024)
 ----------------------
 

--- a/pytket/pytket/_tket/circuit.pyi
+++ b/pytket/pytket/_tket/circuit.pyi
@@ -1331,8 +1331,8 @@ class Circuit:
         Append a :py:class:`CircBox` to the circuit, wiring whole registers together.
         
         :param circbox: The box to append
-        :param qregs: Sequence of :py:class:`QubitRegister` from the outer :py:class:`Circuit`, in order of corresponding registers in the :py:class:`CircBox`
-        :param cregs: Sequence of :py:class:`BitRegister` from the outer :py:class:`Circuit`, in order of corresponding registers in the :py:class:`CircBox`
+        :param qregs: Sequence of :py:class:`QubitRegister` from the outer :py:class:`Circuit`, the order corresponding to the lexicographic order of corresponding registers in the :py:class:`CircBox`
+        :param cregs: Sequence of :py:class:`BitRegister` from the outer :py:class:`Circuit`, the order corresponding to the lexicographic order of corresponding registers in the :py:class:`CircBox`
         :return: the new :py:class:`Circuit`
         """
     def add_circbox_with_regmap(self, circbox: CircBox, qregmap: dict[str, str], cregmap: dict[str, str], **kwargs: Any) -> Circuit:

--- a/pytket/pytket/_tket/circuit.pyi
+++ b/pytket/pytket/_tket/circuit.pyi
@@ -1309,14 +1309,18 @@ class Circuit:
         """
         Append a :py:class:`CircBox` to the circuit.
         
+        The qubits and bits of the :py:class:`CircBox` are wired into the circuit in lexicographic order. Bits follow qubits in the order of arguments.
+        
         :param circbox: The box to append
-        :param args: Indices of the qubits/bits to append the box to
+        :param args: Indices of the (default-register) qubits/bits to append the box to
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def add_circbox(self, circbox: CircBox, args: typing.Sequence[pytket._tket.unit_id.UnitID], **kwargs: Any) -> Circuit:
         """
         Append a :py:class:`CircBox` to the circuit.
+        
+        The qubits and bits of the :py:class:`CircBox` are wired into the circuit in lexicographic order. Bits follow qubits in the order of arguments.
         
         :param circbox: The box to append
         :param args: The qubits/bits to append the box to

--- a/pytket/pytket/_tket/circuit.pyi
+++ b/pytket/pytket/_tket/circuit.pyi
@@ -1326,6 +1326,26 @@ class Circuit:
         :param args: The qubits/bits to append the box to
         :return: the new :py:class:`Circuit`
         """
+    def add_circbox_regwise(self, circbox: CircBox, qregs: typing.Sequence[pytket._tket.unit_id.QubitRegister], cregs: typing.Sequence[pytket._tket.unit_id.BitRegister], **kwargs: Any) -> Circuit:
+        """
+        Append a :py:class:`CircBox` to the circuit, wiring whole registers together.
+        
+        :param circbox: The box to append
+        :param qregs: Sequence of :py:class:`QubitRegister` from the outer :py:class:`Circuit`, in order of corresponding registers in the :py:class:`CircBox`
+        :param cregs: Sequence of :py:class:`BitRegister` from the outer :py:class:`Circuit`, in order of corresponding registers in the :py:class:`CircBox`
+        :return: the new :py:class:`Circuit`
+        """
+    def add_circbox_with_regmap(self, circbox: CircBox, qregmap: dict[str, str], cregmap: dict[str, str], **kwargs: Any) -> Circuit:
+        """
+        Append a :py:class:`CircBox` to the circuit, wiring whole registers together.
+        
+        This method expects two maps (one for qubit registers and one for bit registers), which must have keys corresponding to all register names in the box. The box may not contain any qubits or bits that do not belong to a register, i.e. all must be single-indexed contiguously from zero.
+        
+        :param circbox: The box to append
+        :param qregmap: Map specifying which qubit register in the :py:class:`CircBox` (the map's keys) matches which register in the outer circuit (the map's values)
+        :param cregmap: Map specifying which bit register in the :py:class:`CircBox` (the map's keys) matches which register in the outer circuit (the map's values)
+        :return: the new :py:class:`Circuit`
+        """
     @typing.overload
     def add_circuit(self, circuit: Circuit, qubits: typing.Sequence[pytket._tket.unit_id.Qubit], bits: typing.Sequence[pytket._tket.unit_id.Bit] = []) -> Circuit:
         """
@@ -2357,7 +2377,7 @@ class Circuit:
         """
         Get all classical registers.
         
-        This property is only valid if the bits in the circuit are organized into registers (i.e. all bit indices are single numbers and all sets of bits with the same string identifier consist of bits indexed consecutively from zero).
+        The list only includes registers that are singly-indexed contiguously from zero.
         
         :return: List of :py:class:`BitRegister`
         """
@@ -2412,7 +2432,7 @@ class Circuit:
         """
         Get all quantum registers.
         
-        This property is only valid if the qubits in the circuit are organized into registers (i.e. all qubit indices are single numbers and all sets of qubits with the same string identifier consist of qubits indexed consecutively from zero).
+        The list only includes registers that are singly-indexed contiguously from zero.
         
         :return: List of :py:class:`QubitRegister`
         """

--- a/pytket/tests/circuit_test.py
+++ b/pytket/tests/circuit_test.py
@@ -1372,7 +1372,7 @@ def test_resources() -> None:
     assert two_qubit_gate_depth.get_max() == 13
 
 
-def test_add_circbox_regwise() -> None:
+def test_add_circbox_with_registers() -> None:
     c0 = Circuit()
     areg = c0.add_q_register("a", 2)
     breg = c0.add_q_register("b", 3)
@@ -1387,10 +1387,15 @@ def test_add_circbox_regwise() -> None:
     wreg = c.add_q_register("w", 2)
     for qb in c.qubits:
         c.H(qb)
-    c.add_circbox_regwise(cbox, [wreg, zreg], [])
-    assert c.n_gates == 11
-    DecomposeBoxes().apply(c)
-    assert c.n_gates == 13
+    c1 = c.copy()
+    c1.add_circbox_regwise(cbox, [wreg, zreg], [])
+    assert c1.n_gates == 11
+    DecomposeBoxes().apply(c1)
+    assert c1.n_gates == 13
+    c2 = c.copy()
+    c2.add_circbox_with_regmap(cbox, {"a": "w", "b": "z"}, {})
+    DecomposeBoxes().apply(c2)
+    assert c1 == c2
 
 
 if __name__ == "__main__":

--- a/pytket/tests/circuit_test.py
+++ b/pytket/tests/circuit_test.py
@@ -1372,6 +1372,27 @@ def test_resources() -> None:
     assert two_qubit_gate_depth.get_max() == 13
 
 
+def test_add_circbox_regwise() -> None:
+    c0 = Circuit()
+    areg = c0.add_q_register("a", 2)
+    breg = c0.add_q_register("b", 3)
+    c0.CZ(areg[0], areg[1])
+    c0.CZ(areg[1], breg[0])
+    c0.CCX(breg[0], breg[1], breg[2])
+    cbox = CircBox(c0)
+    c = Circuit()
+    xreg = c.add_q_register("x", 3)
+    yreg = c.add_q_register("y", 2)
+    zreg = c.add_q_register("z", 3)
+    wreg = c.add_q_register("w", 2)
+    for qb in c.qubits:
+        c.H(qb)
+    c.add_circbox_regwise(cbox, [wreg, zreg], [])
+    assert c.n_gates == 11
+    DecomposeBoxes().apply(c)
+    assert c.n_gates == 13
+
+
 if __name__ == "__main__":
     test_circuit_gen()
     test_symbolic_ops()

--- a/pytket/tests/circuit_test.py
+++ b/pytket/tests/circuit_test.py
@@ -1398,6 +1398,47 @@ def test_add_circbox_with_registers() -> None:
     assert c1 == c2
 
 
+def test_add_circbox_with_mixed_registers() -> None:
+    c0 = Circuit()
+    c0_qreg1 = c0.add_q_register("q1", 2)
+    c0_qreg2 = c0.add_q_register("q2", 3)
+    c0_creg1 = c0.add_c_register("c1", 4)
+    c0_creg2 = c0.add_c_register("c2", 5)
+    cbox = CircBox(c0)
+    c = Circuit()
+    c_qreg1 = c.add_q_register("q1", 2)
+    c_qreg2 = c.add_q_register("q2", 3)
+    c_creg1 = c.add_c_register("c1", 4)
+    c_creg2 = c.add_c_register("c2", 5)
+
+    c.add_circbox_with_regmap(
+        cbox, qregmap={"q1": "q1", "q2": "q2"}, cregmap={"c1": "c1", "c2": "c2"}
+    )
+
+    # Incomplete map:
+    with pytest.raises(IndexError):
+        c.add_circbox_with_regmap(
+            cbox, qregmap={"q1": "q1", "q2": "q2"}, cregmap={"c1": "c1"}
+        )
+
+    # Mismatched register sizes:
+    with pytest.raises(RuntimeError):
+        c.add_circbox_with_regmap(
+            cbox, qregmap={"q1": "q2", "q2": "q1"}, cregmap={"c1": "c2", "c2": "c1"}
+        )
+
+    # Non-register qubit in box:
+    c0.add_qubit(Qubit("q3", 1))
+    cbox = CircBox(c0)
+    c.add_qubit(Qubit("q3", 0))
+    with pytest.raises(RuntimeError):
+        c.add_circbox_with_regmap(
+            cbox,
+            qregmap={"q1": "q1", "q2": "q2", "q3": "q3"},
+            cregmap={"c1": "c1", "c2": "c2"},
+        )
+
+
 if __name__ == "__main__":
     test_circuit_gen()
     test_symbolic_ops()

--- a/tket/conanfile.py
+++ b/tket/conanfile.py
@@ -23,7 +23,7 @@ from conan.errors import ConanInvalidConfiguration
 
 class TketConan(ConanFile):
     name = "tket"
-    version = "1.2.90"
+    version = "1.2.91"
     package_type = "library"
     license = "Apache 2"
     homepage = "https://github.com/CQCL/tket"

--- a/tket/conanfile.py
+++ b/tket/conanfile.py
@@ -23,7 +23,7 @@ from conan.errors import ConanInvalidConfiguration
 
 class TketConan(ConanFile):
     name = "tket"
-    version = "1.2.91"
+    version = "1.2.92"
     package_type = "library"
     license = "Apache 2"
     homepage = "https://github.com/CQCL/tket"

--- a/tket/include/tket/Circuit/Boxes.hpp
+++ b/tket/include/tket/Circuit/Boxes.hpp
@@ -134,7 +134,7 @@ Op_ptr set_box_id(BoxT &b, boost::uuids::uuid newid) {
 class CircBox : public Box {
  public:
   /**
-   * Construct from a given circuit. The circuit must be simple.
+   * Construct from a given circuit.
    */
   explicit CircBox(const Circuit &circ);
 

--- a/tket/src/Circuit/Boxes.cpp
+++ b/tket/src/Circuit/Boxes.cpp
@@ -69,7 +69,6 @@ Op_ptr Box::deserialize(const nlohmann::json &j) {
 }
 
 CircBox::CircBox(const Circuit &circ) : Box(OpType::CircBox) {
-  if (!circ.is_simple()) throw SimpleOnly();
   signature_ = op_signature_t(circ.n_qubits(), EdgeType::Quantum);
   op_signature_t bits(circ.n_bits(), EdgeType::Classical);
   signature_.insert(signature_.end(), bits.begin(), bits.end());

--- a/tket/src/Circuit/macro_manipulation.cpp
+++ b/tket/src/Circuit/macro_manipulation.cpp
@@ -699,6 +699,7 @@ bool Circuit::substitute_box_vertex(
   if (op->get_type() == OpType::ClassicalExpBox) return false;
   const Box& b = static_cast<const Box&>(*op);
   Circuit replacement = *b.to_circuit();
+  replacement.flatten_registers();
   if (conditional) {
     substitute_conditional(
         replacement, vert, vertex_deletion, OpGroupTransfer::Merge);

--- a/tket/test/src/Circuit/test_Boxes.cpp
+++ b/tket/test/src/Circuit/test_Boxes.cpp
@@ -41,21 +41,6 @@ using Catch::Matchers::StartsWith;
 namespace tket {
 namespace test_Boxes {
 
-SCENARIO("CircBox requires simple circuits", "[boxes]") {
-  Circuit circ(2);
-  circ.add_op<unsigned>(OpType::Y, {0});
-  circ.add_op<unsigned>(OpType::CX, {0, 1});
-  REQUIRE(circ.is_simple());
-  Qubit qb0(0);
-  Qubit qb1(1);
-  Qubit a0("a", 0);
-  Qubit a1("a", 1);
-  unit_map_t qubit_map = {{qb0, a0}, {qb1, a1}};
-  circ.rename_units(qubit_map);
-  REQUIRE(!circ.is_simple());
-  REQUIRE_THROWS_AS(CircBox(circ), SimpleOnly);
-}
-
 SCENARIO("CircBox in-place symbol substitution") {
   Sym asym = SymEngine::symbol("a");
   Expr alpha(asym);
@@ -134,6 +119,20 @@ SCENARIO("Using Boxes", "[boxes]") {
     Eigen::MatrixXcd uc0 = tket_sim::get_unitary(c0);
     Eigen::MatrixXcd uc0a = tket_sim::get_unitary(c0a);
     REQUIRE((uc0 - uc0a).cwiseAbs().sum() < ERR_EPS);
+  }
+  GIVEN("CircBox with non-default units") {
+    Circuit c0;
+    c0.add_q_register("a", 2);
+    c0.add_q_register("b", 1);
+    c0.add_op<Qubit>(
+        OpType::CCX, {Qubit("a", 1), Qubit("a", 0), Qubit("b", 0)});
+    CircBox cbox(c0);
+    Circuit c(3);
+    c.add_box(cbox, {0, 2, 1});
+    REQUIRE(!test_unitary_comparison(c0, c));
+    Circuit c1(3);
+    c1.add_box(cbox, {0, 1, 2});
+    REQUIRE(test_unitary_comparison(c0, c1));
   }
   GIVEN("Unitary1qBox manipulation") {
     // random 1qb gate

--- a/tket/test/src/Circuit/test_Circ.cpp
+++ b/tket/test/src/Circuit/test_Circ.cpp
@@ -869,7 +869,6 @@ SCENARIO(
       REQUIRE(test2.get_slices().size() == depth_before);
       test2.assert_valid();
     }
-    // test2.print_graph();
     WHEN("The reverse substitution is performed") {
       Edge f1 = test.get_nth_in_edge(h1, 0);
       Edge f2 = test.get_nth_in_edge(h2, 0);
@@ -879,6 +878,19 @@ SCENARIO(
       test.substitute(test2, sub, Circuit::VertexDeletion::Yes);
       REQUIRE(test.get_slices().size() == depth_before);
       test.assert_valid();
+    }
+    WHEN("The circuit to insert is not simple") {
+      unit_map_t qmap;
+      Edge e1 = test2.get_nth_in_edge(x1, 0);
+      Edge e2 = test2.get_nth_in_edge(x2, 0);
+      Edge e3 = test2.get_nth_out_edge(x1, 0);
+      Edge e4 = test2.get_nth_out_edge(x2, 0);
+      Subcircuit sub = {{e1, e2}, {e3, e4}, {x1, x2}};
+      test2.substitute(test, sub);
+      qmap.insert({Qubit(0), Qubit("a", 1)});
+      qmap.insert({Qubit(1), Qubit("b", 0)});
+      test.rename_units(qmap);
+      REQUIRE_THROWS_AS(test2.substitute(test, sub), SimpleOnly);
     }
   }
   GIVEN("Circuits with Classical effects") {


### PR DESCRIPTION
# Description

Drop the restriction that a `CircBox` must have default registers. Add a couple of methods for adding a `CircBox` by matching up registers instead of individual qubits.

# Related issues

Closes #1057 .
Closes #1059 .

# Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented hard-to-understand parts of my code.
- [x] I have made corresponding changes to the public API documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have updated the changelog with any user-facing changes.
