### PR TITLE
Add missing op types to method for converting circuit to unitary tableau

### DIFF
--- a/pytket/conanfile.py
+++ b/pytket/conanfile.py
@@ -32,7 +32,7 @@ class pytketRecipe(ConanFile):
         cmake.install()
 
     def requirements(self):
-        self.requires("tket/1.2.93@tket/stable")
+        self.requires("tket/1.2.94@tket/stable")
         self.requires("tklog/0.3.3@tket/stable")
         self.requires("tkrng/0.3.3@tket/stable")
         self.requires("tkassert/0.3.4@tket/stable")

--- a/pytket/docs/changelog.rst
+++ b/pytket/docs/changelog.rst
@@ -12,6 +12,11 @@ Features:
   providing either an ordered sequence of registers or a mapping of registers
   from the box to the containing circuit.
 
+Fixes:
+
+* Add missing op types to methods for converting Clifford circuits to unitary
+  tableaux.
+
 1.25.0 (February 2024)
 ----------------------
 

--- a/tket/conanfile.py
+++ b/tket/conanfile.py
@@ -23,7 +23,7 @@ from conan.errors import ConanInvalidConfiguration
 
 class TketConan(ConanFile):
     name = "tket"
-    version = "1.2.93"
+    version = "1.2.94"
     package_type = "library"
     license = "Apache 2"
     homepage = "https://github.com/CQCL/tket"

--- a/tket/src/Clifford/SymplecticTableau.cpp
+++ b/tket/src/Clifford/SymplecticTableau.cpp
@@ -187,11 +187,13 @@ void SymplecticTableau::apply_gate(
       apply_S(qbs.at(0));
       break;
     }
-    case OpType::V: {
+    case OpType::V:
+    case OpType::SX: {
       apply_V(qbs.at(0));
       break;
     }
-    case OpType::Vdg: {
+    case OpType::Vdg:
+    case OpType::SXdg: {
       apply_V(qbs.at(0));
       apply_V(qbs.at(0));
       apply_V(qbs.at(0));
@@ -223,6 +225,49 @@ void SymplecticTableau::apply_gate(
       apply_S(qbs.at(1));
       apply_V(qbs.at(1));
       apply_S(qbs.at(1));
+      break;
+    }
+    case OpType::ZZMax: {
+      apply_S(qbs.at(0));
+      apply_S(qbs.at(1));
+      apply_S(qbs.at(1));
+      apply_S(qbs.at(1));
+      apply_V(qbs.at(1));
+      apply_S(qbs.at(1));
+      apply_CX(qbs.at(0), qbs.at(1));
+      apply_S(qbs.at(1));
+      apply_V(qbs.at(1));
+      break;
+    }
+    case OpType::ECR: {
+      apply_S(qbs.at(0));
+      apply_S(qbs.at(0));
+      apply_V(qbs.at(0));
+      apply_V(qbs.at(0));
+      apply_S(qbs.at(0));
+      apply_V(qbs.at(1));
+      apply_V(qbs.at(1));
+      apply_V(qbs.at(1));
+      apply_CX(qbs.at(0), qbs.at(1));
+      break;
+    }
+    case OpType::ISWAPMax: {
+      apply_S(qbs.at(0));
+      apply_S(qbs.at(0));
+      apply_S(qbs.at(1));
+      apply_S(qbs.at(1));
+      apply_V(qbs.at(0));
+      apply_V(qbs.at(0));
+      apply_V(qbs.at(0));
+      apply_V(qbs.at(1));
+      apply_V(qbs.at(1));
+      apply_V(qbs.at(1));
+      apply_CX(qbs.at(0), qbs.at(1));
+      apply_V(qbs.at(0));
+      apply_S(qbs.at(1));
+      apply_V(qbs.at(1));
+      apply_CX(qbs.at(0), qbs.at(1));
+      apply_V(qbs.at(0));
       break;
     }
     case OpType::SWAP: {

--- a/tket/test/src/test_UnitaryTableau.cpp
+++ b/tket/test/src/test_UnitaryTableau.cpp
@@ -521,6 +521,24 @@ SCENARIO("Synthesis of circuits from UnitaryRevTableau") {
     UnitaryRevTableau res_tab = circuit_to_unitary_rev_tableau(res);
     REQUIRE(res_tab == tab);
   }
+  GIVEN("Another circuit containing more OpTypes") {
+    // https://github.com/CQCL/tket/issues/1268
+    Circuit circ(2);
+    circ.add_op<unsigned>(OpType::SX, {0});
+    circ.add_op<unsigned>(OpType::SXdg, {1});
+    circ.add_op<unsigned>(OpType::ZZMax, {0, 1});
+    circ.add_op<unsigned>(OpType::SX, {0});
+    circ.add_op<unsigned>(OpType::SXdg, {1});
+    circ.add_op<unsigned>(OpType::ECR, {0, 1});
+    circ.add_op<unsigned>(OpType::SX, {0});
+    circ.add_op<unsigned>(OpType::SXdg, {1});
+    circ.add_op<unsigned>(OpType::ISWAPMax, {0, 1});
+    UnitaryRevTableau tab = circuit_to_unitary_rev_tableau(circ);
+    Circuit res = unitary_rev_tableau_to_circuit(tab);
+    REQUIRE(test_unitary_comparison(circ, res, true));
+    UnitaryRevTableau res_tab = circuit_to_unitary_rev_tableau(res);
+    REQUIRE(res_tab == tab);
+  }
 }
 
 SCENARIO("UnitaryTableauBoxes in Circuits") {


### PR DESCRIPTION
# Description

Add conversions for `SX`, `SXdg`, `ZZMax`, `ECR` and `ISWAPMax`.

# Related issues

Fixes #1268 .

# Checklist

- [x] I have performed a self-review of my code.
- [ ] I have commented hard-to-understand parts of my code.
- [ ] I have made corresponding changes to the public API documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have updated the changelog with any user-facing changes.
