### PR TITLE
Feature/add circuit name property to circ box

### DIFF
--- a/pytket/binders/circuit/boxes.cpp
+++ b/pytket/binders/circuit/boxes.cpp
@@ -169,7 +169,16 @@ void init_boxes(py::module &m) {
           "any Circuit that the CircBox has been added to "
           "(via Circuit.add_circbox). \n\n:param symbol_map: "
           "A map from SymPy symbols to SymPy expressions",
-          py::arg("symbol_map"));
+          py::arg("symbol_map"))
+      .def_property(
+          "circuit_name", &CircBox::get_circuit_name,
+          &CircBox::set_circuit_name,
+          ":return: the name of the contained circuit. "
+          "\n\n WARNING: "
+          "Setting this property mutates the CircBox and "
+          "any changes are propagated to "
+          "any Circuit that the CircBox has been added to "
+          "(via Circuit.add_circbox).");
   py::class_<Unitary1qBox, std::shared_ptr<Unitary1qBox>, Op>(
       m, "Unitary1qBox",
       "A user-defined one-qubit operation specified by a unitary matrix.")

--- a/pytket/conanfile.py
+++ b/pytket/conanfile.py
@@ -32,7 +32,7 @@ class pytketRecipe(ConanFile):
         cmake.install()
 
     def requirements(self):
-        self.requires("tket/1.2.102@tket/stable")
+        self.requires("tket/1.2.103@tket/stable")
         self.requires("tklog/0.3.3@tket/stable")
         self.requires("tkrng/0.3.3@tket/stable")
         self.requires("tkassert/0.3.4@tket/stable")

--- a/pytket/conanfile.py
+++ b/pytket/conanfile.py
@@ -32,7 +32,7 @@ class pytketRecipe(ConanFile):
         cmake.install()
 
     def requirements(self):
-        self.requires("tket/1.2.100@tket/stable")
+        self.requires("tket/1.2.101@tket/stable")
         self.requires("tklog/0.3.3@tket/stable")
         self.requires("tkrng/0.3.3@tket/stable")
         self.requires("tkassert/0.3.4@tket/stable")

--- a/pytket/conanfile.py
+++ b/pytket/conanfile.py
@@ -32,7 +32,7 @@ class pytketRecipe(ConanFile):
         cmake.install()
 
     def requirements(self):
-        self.requires("tket/1.2.99@tket/stable")
+        self.requires("tket/1.2.100@tket/stable")
         self.requires("tklog/0.3.3@tket/stable")
         self.requires("tkrng/0.3.3@tket/stable")
         self.requires("tkassert/0.3.4@tket/stable")

--- a/pytket/conanfile.py
+++ b/pytket/conanfile.py
@@ -32,7 +32,7 @@ class pytketRecipe(ConanFile):
         cmake.install()
 
     def requirements(self):
-        self.requires("tket/1.2.96@tket/stable")
+        self.requires("tket/1.2.97@tket/stable")
         self.requires("tklog/0.3.3@tket/stable")
         self.requires("tkrng/0.3.3@tket/stable")
         self.requires("tkassert/0.3.4@tket/stable")

--- a/pytket/docs/changelog.rst
+++ b/pytket/docs/changelog.rst
@@ -17,6 +17,7 @@ Features:
   ``BackendResult.get_probability_distribution()`` and to the constructor of a
   ``ProbabilityDistribution``, defaulting to zero. (Previously probabilities
   below 1e-10 were by default treated as zero.)
+* Add ``circuit_name`` property to ``CircBox``.
 
 Fixes:
 

--- a/pytket/pytket/_tket/circuit.pyi
+++ b/pytket/pytket/_tket/circuit.pyi
@@ -133,6 +133,14 @@ class CircBox(Op):
         
         :param symbol_map: A map from SymPy symbols to SymPy expressions
         """
+    @property
+    def circuit_name(self) -> str | None:
+        """
+        :return: the name of the contained circuit
+        """
+    @circuit_name.setter
+    def circuit_name(self, arg1: str) -> None:
+        ...
 class Circuit:
     """
     Encapsulates a quantum circuit using a DAG representation.

--- a/pytket/pytket/_tket/circuit.pyi
+++ b/pytket/pytket/_tket/circuit.pyi
@@ -136,7 +136,9 @@ class CircBox(Op):
     @property
     def circuit_name(self) -> str | None:
         """
-        :return: the name of the contained circuit
+        :return: the name of the contained circuit. 
+        
+         WARNING: Setting this property mutates the CircBox and any changes are propagated to any Circuit that the CircBox has been added to (via Circuit.add_circbox).
         """
     @circuit_name.setter
     def circuit_name(self, arg1: str) -> None:

--- a/pytket/tests/circuit_test.py
+++ b/pytket/tests/circuit_test.py
@@ -322,6 +322,15 @@ def test_symbolic_circbox() -> None:
     assert not c_outer.is_symbolic()
 
 
+def test_renaming_circbox_circuit() -> None:
+    c = Circuit(2).CX(0, 1)
+    cbox = CircBox(c)
+    d = Circuit(2).add_circbox(cbox, [0, 1])
+    cbox.circuit_name = "test_name"
+    assert cbox.circuit_name == "test_name"
+    assert d.get_commands()[0].op.circuit_name == "test_name"
+
+
 def test_subst_4() -> None:
     # https://github.com/CQCL/tket/issues/219
     m = fresh_symbol("m")

--- a/pytket/tests/circuit_test.py
+++ b/pytket/tests/circuit_test.py
@@ -329,7 +329,7 @@ def test_renaming_circbox_circuit() -> None:
     d = Circuit(2).add_circbox(cbox, [0, 1])
     cbox.circuit_name = "test_name"
     assert cbox.circuit_name == "test_name"
-    assert d.get_commands()[0].op.circuit_name == "test_name"
+    assert d.get_commands()[0].op.circuit_name == "test_name"  # type: ignore
 
 
 def test_subst_4() -> None:

--- a/tket/conanfile.py
+++ b/tket/conanfile.py
@@ -23,7 +23,7 @@ from conan.errors import ConanInvalidConfiguration
 
 class TketConan(ConanFile):
     name = "tket"
-    version = "1.2.100"
+    version = "1.2.101"
     package_type = "library"
     license = "Apache 2"
     homepage = "https://github.com/CQCL/tket"

--- a/tket/conanfile.py
+++ b/tket/conanfile.py
@@ -23,7 +23,7 @@ from conan.errors import ConanInvalidConfiguration
 
 class TketConan(ConanFile):
     name = "tket"
-    version = "1.2.99"
+    version = "1.2.100"
     package_type = "library"
     license = "Apache 2"
     homepage = "https://github.com/CQCL/tket"

--- a/tket/conanfile.py
+++ b/tket/conanfile.py
@@ -23,7 +23,7 @@ from conan.errors import ConanInvalidConfiguration
 
 class TketConan(ConanFile):
     name = "tket"
-    version = "1.2.102"
+    version = "1.2.103"
     package_type = "library"
     license = "Apache 2"
     homepage = "https://github.com/CQCL/tket"

--- a/tket/conanfile.py
+++ b/tket/conanfile.py
@@ -23,7 +23,7 @@ from conan.errors import ConanInvalidConfiguration
 
 class TketConan(ConanFile):
     name = "tket"
-    version = "1.2.96"
+    version = "1.2.97"
     package_type = "library"
     license = "Apache 2"
     homepage = "https://github.com/CQCL/tket"

--- a/tket/include/tket/Circuit/Boxes.hpp
+++ b/tket/include/tket/Circuit/Boxes.hpp
@@ -172,6 +172,20 @@ class CircBox : public Box {
 
   static nlohmann::json to_json(const Op_ptr &op);
 
+  /**
+   * Get the name of the inner circuit.
+   *
+   * @return name
+   */
+  std::optional<std::string> get_circuit_name() const;
+
+  /**
+   * Set the name of the inner circuit
+   *
+   * @param _name name string
+   */
+  void set_circuit_name(const std::string _name);
+
  protected:
   void generate_circuit() const override {}  // Already set by constructor
 };

--- a/tket/src/Circuit/Boxes.cpp
+++ b/tket/src/Circuit/Boxes.cpp
@@ -117,6 +117,16 @@ bool CircBox::is_equal(const Op &op_other) const {
   return circ_->circuit_equality(*other.circ_, {}, false);
 }
 
+std::optional<std::string> CircBox::get_circuit_name() const {
+  TKET_ASSERT(circ_ != nullptr);
+  return circ_->get_name();
+}
+
+void CircBox::set_circuit_name(const std::string _name) {
+  TKET_ASSERT(circ_ != nullptr);
+  circ_->set_name(_name);
+}
+
 Unitary1qBox::Unitary1qBox(const Eigen::Matrix2cd &m)
     : Box(OpType::Unitary1qBox), m_(m) {
   if (!is_unitary(m)) {

--- a/tket/test/src/Circuit/test_Boxes.cpp
+++ b/tket/test/src/Circuit/test_Boxes.cpp
@@ -120,8 +120,9 @@ SCENARIO("Using Boxes", "[boxes]") {
     Eigen::MatrixXcd uc0a = tket_sim::get_unitary(c0a);
     REQUIRE((uc0 - uc0a).cwiseAbs().sum() < ERR_EPS);
     // Test circuit name access
-    ubox.set_circuit_name("test_box");
-    REQUIRE(ubox.get_circuit_name() == "test_box");
+    CircBox cbox(Circuit(2));
+    cbox.set_circuit_name("test_box");
+    REQUIRE(cbox.get_circuit_name() == "test_box");
   }
   GIVEN("CircBox with non-default units") {
     Circuit c0;

--- a/tket/test/src/Circuit/test_Boxes.cpp
+++ b/tket/test/src/Circuit/test_Boxes.cpp
@@ -119,6 +119,9 @@ SCENARIO("Using Boxes", "[boxes]") {
     Eigen::MatrixXcd uc0 = tket_sim::get_unitary(c0);
     Eigen::MatrixXcd uc0a = tket_sim::get_unitary(c0a);
     REQUIRE((uc0 - uc0a).cwiseAbs().sum() < ERR_EPS);
+    // Test circuit name access
+    ubox.set_circuit_name("test_box");
+    REQUIRE(ubox.get_circuit_name() == "test_box");
   }
   GIVEN("CircBox with non-default units") {
     Circuit c0;


### PR DESCRIPTION
# Description

Add ``circuit_name`` property to ``CircBox`` to get & set the name of the inner circuit.

# Related issues

#669 

# Checklist

- [x] I have performed a self-review of my code.
- [ ] I have commented hard-to-understand parts of my code.
- [x] I have made corresponding changes to the public API documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have updated the changelog with any user-facing changes.
