### PR TITLE
Cherry-pick doc fixes onto `docmain`

### DIFF
--- a/pytket/conanfile.py
+++ b/pytket/conanfile.py
@@ -32,7 +32,7 @@ class pytketRecipe(ConanFile):
         cmake.install()
 
     def requirements(self):
-        self.requires("tket/1.2.90@tket/stable")
+        self.requires("tket/1.2.91@tket/stable")
         self.requires("tklog/0.3.3@tket/stable")
         self.requires("tkrng/0.3.3@tket/stable")
         self.requires("tkassert/0.3.4@tket/stable")

--- a/pytket/docs/circuit.rst
+++ b/pytket/docs/circuit.rst
@@ -41,6 +41,9 @@ pytket.circuit
 .. autoclass:: pytket.circuit.PauliExpPairBox
     :special-members:
     :members:
+.. autoclass:: pytket.circuit.PauliExpCommutingSetBox
+    :special-members:
+    :members:
 .. autoclass:: pytket.circuit.ToffoliBox
     :special-members:
     :members:

--- a/pytket/docs/extensions.rst
+++ b/pytket/docs/extensions.rst
@@ -2,9 +2,9 @@ pytket extensions
 =================
 
 The pytket extensions are separate python modules which allow pytket to interface with backends from a range of providers including quantum devices from Quantinuum and IBM.
-In pytket a ``Backend`` represents a connection to a QPU (Quantum Processing Unit) or simulator for processing quantum circuits. One can also access additional quantum devices and simulators via the cloud through the extensions for `Azure <https://cqcl.github.io/pytket-qsharp/api/api.html#pytket.extensions.qsharp.AzureBackend>`_ and `Braket <https://tket.quantinuum.com/extensions/pytket-braket/api/api.html#pytket.extensions.braket.BraketBackend>`_ . 
+In pytket a ``Backend`` represents a connection to a QPU (Quantum Processing Unit) or simulator for processing quantum circuits. One can also access additional quantum devices and simulators via the cloud through the extensions for `Azure <https://cqcl.github.io/pytket-qsharp/api/api.html#pytket.extensions.qsharp.AzureBackend>`_ and `Braket <https://tket.quantinuum.com/extensions/pytket-braket/api.html#pytket.extensions.braket.BraketBackend>`_ . 
 
-Additionally, the extensions allow pytket to cross-compile circuits from different quantum computing libraries with the extensions for `qiskit <https://tket.quantinuum.com/extensions/pytket-qiskit/api/index.html>`_, `cirq <https://tket.quantinuum.com/extensions/pytket-cirq/api/index.html>`_ and `pennylane <https://tket.quantinuum.com/extensions/pytket-pennylane/api/index.html>`_ . This enables pytket's compilation features to be used in conjunction with other software tools.
+Additionally, the extensions allow pytket to cross-compile circuits from different quantum computing libraries with the extensions for `qiskit <https://tket.quantinuum.com/extensions/pytket-qiskit/index.html>`_, `cirq <https://tket.quantinuum.com/extensions/pytket-cirq/index.html>`_ and `pennylane <https://tket.quantinuum.com/extensions/pytket-pennylane/index.html>`_ . This enables pytket's compilation features to be used in conjunction with other software tools.
 
 The additional modules can be installed adding the extension name to the installation command for pytket. For example pytket-quantinuum can be installed by running
 
@@ -149,12 +149,12 @@ Other
    pytket-stim <https://tket.quantinuum.com/extensions/pytket-stim>
 
 
-.. _pytket: https://tket.quantinuum.com/tket/pytket/api/
+.. _pytket: https://tket.quantinuum.com/api-docs
 .. _Quantinuum: https://quantinuum.com
-.. _IBMQEmulatorBackend:  https://tket.quantinuum.com/extensions/pytket-qiskit/api/api.html#pytket.extensions.qiskit.IBMQEmulatorBackend
+.. _IBMQEmulatorBackend:  https://tket.quantinuum.com/extensions/pytket-qiskit/api.html#pytket.extensions.qiskit.IBMQEmulatorBackend
 .. _AerStateBackend: https://tket.quantinuum.com/extensions/pytket-qiskit/api.html#pytket.extensions.qiskit.AerStateBackend
-.. _ForestStateBackend: https://tket.quantinuum.com/extensions/pytket-pyquil/api/api.html#pytket.extensions.pyquil.ForestStateBackend
-.. _AerUnitaryBackend: https://tket.quantinuum.com/extensions/pytket-qiskit/api/api.html#pytket.extensions.qiskit.AerUnitaryBackend
-.. _CirqDensityMatrixSampleBackend: https://tket.quantinuum.com/extensions/pytket-cirq/api/api.html#pytket.extensions.cirq.CirqDensityMatrixSampleBackend
-.. _SimplexBackend: https://tket.quantinuum.com/extensions/pytket-simplex/api.html#pytket.extensions.pysimplex.SimplexBackend
+.. _ForestStateBackend: https://tket.quantinuum.com/extensions/pytket-pyquil/api.html#pytket.extensions.pyquil.ForestStateBackend
+.. _AerUnitaryBackend: https://tket.quantinuum.com/extensions/pytket-qiskit/api.html#pytket.extensions.qiskit.AerUnitaryBackend
+.. _CirqDensityMatrixSampleBackend: https://tket.quantinuum.com/extensions/pytket-cirq/api.html#pytket.extensions.cirq.CirqDensityMatrixSampleBackend
+.. _SimplexBackend: https://tket.quantinuum.com/extensions/pytket-pysimplex/api.html#pytket.extensions.pysimplex.SimplexBackend
 .. _QulacsBackend: https://tket.quantinuum.com/extensions/pytket-qulacs/api.html#pytket.extensions.qulacs.QulacsBackend

--- a/pytket/docs/faqs.rst
+++ b/pytket/docs/faqs.rst
@@ -1,6 +1,6 @@
 TKET FAQs
 ~~~~~~~~~
-These are frequently asked questions that relate to the use of pytket. For installation FAQs see the `installation troubleshooting <https://cqcl.github.io/tket/pytket/api/install.html>`_ page. 
+These are frequently asked questions that relate to the use of pytket. For installation FAQs see the `installation troubleshooting <https://tket.quantinuum.com/api-docs/install.html>`_ page. 
 
 Rebases
 -------
@@ -30,7 +30,7 @@ Qiskit to TKET Conversion
 
 Q: How can I convert my qiskit :py:class:`QuantumCircuit` to a pytket :py:class:`Circuit`?
 
-A: This can be achieved using the :py:meth:`qiskit_to_tk` function from the `pytket-qiskit extension <https://cqcl.github.io/pytket-qiskit/api/index.html>`_
+A: This can be achieved using the :py:meth:`qiskit_to_tk` function from the `pytket-qiskit extension <https://tket.quantinuum.com/extensions/pytket-qiskit/>`_
 
 ::
 

--- a/pytket/docs/getting_started.rst
+++ b/pytket/docs/getting_started.rst
@@ -93,7 +93,7 @@ This prints out a summary of readouts (the final values of the classical bits) a
 
 Each pytket :py:class:`Backend` comes with its own default compilation method. This is a recommended sequence of optimisation passes to meet the requirements of the specific :py:class:`Backend`. 
 
-The following code snippet will show how to compile a circuit to run on an IBM device. This requires setting up IBM credentials (see the `credentials guide <https://cqcl.github.io/pytket-qiskit/api/index.html#access-and-credentials>`_).
+The following code snippet will show how to compile a circuit to run on an IBM device. This requires setting up IBM credentials (see the `credentials guide <https://tket.quantinuum.com/extensions/pytket-qiskit/#access-and-credentials>`_).
 
 ::
 
@@ -106,7 +106,7 @@ The following code snippet will show how to compile a circuit to run on an IBM d
     compiled_circ = nairobi_device.get_compiled_circuit(circ)
     result = backend.run_circuit(compiled_circ, n_shots=100)
 
-Here the default compilation pass is applied by :py:meth:`IBMQBackend.get_compiled_circuit`. See `this page <https://cqcl.github.io/pytket-qiskit/api/index.html#default-compilation>`_ for more details.
+Here the default compilation pass is applied by :py:meth:`IBMQBackend.get_compiled_circuit`. See `this page <https://tket.quantinuum.com/extensions/pytket-qiskit/#default-compilation>`_ for more details.
 
 As an alternative, We can experiment with constructing our own circuit compilation routines in pytket. Passes from the :py:mod:`pytket.passes` module can be applied individually or composed in sequence. 
 See the section of the user manual on `circuit compilation <https://tket.quantinuum.com/user-manual/manual_compiler.html>`_ and the corresponding `notebook example <https://github.com/CQCL/pytket/blob/main/examples/compilation_example.ipynb>`_ for more.

--- a/pytket/docs/index.rst
+++ b/pytket/docs/index.rst
@@ -14,7 +14,7 @@ Windows. To install, run
 
 
 
-If you have issues installing ``pytket`` please visit the `installation troubleshooting <https://cqcl.github.io/tket/pytket/api/install.html>`_ page.
+If you have issues installing ``pytket`` please visit the `installation troubleshooting <https://tket.quantinuum.com/api-docs/install.html>`_ page.
 
 To use ``pytket``, you can simply import the appropriate modules into your python code or in an interactive Python notebook. We can build circuits directly using the ``pytket`` interface by creating a blank circuit and adding gates in the order we want to apply them.
 

--- a/pytket/docs/passes.rst
+++ b/pytket/docs/passes.rst
@@ -1,13 +1,13 @@
 pytket.passes
 ==================================
 
-In pytket, compilation passes perform in-place transformations of circuits. From a user's point of view, passes are similar to `transforms <https://cqcl.github.io/tket/pytket/api/transform.html#>`_; however passes allow for additional predicate checking and compositionality. 
+In pytket, compilation passes perform in-place transformations of circuits. From a user's point of view, passes are similar to `transforms <https://tket.quantinuum.com/api-docs/transform.html>`_; however passes allow for additional predicate checking and compositionality. 
 
-There are passes such as `FullPeepholeOptimise <https://cqcl.github.io/tket/pytket/api/passes.html#pytket.passes.FullPeepholeOptimise>`_ and  `KAKDecomposition <https://cqcl.github.io/tket/pytket/api/passes.html#pytket.passes.KAKDecomposition>`_ which are designed for general purpose circuit optimisation.
+There are passes such as `FullPeepholeOptimise <https://tket.quantinuum.com/api-docs/passes.html#pytket.passes.FullPeepholeOptimise>`_ and  `KAKDecomposition <https://tket.quantinuum.com/api-docs/passes.html#pytket.passes.KAKDecomposition>`_ which are designed for general purpose circuit optimisation.
 
-Also there are special purpose passes such as `OptimisePhaseGadgets <https://cqcl.github.io/tket/pytket/api/passes.html#pytket.passes.OptimisePhaseGadgets>`_ and `PauliSimp <https://cqcl.github.io/tket/pytket/api/passes.html#pytket.passes.PauliSimp>`_ which perform optimisation by targeting phase gadget and Pauli gadget structures within circuits. For more on these optimisation techniques see the `corresponding publication <https://arxiv.org/abs/1906.01734>`_.
+Also there are special purpose passes such as `OptimisePhaseGadgets <https://tket.quantinuum.com/api-docs/passes.html#pytket.passes.OptimisePhaseGadgets>`_ and `PauliSimp <https://tket.quantinuum.com/api-docs/passes.html#pytket.passes.PauliSimp>`_ which perform optimisation by targeting phase gadget and Pauli gadget structures within circuits. For more on these optimisation techniques see the `corresponding publication <https://arxiv.org/abs/1906.01734>`_.
 
-Rebase passes can be used to convert a circuit to a desired gateset. See `RebaseCustom <https://cqcl.github.io/tket/pytket/api/passes.html#pytket.passes.RebaseCustom>`_ and `auto_rebase_pass <https://cqcl.github.io/tket/pytket/api/passes.html#module-pytket.passes.auto_rebase>`_.
+Rebase passes can be used to convert a circuit to a desired gateset. See `RebaseCustom <https://tket.quantinuum.com/api-docs/passes.html#pytket.passes.RebaseCustom>`_ and `auto_rebase_pass <https://tket.quantinuum.com/api-docs/passes.html#pytket.passes.auto_rebase.auto_rebase_pass>`_.
 
 For more on pytket passes see the `compilation <https://tket.quantinuum.com/user-manual/manual_compiler.html>`_ section of the user manual or the `notebook tutorials <https://tket.quantinuum.com/examples>`_
 

--- a/pytket/package.md
+++ b/pytket/package.md
@@ -10,7 +10,7 @@ To install run the pip command:
 
 `` pip install pytket``
 
-See [Installation troubleshooting](https://cqcl.github.io/tket/pytket/api/install.html) for help with installation.
+See [Installation troubleshooting](https://tket.quantinuum.com/api-docs/install.html) for help with installation.
 
 To install the pytket extension modules add a hyphen and the extension name to the command:
 
@@ -25,7 +25,7 @@ official Python distribution instead.
 
 ## Documentation and Examples
 
-API reference: https://cqcl.github.io/tket/pytket/api/
+API reference: https://tket.quantinuum.com/api-docs/
 
 To get started using pytket see the [user manual](https://tket.quantinuum.com/user-manual/).
 

--- a/pytket/setup.py
+++ b/pytket/setup.py
@@ -180,7 +180,7 @@ setup(
     author_email="tket-support@cambridgequantum.com",
     python_requires=">=3.10",
     project_urls={
-        "Documentation": "https://cqcl.github.io/tket/pytket/api/index.html",
+        "Documentation": "https://tket.quantinuum.com/api-docs/index.html",
         "Source": "https://github.com/CQCL/tket",
         "Tracker": "https://github.com/CQCL/tket/issues",
     },

--- a/tket/conanfile.py
+++ b/tket/conanfile.py
@@ -23,7 +23,7 @@ from conan.errors import ConanInvalidConfiguration
 
 class TketConan(ConanFile):
     name = "tket"
-    version = "1.2.90"
+    version = "1.2.91"
     package_type = "library"
     license = "Apache 2"
     homepage = "https://github.com/CQCL/tket"

--- a/tket/include/tket/Gate/GateUnitaryMatrixImplementations.hpp
+++ b/tket/include/tket/Gate/GateUnitaryMatrixImplementations.hpp
@@ -34,7 +34,7 @@ struct GateUnitaryMatrixImplementations {
   // so dense->sparse routines would be needed).
 
   // Roughly follows the order in
-  // https://cqcl.github.io/tket/pytket/api/optype.html
+  // https://tket.quantinuum.com/api-docs/optype.html
 
   // Note: the below functions do not check double parameter values,
   // the caller must do that.


### PR DESCRIPTION
# Description

Cherry-picking the fixes from #1258 and #1261 onto `docmain` so we don't have to wait for the next release for the fixes to be in the API docs.


# Checklist

- [x] I have performed a self-review of my code.
- [ ] I have commented hard-to-understand parts of my code.
- [ ] I have made corresponding changes to the public API documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the changelog with any user-facing changes.
