### PR TITLE
Make trivial renames on registerwise classical operations possible

### DIFF
--- a/pytket/conanfile.py
+++ b/pytket/conanfile.py
@@ -32,7 +32,7 @@ class pytketRecipe(ConanFile):
         cmake.install()
 
     def requirements(self):
-        self.requires("tket/1.2.99@tket/stable")
+        self.requires("tket/1.2.100@tket/stable")
         self.requires("tklog/0.3.3@tket/stable")
         self.requires("tkrng/0.3.3@tket/stable")
         self.requires("tkassert/0.3.4@tket/stable")

--- a/pytket/conanfile.py
+++ b/pytket/conanfile.py
@@ -32,7 +32,7 @@ class pytketRecipe(ConanFile):
         cmake.install()
 
     def requirements(self):
-        self.requires("tket/1.2.98@tket/stable")
+        self.requires("tket/1.2.99@tket/stable")
         self.requires("tklog/0.3.3@tket/stable")
         self.requires("tkrng/0.3.3@tket/stable")
         self.requires("tkassert/0.3.4@tket/stable")

--- a/pytket/pytket/circuit/logic_exp.py
+++ b/pytket/pytket/circuit/logic_exp.py
@@ -279,6 +279,8 @@ class LogicExp:
         """Rename the Bits according to a Bit map. Raise ValueError if
         a bit is being used in a register-wise expression.
         """
+        if all(old_bit == new_bit for old_bit, new_bit in cmap.items()):
+            return False
         renamed_regs = set([key.reg_name for key in cmap.keys()])
         return self._rename_args_recursive(cmap, renamed_regs)
 

--- a/pytket/tests/circuit_test.py
+++ b/pytket/tests/circuit_test.py
@@ -1471,6 +1471,17 @@ def test_deserialization_from_junk() -> None:
         )
 
 
+def test_decompose_clexpbox() -> None:
+    # https://github.com/CQCL/tket/issues/1289
+    c0 = Circuit()
+    c_reg = c0.add_c_register("c", 2)
+    c0.add_classicalexpbox_register(c_reg | c_reg, c_reg)  # type: ignore
+    cbox = CircBox(c0)
+    c = Circuit(0, 2)
+    c.add_circbox(cbox, [0, 1])
+    assert Transform.DecomposeBoxes().apply(c)
+
+
 if __name__ == "__main__":
     test_circuit_gen()
     test_symbolic_ops()

--- a/pytket/tests/circuit_test.py
+++ b/pytket/tests/circuit_test.py
@@ -53,6 +53,7 @@ from pytket.circuit import (
     ResourceBounds,
     ResourceData,
     DummyBox,
+    ClassicalExpBox,
 )
 from pytket.circuit.display import get_circuit_renderer, render_circuit_as_html
 from pytket.circuit.named_types import (
@@ -1493,6 +1494,7 @@ def test_decompose_clexpbox() -> None:
     cmds = c.get_commands()
     assert len(cmds) == 1
     op = cmds[0].op
+    assert isinstance(op, ClassicalExpBox)
     assert op.get_n_io() == 2
     expr = op.get_exp()
     assert expr.args == [BitRegister("c", 2), BitRegister("c", 2)]

--- a/pytket/tests/circuit_test.py
+++ b/pytket/tests/circuit_test.py
@@ -1490,6 +1490,12 @@ def test_decompose_clexpbox() -> None:
     c = Circuit(0, 2)
     c.add_circbox(cbox, [0, 1])
     assert Transform.DecomposeBoxes().apply(c)
+    cmds = c.get_commands()
+    assert len(cmds) == 1
+    op = cmds[0].op
+    assert op.get_n_io() == 2
+    expr = op.get_exp()
+    assert expr.args == [BitRegister("c", 2), BitRegister("c", 2)]
 
 
 def test_bad_circbox() -> None:

--- a/pytket/tests/circuit_test.py
+++ b/pytket/tests/circuit_test.py
@@ -1482,6 +1482,16 @@ def test_decompose_clexpbox() -> None:
     assert Transform.DecomposeBoxes().apply(c)
 
 
+def test_bad_circbox() -> None:
+    circ = Circuit(3)
+    a = circ.add_c_register("a", 5)
+    b = circ.add_c_register("b", 5)
+    c = circ.add_c_register("c", 5)
+    circ.add_classicalexpbox_register(a | b, c.to_list())
+    with pytest.raises(RuntimeError) as e:
+        _ = CircBox(circ)
+
+
 if __name__ == "__main__":
     test_circuit_gen()
     test_symbolic_ops()

--- a/tket/conanfile.py
+++ b/tket/conanfile.py
@@ -23,7 +23,7 @@ from conan.errors import ConanInvalidConfiguration
 
 class TketConan(ConanFile):
     name = "tket"
-    version = "1.2.98"
+    version = "1.2.99"
     package_type = "library"
     license = "Apache 2"
     homepage = "https://github.com/CQCL/tket"

--- a/tket/conanfile.py
+++ b/tket/conanfile.py
@@ -23,7 +23,7 @@ from conan.errors import ConanInvalidConfiguration
 
 class TketConan(ConanFile):
     name = "tket"
-    version = "1.2.99"
+    version = "1.2.100"
     package_type = "library"
     license = "Apache 2"
     homepage = "https://github.com/CQCL/tket"

--- a/tket/src/Circuit/Boxes.cpp
+++ b/tket/src/Circuit/Boxes.cpp
@@ -14,8 +14,11 @@
 
 #include "tket/Circuit/Boxes.hpp"
 
+#include <exception>
 #include <memory>
 #include <numeric>
+#include <sstream>
+#include <stdexcept>
 #include <tkassert/Assert.hpp>
 
 #include "tket/Circuit/AssertionSynthesis.hpp"
@@ -69,6 +72,14 @@ Op_ptr Box::deserialize(const nlohmann::json &j) {
 }
 
 CircBox::CircBox(const Circuit &circ) : Box(OpType::CircBox) {
+  try {
+    Circuit circ1 = circ;
+    circ1.flatten_registers();
+  } catch (const std::exception &e) {
+    std::stringstream ss;
+    ss << "Unable to construct CircBox: " << e.what();
+    throw std::runtime_error(ss.str());
+  }
   signature_ = op_signature_t(circ.n_qubits(), EdgeType::Quantum);
   op_signature_t bits(circ.n_bits(), EdgeType::Classical);
   signature_.insert(signature_.end(), bits.begin(), bits.end());


### PR DESCRIPTION
# Description

Also add an early check to the `CircBox` constructor that the circuit is boxable.

# Related issues

Fixes #1289 .

# Checklist

- [x] I have performed a self-review of my code.
- [ ] I have commented hard-to-understand parts of my code.
- [ ] I have made corresponding changes to the public API documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the changelog with any user-facing changes.
