### PR TITLE
doc: Fix incorrect build/test instructions in the README

### DIFF
--- a/tket/README.md
+++ b/tket/README.md
@@ -38,7 +38,7 @@ wget http://mirrors.ctan.org/graphics/pgf/contrib/quantikz/tikzlibraryquantikz.c
 To build tket and its dependencies and run all unit and property tests, use:
 
 ```shell
-conan build tket --build=missing -o "boost/*":header_only=True -o with_all_tests=True
+conan build tket --user=tket --channel=stable --build=missing -o "boost/*":header_only=True -o with_all_tests=True
 ```
 or `with_test`/`with_proptest` to only build and run the unit tests or proptests, respectively.
  
@@ -51,8 +51,8 @@ build directories `tket/build/Release` and/or `tket/build/Debug`.
 They can be run from those directories, e.g.:
 ```shell
 cd tket/build/Release
-./test/tket-test
-./proptest/tket-proptest
+./test/test-tket
+./proptest/proptest-tket
 ```
 
 The tests with a running time >=1 second (on a regular modern laptop) are marked


### PR DESCRIPTION
# Description

The instructions for building and testing `tket` in the README were incorrect.

# Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented hard-to-understand parts of my code.
- [x] I have made corresponding changes to the public API documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have updated the changelog with any user-facing changes.
