### PR TITLE
Update to clang-format 18

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -88,7 +88,7 @@ jobs:
       - name: Check C++ code formatting
         run: |
           brew update
-          brew install clang-format@17
+          brew install clang-format@18
           git ls-files "*.cpp" "*.hpp" | xargs clang-format -style=file --dry-run --Werror
 
   build_test_tket:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ repo.
 C++20 features may be used whenever they are supported by all the compilers
 used on the CI (listed in the README).
 
-All C++ code should be formatted with `clang-format` (v17) using the
+All C++ code should be formatted with `clang-format` (v18) using the
 configuration file `.clang-format` in the root directory. This is checked on
 the CI. The script `do-clang-format` will run this over all C++ files in the
 repository and fix them up.

--- a/libs/tklog/src/TketLog.cpp
+++ b/libs/tklog/src/TketLog.cpp
@@ -63,8 +63,8 @@ void Logger::log(const char *levstr, const std::string &s, std::ostream &os) {
 #else
   plt = std::localtime(&t);
 #endif
-  os << "[" << std::put_time(plt, "%Y-%m-%d %H:%M:%S") << "]"
-     << " [tket] [" << levstr << "] " << s << std::endl;
+  os << "[" << std::put_time(plt, "%Y-%m-%d %H:%M:%S") << "]" << " [tket] ["
+     << levstr << "] " << s << std::endl;
 }
 
 void Logger::set_level(LogLevel lev) { level = lev; }

--- a/pytket/conanfile.py
+++ b/pytket/conanfile.py
@@ -32,7 +32,7 @@ class pytketRecipe(ConanFile):
         cmake.install()
 
     def requirements(self):
-        self.requires("tket/1.2.92@tket/stable")
+        self.requires("tket/1.2.93@tket/stable")
         self.requires("tklog/0.3.3@tket/stable")
         self.requires("tkrng/0.3.3@tket/stable")
         self.requires("tkassert/0.3.4@tket/stable")

--- a/tket/conanfile.py
+++ b/tket/conanfile.py
@@ -23,7 +23,7 @@ from conan.errors import ConanInvalidConfiguration
 
 class TketConan(ConanFile):
     name = "tket"
-    version = "1.2.92"
+    version = "1.2.93"
     package_type = "library"
     license = "Apache 2"
     homepage = "https://github.com/CQCL/tket"

--- a/tket/src/Architecture/DistancesFromArchitecture.cpp
+++ b/tket/src/Architecture/DistancesFromArchitecture.cpp
@@ -80,8 +80,8 @@ std::size_t DistancesFromArchitecture::operator()(
         distance_entry > 0 ||
         AssertMessage() << "DistancesFromArchitecture: architecture has "
                         << arch.n_nodes() << " vertices, "
-                        << arch.n_connections() << " edges; "
-                        << " and d(" << vertex1 << "," << vertex2
+                        << arch.n_connections() << " edges; " << " and d("
+                        << vertex1 << "," << vertex2
                         << ")=0. "
                            "Is the graph connected?");
     // GCOVR_EXCL_STOP

--- a/tket/src/Clifford/UnitaryTableau.cpp
+++ b/tket/src/Clifford/UnitaryTableau.cpp
@@ -594,16 +594,16 @@ std::ostream& operator<<(std::ostream& os, const UnitaryRevTableau& tab) {
   for (unsigned i = 0; i < nqs; ++i) {
     Qubit qi = tab.tab_.qubits_.right.at(i);
     os << tab.tab_.tab_.xmat_.row(i) << "   " << tab.tab_.tab_.zmat_.row(i)
-       << "   " << tab.tab_.tab_.phase_(i) << "\t->\t"
-       << "X@" << qi.repr() << std::endl;
+       << "   " << tab.tab_.tab_.phase_(i) << "\t->\t" << "X@" << qi.repr()
+       << std::endl;
   }
   os << "--" << std::endl;
   for (unsigned i = 0; i < nqs; ++i) {
     Qubit qi = tab.tab_.qubits_.right.at(i);
     os << tab.tab_.tab_.xmat_.row(i + nqs) << "   "
        << tab.tab_.tab_.zmat_.row(i + nqs) << "   "
-       << tab.tab_.tab_.phase_(i + nqs) << "\t->\t"
-       << "Z@" << qi.repr() << std::endl;
+       << tab.tab_.tab_.phase_(i + nqs) << "\t->\t" << "Z@" << qi.repr()
+       << std::endl;
   }
   return os;
 }

--- a/tket/src/Predicates/Predicates.cpp
+++ b/tket/src/Predicates/Predicates.cpp
@@ -52,9 +52,11 @@ static std::string auto_name(const T&) {
   return predicate_name(typeid(T));
 }
 
+#define SET_PRED_NAME(a) \
+  { typeid(a), #a }
+
 const std::string& predicate_name(std::type_index idx) {
   static const std::map<std::type_index, std::string> predicate_names = {
-#define SET_PRED_NAME(a) {typeid(a), #a}
       SET_PRED_NAME(CliffordCircuitPredicate),
       SET_PRED_NAME(ConnectivityPredicate),
       SET_PRED_NAME(DefaultRegisterPredicate),
@@ -75,9 +77,10 @@ const std::string& predicate_name(std::type_index idx) {
       SET_PRED_NAME(NoWireSwapsPredicate),
       SET_PRED_NAME(PlacementPredicate),
       SET_PRED_NAME(UserDefinedPredicate)};
-#undef SET_PRED_NAME
   return predicate_names.at(idx);
 }
+
+#undef SET_PRED_NAME
 
 /////////////////////
 // PREDICATE METHODS//


### PR DESCRIPTION
v17 is no longer available from homebrew and the default has been changed to 18; therefore use v18 and format code accordingly.