### PR TITLE
Fix subcircuit finding algorithm

### DIFF
--- a/pytket/conanfile.py
+++ b/pytket/conanfile.py
@@ -32,7 +32,7 @@ class pytketRecipe(ConanFile):
         cmake.install()
 
     def requirements(self):
-        self.requires("tket/1.2.97@tket/stable")
+        self.requires("tket/1.2.98@tket/stable")
         self.requires("tklog/0.3.3@tket/stable")
         self.requires("tkrng/0.3.3@tket/stable")
         self.requires("tkassert/0.3.4@tket/stable")

--- a/pytket/conanfile.py
+++ b/pytket/conanfile.py
@@ -32,7 +32,7 @@ class pytketRecipe(ConanFile):
         cmake.install()
 
     def requirements(self):
-        self.requires("tket/1.2.96@tket/stable")
+        self.requires("tket/1.2.97@tket/stable")
         self.requires("tklog/0.3.3@tket/stable")
         self.requires("tkrng/0.3.3@tket/stable")
         self.requires("tkassert/0.3.4@tket/stable")

--- a/tket/conanfile.py
+++ b/tket/conanfile.py
@@ -23,7 +23,7 @@ from conan.errors import ConanInvalidConfiguration
 
 class TketConan(ConanFile):
     name = "tket"
-    version = "1.2.97"
+    version = "1.2.98"
     package_type = "library"
     license = "Apache 2"
     homepage = "https://github.com/CQCL/tket"

--- a/tket/conanfile.py
+++ b/tket/conanfile.py
@@ -23,7 +23,7 @@ from conan.errors import ConanInvalidConfiguration
 
 class TketConan(ConanFile):
     name = "tket"
-    version = "1.2.96"
+    version = "1.2.97"
     package_type = "library"
     license = "Apache 2"
     homepage = "https://github.com/CQCL/tket"

--- a/tket/include/tket/Circuit/Circuit.hpp
+++ b/tket/include/tket/Circuit/Circuit.hpp
@@ -1628,7 +1628,7 @@ class Circuit {
    *   satisfying the criterion.
    */
   std::vector<VertexSet> get_subcircuits(
-      std::function<bool(Op_ptr)> criterion) const;
+      std::function<bool(Op_ptr)> criterion) /*const*/;
 
   /**
    * Constructs a @ref Subcircuit with a given vertex set.

--- a/tket/test/src/Passes/test_CliffordResynthesis.cpp
+++ b/tket/test/src/Passes/test_CliffordResynthesis.cpp
@@ -92,6 +92,15 @@ SCENARIO("SynthesiseCliffordResynthesis correctness") {
     c.add_op<unsigned>(OpType::ZZMax, {0, 1});
     check_clifford_resynthesis(c);
   }
+  GIVEN("A troublesome circuit") {
+    // https://github.com/CQCL/tket/issues/1279
+    Circuit c(3);
+    c.add_op<unsigned>(OpType::ECR, {1, 2});
+    c.add_op<unsigned>(OpType::CnRy, 0., {0, 1});
+    c.add_op<unsigned>(OpType::Rz, 0., {1});
+    c.add_op<unsigned>(OpType::ZZMax, {2, 1});
+    check_clifford_resynthesis(c);
+  }
 }
 
 }  // namespace test_CliffordResynthesis


### PR DESCRIPTION
# Description

The failures were due to the fact that we were implicitly identifying the vertices of the graph constructed by `boost::transitive_closure()` with the vertices of the original graph. I tried to fix this by providing an associative map; but for some reason the resulting generated graph was always the complete graph on all vertices. In the end I implemented transitive closure myself, which we can do fairly efficiently for DAGs if we start with a topological sort.

# Related issues

Fixes #1279 .

# Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented hard-to-understand parts of my code.
- [ ] I have made corresponding changes to the public API documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the changelog with any user-facing changes.
