### PR TITLE
Decompose boxes before converting to QASM

### DIFF
--- a/pytket/docs/changelog.rst
+++ b/pytket/docs/changelog.rst
@@ -12,6 +12,10 @@ Features:
 
 * Add ``circuit_name`` property to ``CircBox``.
 
+Fixes:
+
+* Correct handling of ``CustomGate`` when converting from pytket to QASM.
+
 1.26.0 (March 2024)
 -------------------
 

--- a/pytket/pytket/qasm/qasm.py
+++ b/pytket/pytket/qasm/qasm.py
@@ -1060,11 +1060,11 @@ def _filtered_qasm_str(qasm: str) -> str:
     return "\n".join(lines)
 
 
-def is_empty_customgate(op: Op):
-    return op.type == OpType.CustomGate and op.get_circuit().n_gates == 0
+def is_empty_customgate(op: Op) -> bool:
+    return op.type == OpType.CustomGate and op.get_circuit().n_gates == 0  # type: ignore
 
 
-def check_can_convert_circuit(circ: Circuit, header: str, maxwidth: int):
+def check_can_convert_circuit(circ: Circuit, header: str, maxwidth: int) -> None:
     if any(
         circ.n_gates_of_type(typ)
         for typ in (

--- a/pytket/tests/qasm_test.py
+++ b/pytket/tests/qasm_test.py
@@ -460,7 +460,7 @@ def test_opaque() -> None:
     )
     with pytest.raises(QASMUnsupportedError) as e:
         circuit_to_qasm_str(c)
-    assert "CustomGate myopaq has empty definition" in str(e.value)
+    assert "Empty CustomGates and opaque gates are not supported" in str(e.value)
 
 
 def test_alternate_encoding() -> None:

--- a/pytket/tests/qasm_test.py
+++ b/pytket/tests/qasm_test.py
@@ -888,6 +888,38 @@ def test_register_name_check() -> None:
     assert err_msg in str(e2.value)
 
 
+def test_conditional_custom() -> None:
+    # https://github.com/CQCL/tket/issues/1299
+    qasm0 = """
+    OPENQASM 2.0;
+    include "qelib1.inc";
+
+    gate cx_o0 q0,q1 { x q0; cx q0,q1; x q0; }
+
+    qreg q[2];
+    creg c[1];
+
+    if(c==1) cx_o0 q[1],q[0];
+    measure q[0] -> c[0];
+    """
+
+    circ = circuit_from_qasm_str(qasm0)
+    qasm1 = circuit_to_qasm_str(circ)
+    assert (
+        qasm1
+        == """OPENQASM 2.0;
+include "qelib1.inc";
+
+qreg q[2];
+creg c[1];
+if(c==1) x q[1];
+if(c==1) cx q[1],q[0];
+if(c==1) x q[1];
+measure q[0] -> c[0];
+"""
+    )
+
+
 if __name__ == "__main__":
     test_qasm_correct()
     test_qasm_qubit()


### PR DESCRIPTION
# Description

Add special logic to detect (and raise an error for) empty custom gates, to match previous behaviour.

# Related issues

Fixes #1299 .

# Checklist

- [x] I have performed a self-review of my code.
- [ ] I have commented hard-to-understand parts of my code.
- [ ] I have made corresponding changes to the public API documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have updated the changelog with any user-facing changes.
