### PR TITLE
add wasm files that had gone missing

### DIFF
--- a/pytket/tests/wasm-generation/wasmfromrust/src/lib-2.rs
+++ b/pytket/tests/wasm-generation/wasmfromrust/src/lib-2.rs
@@ -1,0 +1,107 @@
+// src/lib.rs
+
+#[no_mangle]
+fn init() {    
+}
+
+#[no_mangle]
+pub extern "C" fn add_one(x: i32) -> i32 {
+    x + 1
+}
+
+
+#[no_mangle]
+pub extern "C" fn multi(x: i32, y: i32) -> i32 {
+    x * y
+}
+
+
+#[no_mangle]
+pub extern "C" fn add_two(x: i32) -> i32 {
+    x + 2
+}
+
+#[no_mangle]
+pub extern "C" fn add_something(x: i64) -> i64 {
+    x + 11
+}
+
+#[no_mangle]
+pub extern "C" fn add_something_32(x: i32, y: i32) -> i32 {
+    x + y
+}
+
+#[no_mangle]
+pub extern "C" fn add_eleven(x: i32) -> i32 {
+    x + 11
+}
+
+#[no_mangle]
+pub extern "C" fn no_return(x: i32) {
+    let _y = x + 11;
+}
+
+#[no_mangle]
+pub extern "C" fn no_parameters() -> i32 {
+    11
+}
+
+#[no_mangle]
+pub extern "C" fn new_function() -> i32 {
+    13
+}
+
+#[no_mangle]
+pub extern "C" fn mixed_up(limit: i32) -> i32 {
+    let mut i = 0;
+
+    while i < limit {
+        i = i * 2;
+    }
+return i
+}
+
+#[no_mangle]
+pub fn mixed_up_2(limit: i32, limit2: i32) -> i32 {
+    let mut i = 0;
+
+    while i < limit {
+        i = i * 2;
+    }
+
+    while i < limit2 {
+        i = i * 3;
+    }
+return i
+}
+
+
+#[no_mangle]
+fn mixed_up_3(limit: i32, limit2: i32, limit3: i32) -> i32 {
+    let mut i = 0;
+
+    while i < limit {
+        i = i * 2;
+    }
+
+    while i < limit2 {
+        i = i * 3;
+    }
+
+    while i < limit3 {
+        i = i * 4;
+    }
+
+    return i
+}
+
+
+#[no_mangle]
+fn unse_internal(p: i32) -> i32 {
+    let mut r = no_parameters();
+
+    r = add_eleven(r);
+    r = add_something_32(r, p);
+
+    return r
+}

--- a/pytket/tests/wasm-generation/wasmfromrust/src/lib-2.rs
+++ b/pytket/tests/wasm-generation/wasmfromrust/src/lib-2.rs
@@ -1,3 +1,4 @@
+#![deny(warnings)]
 // src/lib.rs
 
 #[no_mangle]

--- a/pytket/tests/wasm-generation/wasmfromrust/src/lib.rs
+++ b/pytket/tests/wasm-generation/wasmfromrust/src/lib.rs
@@ -1,0 +1,48 @@
+// src/lib.rs
+
+#[no_mangle]
+pub extern "C" fn init() {    
+}
+
+#[no_mangle]
+pub extern "C" fn add_one(x: i32) -> i32 {
+    x + 1
+}
+
+
+#[no_mangle]
+pub extern "C" fn multi(x: i32, y: i32) -> i32 {
+    x * y
+}
+
+
+#[no_mangle]
+pub extern "C" fn add_two(x: i32) -> i32 {
+    x + 2
+}
+
+#[no_mangle]
+pub extern "C" fn add_something(x: i64) -> i64 {
+    x + 11
+}
+
+#[no_mangle]
+pub extern "C" fn add_eleven(x: i32) -> i32 {
+    x + 11
+}
+
+#[no_mangle]
+pub extern "C" fn no_return(x: i32) {
+    let _y = x + 11;
+}
+
+#[no_mangle]
+pub extern "C" fn no_parameters() -> i32 {
+    11
+}
+
+#[no_mangle]
+pub extern "C" fn new_function() -> i32 {
+    13
+}
+

--- a/pytket/tests/wasm-generation/wasmfromrust/src/lib.rs
+++ b/pytket/tests/wasm-generation/wasmfromrust/src/lib.rs
@@ -1,3 +1,4 @@
+#![deny(warnings)]
 // src/lib.rs
 
 #[no_mangle]


### PR DESCRIPTION
# Description

The files where the wasm is compiled from via rust had gone missing. I have added them back in.

When adding them back in, I was hit by:

```git add wasmfromrust/src/
The following paths are ignored by one of your .gitignore files:
pytket/tests/wasm-generation/wasmfromrust/src
hint: Use -f if you really want to add them.
hint: Turn this message off by running
hint: "git config advice.addIgnoredFile false"
```

But I have not found any ignores that would explain this. Any ideas?

# Related issues

Please mention any github issues addressed by this PR.

# Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented hard-to-understand parts of my code.
- [x] I have made corresponding changes to the public API documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have updated the changelog with any user-facing changes.
