### PR TITLE
Make probability threshold configurable, defaulting to zero

### DIFF
--- a/pytket/docs/changelog.rst
+++ b/pytket/docs/changelog.rst
@@ -13,6 +13,10 @@ Features:
   from the box to the containing circuit.
 * Add ``CliffordResynthesis`` pass to apply Clifford resynthesis (optionally
   with a user-defined resynthesis method) on all Clifford subcircuits.
+* Add optional ``min_p`` argument to
+  ``BackendResult.get_probability_distribution()`` and to the constructor of a
+  ``ProbabilityDistribution``, defaulting to zero. (Previously probabilities
+  below 1e-10 were by default treated as zero.)
 
 Fixes:
 

--- a/pytket/pytket/backends/backendresult.py
+++ b/pytket/pytket/backends/backendresult.py
@@ -561,13 +561,16 @@ class BackendResult:
         return EmpiricalDistribution(self.get_counts(bits))
 
     def get_probability_distribution(
-        self, qubits: Optional[Sequence[Qubit]] = None
+        self, qubits: Optional[Sequence[Qubit]] = None, min_p: float = 0.0
     ) -> ProbabilityDistribution[Tuple[int, ...]]:
         """Convert to a :py:class:`pytket.utils.distribution.ProbabilityDistribution`
         where the possible outcomes are sequences of 0s and 1s.
 
         :param qubits: Optionally provide the :py:class:`Qubit` s over which to
             marginalize the distribution.
+        :param min_p: Optional probability below which to ignore values (for
+            example to avoid spurious values due to rounding errors in
+            statevector computations). Default 0.
         :return: A distribution where the possible outcomes are tuples of 0s and 1s.
         """
         if not self.contains_state_results:
@@ -575,7 +578,7 @@ class BackendResult:
                 "Probability distribution only available for statevector result types."
             )
         state = self.get_state(qubits)
-        return ProbabilityDistribution(probs_from_state(state))
+        return ProbabilityDistribution(probs_from_state(state), min_p=min_p)
 
     def get_debug_info(self) -> Dict[str, float]:
         """Calculate the success rate of each assertion averaged across shots.

--- a/pytket/tests/distribution_test.py
+++ b/pytket/tests/distribution_test.py
@@ -26,12 +26,14 @@ def test_probability_distribution() -> None:
     pd = ProbabilityDistribution({"a": 1 / 3, "b": 2 / 3})
     with pytest.raises(ValueError):
         pd = ProbabilityDistribution({"a": 1 / 3, "b": 1, "c": -1 / 3})
-    pd1 = ProbabilityDistribution({"a": 1 / 3, "b": 2 / 3 - 1e-15, "c": 1e-15})
+    pd1 = ProbabilityDistribution(
+        {"a": 1 / 3, "b": 2 / 3 - 1e-15, "c": 1e-15}, min_p=1e-10
+    )
     assert pd1.support == set(["a", "b"])
     assert isclose(pd1["a"], 1 / 3)
     assert pd1["c"] == 0.0
     assert pd == pd1
-    with pytest.raises(ValueError):
+    with pytest.warns(UserWarning):
         pd2 = ProbabilityDistribution({"a": 2 / 3, "b": 4 / 3})
     pd3 = ProbabilityDistribution({"a": 2 / 9, "b": 4 / 9, "c": 1 / 3})
     pd4 = convex_combination([(pd, 1 / 3), (pd3, 2 / 3)])


### PR DESCRIPTION
# Description

Add an optional `min_p` argument to `BackendResult.get_probability_distribution()` and to the constructor of a `ProbabilityDistribution`.

# Related issues

Closes #1253 .

# Checklist

- [x] I have performed a self-review of my code.
- [ ] I have commented hard-to-understand parts of my code.
- [x] I have made corresponding changes to the public API documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have updated the changelog with any user-facing changes.
