### PR TITLE
fix: Explicit types in Architecture initializers

### DIFF
--- a/pytket/binders/unitid.cpp
+++ b/pytket/binders/unitid.cpp
@@ -205,9 +205,7 @@ PYBIND11_MODULE(unit_id, m) {
       .def("__eq__", &py_equals<Bit>)
       .def("__hash__", [](const Bit &b) { return hash_value(b); })
       .def(py::pickle(
-          [](const Bit &b) {
-            return py::make_tuple(b.reg_name(), b.index());
-          },
+          [](const Bit &b) { return py::make_tuple(b.reg_name(), b.index()); },
           [](const py::tuple &t) {
             if (t.size() != 2)
               throw std::runtime_error(

--- a/pytket/conanfile.py
+++ b/pytket/conanfile.py
@@ -32,7 +32,7 @@ class pytketRecipe(ConanFile):
         cmake.install()
 
     def requirements(self):
-        self.requires("tket/1.2.104@tket/stable")
+        self.requires("tket/1.2.105@tket/stable")
         self.requires("tklog/0.3.3@tket/stable")
         self.requires("tkrng/0.3.3@tket/stable")
         self.requires("tkassert/0.3.4@tket/stable")

--- a/tket/conanfile.py
+++ b/tket/conanfile.py
@@ -23,7 +23,7 @@ from conan.errors import ConanInvalidConfiguration
 
 class TketConan(ConanFile):
     name = "tket"
-    version = "1.2.104"
+    version = "1.2.105"
     package_type = "library"
     license = "Apache 2"
     homepage = "https://github.com/CQCL/tket"

--- a/tket/test/src/Graphs/test_ArticulationPoints.cpp
+++ b/tket/test/src/Graphs/test_ArticulationPoints.cpp
@@ -145,7 +145,8 @@ SCENARIO("Find APs of disconnected nodes") {
 }
 
 SCENARIO("Test APs in Architecture", "[architectures],[routing]") {
-  Architecture arc({{0, 1}, {1, 2}, {2, 3}});
+  Architecture arc(
+      {{Node(0), Node(1)}, {Node(1), Node(2)}, {Node(2), Node(3)}});
   node_set_t ap = arc.get_articulation_points();
 
   GIVEN("Removing node that preserves connected graph") {
@@ -157,7 +158,11 @@ SCENARIO("Test APs in Architecture", "[architectures],[routing]") {
     REQUIRE(ap.find(Node(2)) != ap.end());
   }
 
-  Architecture arc2({{0, 1}, {0, 2}, {0, 3}, {2, 3}});
+  Architecture arc2(
+      {{Node(0), Node(1)},
+       {Node(0), Node(2)},
+       {Node(0), Node(3)},
+       {Node(2), Node(3)}});
   ap = arc2.get_articulation_points();
   REQUIRE(ap.find(Node(0)) != ap.end());
 

--- a/tket/test/src/test_Architectures.cpp
+++ b/tket/test/src/test_Architectures.cpp
@@ -123,12 +123,20 @@ SCENARIO("Diameters") {
     CHECK(arc.get_diameter() == 0);
   }
   GIVEN("a connected architecture") {
-    Architecture arc({{0, 1}, {1, 2}, {2, 3}, {3, 0}});
+    Architecture arc(
+        {{Node(0), Node(1)},
+         {Node(1), Node(2)},
+         {Node(2), Node(3)},
+         {Node(3), Node(0)}});
     CHECK(arc.get_diameter() == 2);
   }
   GIVEN("a disconnected architecture") {
     // TKET-1425
-    Architecture arc({{0, 1}, {1, 2}, {2, 0}, {3, 4}});
+    Architecture arc(
+        {{Node(0), Node(1)},
+         {Node(1), Node(2)},
+         {Node(2), Node(0)},
+         {Node(3), Node(4)}});
     CHECK_THROWS(arc.get_diameter());
   }
 }

--- a/tket/test/src/test_CompilerPass.cpp
+++ b/tket/test/src/test_CompilerPass.cpp
@@ -617,7 +617,8 @@ SCENARIO("gen_placement_pass test") {
   GIVEN("A simple circuit and device and base Placement.") {
     Circuit circ(4);
     add_2qb_gates(circ, OpType::CX, {{0, 1}, {2, 1}, {2, 3}});
-    Architecture arc({{0, 1}, {1, 2}, {3, 2}});
+    Architecture arc(
+        {{Node(0), Node(1)}, {Node(1), Node(2)}, {Node(3), Node(2)}});
     Placement::Ptr plptr = std::make_shared<Placement>(arc);
     PassPtr pp_place = gen_placement_pass(plptr);
     CompilationUnit cu(circ);
@@ -632,7 +633,8 @@ SCENARIO("gen_placement_pass test") {
   GIVEN("A simple circuit and device and GraphPlacement.") {
     Circuit circ(4);
     add_2qb_gates(circ, OpType::CX, {{0, 1}, {2, 1}, {2, 3}});
-    Architecture arc({{0, 1}, {1, 2}, {3, 2}});
+    Architecture arc(
+        {{Node(0), Node(1)}, {Node(1), Node(2)}, {Node(3), Node(2)}});
     Placement::Ptr plptr = std::make_shared<GraphPlacement>(arc);
     PassPtr pp_place = gen_placement_pass(plptr);
     CompilationUnit cu(circ);
@@ -1371,7 +1373,8 @@ SCENARIO("Commute measurements to the end of a circuit") {
     add_1qb_gates(test, OpType::X, {2, 2});
     test.add_op<unsigned>(OpType::CX, {0, 2});
 
-    Architecture line({{0, 1}, {1, 2}, {2, 3}});
+    Architecture line(
+        {{Node(0), Node(1)}, {Node(1), Node(2)}, {Node(2), Node(3)}});
     Placement::Ptr pp = std::make_shared<Placement>(line);
     PassPtr route_pass = gen_full_mapping_pass(
         line, pp,
@@ -1432,7 +1435,11 @@ static bool is_classical_map(const Circuit& c) {
 SCENARIO("CX mapping pass") {
   // TKET-1045
   GIVEN("A device with a linear architecture") {
-    Architecture line({{0, 1}, {1, 2}, {2, 3}, {3, 4}});
+    Architecture line(
+        {{Node(0), Node(1)},
+         {Node(1), Node(2)},
+         {Node(2), Node(3)},
+         {Node(3), Node(4)}});
 
     // Noise-aware placement and rebase
     Placement::Ptr placer = std::make_shared<GraphPlacement>(line);

--- a/tket/test/src/test_LexiRoute.cpp
+++ b/tket/test/src/test_LexiRoute.cpp
@@ -1063,7 +1063,7 @@ SCENARIO("Test routing on a directed architecture with bidirectional edges") {
     circ.add_op<unsigned>(OpType::H, {0});
     circ.add_op<unsigned>(OpType::CX, {0, 1});
     Architecture arc({{Node(0), Node(1)}, {Node(1), Node(0)}});
-    Architecture arc2(std::vector<std::pair<unsigned, unsigned>>{{0, 1}});
+    Architecture arc2({std::pair<Node, Node>{Node(0), Node(1)}});
 
     // routing ignored bi directional edge and solves correctly
     MappingManager mm(std::make_shared<Architecture>(arc));
@@ -1091,7 +1091,7 @@ SCENARIO(
     circ.add_op<unsigned>(OpType::CRz, 0.5, {1, 0});
     circ.add_op<unsigned>(OpType::CRz, 0.5, {0, 1});
 
-    Architecture arc(std::vector<std::pair<unsigned, unsigned>>{{0, 1}});
+    Architecture arc({std::pair<Node, Node>{Node(0), Node(1)}});
     MappingManager mm(std::make_shared<Architecture>(arc));
     REQUIRE(mm.route_circuit(
         circ, {std::make_shared<LexiLabellingMethod>(),
@@ -1114,7 +1114,7 @@ SCENARIO("Dense CX circuits route succesfully") {
         }
       }
     }
-    Architecture arc((std::vector<std::pair<unsigned, unsigned>>){
+    Architecture arc(std::vector<std::pair<unsigned, unsigned>>{
         {0, 1},   {1, 2},   {2, 3},   {3, 4},   {0, 5},   {1, 6},   {1, 7},
         {2, 6},   {2, 7},   {3, 8},   {3, 9},   {4, 8},   {4, 9},   {5, 6},
         {5, 10},  {5, 11},  {6, 10},  {6, 11},  {6, 7},   {7, 12},  {7, 13},
@@ -1172,7 +1172,7 @@ SCENARIO(
         }
       }
     }
-    Architecture arc((std::vector<std::pair<unsigned, unsigned>>){
+    Architecture arc(std::vector<std::pair<unsigned, unsigned>>{
         {0, 1},
         {2, 0},
         {2, 4},
@@ -1629,7 +1629,7 @@ SCENARIO("Test failing case") {
   std::ifstream circuit_file("lexiroute_circuit.json");
   nlohmann::json j = nlohmann::json::parse(circuit_file);
   auto c = j.get<Circuit>();
-  Architecture arc((std::vector<std::pair<unsigned, unsigned>>){
+  Architecture arc(std::vector<std::pair<unsigned, unsigned>>{
       {0, 1},   {1, 2},   {2, 3},   {3, 5},   {4, 1},   {4, 7},   {5, 8},
       {6, 7},   {7, 10},  {8, 9},   {8, 11},  {10, 12}, {11, 14}, {12, 13},
       {14, 13}, {14, 16}, {12, 15}, {15, 18}, {17, 18}, {16, 19}, {19, 20},

--- a/tket/test/src/test_LexiRoute.cpp
+++ b/tket/test/src/test_LexiRoute.cpp
@@ -995,7 +995,11 @@ SCENARIO(
     test_circuit.add_blank_wires(4);
     add_2qb_gates(test_circuit, OpType::CX, {{0, 1}, {1, 2}, {2, 3}, {3, 0}});
 
-    Architecture test_arc({{0, 1}, {1, 2}, {2, 3}, {3, 0}});
+    Architecture test_arc(
+        {{Node(0), Node(1)},
+         {Node(1), Node(2)},
+         {Node(2), Node(3)},
+         {Node(3), Node(0)}});
     Placement test_p(test_arc);
 
     std::map<Qubit, Node> map_;
@@ -1020,7 +1024,8 @@ SCENARIO("Empty Circuit test") {
   GIVEN("An Empty Circuit") {
     Circuit circ;
     circ.add_blank_wires(4);
-    Architecture arc({{0, 1}, {1, 2}, {2, 3}});
+    Architecture arc(
+        {{Node(0), Node(1)}, {Node(1), Node(2)}, {Node(2), Node(3)}});
     MappingManager mm(std::make_shared<Architecture>(arc));
     REQUIRE(mm.route_circuit(
         circ, {
@@ -1040,7 +1045,8 @@ SCENARIO("Routing on circuit with no multi-qubit gates") {
     circ.add_op<unsigned>(OpType::Y, {1});
 
     unsigned orig_vertices = circ.n_vertices();
-    Architecture arc({{0, 1}, {1, 2}, {2, 3}});
+    Architecture arc(
+        {{Node(0), Node(1)}, {Node(1), Node(2)}, {Node(2), Node(3)}});
     MappingManager mm(std::make_shared<Architecture>(arc));
     REQUIRE(mm.route_circuit(
         circ, {
@@ -1056,7 +1062,7 @@ SCENARIO("Test routing on a directed architecture with bidirectional edges") {
     Circuit circ(2);
     circ.add_op<unsigned>(OpType::H, {0});
     circ.add_op<unsigned>(OpType::CX, {0, 1});
-    Architecture arc({{0, 1}, {1, 0}});
+    Architecture arc({{Node(0), Node(1)}, {Node(1), Node(0)}});
     Architecture arc2(std::vector<std::pair<unsigned, unsigned>>{{0, 1}});
 
     // routing ignored bi directional edge and solves correctly
@@ -1108,13 +1114,13 @@ SCENARIO("Dense CX circuits route succesfully") {
         }
       }
     }
-    Architecture arc(
-        {{0, 1},   {1, 2},   {2, 3},   {3, 4},   {0, 5},   {1, 6},   {1, 7},
-         {2, 6},   {2, 7},   {3, 8},   {3, 9},   {4, 8},   {4, 9},   {5, 6},
-         {5, 10},  {5, 11},  {6, 10},  {6, 11},  {6, 7},   {7, 12},  {7, 13},
-         {7, 8},   {8, 12},  {8, 13},  {8, 9},   {10, 11}, {11, 16}, {11, 17},
-         {11, 12}, {12, 16}, {12, 17}, {12, 13}, {13, 18}, {13, 19}, {13, 14},
-         {14, 18}, {14, 19}, {15, 16}, {16, 17}, {17, 18}, {18, 19}});
+    Architecture arc((std::vector<std::pair<unsigned, unsigned>>){
+        {0, 1},   {1, 2},   {2, 3},   {3, 4},   {0, 5},   {1, 6},   {1, 7},
+        {2, 6},   {2, 7},   {3, 8},   {3, 9},   {4, 8},   {4, 9},   {5, 6},
+        {5, 10},  {5, 11},  {6, 10},  {6, 11},  {6, 7},   {7, 12},  {7, 13},
+        {7, 8},   {8, 12},  {8, 13},  {8, 9},   {10, 11}, {11, 16}, {11, 17},
+        {11, 12}, {12, 16}, {12, 17}, {12, 13}, {13, 18}, {13, 19}, {13, 14},
+        {14, 18}, {14, 19}, {15, 16}, {16, 17}, {17, 18}, {18, 19}});
     MappingManager mm(std::make_shared<Architecture>(arc));
     REQUIRE(mm.route_circuit(
         circ, {std::make_shared<LexiLabellingMethod>(),
@@ -1166,22 +1172,22 @@ SCENARIO(
         }
       }
     }
-    Architecture arc(
-        {{0, 1},
-         {2, 0},
-         {2, 4},
-         {6, 4},
-         {8, 6},
-         {8, 10},
-         {12, 10},
-         {3, 1},
-         {3, 5},
-         {7, 5},
-         {7, 9},
-         {11, 9},
-         {11, 13},
-         {12, 13},
-         {6, 7}});
+    Architecture arc((std::vector<std::pair<unsigned, unsigned>>){
+        {0, 1},
+        {2, 0},
+        {2, 4},
+        {6, 4},
+        {8, 6},
+        {8, 10},
+        {12, 10},
+        {3, 1},
+        {3, 5},
+        {7, 5},
+        {7, 9},
+        {11, 9},
+        {11, 13},
+        {12, 13},
+        {6, 7}});
     MappingManager mm(std::make_shared<Architecture>(arc));
     REQUIRE(mm.route_circuit(
         circ, {std::make_shared<LexiLabellingMethod>(),
@@ -1525,7 +1531,11 @@ SCENARIO("Initial map should contain all data qubits") {
   }
 }
 SCENARIO("Unlabelled qubits should be assigned to ancilla qubits.") {
-  Architecture arc({{0, 1}, {1, 2}, {2, 3}, {3, 0}});
+  Architecture arc(
+      {{Node(0), Node(1)},
+       {Node(1), Node(2)},
+       {Node(2), Node(3)},
+       {Node(3), Node(0)}});
   Circuit c(4);
   c.add_op<unsigned>(OpType::CZ, {0, 3});
   c.add_op<unsigned>(OpType::CZ, {1, 0});
@@ -1556,7 +1566,7 @@ SCENARIO("Unlabelled qubits should be assigned to ancilla qubits.") {
 }
 SCENARIO("Lexi relabel with partially mapped circuit") {
   GIVEN("With an unplaced qubit") {
-    Architecture arc({{0, 1}, {1, 2}});
+    Architecture arc({{Node(0), Node(1)}, {Node(1), Node(2)}});
     Circuit c(3);
     c.add_op<unsigned>(OpType::CZ, {0, 1}, "cz0,1");
     c.add_op<unsigned>(OpType::CZ, {1, 2}, "cz1,2");
@@ -1587,7 +1597,12 @@ SCENARIO("Lexi relabel with partially mapped circuit") {
     c.add_op<unsigned>(OpType::CZ, {1, 3}, "cz1,3");
     c.add_op<unsigned>(OpType::CZ, {3, 2}, "cz3,2");
 
-    Architecture arc({{0, 1}, {0, 2}, {0, 3}, {4, 1}, {4, 2}});
+    Architecture arc(
+        {{Node(0), Node(1)},
+         {Node(0), Node(2)},
+         {Node(0), Node(3)},
+         {Node(4), Node(1)},
+         {Node(4), Node(2)}});
     PassPtr plac_p = gen_placement_pass(std::make_shared<GraphPlacement>(arc));
     CompilationUnit cu(c);
     REQUIRE(plac_p->apply(cu));
@@ -1614,11 +1629,11 @@ SCENARIO("Test failing case") {
   std::ifstream circuit_file("lexiroute_circuit.json");
   nlohmann::json j = nlohmann::json::parse(circuit_file);
   auto c = j.get<Circuit>();
-  Architecture arc({{0, 1},   {1, 2},   {2, 3},   {3, 5},   {4, 1},   {4, 7},
-                    {5, 8},   {6, 7},   {7, 10},  {8, 9},   {8, 11},  {10, 12},
-                    {11, 14}, {12, 13}, {14, 13}, {14, 16}, {12, 15}, {15, 18},
-                    {17, 18}, {16, 19}, {19, 20}, {18, 21}, {21, 23}, {19, 22},
-                    {22, 25}, {23, 24}, {24, 25}, {25, 26}});
+  Architecture arc((std::vector<std::pair<unsigned, unsigned>>){
+      {0, 1},   {1, 2},   {2, 3},   {3, 5},   {4, 1},   {4, 7},   {5, 8},
+      {6, 7},   {7, 10},  {8, 9},   {8, 11},  {10, 12}, {11, 14}, {12, 13},
+      {14, 13}, {14, 16}, {12, 15}, {15, 18}, {17, 18}, {16, 19}, {19, 20},
+      {18, 21}, {21, 23}, {19, 22}, {22, 25}, {23, 24}, {24, 25}, {25, 26}});
 
   CompilationUnit cu(c);
   PassPtr r_p = gen_routing_pass(

--- a/tket/test/src/test_MappingVerification.cpp
+++ b/tket/test/src/test_MappingVerification.cpp
@@ -25,11 +25,15 @@ SCENARIO(
     "Test validity of circuit against architecture using "
     "respects_connectivity_constraints method.",
     "[routing]") {
-  Architecture arc({{1, 0}, {1, 2}});
+  Architecture arc({{Node(1), Node(0)}, {Node(1), Node(2)}});
   GIVEN("A simple CX circuit and a line_placement map.") {
     Circuit circ(5);
     add_2qb_gates(circ, OpType::CX, {{0, 1}, {0, 3}, {2, 4}, {1, 4}, {0, 4}});
-    Architecture test_arc({{0, 1}, {1, 2}, {2, 3}, {3, 4}});
+    Architecture test_arc(
+        {{Node(0), Node(1)},
+         {Node(1), Node(2)},
+         {Node(2), Node(3)},
+         {Node(3), Node(4)}});
     LinePlacement lp_obj(test_arc);
     lp_obj.place(circ);
     MappingManager mm(std::make_shared<Architecture>(test_arc));

--- a/tket/test/src/test_Predicates.cpp
+++ b/tket/test/src/test_Predicates.cpp
@@ -438,7 +438,13 @@ SCENARIO("Test PlacementPredicate") {
   GIVEN(
       "Does the Placement class correctly modify Circuits and return "
       "maps?") {
-    Architecture test_arc({{0, 1}, {1, 2}, {1, 3}, {1, 4}, {2, 3}, {2, 5}});
+    Architecture test_arc(
+        {{Node(0), Node(1)},
+         {Node(1), Node(2)},
+         {Node(1), Node(3)},
+         {Node(1), Node(4)},
+         {Node(2), Node(3)},
+         {Node(2), Node(5)}});
 
     PredicatePtr placement_pred =
         std::make_shared<PlacementPredicate>(test_arc);
@@ -476,7 +482,8 @@ SCENARIO("Test PlacementPredicate") {
 
 SCENARIO("Test ConnectivityPredicate") {
   // https://github.com/CQCL/tket/issues/683
-  Architecture arc({{0, 1}, {0, 2}, {1, 2}});
+  Architecture arc(
+      {{Node(0), Node(1)}, {Node(0), Node(2)}, {Node(1), Node(2)}});
   Circuit c(2, 2);
   c.add_conditional_gate<unsigned>(OpType::Phase, {0.5}, {}, {0}, 1);
   PredicatePtr conn = std::make_shared<ConnectivityPredicate>(arc);

--- a/tket/test/src/test_RoutingPasses.cpp
+++ b/tket/test/src/test_RoutingPasses.cpp
@@ -41,7 +41,12 @@ namespace tket {
 using Connection = Architecture::Connection;
 
 SCENARIO("Test decompose_SWAP_to_CX pass", ) {
-  Architecture arc({{0, 1}, {1, 2}, {2, 3}, {3, 4}, {4, 0}});
+  Architecture arc(
+      {{Node(0), Node(1)},
+       {Node(1), Node(2)},
+       {Node(2), Node(3)},
+       {Node(3), Node(4)},
+       {Node(4), Node(0)}});
   GIVEN("A single SWAP gate. Finding if correct number of vertices added") {
     Circuit circ(5);
     circ.add_op<unsigned>(OpType::SWAP, {0, 1});
@@ -154,7 +159,7 @@ SCENARIO("Test decompose_SWAP_to_CX pass", ) {
   GIVEN(
       "A circuit that with no CX gates, but with directed architecture, "
       "opposite case.") {
-    Architecture dummy_arc({{1, 0}});
+    Architecture dummy_arc({std::pair(Node(1), Node(0))});
     Circuit circ(2);
     circ.add_op<unsigned>(OpType::SWAP, {1, 0});
     reassign_boundary(circ);
@@ -208,7 +213,7 @@ SCENARIO("Test decompose_SWAP_to_CX pass", ) {
 }
 
 SCENARIO("Test redirect_CX_gates pass", "[routing]") {
-  Architecture arc({{1, 0}, {1, 2}});
+  Architecture arc({{Node(1), Node(0)}, {Node(1), Node(2)}});
   GIVEN("A circuit that requires no redirection.") {
     Circuit circ(3);
     add_2qb_gates(circ, OpType::CX, {{1, 0}, {1, 2}});
@@ -356,7 +361,7 @@ SCENARIO(
     "Methods related to correct routing and decomposition of circuits with "
     "classical wires.") {
   GIVEN("A circuit with classical wires on CX gates.") {
-    Architecture test_arc({{0, 1}, {1, 2}});
+    Architecture test_arc({{Node(0), Node(1)}, {Node(1), Node(2)}});
     Circuit circ(3, 2);
     circ.add_op<unsigned>(OpType::CX, {0, 1});
     circ.add_op<unsigned>(OpType::H, {0});
@@ -379,7 +384,11 @@ SCENARIO(
   GIVEN(
       "A circuit that requires modification to satisfy architecture "
       "constraints.") {
-    Architecture arc({{0, 1}, {1, 2}, {2, 3}, {3, 4}});
+    Architecture arc(
+        {{Node(0), Node(1)},
+         {Node(1), Node(2)},
+         {Node(2), Node(3)},
+         {Node(3), Node(4)}});
     Circuit circ(5, 1);
     circ.add_conditional_gate<unsigned>(OpType::CX, {}, {0, 1}, {0}, 1);
     add_2qb_gates(circ, OpType::CX, {{0, 1}, {1, 2}, {1, 3}, {1, 4}, {0, 1}});
@@ -398,7 +407,7 @@ SCENARIO(
     REQUIRE(classical_com.get_args()[0] == circ.all_bits()[0]);
   }
   GIVEN("A single Bridge gate with multiple classical wires, decomposed.") {
-    Architecture arc({{0, 1}, {1, 2}});
+    Architecture arc({{Node(0), Node(1)}, {Node(1), Node(2)}});
     Circuit circ(3, 3);
     circ.add_conditional_gate<unsigned>(
         OpType::BRIDGE, {}, {0, 1, 2}, {0, 1, 2}, 1);
@@ -480,7 +489,13 @@ SCENARIO(
          {0, 4},
          {2, 1},
          {0, 3}});
-    Architecture arc({{1, 0}, {0, 2}, {1, 2}, {2, 3}, {2, 4}, {4, 3}});
+    Architecture arc(
+        {{Node(1), Node(0)},
+         {Node(0), Node(2)},
+         {Node(1), Node(2)},
+         {Node(2), Node(3)},
+         {Node(2), Node(4)},
+         {Node(4), Node(3)}});
     MappingManager mm(std::make_shared<Architecture>(arc));
     REQUIRE(mm.route_circuit(
         circ, {std::make_shared<LexiLabellingMethod>(),

--- a/tket/test/src/test_RoutingPasses.cpp
+++ b/tket/test/src/test_RoutingPasses.cpp
@@ -422,7 +422,7 @@ SCENARIO(
     }
   }
   GIVEN("A directed architecture, a single CX gate that requires flipping.") {
-    Architecture arc(std::vector<std::pair<unsigned, unsigned>>{{0, 1}});
+    Architecture arc({std::pair{Node(0), Node(1)}});
     Circuit circ(2, 2);
     circ.add_conditional_gate<unsigned>(OpType::CX, {}, {0, 1}, {1, 0}, 0);
     circ.add_conditional_gate<unsigned>(OpType::CX, {}, {1, 0}, {0, 1}, 1);

--- a/tket/test/src/test_json.cpp
+++ b/tket/test/src/test_json.cpp
@@ -693,7 +693,7 @@ SCENARIO("Test Circuit serialization") {
 
 SCENARIO("Test device serializations") {
   GIVEN("Architecture") {
-    Architecture arc({{0, 1}, {1, 2}});
+    Architecture arc({{Node(0), Node(1)}, {Node(1), Node(2)}});
     nlohmann::json j_arc = arc;
     Architecture loaded_arc = j_arc.get<Architecture>();
     CHECK(arc == loaded_arc);


### PR DESCRIPTION
# Description

Adds explicit parameter types when constructing `Architecture`s on the tests.

In my machine, compilation was failing due to dissambiguation errors:

```bash
../../test/src/Graphs/test_ArticulationPoints.cpp:148:44: error: call of overloaded ‘Architecture(<brace-enclosed initializer list>)’ is ambiguous
  148 |   Architecture arc({{0, 1}, {1, 2}, {2, 3}});
      |                                            ^

In file included from ../../test/src/Graphs/test_ArticulationPoints.cpp:21:
../../include/tket/Architecture/Architecture.hpp:92:12: note: candidate: ‘tket::Architecture::Architecture(const std::vector<std::pair<unsigned int, unsigned int> >&)’
   92 |   explicit Architecture(const std::vector<std::pair<unsigned, unsigned>> &edges)
      |            ^~~~~~~~~~~~

../../include/tket/Architecture/Architecture.hpp:86:12: note: candidate: ‘tket::Architecture::Architecture(const std::vector<std::pair<tket::Node, tket::Node>, std::allocator<std::pair<tket::Node, tket::Node> > >&)’
   86 |   explicit Architecture(const std::vector<std::pair<Node, Node>> &edges)
      |            ^~~~~~~~~~~~
```

I'm not sure why this doesn't fail in CI.

# Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented hard-to-understand parts of my code.
- [x] I have made corresponding changes to the public API documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have updated the changelog with any user-facing changes.
