### PR TITLE
Subcircuit finding and Clifford resynthesis

### DIFF
--- a/pytket/binders/passes.cpp
+++ b/pytket/binders/passes.cpp
@@ -14,6 +14,7 @@
 
 #include <pybind11/functional.h>
 
+#include <optional>
 #include <tklog/TketLog.hpp>
 
 #include "binder_json.hpp"
@@ -829,7 +830,7 @@ PYBIND11_MODULE(passes, m) {
       "(only relevant to the default resynthesis method used when the "
       "`transform` argument is not provided)"
       "\n:return: a pass to perform the rewriting",
-      py::arg("transform") = nullptr, py::arg("allow_swaps") = true);
+      py::arg("transform") = std::nullopt, py::arg("allow_swaps") = true);
 
   m.def(
       "DecomposeSwapsToCXs", &gen_decompose_routing_gates_to_cxs_pass,

--- a/pytket/binders/passes.cpp
+++ b/pytket/binders/passes.cpp
@@ -821,9 +821,15 @@ PYBIND11_MODULE(passes, m) {
       "CliffordResynthesis", &gen_clifford_resynthesis_pass,
       "An optimisation pass that resynhesises all Clifford subcircuits and "
       "then applies some rewrite rules to simplify them further."
-      "\n\n:param allow_swaps: whether the rewriting may introduce wire swaps"
+      "\n\n:param transform: optional user-provided resynthesis method to "
+      "apply to all Clifford subcircuits (a function taking a Clifford "
+      "circuit as an argument and returning an equivalent circuit); if not "
+      "provided, a default resynthesis method is applied"
+      "\n:param allow_swaps: whether the rewriting may introduce wire swaps "
+      "(only relevant to the default resynthesis method used when the "
+      "`transform` argument is not provided)"
       "\n:return: a pass to perform the rewriting",
-      py::arg("allow_swaps") = true);
+      py::arg("transform") = nullptr, py::arg("allow_swaps") = true);
 
   m.def(
       "DecomposeSwapsToCXs", &gen_decompose_routing_gates_to_cxs_pass,

--- a/pytket/binders/passes.cpp
+++ b/pytket/binders/passes.cpp
@@ -818,6 +818,14 @@ PYBIND11_MODULE(passes, m) {
       py::arg("allow_swaps") = true);
 
   m.def(
+      "CliffordResynthesis", &gen_clifford_resynthesis_pass,
+      "An optimisation pass that resynhesises all Clifford subcircuits and "
+      "then applies some rewrite rules to simplify them further."
+      "\n\n:param allow_swaps: whether the rewriting may introduce wire swaps"
+      "\n:return: a pass to perform the rewriting",
+      py::arg("allow_swaps") = true);
+
+  m.def(
       "DecomposeSwapsToCXs", &gen_decompose_routing_gates_to_cxs_pass,
       "Construct a pass to decompose SWAP and BRIDGE gates to CX gates, "
       "constraining connectivity to an :py:class:`Architecture`, optionally "

--- a/pytket/conanfile.py
+++ b/pytket/conanfile.py
@@ -32,7 +32,7 @@ class pytketRecipe(ConanFile):
         cmake.install()
 
     def requirements(self):
-        self.requires("tket/1.2.93@tket/stable")
+        self.requires("tket/1.2.94@tket/stable")
         self.requires("tklog/0.3.3@tket/stable")
         self.requires("tkrng/0.3.3@tket/stable")
         self.requires("tkassert/0.3.4@tket/stable")

--- a/pytket/conanfile.py
+++ b/pytket/conanfile.py
@@ -32,7 +32,7 @@ class pytketRecipe(ConanFile):
         cmake.install()
 
     def requirements(self):
-        self.requires("tket/1.2.94@tket/stable")
+        self.requires("tket/1.2.95@tket/stable")
         self.requires("tklog/0.3.3@tket/stable")
         self.requires("tkrng/0.3.3@tket/stable")
         self.requires("tkassert/0.3.4@tket/stable")

--- a/pytket/conanfile.py
+++ b/pytket/conanfile.py
@@ -32,7 +32,7 @@ class pytketRecipe(ConanFile):
         cmake.install()
 
     def requirements(self):
-        self.requires("tket/1.2.92@tket/stable")
+        self.requires("tket/1.2.93@tket/stable")
         self.requires("tklog/0.3.3@tket/stable")
         self.requires("tkrng/0.3.3@tket/stable")
         self.requires("tkassert/0.3.4@tket/stable")

--- a/pytket/docs/changelog.rst
+++ b/pytket/docs/changelog.rst
@@ -11,6 +11,8 @@ Features:
   ``Circuit.add_circbox_with_regmap()`` for adding a ``CircBox`` to a circuit
   providing either an ordered sequence of registers or a mapping of registers
   from the box to the containing circuit.
+* Add ``CliffordResynthesis`` pass to apply Clifford resynthesis (optionally
+  with a user-defined resynthesis method) on all Clifford subcircuits.
 
 1.25.0 (February 2024)
 ----------------------

--- a/pytket/pytket/_tket/passes.pyi
+++ b/pytket/pytket/_tket/passes.pyi
@@ -224,7 +224,7 @@ def CXMappingPass(arc: pytket._tket.architecture.Architecture, placer: pytket._t
     :param \**kwargs: Parameters for routing: (bool)directed_cx=false, (bool)delay_measures=true
     :return: a pass to perform the remapping
     """
-def CliffordResynthesis(transform: typing.Callable[[pytket._tket.circuit.Circuit], pytket._tket.circuit.Circuit] = None, allow_swaps: bool = True) -> BasePass:
+def CliffordResynthesis(transform: typing.Callable[[pytket._tket.circuit.Circuit], pytket._tket.circuit.Circuit] | None = None, allow_swaps: bool = True) -> BasePass:
     """
     An optimisation pass that resynhesises all Clifford subcircuits and then applies some rewrite rules to simplify them further.
     

--- a/pytket/pytket/_tket/passes.pyi
+++ b/pytket/pytket/_tket/passes.pyi
@@ -9,7 +9,7 @@ import pytket._tket.transform
 import pytket._tket.unit_id
 import sympy
 import typing
-__all__ = ['AASRouting', 'Audit', 'BasePass', 'CNotSynthType', 'CXMappingPass', 'CliffordSimp', 'CnXPairwiseDecomposition', 'CommuteThroughMultis', 'ComposePhasePolyBoxes', 'ContextSimp', 'CustomPass', 'CustomRoutingPass', 'DecomposeArbitrarilyControlledGates', 'DecomposeBoxes', 'DecomposeClassicalExp', 'DecomposeMultiQubitsCX', 'DecomposeSingleQubitsTK1', 'DecomposeSwapsToCXs', 'DecomposeSwapsToCircuit', 'DecomposeTK2', 'Default', 'DefaultMappingPass', 'DelayMeasures', 'EulerAngleReduction', 'FlattenRegisters', 'FlattenRelabelRegistersPass', 'FullMappingPass', 'FullPeepholeOptimise', 'GlobalisePhasedX', 'GuidedPauliSimp', 'HamPath', 'KAKDecomposition', 'NaivePlacementPass', 'NormaliseTK2', 'OptimisePhaseGadgets', 'PauliExponentials', 'PauliSimp', 'PauliSquash', 'PeepholeOptimise2Q', 'PlacementPass', 'RebaseCustom', 'RebaseTket', 'Rec', 'RemoveBarriers', 'RemoveDiscarded', 'RemoveImplicitQubitPermutation', 'RemoveRedundancies', 'RenameQubitsPass', 'RepeatPass', 'RepeatUntilSatisfiedPass', 'RepeatWithMetricPass', 'RoundAngles', 'RoutingPass', 'SWAP', 'SafetyMode', 'SequencePass', 'SimplifyInitial', 'SimplifyMeasured', 'SquashCustom', 'SquashRzPhasedX', 'SquashTK1', 'SynthesiseHQS', 'SynthesiseOQC', 'SynthesiseTK', 'SynthesiseTket', 'SynthesiseUMD', 'ThreeQubitSquash', 'ZXGraphlikeOptimisation', 'ZZPhaseToRz']
+__all__ = ['AASRouting', 'Audit', 'BasePass', 'CNotSynthType', 'CXMappingPass', 'CliffordResynthesis', 'CliffordSimp', 'CnXPairwiseDecomposition', 'CommuteThroughMultis', 'ComposePhasePolyBoxes', 'ContextSimp', 'CustomPass', 'CustomRoutingPass', 'DecomposeArbitrarilyControlledGates', 'DecomposeBoxes', 'DecomposeClassicalExp', 'DecomposeMultiQubitsCX', 'DecomposeSingleQubitsTK1', 'DecomposeSwapsToCXs', 'DecomposeSwapsToCircuit', 'DecomposeTK2', 'Default', 'DefaultMappingPass', 'DelayMeasures', 'EulerAngleReduction', 'FlattenRegisters', 'FlattenRelabelRegistersPass', 'FullMappingPass', 'FullPeepholeOptimise', 'GlobalisePhasedX', 'GuidedPauliSimp', 'HamPath', 'KAKDecomposition', 'NaivePlacementPass', 'NormaliseTK2', 'OptimisePhaseGadgets', 'PauliExponentials', 'PauliSimp', 'PauliSquash', 'PeepholeOptimise2Q', 'PlacementPass', 'RebaseCustom', 'RebaseTket', 'Rec', 'RemoveBarriers', 'RemoveDiscarded', 'RemoveImplicitQubitPermutation', 'RemoveRedundancies', 'RenameQubitsPass', 'RepeatPass', 'RepeatUntilSatisfiedPass', 'RepeatWithMetricPass', 'RoundAngles', 'RoutingPass', 'SWAP', 'SafetyMode', 'SequencePass', 'SimplifyInitial', 'SimplifyMeasured', 'SquashCustom', 'SquashRzPhasedX', 'SquashTK1', 'SynthesiseHQS', 'SynthesiseOQC', 'SynthesiseTK', 'SynthesiseTket', 'SynthesiseUMD', 'ThreeQubitSquash', 'ZXGraphlikeOptimisation', 'ZZPhaseToRz']
 class BasePass:
     """
     Base class for passes.
@@ -223,6 +223,14 @@ def CXMappingPass(arc: pytket._tket.architecture.Architecture, placer: pytket._t
     :param placer: The placement used for relabelling.
     :param \**kwargs: Parameters for routing: (bool)directed_cx=false, (bool)delay_measures=true
     :return: a pass to perform the remapping
+    """
+def CliffordResynthesis(transform: typing.Callable[[pytket._tket.circuit.Circuit], pytket._tket.circuit.Circuit] = None, allow_swaps: bool = True) -> BasePass:
+    """
+    An optimisation pass that resynhesises all Clifford subcircuits and then applies some rewrite rules to simplify them further.
+    
+    :param transform: optional user-provided resynthesis method to apply to all Clifford subcircuits (a function taking a Clifford circuit as an argument and returning an equivalent circuit); if not provided, a default resynthesis method is applied
+    :param allow_swaps: whether the rewriting may introduce wire swaps (only relevant to the default resynthesis method used when the `transform` argument is not provided)
+    :return: a pass to perform the rewriting
     """
 def CliffordSimp(allow_swaps: bool = True) -> BasePass:
     """

--- a/pytket/tests/predicates_test.py
+++ b/pytket/tests/predicates_test.py
@@ -1016,7 +1016,7 @@ def test_clifford_resynthesis() -> None:
 
 
 def test_clifford_resynthesis_implicit_swaps() -> None:
-    def T(c):
+    def T(c: Circuit) -> Circuit:
         c1 = c.copy()
         CliffordSimp().apply(c1)
         return c1

--- a/pytket/tests/predicates_test.py
+++ b/pytket/tests/predicates_test.py
@@ -71,6 +71,7 @@ from pytket.passes import (
     RoundAngles,
     PeepholeOptimise2Q,
     SynthesiseHQS,
+    CliffordResynthesis,
 )
 from pytket.predicates import (
     GateSetPredicate,
@@ -976,6 +977,33 @@ def test_SynthesiseHQS_deprecation(capfd: Any) -> None:
     assert "[warn]" in out
     assert "deprecated" in out
     logging.set_level(logging.level.err)
+
+
+def test_clifford_resynthesis() -> None:
+    circ = (
+        Circuit(5)
+        .H(0)
+        .X(1)
+        .T(2)
+        .Y(3)
+        .Z(4)
+        .SX(1)
+        .CX(2, 3)
+        .T(2)
+        .S(3)
+        .V(2)
+        .Vdg(3)
+        .CY(1, 3)
+        .CZ(3, 4)
+        .SWAP(2, 3)
+        .Sdg(4)
+        .ZZMax(0, 3)
+        .SXdg(0)
+        .measure_all()
+    )
+    CliffordResynthesis().apply(circ)
+    assert circ.depth() <= 9
+    assert circ.n_2qb_gates() <= 4
 
 
 if __name__ == "__main__":

--- a/pytket/tests/predicates_test.py
+++ b/pytket/tests/predicates_test.py
@@ -1001,9 +1001,17 @@ def test_clifford_resynthesis() -> None:
         .SXdg(0)
         .measure_all()
     )
-    CliffordResynthesis().apply(circ)
-    assert circ.depth() <= 9
-    assert circ.n_2qb_gates() <= 4
+    circ0 = circ.copy()
+    CliffordResynthesis().apply(circ0)
+    assert circ0.depth() <= 9
+    assert circ0.n_2qb_gates() <= 4
+    circ1 = circ.copy()
+    CliffordResynthesis(allow_swaps=False).apply(circ1)
+    assert circ1.depth() <= 16
+    assert circ1.n_2qb_gates() <= 9
+    circ2 = circ.copy()
+    CliffordResynthesis(transform=lambda c: c.copy()).apply(circ2)
+    assert circ2 == circ
 
 
 if __name__ == "__main__":

--- a/pytket/tests/predicates_test.py
+++ b/pytket/tests/predicates_test.py
@@ -72,6 +72,7 @@ from pytket.passes import (
     PeepholeOptimise2Q,
     SynthesiseHQS,
     CliffordResynthesis,
+    CliffordSimp,
 )
 from pytket.predicates import (
     GateSetPredicate,
@@ -1012,6 +1013,18 @@ def test_clifford_resynthesis() -> None:
     circ2 = circ.copy()
     CliffordResynthesis(transform=lambda c: c.copy()).apply(circ2)
     assert circ2 == circ
+
+
+def test_clifford_resynthesis_implicit_swaps() -> None:
+    def T(c):
+        c1 = c.copy()
+        CliffordSimp().apply(c1)
+        return c1
+
+    circ = Circuit(2).CX(0, 1).CX(1, 0).CX(0, 1)
+    CliffordResynthesis(transform=T).apply(circ)
+    assert circ.n_gates == 0
+    assert circ.implicit_qubit_permutation() == {Qubit(0): Qubit(1), Qubit(1): Qubit(0)}
 
 
 if __name__ == "__main__":

--- a/tket/CMakeLists.txt
+++ b/tket/CMakeLists.txt
@@ -265,6 +265,7 @@ target_sources(tket
         src/Transformations/PauliOptimisation.cpp
         src/Transformations/CliffordOptimisation.cpp
         src/Transformations/CliffordReductionPass.cpp
+        src/Transformations/CliffordResynthesis.cpp
         src/Transformations/OptimisationPass.cpp
         src/Transformations/PhaseOptimisation.cpp
         src/Transformations/Decomposition.cpp
@@ -406,6 +407,7 @@ target_sources(tket
         include/tket/Transformations/BasicOptimisation.hpp
         include/tket/Transformations/CliffordOptimisation.hpp
         include/tket/Transformations/CliffordReductionPass.hpp
+        include/tket/Transformations/CliffordResynthesis.hpp
         include/tket/Transformations/Combinator.hpp
         include/tket/Transformations/ContextualReduction.hpp
         include/tket/Transformations/Decomposition.hpp

--- a/tket/CMakeLists.txt
+++ b/tket/CMakeLists.txt
@@ -174,6 +174,7 @@ target_sources(tket
         src/Circuit/basic_circ_manip.cpp
         src/Circuit/latex_drawing.cpp
         src/Circuit/macro_circ_info.cpp
+        src/Circuit/SubcircuitFinder.cpp
         src/Circuit/setters_and_getters.cpp
         src/Circuit/CircUtils.cpp
         src/Circuit/ThreeQubitConversion.cpp

--- a/tket/conanfile.py
+++ b/tket/conanfile.py
@@ -23,7 +23,7 @@ from conan.errors import ConanInvalidConfiguration
 
 class TketConan(ConanFile):
     name = "tket"
-    version = "1.2.94"
+    version = "1.2.95"
     package_type = "library"
     license = "Apache 2"
     homepage = "https://github.com/CQCL/tket"

--- a/tket/conanfile.py
+++ b/tket/conanfile.py
@@ -23,7 +23,7 @@ from conan.errors import ConanInvalidConfiguration
 
 class TketConan(ConanFile):
     name = "tket"
-    version = "1.2.92"
+    version = "1.2.93"
     package_type = "library"
     license = "Apache 2"
     homepage = "https://github.com/CQCL/tket"

--- a/tket/conanfile.py
+++ b/tket/conanfile.py
@@ -23,7 +23,7 @@ from conan.errors import ConanInvalidConfiguration
 
 class TketConan(ConanFile):
     name = "tket"
-    version = "1.2.93"
+    version = "1.2.94"
     package_type = "library"
     license = "Apache 2"
     homepage = "https://github.com/CQCL/tket"

--- a/tket/include/tket/Circuit/Circuit.hpp
+++ b/tket/include/tket/Circuit/Circuit.hpp
@@ -1220,6 +1220,15 @@ class Circuit {
 
   Circuit subcircuit(const Subcircuit &sc) const;
 
+  /**
+   * Construct a subcircuit consisting of a single vertex.
+   *
+   * @param v vertex
+   *
+   * @return subcircuit
+   */
+  Subcircuit singleton_subcircuit(const Vertex &v) const;
+
   // returns qubit path via vertices & inhabited port in vertices
   QPathDetailed unit_path(const UnitID &unit) const;  // vector<vertex,port>
   // returns a vector of each qubits path via qubit_path
@@ -1601,6 +1610,30 @@ class Circuit {
    * @return index map from Vertex to int
    */
   IndexMap index_map() const;
+
+  /**
+   * Return a partition into connected convex subcircuits of the set of ops
+   * satisfying the given criterion.
+   *
+   * @param criterion criterion satisfied by all ops in all subcircuits
+   *
+   * @return vector of disjoint vertex sets whose union includes all ops
+   *   satisfying the criterion.
+   */
+  std::vector<VertexSet> get_subcircuits(
+      std::function<bool(Op_ptr)> criterion) const;
+
+  /**
+   * Constructs a @ref Subcircuit with a given vertex set.
+   *
+   * The vertex set is assumed to be connected and convex. (This is not
+   * checked.)
+   *
+   * @param verts set of vertices
+   *
+   * @return corresponding @ref Subcircuit
+   */
+  Subcircuit make_subcircuit(VertexSet verts) const;
 
   /**
    * Get the global phase offset as a multiple of pi (in the range [0,2)).

--- a/tket/include/tket/Circuit/Circuit.hpp
+++ b/tket/include/tket/Circuit/Circuit.hpp
@@ -1218,6 +1218,13 @@ class Circuit {
   std::map<Vertex, unsigned> vertex_rev_depth_map() const;
   std::map<Edge, UnitID> edge_unit_map() const;
 
+  /**
+   * Construct a new circuit representing the given subcircuit.
+   *
+   * @param sc subcircuit specification
+   *
+   * @return new circuit representing a copy of the subcircuit
+   */
   Circuit subcircuit(const Subcircuit &sc) const;
 
   /**

--- a/tket/include/tket/Circuit/DAGDefs.hpp
+++ b/tket/include/tket/Circuit/DAGDefs.hpp
@@ -64,7 +64,7 @@ typedef boost::adjacency_list<
     boost::bidirectionalS,
 
     // indexing needed for algorithms such as topological sort
-    boost::property<boost::vertex_index_t, int, VertexProperties>,
+    boost::property<boost::vertex_index_t, std::size_t, VertexProperties>,
 
     EdgeProperties>
     DAG;
@@ -76,7 +76,7 @@ typedef std::vector<Vertex> VertexVec;
 typedef std::list<Vertex> VertexList;
 typedef std::unordered_map<Vertex, unsigned> IndexMap;
 typedef boost::adj_list_vertex_property_map<
-    DAG, int, int&, boost::vertex_index_t>
+    DAG, std::size_t, std::size_t&, boost::vertex_index_t>
     VIndex;
 
 /**

--- a/tket/include/tket/Predicates/PassGenerators.hpp
+++ b/tket/include/tket/Predicates/PassGenerators.hpp
@@ -57,6 +57,13 @@ PassPtr gen_euler_pass(const OpType& q, const OpType& p, bool strict = false);
 PassPtr gen_clifford_simp_pass(bool allow_swaps = true);
 
 /**
+ * Pass to resynthesise Clifford subcircuits.
+ *
+ * @return pass to perform Clifford resynthesis
+ */
+PassPtr gen_clifford_resynthesis_pass();
+
+/**
  * Pass to remove empty Quantum edges from a Circuit and then relabel
  * all Qubit to some new register defined by a passed label.
  * Qubits removed from the Circuit are preserved in the bimap, but not updated

--- a/tket/include/tket/Predicates/PassGenerators.hpp
+++ b/tket/include/tket/Predicates/PassGenerators.hpp
@@ -61,7 +61,7 @@ PassPtr gen_clifford_simp_pass(bool allow_swaps = true);
  *
  * @return pass to perform Clifford resynthesis
  */
-PassPtr gen_clifford_resynthesis_pass();
+PassPtr gen_clifford_resynthesis_pass(bool allow_swaps = true);
 
 /**
  * Pass to remove empty Quantum edges from a Circuit and then relabel

--- a/tket/include/tket/Predicates/PassGenerators.hpp
+++ b/tket/include/tket/Predicates/PassGenerators.hpp
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <optional>
+
 #include "CompilerPass.hpp"
 #include "tket/ArchAwareSynth/SteinerForest.hpp"
 #include "tket/Circuit/Circuit.hpp"
@@ -69,7 +71,8 @@ PassPtr gen_clifford_simp_pass(bool allow_swaps = true);
  * @return pass to perform Clifford resynthesis
  */
 PassPtr gen_clifford_resynthesis_pass(
-    std::function<Circuit(const Circuit&)> transform = nullptr,
+    std::optional<std::function<Circuit(const Circuit&)>> transform =
+        std::nullopt,
     bool allow_swaps = true);
 
 /**

--- a/tket/include/tket/Predicates/PassGenerators.hpp
+++ b/tket/include/tket/Predicates/PassGenerators.hpp
@@ -57,7 +57,7 @@ PassPtr gen_euler_pass(const OpType& q, const OpType& p, bool strict = false);
 PassPtr gen_clifford_simp_pass(bool allow_swaps = true);
 
 /**
- * Pass to resynthesise Clifford subcircuits.
+ * Pass to resynthesise Clifford subcircuits and simplify using Clifford rules.
  *
  * @return pass to perform Clifford resynthesis
  */

--- a/tket/include/tket/Predicates/PassGenerators.hpp
+++ b/tket/include/tket/Predicates/PassGenerators.hpp
@@ -59,9 +59,18 @@ PassPtr gen_clifford_simp_pass(bool allow_swaps = true);
 /**
  * Pass to resynthesise Clifford subcircuits and simplify using Clifford rules.
  *
+ * @param transform optional user-provided resynthesis method to apply to all
+ *   Clifford subcircuits (a function taking a Clifford circuit as an argument
+ *   and returning an equivalent circuit); if not provided, a default
+ *   resynthesis method is applied
+ * @param allow_swaps whether the rewriting may introduce wire swaps (only
+ *   relevant to the default resynthesis method used when the `transform`
+ *   argument is not provided)
  * @return pass to perform Clifford resynthesis
  */
-PassPtr gen_clifford_resynthesis_pass(bool allow_swaps = true);
+PassPtr gen_clifford_resynthesis_pass(
+    std::function<Circuit(const Circuit&)> transform = nullptr,
+    bool allow_swaps = true);
 
 /**
  * Pass to remove empty Quantum edges from a Circuit and then relabel

--- a/tket/include/tket/Transformations/CliffordResynthesis.hpp
+++ b/tket/include/tket/Transformations/CliffordResynthesis.hpp
@@ -20,7 +20,7 @@ namespace tket {
 
 namespace Transforms {
 
-Transform clifford_resynthesis();
+Transform clifford_resynthesis(bool allow_swaps = true);
 
 }  // namespace Transforms
 

--- a/tket/include/tket/Transformations/CliffordResynthesis.hpp
+++ b/tket/include/tket/Transformations/CliffordResynthesis.hpp
@@ -1,0 +1,27 @@
+// Copyright 2019-2024 Cambridge Quantum Computing
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "Transform.hpp"
+
+namespace tket {
+
+namespace Transforms {
+
+Transform clifford_resynthesis();
+
+}  // namespace Transforms
+
+}  // namespace tket

--- a/tket/include/tket/Transformations/CliffordResynthesis.hpp
+++ b/tket/include/tket/Transformations/CliffordResynthesis.hpp
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <optional>
+
 #include "Transform.hpp"
 
 namespace tket {
@@ -33,7 +35,8 @@ namespace Transforms {
  * @return transform to perform Clifford resynthesis
  */
 Transform clifford_resynthesis(
-    std::function<Circuit(const Circuit&)> transform = nullptr,
+    std::optional<std::function<Circuit(const Circuit&)>> transform =
+        std::nullopt,
     bool allow_swaps = true);
 
 }  // namespace Transforms

--- a/tket/include/tket/Transformations/CliffordResynthesis.hpp
+++ b/tket/include/tket/Transformations/CliffordResynthesis.hpp
@@ -23,10 +23,18 @@ namespace Transforms {
 /**
  * Resynthesise all Clifford subcircuits and simplify using Clifford rules.
  *
- * @param allow_swaps whether to allow introduction of implicit wire swaps
+ * @param transform optional user-provided resynthesis method to apply to all
+ *   Clifford subcircuits (a function taking a Clifford circuit as an argument
+ *   and returning an equivalent circuit); if not provided, a default
+ *   resynthesis method is applied
+ * @param allow_swaps whether the rewriting may introduce wire swaps (only
+ *   relevant to the default resynthesis method used when the `transform`
+ *   argument is not provided)
  * @return transform to perform Clifford resynthesis
  */
-Transform clifford_resynthesis(bool allow_swaps = true);
+Transform clifford_resynthesis(
+    std::function<Circuit(const Circuit&)> transform = nullptr,
+    bool allow_swaps = true);
 
 }  // namespace Transforms
 

--- a/tket/include/tket/Transformations/CliffordResynthesis.hpp
+++ b/tket/include/tket/Transformations/CliffordResynthesis.hpp
@@ -20,6 +20,12 @@ namespace tket {
 
 namespace Transforms {
 
+/**
+ * Resynthesise all Clifford subcircuits and simplify using Clifford rules.
+ *
+ * @param allow_swaps whether to allow introduction of implicit wire swaps
+ * @return transform to perform Clifford resynthesis
+ */
 Transform clifford_resynthesis(bool allow_swaps = true);
 
 }  // namespace Transforms

--- a/tket/proptest/src/proptest.cpp
+++ b/tket/proptest/src/proptest.cpp
@@ -55,7 +55,8 @@ using namespace tket;
   DO(SquashRzPhasedX)                     \
   DO(CnXPairwiseDecomposition)            \
   DO(RemoveImplicitQubitPermutation)      \
-  DO(ZXGraphlikeOptimisation)
+  DO(ZXGraphlikeOptimisation)             \
+  DO(gen_clifford_resynthesis_pass)
 
 static const std::map<PassPtr, std::string> &pass_name() {
   // Map from PassPtr to readable name
@@ -320,9 +321,11 @@ bool check_passes() {
             for (auto postcon : postcons) {
               RC_ASSERT(postcon.second->verify(c1));
             }
+            std::string name = pass_name().at(p);
             check_correctness(
                 c, cu,
-                (pass_name().at(p) == "ZXGraphlikeOptimisation")
+                (name == "ZXGraphlikeOptimisation" ||
+                 name == "gen_clifford_resynthesis_pass")
                     ? tket_sim::MatrixEquivalence::EQUAL_UP_TO_GLOBAL_PHASE
                     : tket_sim::MatrixEquivalence::EQUAL);
           } else {

--- a/tket/src/Circuit/Boxes.cpp
+++ b/tket/src/Circuit/Boxes.cpp
@@ -83,7 +83,9 @@ CircBox::CircBox() : Box(OpType::CircBox) {
 
 bool CircBox::is_clifford() const {
   BGL_FORALL_VERTICES(v, circ_->dag, DAG) {
-    if (!circ_->get_Op_ptr_from_Vertex(v)->is_clifford()) return false;
+    Op_ptr op = circ_->get_Op_ptr_from_Vertex(v);
+    if (op->get_desc().is_meta()) continue;
+    if (!op->is_clifford()) return false;
   }
   return true;
 }
@@ -344,7 +346,9 @@ std::string CustomGate::get_name(bool) const {
 bool CustomGate::is_clifford() const {
   std::shared_ptr<Circuit> circ = to_circuit();
   BGL_FORALL_VERTICES(v, circ->dag, DAG) {
-    if (!circ->get_Op_ptr_from_Vertex(v)->is_clifford()) return false;
+    Op_ptr op = circ->get_Op_ptr_from_Vertex(v);
+    if (op->get_desc().is_meta()) continue;
+    if (!op->is_clifford()) return false;
   }
   return true;
 }

--- a/tket/src/Circuit/Circuit.cpp
+++ b/tket/src/Circuit/Circuit.cpp
@@ -15,6 +15,7 @@
 #include "tket/Circuit/Circuit.hpp"
 
 #include <algorithm>
+#include <cstddef>
 #include <fstream>
 #include <numeric>
 #include <optional>
@@ -119,7 +120,7 @@ VertexVec Circuit::all_vertices() const {
 
 void Circuit::index_vertices() /*const*/ {
   VIndex index = boost::get(boost::vertex_index, dag);
-  int i = 0;
+  std::size_t i = 0;
   BGL_FORALL_VERTICES(v, dag, DAG) { boost::put(index, v, i++); }
 }
 

--- a/tket/src/Circuit/SubcircuitFinder.cpp
+++ b/tket/src/Circuit/SubcircuitFinder.cpp
@@ -1,0 +1,285 @@
+// Copyright 2019-2024 Cambridge Quantum Computing
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <algorithm>
+#include <boost/graph/transitive_closure.hpp>
+#include <cstddef>
+#include <iterator>
+#include <memory>
+#include <optional>
+#include <tkassert/Assert.hpp>
+#include <vector>
+
+#include "tket/Circuit/Circuit.hpp"
+#include "tket/Circuit/DAGDefs.hpp"
+#include "tket/OpType/EdgeType.hpp"
+
+namespace tket {
+
+// Representation of a connected convex subcircuit.
+typedef struct {
+  VertexSet verts;  // all vertices in the subcircuit
+  VertexSet preds;  // all predecessors of vertices in the subcircuit that are
+                    // not themselves in it
+  VertexSet succs;  // all successors of vertices in the subcircuit that are not
+                    // themselves in it
+} subcircuit_info_t;
+
+// Test whether the union of two connected convex subcircuits is connected.
+static bool union_is_connected(
+    const subcircuit_info_t &subcircuit_info0,
+    const subcircuit_info_t &subcircuit_info1) {
+  const VertexSet &verts0 = subcircuit_info0.verts;
+  const VertexSet &verts1 = subcircuit_info1.verts;
+  for (const Vertex &v : subcircuit_info0.succs) {
+    if (verts1.contains(v)) {
+      return true;
+    }
+  }
+  for (const Vertex &v : subcircuit_info1.succs) {
+    if (verts0.contains(v)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+// Return the union of two disjoint convex connected subcircuits, assuming that
+// the union is convex and connected.
+static subcircuit_info_t convex_union(
+    const subcircuit_info_t &subcircuit_info0,
+    const subcircuit_info_t &subcircuit_info1) {
+  const VertexSet &verts0 = subcircuit_info0.verts;
+  const VertexSet &preds0 = subcircuit_info0.preds;
+  const VertexSet &succs0 = subcircuit_info0.succs;
+  const VertexSet &verts1 = subcircuit_info1.verts;
+  const VertexSet &preds1 = subcircuit_info1.preds;
+  const VertexSet &succs1 = subcircuit_info1.succs;
+
+  // verts = verts0 ∪ verts1
+  VertexSet verts = verts0;
+  verts.insert(verts1.begin(), verts1.end());
+
+  // preds = (preds0 ∖ verts1) ∪ (preds1 ∖ verts0)
+  VertexVec p0mv1;
+  std::set_difference(
+      preds0.begin(), preds0.end(), verts1.begin(), verts1.end(),
+      std::inserter(p0mv1, p0mv1.begin()));
+  VertexVec p1mv0;
+  std::set_difference(
+      preds1.begin(), preds1.end(), verts0.begin(), verts0.end(),
+      std::inserter(p1mv0, p1mv0.begin()));
+  VertexSet preds{p0mv1.begin(), p0mv1.end()};
+  preds.insert(p1mv0.begin(), p1mv0.end());
+
+  // succs = (succs0 ∖ verts1) ∪ (succs1 ∖ verts0)
+  VertexVec s0mv1;
+  std::set_difference(
+      succs0.begin(), succs0.end(), verts1.begin(), verts1.end(),
+      std::inserter(s0mv1, s0mv1.begin()));
+  VertexVec s1mv0;
+  std::set_difference(
+      succs1.begin(), succs1.end(), verts0.begin(), verts0.end(),
+      std::inserter(s1mv0, s1mv0.begin()));
+  VertexSet succs{s0mv1.begin(), s0mv1.end()};
+  succs.insert(s1mv0.begin(), s1mv0.end());
+
+  return {verts, preds, succs};
+}
+
+// Helper class for finding connected convex subcircuits.
+class SubcircuitFinder {
+ public:
+  SubcircuitFinder(const Circuit *circ) : circ_(circ) {
+    // Compute the partial order on the DAG:
+    DAG TC;
+    boost::transitive_closure(circ_->dag, TC);
+    BGL_FORALL_VERTICES(v, circ_->dag, DAG) { order_relations_.insert({v, v}); }
+    BGL_FORALL_EDGES(e, TC, DAG) {
+      order_relations_.insert({boost::source(e, TC), boost::target(e, TC)});
+    }
+  }
+  std::vector<VertexSet> find_subcircuits(
+      std::function<bool(Op_ptr)> criterion) {
+    // Find a maximal partition of the vertices satisfying the criterion into
+    // connected convex subcircuits. We use a greedy algorithm, beginning with
+    // the trivial partition into singletons, and then repeatedly looking for a
+    // pair that we can merge.
+    std::vector<subcircuit_info_t> subcircuit_infos;
+    // Form a trivial partition, one node per subcircuit:
+    BGL_FORALL_VERTICES(v, circ_->dag, DAG) {
+      if (criterion(circ_->get_Op_ptr_from_Vertex(v))) {
+        VertexVec preds = circ_->get_predecessors(v);
+        VertexVec succs = circ_->get_successors(v);
+        subcircuit_infos.push_back(
+            {{v}, {preds.begin(), preds.end()}, {succs.begin(), succs.end()}});
+      }
+    }
+    while (true) {
+      // If possible, find a mergeable pair of subcircuits and merge them.
+      std::optional<std::pair<std::size_t, std::size_t>> indices =
+          find_mergeable_pair(subcircuit_infos);
+      if (!indices.has_value()) {
+        break;
+      } else {
+        std::size_t i0 = indices->first;
+        std::size_t i1 = indices->second;
+        TKET_ASSERT(i0 < i1);
+        subcircuit_info_t subcircuit_info0 = subcircuit_infos[i0];
+        subcircuit_info_t subcircuit_info1 = subcircuit_infos[i1];
+        // Must erase in this order, since i0 < i1:
+        subcircuit_infos.erase(subcircuit_infos.begin() + i1);
+        subcircuit_infos.erase(subcircuit_infos.begin() + i0);
+        subcircuit_infos.push_back(
+            convex_union(subcircuit_info0, subcircuit_info1));
+      }
+    }
+    std::vector<VertexSet> subcircuits;
+    for (const subcircuit_info_t &subcircuit_info : subcircuit_infos) {
+      subcircuits.push_back(subcircuit_info.verts);
+    }
+    return subcircuits;
+  }
+
+ private:
+  // Test whether the union of two disjoint connected convex subcircuits is
+  // convex.
+  bool union_is_convex(
+      const subcircuit_info_t &subcircuit_info0,
+      const subcircuit_info_t &subcircuit_info1) {
+    const VertexSet &preds0 = subcircuit_info0.preds;
+    const VertexSet &succs0 = subcircuit_info0.succs;
+    const VertexSet &preds1 = subcircuit_info1.preds;
+    const VertexSet &succs1 = subcircuit_info0.succs;
+    for (const Vertex &v0 : succs0) {
+      for (const Vertex &v1 : preds1) {
+        if (order_relations_.contains({v0, v1})) {
+          return false;
+        }
+      }
+    }
+    for (const Vertex &v1 : succs1) {
+      for (const Vertex &v0 : preds0) {
+        if (order_relations_.contains({v1, v0})) {
+          return false;
+        }
+      }
+    }
+    return true;
+  }
+
+  // Given a vector of disjoint connected convex subcircuits, look for a pair
+  // whose union is connected and convex, and return the indices of such a pair
+  // if it exists.
+  std::optional<std::pair<std::size_t, std::size_t>> find_mergeable_pair(
+      const std::vector<subcircuit_info_t> &subcircuit_infos) {
+    std::size_t n_subcircuits = subcircuit_infos.size();
+    for (std::size_t i0 = 0; i0 < n_subcircuits; i0++) {
+      for (std::size_t i1 = i0 + 1; i1 < n_subcircuits; i1++) {
+        const subcircuit_info_t &subcircuit_info0 = subcircuit_infos[i0];
+        const subcircuit_info_t &subcircuit_info1 = subcircuit_infos[i1];
+        if (union_is_connected(subcircuit_info0, subcircuit_info1) &&
+            union_is_convex(subcircuit_info0, subcircuit_info1)) {
+          return std::pair<std::size_t, std::size_t>{i0, i1};
+        }
+      }
+    }
+    return std::nullopt;
+  }
+  const Circuit *circ_;
+  std::set<std::pair<Vertex, Vertex>> order_relations_;
+};
+
+std::vector<VertexSet> Circuit::get_subcircuits(
+    std::function<bool(Op_ptr)> criterion) const {
+  SubcircuitFinder finder(this);
+  return finder.find_subcircuits(criterion);
+}
+
+Subcircuit Circuit::make_subcircuit(VertexSet verts) const {
+  const std::map<Edge, UnitID> unitmap = edge_unit_map();
+  EdgeSet q_ins, q_outs, c_ins, c_outs;
+  for (const Vertex &v : verts) {
+    for (const Edge &v_in : get_in_edges(v)) {
+      if (!verts.contains(source(v_in))) {
+        switch (get_edgetype(v_in)) {
+          case EdgeType::Quantum:
+            q_ins.insert(v_in);
+            break;
+          case EdgeType::Classical:
+            c_ins.insert(v_in);
+            break;
+          default:
+            // Boolean and WASM edges ignored.
+            // TODO What to do? Throw?
+            break;
+        }
+      }
+    }
+    for (const Edge &v_out : get_all_out_edges(v)) {
+      if (!verts.contains(target(v_out))) {
+        switch (get_edgetype(v_out)) {
+          case EdgeType::Quantum:
+            q_outs.insert(v_out);
+            break;
+          case EdgeType::Classical:
+            c_outs.insert(v_out);
+            break;
+          default:
+            // Boolean and WASM edges ignored.
+            // TODO What to do? Throw?
+            break;
+        }
+      }
+    }
+  }
+  EdgeSet crs;
+  for (const Edge &e : c_outs) {
+    Vertex v = source(e);
+    for (const Edge &b_out : get_out_edges_of_type(v, EdgeType::Boolean)) {
+      crs.insert(b_out);
+    }
+  }
+  // Convert to vectors, taking care of order:
+  TKET_ASSERT(q_ins.size() == q_outs.size());
+  TKET_ASSERT(c_ins.size() == c_outs.size());
+  EdgeVec q_ins_vec{q_ins.begin(), q_ins.end()};
+  EdgeVec q_outs_vec{q_outs.begin(), q_outs.end()};
+  EdgeVec c_ins_vec{c_ins.begin(), c_ins.end()};
+  EdgeVec c_outs_vec{c_outs.begin(), c_outs.end()};
+  EdgeVec crs_vec{crs.begin(), crs.end()};
+  std::sort(
+      q_ins_vec.begin(), q_ins_vec.end(),
+      [&unitmap](const Edge &e0, const Edge &e1) {
+        return unitmap.at(e0) < unitmap.at(e1);
+      });
+  std::sort(
+      q_outs_vec.begin(), q_outs_vec.end(),
+      [&unitmap](const Edge &e0, const Edge &e1) {
+        return unitmap.at(e0) < unitmap.at(e1);
+      });
+  std::sort(
+      c_ins_vec.begin(), c_ins_vec.end(),
+      [&unitmap](const Edge &e0, const Edge &e1) {
+        return unitmap.at(e0) < unitmap.at(e1);
+      });
+  std::sort(
+      c_outs_vec.begin(), c_outs_vec.end(),
+      [&unitmap](const Edge &e0, const Edge &e1) {
+        return unitmap.at(e0) < unitmap.at(e1);
+      });
+  return {q_ins_vec, q_outs_vec, c_ins_vec, c_outs_vec, crs_vec, verts};
+}
+
+}  // namespace tket

--- a/tket/src/Circuit/macro_circ_info.cpp
+++ b/tket/src/Circuit/macro_circ_info.cpp
@@ -206,6 +206,16 @@ Circuit Circuit::subcircuit(const Subcircuit& sc) const {
   return sub;
 }
 
+Subcircuit Circuit::singleton_subcircuit(const Vertex& v) const {
+  return {
+      get_in_edges_of_type(v, EdgeType::Quantum),
+      get_out_edges_of_type(v, EdgeType::Quantum),
+      get_in_edges_of_type(v, EdgeType::Classical),
+      get_out_edges_of_type(v, EdgeType::Classical),
+      get_out_edges_of_type(v, EdgeType::Boolean),
+      {v}};
+}
+
 // returns qubit path via vertices & inhabited port in vertices
 // used to construct a routing grid
 QPathDetailed Circuit::unit_path(const UnitID& unit) const {

--- a/tket/src/Circuit/macro_manipulation.cpp
+++ b/tket/src/Circuit/macro_manipulation.cpp
@@ -323,13 +323,7 @@ void Circuit::substitute(
 void Circuit::substitute(
     const Circuit& to_insert, const Vertex& to_replace,
     VertexDeletion vertex_deletion, OpGroupTransfer opgroup_transfer) {
-  Subcircuit sub = {
-      get_in_edges_of_type(to_replace, EdgeType::Quantum),
-      get_out_edges_of_type(to_replace, EdgeType::Quantum),
-      get_in_edges_of_type(to_replace, EdgeType::Classical),
-      get_out_edges_of_type(to_replace, EdgeType::Classical),
-      get_out_edges_of_type(to_replace, EdgeType::Boolean),
-      {to_replace}};
+  Subcircuit sub = singleton_subcircuit(to_replace);
   substitute(to_insert, sub, vertex_deletion, opgroup_transfer);
 }
 
@@ -340,13 +334,7 @@ void Circuit::substitute_conditional(
   if (op->get_type() != OpType::Conditional)
     throw CircuitInvalidity(
         "substitute_conditional called with an unconditional gate");
-  Subcircuit sub = {
-      get_in_edges_of_type(to_replace, EdgeType::Quantum),
-      get_out_edges_of_type(to_replace, EdgeType::Quantum),
-      get_in_edges_of_type(to_replace, EdgeType::Classical),
-      get_out_edges_of_type(to_replace, EdgeType::Classical),
-      get_out_edges_of_type(to_replace, EdgeType::Boolean),
-      {to_replace}};
+  Subcircuit sub = singleton_subcircuit(to_replace);
   const Conditional& cond = static_cast<const Conditional&>(*op);
   unsigned width = cond.get_width();
   // Conditions are first few args, so increase index of all others

--- a/tket/src/Ops/MetaOp.cpp
+++ b/tket/src/Ops/MetaOp.cpp
@@ -42,7 +42,7 @@ op_signature_t MetaOp::get_signature() const {
     return signature_;
 }
 
-bool MetaOp::is_clifford() const { return true; }
+bool MetaOp::is_clifford() const { return false; }
 
 MetaOp::~MetaOp() {}
 

--- a/tket/src/Predicates/PassGenerators.cpp
+++ b/tket/src/Predicates/PassGenerators.cpp
@@ -163,7 +163,8 @@ PassPtr gen_clifford_simp_pass(bool allow_swaps) {
 }
 
 PassPtr gen_clifford_resynthesis_pass(
-    std::function<Circuit(const Circuit&)> transform, bool allow_swaps) {
+    std::optional<std::function<Circuit(const Circuit&)>> transform,
+    bool allow_swaps) {
   Transform t = Transforms::clifford_resynthesis(transform, allow_swaps);
   PredicatePtrMap precons;
   PostConditions pc{{}, {}, Guarantee::Preserve};

--- a/tket/src/Predicates/PassGenerators.cpp
+++ b/tket/src/Predicates/PassGenerators.cpp
@@ -162,8 +162,8 @@ PassPtr gen_clifford_simp_pass(bool allow_swaps) {
   return std::make_shared<StandardPass>(precons, t, postcon, j);
 }
 
-PassPtr gen_clifford_resynthesis_pass() {
-  Transform t = Transforms::clifford_resynthesis();
+PassPtr gen_clifford_resynthesis_pass(bool allow_swaps) {
+  Transform t = Transforms::clifford_resynthesis(allow_swaps);
   PredicatePtrMap precons;
   PostConditions pc{{}, {}, Guarantee::Preserve};
   nlohmann::json j;

--- a/tket/src/Predicates/PassGenerators.cpp
+++ b/tket/src/Predicates/PassGenerators.cpp
@@ -32,6 +32,7 @@
 #include "tket/Predicates/PassLibrary.hpp"
 #include "tket/Predicates/Predicates.hpp"
 #include "tket/Transformations/BasicOptimisation.hpp"
+#include "tket/Transformations/CliffordResynthesis.hpp"
 #include "tket/Transformations/ContextualReduction.hpp"
 #include "tket/Transformations/Decomposition.hpp"
 #include "tket/Transformations/OptimisationPass.hpp"
@@ -159,6 +160,15 @@ PassPtr gen_clifford_simp_pass(bool allow_swaps) {
   j["allow_swaps"] = allow_swaps;
 
   return std::make_shared<StandardPass>(precons, t, postcon, j);
+}
+
+PassPtr gen_clifford_resynthesis_pass() {
+  Transform t = Transforms::clifford_resynthesis();
+  PredicatePtrMap precons;
+  PostConditions pc{{}, {}, Guarantee::Preserve};
+  nlohmann::json j;
+  j["name"] = "CliffordResynthesis";
+  return std::make_shared<StandardPass>(precons, t, pc, j);
 }
 
 PassPtr gen_flatten_relabel_registers_pass(const std::string& label) {

--- a/tket/src/Predicates/PassGenerators.cpp
+++ b/tket/src/Predicates/PassGenerators.cpp
@@ -162,8 +162,9 @@ PassPtr gen_clifford_simp_pass(bool allow_swaps) {
   return std::make_shared<StandardPass>(precons, t, postcon, j);
 }
 
-PassPtr gen_clifford_resynthesis_pass(bool allow_swaps) {
-  Transform t = Transforms::clifford_resynthesis(allow_swaps);
+PassPtr gen_clifford_resynthesis_pass(
+    std::function<Circuit(const Circuit&)> transform, bool allow_swaps) {
+  Transform t = Transforms::clifford_resynthesis(transform, allow_swaps);
   PredicatePtrMap precons;
   PostConditions pc{{}, {}, Guarantee::Preserve};
   nlohmann::json j;

--- a/tket/src/Predicates/Predicates.cpp
+++ b/tket/src/Predicates/Predicates.cpp
@@ -447,7 +447,9 @@ std::string DirectednessPredicate::to_string() const {
 
 bool CliffordCircuitPredicate::verify(const Circuit& circ) const {
   BGL_FORALL_VERTICES(v, circ.dag, DAG) {
-    if (!circ.get_Op_ptr_from_Vertex(v)->is_clifford()) return false;
+    Op_ptr op = circ.get_Op_ptr_from_Vertex(v);
+    if (op->get_desc().is_meta()) continue;
+    if (!op->is_clifford()) return false;
   }
   return true;
 }

--- a/tket/src/Transformations/CliffordResynthesis.cpp
+++ b/tket/src/Transformations/CliffordResynthesis.cpp
@@ -33,7 +33,7 @@ static Circuit resynthesised_circuit(
   if (transform.has_value()) {
     return (*transform)(circ);
   } else {
-    // Work around https://github.com/CQCL/tket/issues/1268 :
+    // Ensure all recognized Clifford gates are Clifford types:
     decompose_multi_qubits_CX().apply(circ);
     decompose_cliffords_std().apply(circ);
     remove_redundancies().apply(circ);

--- a/tket/src/Transformations/CliffordResynthesis.cpp
+++ b/tket/src/Transformations/CliffordResynthesis.cpp
@@ -31,11 +31,18 @@ static bool resynthesise_cliffords(Circuit &circ, bool allow_swaps = true) {
        circ.get_subcircuits([](Op_ptr op) { return op->is_clifford(); })) {
     Subcircuit subcircuit = circ.make_subcircuit(verts);
     Circuit subc = circ.subcircuit(subcircuit);
-    decompose_cliffords_std().apply(
-        subc);  // works around https://github.com/CQCL/tket/issues/1268
+
+    // Work around https://github.com/CQCL/tket/issues/1268 :
+    decompose_multi_qubits_CX().apply(subc);
+    decompose_cliffords_std().apply(subc);
+
+    // Convert to tableau and back:
     const UnitaryTableau tab = circuit_to_unitary_tableau(subc);
     Circuit newsubc = unitary_tableau_to_circuit(tab);
+
+    // Simplify:
     clifford_simp(allow_swaps).apply(newsubc);
+
     circ.substitute(newsubc, subcircuit);
     changed = true;
   }

--- a/tket/src/Transformations/CliffordResynthesis.cpp
+++ b/tket/src/Transformations/CliffordResynthesis.cpp
@@ -14,6 +14,7 @@
 
 #include "tket/Transformations/CliffordResynthesis.hpp"
 
+#include "Transformations/Decomposition.hpp"
 #include "tket/Circuit/Circuit.hpp"
 #include "tket/Clifford/UnitaryTableau.hpp"
 #include "tket/Converters/Converters.hpp"
@@ -28,7 +29,9 @@ static bool resynthesise_cliffords(Circuit &circ) {
   for (const VertexSet &verts :
        circ.get_subcircuits([](Op_ptr op) { return op->is_clifford(); })) {
     Subcircuit subcircuit = circ.make_subcircuit(verts);
-    const Circuit subc = circ.subcircuit(subcircuit);
+    Circuit subc = circ.subcircuit(subcircuit);
+    decompose_cliffords_std().apply(
+        subc);  // works around https://github.com/CQCL/tket/issues/1268
     const UnitaryTableau tab = circuit_to_unitary_tableau(subc);
     const Circuit newsubc = unitary_tableau_to_circuit(tab);
     circ.substitute(newsubc, subcircuit);

--- a/tket/src/Transformations/CliffordResynthesis.cpp
+++ b/tket/src/Transformations/CliffordResynthesis.cpp
@@ -18,6 +18,7 @@
 #include "tket/Circuit/Circuit.hpp"
 #include "tket/Clifford/UnitaryTableau.hpp"
 #include "tket/Converters/Converters.hpp"
+#include "tket/Transformations/OptimisationPass.hpp"
 #include "tket/Transformations/Transform.hpp"
 
 namespace tket {
@@ -33,7 +34,8 @@ static bool resynthesise_cliffords(Circuit &circ) {
     decompose_cliffords_std().apply(
         subc);  // works around https://github.com/CQCL/tket/issues/1268
     const UnitaryTableau tab = circuit_to_unitary_tableau(subc);
-    const Circuit newsubc = unitary_tableau_to_circuit(tab);
+    Circuit newsubc = unitary_tableau_to_circuit(tab);
+    clifford_simp().apply(newsubc);
     circ.substitute(newsubc, subcircuit);
     changed = true;
   }

--- a/tket/src/Transformations/CliffordResynthesis.cpp
+++ b/tket/src/Transformations/CliffordResynthesis.cpp
@@ -1,0 +1,46 @@
+// Copyright 2019-2024 Cambridge Quantum Computing
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "tket/Transformations/CliffordResynthesis.hpp"
+
+#include "tket/Circuit/Circuit.hpp"
+#include "tket/Clifford/UnitaryTableau.hpp"
+#include "tket/Converters/Converters.hpp"
+#include "tket/Transformations/Transform.hpp"
+
+namespace tket {
+
+namespace Transforms {
+
+static bool resynthesise_cliffords(Circuit &circ) {
+  bool changed = false;
+  for (const VertexSet &verts :
+       circ.get_subcircuits([](Op_ptr op) { return op->is_clifford(); })) {
+    Subcircuit subcircuit = circ.make_subcircuit(verts);
+    const Circuit subc = circ.subcircuit(subcircuit);
+    const UnitaryTableau tab = circuit_to_unitary_tableau(subc);
+    const Circuit newsubc = unitary_tableau_to_circuit(tab);
+    circ.substitute(newsubc, subcircuit);
+    changed = true;
+  }
+  return changed;
+}
+
+Transform clifford_resynthesis() {
+  return Transform([](Circuit &circ) { return resynthesise_cliffords(circ); });
+}
+
+}  // namespace Transforms
+
+}  // namespace tket

--- a/tket/src/Transformations/CliffordResynthesis.cpp
+++ b/tket/src/Transformations/CliffordResynthesis.cpp
@@ -14,10 +14,11 @@
 
 #include "tket/Transformations/CliffordResynthesis.hpp"
 
-#include "Transformations/Decomposition.hpp"
 #include "tket/Circuit/Circuit.hpp"
 #include "tket/Clifford/UnitaryTableau.hpp"
 #include "tket/Converters/Converters.hpp"
+#include "tket/Transformations/BasicOptimisation.hpp"
+#include "tket/Transformations/Decomposition.hpp"
 #include "tket/Transformations/OptimisationPass.hpp"
 #include "tket/Transformations/Transform.hpp"
 
@@ -34,6 +35,7 @@ static Circuit resynthesised_circuit(
     // Work around https://github.com/CQCL/tket/issues/1268 :
     decompose_multi_qubits_CX().apply(circ);
     decompose_cliffords_std().apply(circ);
+    remove_redundancies().apply(circ);
 
     // Convert to tableau and back:
     const UnitaryTableau tab = circuit_to_unitary_tableau(circ);

--- a/tket/src/Transformations/CliffordResynthesis.cpp
+++ b/tket/src/Transformations/CliffordResynthesis.cpp
@@ -27,10 +27,11 @@ namespace tket {
 namespace Transforms {
 
 static Circuit resynthesised_circuit(
-    Circuit &circ, std::function<Circuit(const Circuit &)> transform = nullptr,
+    Circuit &circ,
+    std::optional<std::function<Circuit(const Circuit &)>> transform = nullptr,
     bool allow_swaps = true) {
-  if (transform) {
-    return transform(circ);
+  if (transform.has_value()) {
+    return (*transform)(circ);
   } else {
     // Work around https://github.com/CQCL/tket/issues/1268 :
     decompose_multi_qubits_CX().apply(circ);
@@ -49,7 +50,8 @@ static Circuit resynthesised_circuit(
 }
 
 static bool resynthesise_cliffords(
-    Circuit &circ, std::function<Circuit(const Circuit &)> transform = nullptr,
+    Circuit &circ,
+    std::optional<std::function<Circuit(const Circuit &)>> transform = nullptr,
     bool allow_swaps = true) {
   bool changed = false;
   for (const VertexSet &verts :
@@ -64,7 +66,8 @@ static bool resynthesise_cliffords(
 }
 
 Transform clifford_resynthesis(
-    std::function<Circuit(const Circuit &)> transform, bool allow_swaps) {
+    std::optional<std::function<Circuit(const Circuit &)>> transform,
+    bool allow_swaps) {
   return Transform([transform, allow_swaps](Circuit &circ) {
     return resynthesise_cliffords(circ, transform, allow_swaps);
   });

--- a/tket/src/Transformations/CliffordResynthesis.cpp
+++ b/tket/src/Transformations/CliffordResynthesis.cpp
@@ -25,7 +25,7 @@ namespace tket {
 
 namespace Transforms {
 
-static bool resynthesise_cliffords(Circuit &circ) {
+static bool resynthesise_cliffords(Circuit &circ, bool allow_swaps = true) {
   bool changed = false;
   for (const VertexSet &verts :
        circ.get_subcircuits([](Op_ptr op) { return op->is_clifford(); })) {
@@ -35,15 +35,17 @@ static bool resynthesise_cliffords(Circuit &circ) {
         subc);  // works around https://github.com/CQCL/tket/issues/1268
     const UnitaryTableau tab = circuit_to_unitary_tableau(subc);
     Circuit newsubc = unitary_tableau_to_circuit(tab);
-    clifford_simp().apply(newsubc);
+    clifford_simp(allow_swaps).apply(newsubc);
     circ.substitute(newsubc, subcircuit);
     changed = true;
   }
   return changed;
 }
 
-Transform clifford_resynthesis() {
-  return Transform([](Circuit &circ) { return resynthesise_cliffords(circ); });
+Transform clifford_resynthesis(bool allow_swaps) {
+  return Transform([allow_swaps](Circuit &circ) {
+    return resynthesise_cliffords(circ, allow_swaps);
+  });
 }
 
 }  // namespace Transforms

--- a/tket/test/CMakeLists.txt
+++ b/tket/test/CMakeLists.txt
@@ -103,6 +103,7 @@ add_executable(test-tket
     src/Ops/test_Expression.cpp
     src/Ops/test_Ops.cpp
     src/OpType/test_OpTypeFunctions.cpp
+    src/Passes/test_CliffordResynthesis.cpp
     src/Passes/test_SynthesiseTK.cpp
     src/Passes/test_SynthesiseTket.cpp
     src/Gate/test_Rotation.cpp

--- a/tket/test/src/Passes/test_CliffordResynthesis.cpp
+++ b/tket/test/src/Passes/test_CliffordResynthesis.cpp
@@ -1,0 +1,98 @@
+// Copyright 2019-2024 Cambridge Quantum Computing
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "../testutil.hpp"
+#include "tket/Circuit/Circuit.hpp"
+#include "tket/OpType/OpType.hpp"
+#include "tket/Predicates/CompilationUnit.hpp"
+#include "tket/Predicates/PassGenerators.hpp"
+
+namespace tket {
+namespace test_CliffordResynthesis {
+
+void check_clifford_resynthesis(const Circuit& c) {
+  Circuit c0 = c;
+  CompilationUnit cu(c0);
+  gen_clifford_resynthesis_pass()->apply(cu);
+  Circuit c1 = cu.get_circ_ref();
+
+  REQUIRE(test_unitary_comparison(c0, c1, true));
+}
+
+SCENARIO("SynthesiseCliffordResynthesis correctness") {
+  GIVEN("A small Clifford circuit") {
+    Circuit c(2);
+    c.add_op<unsigned>(OpType::H, {0});
+    c.add_op<unsigned>(OpType::CX, {0, 1});
+    check_clifford_resynthesis(c);
+  }
+  GIVEN("A Clifford and a non-Clifford operation") {
+    Circuit c(2);
+    c.add_op<unsigned>(OpType::CX, {0, 1});
+    c.add_op<unsigned>(OpType::T, {0});
+    check_clifford_resynthesis(c);
+  }
+  GIVEN("A circuit with two Clifford subcircuits") {
+    Circuit c(4);
+    c.add_op<unsigned>(OpType::T, {0});
+    c.add_op<unsigned>(OpType::CX, {0, 1});  // (0)
+    c.add_op<unsigned>(OpType::CY, {1, 2});  // (0)
+    c.add_op<unsigned>(OpType::CZ, {0, 1});  // (0)
+    c.add_op<unsigned>(OpType::TK2, {0.1, 0.2, 0.3}, {2, 3});
+    c.add_op<unsigned>(OpType::T, {1});
+    c.add_op<unsigned>(OpType::CX, {1, 2});  // (1)
+    c.add_op<unsigned>(OpType::H, {2});      // (1)
+    c.add_op<unsigned>(OpType::CY, {2, 3});  // (1)
+    c.add_op<unsigned>(OpType::TK2, {0.1, 0.2, 0.3}, {1, 2});
+    check_clifford_resynthesis(c);
+  }
+  GIVEN("A more complex example") {
+    Circuit c(5);
+    c.add_op<unsigned>(OpType::H, {0});
+    c.add_op<unsigned>(OpType::X, {1});
+    c.add_op<unsigned>(OpType::T, {2});
+    c.add_op<unsigned>(OpType::Y, {3});
+    c.add_op<unsigned>(OpType::Z, {4});
+    c.add_op<unsigned>(OpType::CX, {2, 3});
+    c.add_op<unsigned>(OpType::T, {2});
+    c.add_op<unsigned>(OpType::S, {3});
+    c.add_op<unsigned>(OpType::V, {1});
+    c.add_op<unsigned>(OpType::V, {2});
+    c.add_op<unsigned>(OpType::Vdg, {3});
+    c.add_op<unsigned>(OpType::CY, {1, 3});
+    c.add_op<unsigned>(OpType::CZ, {3, 4});
+    c.add_op<unsigned>(OpType::SWAP, {2, 3});
+    c.add_op<unsigned>(OpType::Sdg, {4});
+    c.add_op<unsigned>(OpType::CX, {3, 0});
+    c.add_op<unsigned>(OpType::V, {0});
+    check_clifford_resynthesis(c);
+  }
+  GIVEN("A circuit with no Clifford gates") {
+    Circuit c(1);
+    c.add_op<unsigned>(OpType::T, {0});
+    check_clifford_resynthesis(c);
+  }
+  GIVEN("An Rz(0) gate and a ZZMax gate") {
+    // Test workaround for https://github.com/CQCL/tket/issues/1268
+    Circuit c(2);
+    c.add_op<unsigned>(OpType::Rz, 0., {0});
+    c.add_op<unsigned>(OpType::ZZMax, {0, 1});
+    check_clifford_resynthesis(c);
+  }
+}
+
+}  // namespace test_CliffordResynthesis
+}  // namespace tket


### PR DESCRIPTION
# Description

- Add a method to partition the vertices of a circuit having a given property into large connected convex subsets.
- Using this method with the "Clifford" property, add a new Clifford resynthesis pass, which can either apply a default resynthesis method or one provided by the user. The default method essentially converts to a unitary tableau and back and then applies the existing `clifford_simp()` transform.

# Related issues

Closes #1266 .

Relates to #1267 .

# Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented hard-to-understand parts of my code.
- [x] I have made corresponding changes to the public API documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have updated the changelog with any user-facing changes.
