### PR TITLE
Add `PauliExpCommutingSetBox` to API docs

### DIFF
--- a/pytket/docs/circuit.rst
+++ b/pytket/docs/circuit.rst
@@ -43,6 +43,9 @@ pytket.circuit
 .. autoclass:: pytket.circuit.PauliExpPairBox
     :special-members:
     :members:
+.. autoclass:: pytket.circuit.PauliExpCommutingSetBox
+    :special-members:
+    :members:
 .. autoclass:: pytket.circuit.ToffoliBox
     :special-members:
     :members:


### PR DESCRIPTION
# Description

Adding the `PauliExpCommutingSetBox` to the `pytket.circuit` docs. This was added in [pytket 1.17](https://tket.quantinuum.com/api-docs/changelog.html#id9) but was left out of the API docs.

Hopefully we can catch these sorts  API docs omissions using the [sphinx.ext.coverage extension](https://www.sphinx-doc.org/en/master/usage/extensions/coverage.html).

# Related issues

closes #1261 

# Checklist

- [x] I have performed a self-review of my code.
- [ ] I have commented hard-to-understand parts of my code.
- [x] I have made corresponding changes to the public API documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the changelog with any user-facing changes.
