### PR TITLE
README updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@
 
 ## Introduction
 
-This repository contains the full source code for TKET, a quantum compiler and software development kit.
+This repository contains the full source code for the TKET quantum compiler and its pytket python bindings.
 
-TKET is primarily a high performance quantum compiler capable of optimising circuits for a wide range quantum computing architectures and simulators.
+TKET is primarily a high performance quantum compiler capable of optimising circuits for execution on a wide range quantum computing architectures and simulators.
 
-The standard way of using TKET is via its `pytket` python API.
+The standard way of using TKET is via its pytket python API.
 
-If you just want to use tket via Python, the easiest way is to install it with
+If you just want to use tket via Python, the easiest way is to install pytket with
 `pip`:
 
 ```shell

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 ## Introduction
 
-TKET (pronounced ticket) is a high performance quantum compiler capable of optimising circuits for execution on a wide range quantum computing architectures and simulators.
+TKET (pronounced ticket) is a high performance quantum compiler that can optimise circuits for execution on a wide range quantum computing architectures and simulators.
 
 This repository contains the full source code for TKET and its python bindings.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ## Introduction
 
-TKET (pronounced ticket) is a high performance quantum compiler that can optimise circuits for execution on a wide range quantum computing architectures and simulators.
+TKET (pronounced ticket) is a high performance quantum compiler that can optimise circuits for execution on a wide range of quantum computing architectures.
 
 This repository contains the full source code for TKET and its python bindings.
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ TKET is primarily a high performance quantum compiler capable of optimising circ
 
 The standard way of using TKET is via its `pytket` python API.
 
-This can simply be installed with `pip`
+If you just want to use tket via python, the easiest way is to install it with
+`pip`:
 
 ```shell
 pip install pytket

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@
 
 ## Introduction
 
-TKET is primarily a high performance quantum compiler capable of optimising circuits for execution on a wide range quantum computing architectures and simulators.
+TKET (pronounced ticket) is a high performance quantum compiler capable of optimising circuits for execution on a wide range quantum computing architectures and simulators.
 
-This repository contains the full source code for the TKET and its python bindings.
+This repository contains the full source code for TKET and its python bindings.
 
 The standard way of using TKET is via its pytket python API.
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ TKET is primarily a high performance quantum compiler capable of optimising circ
 
 The standard way of using TKET is via its `pytket` python API.
 
-If you just want to use tket via python, the easiest way is to install it with
+If you just want to use tket via Python, the easiest way is to install it with
 `pip`:
 
 ```shell

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ pip install pytket
 
 For getting started using pytket, check out the user manual and notebook examples.
 
-User manual - https://tket.quantinuum.com/user-manual/
-Notebook examples - https://tket.quantinuum.com/examples/
+- User manual - https://tket.quantinuum.com/user-manual/
+- Notebook examples - https://tket.quantinuum.com/examples/
 
 The source content for the manual and notebook examples can be found in the [pytket-docs repository](https://github.com/CQCL/pytket-docs).
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 ## Introduction
 
-This repository contains the full source code for the TKET quantum compiler and its pytket python bindings.
+This repository contains the full source code for the TKET quantum compiler and its python bindings.
 
 TKET is primarily a high performance quantum compiler capable of optimising circuits for execution on a wide range quantum computing architectures and simulators.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ## Introduction
 
-TKET (pronounced ticket) is a high performance quantum compiler that can optimise circuits for a wide range of quantum computing architectures.
+TKET (pronounced "ticket") is a high-performance quantum compiler that can optimise circuits for a wide range of quantum computing architectures.
 
 This repository contains the full source code for TKET and its python bindings.
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,32 @@
 # tket
 
+[![Slack](https://img.shields.io/badge/Slack-4A154B?style=for-the-badge&logo=slack&logoColor=white)](https://tketusers.slack.com/join/shared_invite/zt-18qmsamj9-UqQFVdkRzxnXCcKtcarLRA#/shared-invite/email)
+[![PyPI version](https://badge.fury.io/py/pytket.svg)](https://badge.fury.io/py/pytket)
+
 ## Introduction
 
-This repository contains the full source code for tket, a quantum SDK.
+This repository contains the full source code for TKET, a quantum compiler and software development kit.
 
-If you just want to use tket via Python, the easiest way is to install it with
-`pip`:
+TKET is primarily a high performance quantum compiler capable of optimising circuits for a wide range quantum computing architectures and simulators.
+
+The standard way of using TKET is via its `pytket` python API.
+
+This can simply be installed with `pip`
 
 ```shell
 pip install pytket
 ```
+
+As well as being an interface to the TKET compiler, pytket also provides an extensive API for other quantum computing tasks. These include constructing quantum circuits and handling the execution of experiments on devices and simulators.
+
+## Documentation
+
+The `tket` (C++) API documentation (generated with `doxygen`, and still rather
+patchy) is available
+[here](https://cqcl.github.io/tket/tket/api/index.html).
+
+The `pytket` (Python) API documentation is available
+[here](https://tket.quantinuum.com/api-docs).
 
 For getting started using pytket, check out the user manual and notebook examples.
 
@@ -18,6 +35,7 @@ For getting started using pytket, check out the user manual and notebook example
 
 The source content for the manual and notebook examples can be found in the [pytket-docs repository](https://github.com/CQCL/pytket-docs).
 
+## Extensions
 
 In addition to the core pytket package there are pytket extension modules which allow pytket to interface with quantum devices and simulators. Some extensions also provide interoperability with other software libraries such as qiskit, cirq and pennylane.
 
@@ -25,7 +43,9 @@ For a list of available pytket extensions see the [extensions index page](https:
 
 These extensions are installed as separate python packages and the source code for each extension lives in its own github repository.
 
-If you would like to build tket yourself and help to improve it, read on!
+## How to build TKET and pytket
+
+If you would like to build TKET yourself and help to improve it, read on!
 
 The codebase is split into two main projects:
  - [tket](tket): the core functionality of tket, optimised for execution speed
@@ -35,8 +55,6 @@ The codebase is split into two main projects:
    shared library) and pure Python code that defines abstract interfaces 
    used by the extension modules such as the `Backend` and `BackendResult` classes,
    as well as various other utilities.
-
-## How to build tket and pytket
 
 ### Prerequisites
 
@@ -133,12 +151,3 @@ building and testing pytket.
 Tket and pytket are available as a Nix flake, with support for Linux and Apple Silicon systems.
 See the [README](nix-support/README.md) in the `nix-support` directory for instructions
 on building and testing tket and pytket through Nix, and on how to use it within a Nix project.
-
-## API documentation
-
-The `tket` (C++) API documentation (generated with `doxygen`, and still rather
-patchy) is available
-[here](https://cqcl.github.io/tket/tket/api/index.html).
-
-The `pytket` (Python) API documentation is available
-[here](https://cqcl.github.io/tket/pytket/api/index.html).

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # tket
 
-[![Slack](https://img.shields.io/badge/Slack-4A154B?style=for-the-badge&logo=slack&logoColor=white)](https://tketusers.slack.com/join/shared_invite/zt-18qmsamj9-UqQFVdkRzxnXCcKtcarLRA#/shared-invite/email)
-[![Stack Exchange](https://img.shields.io/badge/StackExchange-%23ffffff.svg?style=for-the-badge&logo=StackExchange)](https://quantumcomputing.stackexchange.com/search?q=user:19610+[pytket])
+[![Slack](https://img.shields.io/badge/Slack-4A154B?style=for-the-badge&logo=slack&logoColor=white)](https://tketusers.slack.com/join/shared_invite/zt-18qmsamj9-UqQFVdkRzxnXCcKtcarLRA#)
+[![Stack Exchange](https://img.shields.io/badge/StackExchange-%23ffffff.svg?style=for-the-badge&logo=StackExchange)](https://quantumcomputing.stackexchange.com/tags/pytket)
 [![PyPI version](https://badge.fury.io/py/pytket.svg)](https://badge.fury.io/py/pytket)
 
 ## Introduction

--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@
 
 ## Introduction
 
-This repository contains the full source code for the TKET quantum compiler and its python bindings.
-
 TKET is primarily a high performance quantum compiler capable of optimising circuits for execution on a wide range quantum computing architectures and simulators.
+
+This repository contains the full source code for the TKET and its python bindings.
 
 The standard way of using TKET is via its pytket python API.
 
-If you just want to use tket via Python, the easiest way is to install pytket with
+If you just want to use TKET via Python, the easiest way is to install pytket with
 `pip`:
 
 ```shell

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ## Introduction
 
-TKET (pronounced ticket) is a high performance quantum compiler that can optimise circuits for execution on a wide range of quantum computing architectures.
+TKET (pronounced ticket) is a high performance quantum compiler that can optimise circuits for a wide range of quantum computing architectures.
 
 This repository contains the full source code for TKET and its python bindings.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # tket
 
 [![Slack](https://img.shields.io/badge/Slack-4A154B?style=for-the-badge&logo=slack&logoColor=white)](https://tketusers.slack.com/join/shared_invite/zt-18qmsamj9-UqQFVdkRzxnXCcKtcarLRA#/shared-invite/email)
+[![Stack Exchange](https://img.shields.io/badge/StackExchange-%23ffffff.svg?style=for-the-badge&logo=StackExchange)](https://quantumcomputing.stackexchange.com/search?q=user:19610+[pytket])
 [![PyPI version](https://badge.fury.io/py/pytket.svg)](https://badge.fury.io/py/pytket)
 
 ## Introduction


### PR DESCRIPTION
# Description

I realised I messed up some spacing for the manual and examples links in the README in #1284. Rather than just fix the spacing  I thought I would add the following edits.

* Added a brief explanation of what TKET is. Hopefully clarifying the difference between TKET and pytket.
* Reordered some subsections - moving the API docs links further up.
* Added badges for pypi release number, slack and stack exchange (can remove these if preferred).
