### PR TITLE
Correct position of custom gate definitions needed for conditional operations

### DIFF
--- a/pytket/docs/changelog.rst
+++ b/pytket/docs/changelog.rst
@@ -18,6 +18,8 @@ Fixes:
 * Correct handling of ``CustomGate`` when converting from pytket to QASM.
 * Ensure that ECR, CS and CSdg operations have gate definitions in QASM
   conversion.
+* Correct position of custom gate definitions needed for conditional operations
+  in QASM conversion.
 
 1.26.0 (March 2024)
 -------------------

--- a/pytket/pytket/qasm/qasm.py
+++ b/pytket/pytket/qasm/qasm.py
@@ -1599,7 +1599,7 @@ class QasmWriter:
         self.write_params(params)
         self.write_args(args)
 
-    def add_extra_noparams(self, op: Op, args: List[UnitID]) -> None:
+    def add_extra_noparams(self, op: Op, args: List[UnitID]) -> Tuple[str, str]:
         optype = op.type
         opstr = _tk_to_qasm_extra_noparams[optype]
         gatedefstr = ""
@@ -1607,10 +1607,9 @@ class QasmWriter:
             self.added_gate_definitions.add(opstr)
             gatedefstr = self.make_gate_definition(op.n_qubits, opstr, optype)
         mainstr = opstr + " " + make_args_str(args)
-        self.strings.add_string(gatedefstr)
-        self.strings.add_string(mainstr)
+        return gatedefstr, mainstr
 
-    def add_extra_params(self, op: Op, args: List[UnitID]) -> None:
+    def add_extra_params(self, op: Op, args: List[UnitID]) -> Tuple[str, str]:
         optype, params = _get_optype_and_params(op)
         assert params is not None
         opstr = _tk_to_qasm_extra_params[optype]
@@ -1621,8 +1620,7 @@ class QasmWriter:
                 op.n_qubits, opstr, optype, len(params)
             )
         mainstr = opstr + make_params_str(params) + make_args_str(args)
-        self.strings.add_string(gatedefstr)
-        self.strings.add_string(mainstr)
+        return gatedefstr, mainstr
 
     def add_op(self, op: Op, args: List[UnitID]) -> None:
         optype, _params = _get_optype_and_params(op)
@@ -1672,9 +1670,13 @@ class QasmWriter:
         ):
             self.add_gate_params(op, args)
         elif optype in _tk_to_qasm_extra_noparams:
-            self.add_extra_noparams(op, args)
+            gatedefstr, mainstr = self.add_extra_noparams(op, args)
+            self.strings.add_string(gatedefstr)
+            self.strings.add_string(mainstr)
         elif optype in _tk_to_qasm_extra_params:
-            self.add_extra_params(op, args)
+            gatedefstr, mainstr = self.add_extra_params(op, args)
+            self.strings.add_string(gatedefstr)
+            self.strings.add_string(mainstr)
         else:
             raise QASMUnsupportedError(
                 "Cannot print command of type: {}".format(op.get_name())

--- a/pytket/pytket/qasm/qasm.py
+++ b/pytket/pytket/qasm/qasm.py
@@ -1232,6 +1232,43 @@ class LabelledStringList:
         return "".join(self.strings.values())
 
 
+def make_params_str(params: Optional[List[Union[float, Expr]]]) -> str:
+    s = ""
+    if params is not None:
+        n_params = len(params)
+        s += "("
+        for i in range(n_params):
+            reduced = True
+            try:
+                p: Union[float, Expr] = float(params[i])
+            except TypeError:
+                reduced = False
+                p = params[i]
+            if i < n_params - 1:
+                if reduced:
+                    s += "{}*pi,".format(p)
+                else:
+                    s += "({})*pi,".format(p)
+            else:
+                if reduced:
+                    s += "{}*pi)".format(p)
+                else:
+                    s += "({})*pi)".format(p)
+    s += " "
+    return s
+
+
+def make_args_str(args: List[UnitID]):
+    s = ""
+    for i in range(len(args)):
+        s += f"{args[i]}"
+        if i < len(args) - 1:
+            s += ","
+        else:
+            s += ";\n"
+    return s
+
+
 class QasmWriter:
     """
     Helper class for converting a sequence of TKET Commands to QASM, and retrieving the
@@ -1303,47 +1340,12 @@ class QasmWriter:
             self.cregs = {}
             self.qregs = {}
 
-    def make_params_str(self, params: Optional[List[Union[float, Expr]]]) -> str:
-        s = ""
-        if params is not None:
-            n_params = len(params)
-            s += "("
-            for i in range(n_params):
-                reduced = True
-                try:
-                    p: Union[float, Expr] = float(params[i])
-                except TypeError:
-                    reduced = False
-                    p = params[i]
-                if i < n_params - 1:
-                    if reduced:
-                        s += "{}*pi,".format(p)
-                    else:
-                        s += "({})*pi,".format(p)
-                else:
-                    if reduced:
-                        s += "{}*pi)".format(p)
-                    else:
-                        s += "({})*pi)".format(p)
-        s += " "
-        return s
-
     def write_params(self, params: Optional[List[Union[float, Expr]]]) -> None:
-        params_str = self.make_params_str(params)
+        params_str = make_params_str(params)
         self.strings.add_string(params_str)
 
-    def make_args_str(self, args: List[UnitID]):
-        s = ""
-        for i in range(len(args)):
-            s += f"{args[i]}"
-            if i < len(args) - 1:
-                s += ","
-            else:
-                s += ";\n"
-        return s
-
     def write_args(self, args: List[UnitID]) -> None:
-        args_str = self.make_args_str(args)
+        args_str = make_args_str(args)
         self.strings.add_string(args_str)
 
     def make_gate_definition(

--- a/pytket/pytket/qasm/qasm.py
+++ b/pytket/pytket/qasm/qasm.py
@@ -1290,6 +1290,7 @@ class QasmWriter:
         self.include_module_gates.update(
             _load_include_module(header, False, True).keys()
         )
+        self.prefix = ""
         self.strings = LabelledStringList()
 
         # Record of `RangePredicate` operations that set a "scratch" bit to 0 or 1
@@ -1311,9 +1312,7 @@ class QasmWriter:
             self.include_gate_defs = self.include_module_gates
             self.include_gate_defs.update(NOPARAM_EXTRA_COMMANDS.keys())
             self.include_gate_defs.update(PARAM_EXTRA_COMMANDS.keys())
-            self.strings.add_string(
-                'OPENQASM 2.0;\ninclude "{}.inc";\n\n'.format(header)
-            )
+            self.prefix = 'OPENQASM 2.0;\ninclude "{}.inc";\n\n'.format(header)
             self.qregs = _retrieve_registers(cast(list[UnitID], qubits), QubitRegister)
             self.cregs = _retrieve_registers(cast(list[UnitID], bits), BitRegister)
             for reg in self.qregs.values():
@@ -1683,7 +1682,7 @@ class QasmWriter:
             )
 
     def finalize(self) -> str:
-        return _filtered_qasm_str(self.strings.get_full_string())
+        return self.prefix + _filtered_qasm_str(self.strings.get_full_string())
 
 
 def circuit_to_qasm_io(

--- a/pytket/pytket/qasm/qasm.py
+++ b/pytket/pytket/qasm/qasm.py
@@ -1602,25 +1602,32 @@ class QasmWriter:
     def add_extra_noparams(self, op: Op, args: List[UnitID]) -> None:
         optype = op.type
         opstr = _tk_to_qasm_extra_noparams[optype]
+        gatedefstr = ""
         if opstr not in self.added_gate_definitions:
             self.added_gate_definitions.add(opstr)
-            s = self.make_gate_definition(op.n_qubits, opstr, optype)
-            self.strings.add_string(s)
+            gatedefstr = self.make_gate_definition(op.n_qubits, opstr, optype)
+        args_str = make_args_str(args)
+        self.strings.add_string(gatedefstr)
         self.strings.add_string(opstr)
         self.strings.add_string(" ")
-        self.write_args(args)
+        self.strings.add_string(args_str)
 
     def add_extra_params(self, op: Op, args: List[UnitID]) -> None:
         optype, params = _get_optype_and_params(op)
         assert params is not None
         opstr = _tk_to_qasm_extra_params[optype]
+        gatedefstr = ""
         if opstr not in self.added_gate_definitions:
             self.added_gate_definitions.add(opstr)
-            s = self.make_gate_definition(op.n_qubits, opstr, optype, len(params))
-            self.strings.add_string(s)
+            gatedefstr = self.make_gate_definition(
+                op.n_qubits, opstr, optype, len(params)
+            )
+        params_str = make_params_str(params)
+        args_str = make_args_str(args)
+        self.strings.add_string(gatedefstr)
         self.strings.add_string(opstr)
-        self.write_params(params)
-        self.write_args(args)
+        self.strings.add_string(params_str)
+        self.strings.add_string(args_str)
 
     def add_op(self, op: Op, args: List[UnitID]) -> None:
         optype, _params = _get_optype_and_params(op)

--- a/pytket/pytket/qasm/qasm.py
+++ b/pytket/pytket/qasm/qasm.py
@@ -1291,6 +1291,7 @@ class QasmWriter:
             _load_include_module(header, False, True).keys()
         )
         self.prefix = ""
+        self.gatedefs = ""
         self.strings = LabelledStringList()
 
         # Record of `RangePredicate` operations that set a "scratch" bit to 0 or 1
@@ -1670,11 +1671,11 @@ class QasmWriter:
             self.add_gate_params(op, args)
         elif optype in _tk_to_qasm_extra_noparams:
             gatedefstr, mainstr = self.add_extra_noparams(op, args)
-            self.strings.add_string(gatedefstr)
+            self.gatedefs += gatedefstr
             self.strings.add_string(mainstr)
         elif optype in _tk_to_qasm_extra_params:
             gatedefstr, mainstr = self.add_extra_params(op, args)
-            self.strings.add_string(gatedefstr)
+            self.gatedefs += gatedefstr
             self.strings.add_string(mainstr)
         else:
             raise QASMUnsupportedError(
@@ -1682,7 +1683,11 @@ class QasmWriter:
             )
 
     def finalize(self) -> str:
-        return self.prefix + _filtered_qasm_str(self.strings.get_full_string())
+        return (
+            self.prefix
+            + self.gatedefs
+            + _filtered_qasm_str(self.strings.get_full_string())
+        )
 
 
 def circuit_to_qasm_io(

--- a/pytket/pytket/qasm/qasm.py
+++ b/pytket/pytket/qasm/qasm.py
@@ -1368,16 +1368,6 @@ class QasmWriter:
         s += "}\n"
         return s
 
-    def write_gate_definition(
-        self,
-        n_qubits: int,
-        opstr: str,
-        optype: OpType,
-        n_params: Optional[int] = None,
-    ) -> None:
-        s = self.make_gate_definition(n_qubits, opstr, optype, n_params)
-        self.strings.add_string(s)
-
     def mark_as_written(self, written_variable: str) -> None:
         """Remove any references to the written-to variable in `self.range_preds`, so
         that we don't try and replace instances of the variable with stale aliases.
@@ -1598,7 +1588,8 @@ class QasmWriter:
         opstr = _tk_to_qasm_extra_noparams[optype]
         if opstr not in self.added_gate_definitions:
             self.added_gate_definitions.add(opstr)
-            self.write_gate_definition(op.n_qubits, opstr, optype)
+            s = self.make_gate_definition(op.n_qubits, opstr, optype)
+            self.strings.add_string(s)
         self.strings.add_string(opstr)
         self.strings.add_string(" ")
         self.write_args(args)
@@ -1609,7 +1600,8 @@ class QasmWriter:
         opstr = _tk_to_qasm_extra_params[optype]
         if opstr not in self.added_gate_definitions:
             self.added_gate_definitions.add(opstr)
-            self.write_gate_definition(op.n_qubits, opstr, optype, len(params))
+            s = self.make_gate_definition(op.n_qubits, opstr, optype, len(params))
+            self.strings.add_string(s)
         self.strings.add_string(opstr)
         self.write_params(params)
         self.write_args(args)

--- a/pytket/pytket/qasm/qasm.py
+++ b/pytket/pytket/qasm/qasm.py
@@ -17,7 +17,6 @@ import os
 import re
 import uuid
 
-# TODO: Output custom gates
 from collections import OrderedDict
 from importlib import import_module
 from itertools import chain, groupby

--- a/pytket/pytket/qasm/qasm.py
+++ b/pytket/pytket/qasm/qasm.py
@@ -1258,7 +1258,7 @@ def make_params_str(params: Optional[List[Union[float, Expr]]]) -> str:
     return s
 
 
-def make_args_str(args: List[UnitID]):
+def make_args_str(args: List[UnitID]) -> str:
     s = ""
     for i in range(len(args)):
         s += f"{args[i]}"

--- a/pytket/pytket/qasm/qasm.py
+++ b/pytket/pytket/qasm/qasm.py
@@ -1303,10 +1303,11 @@ class QasmWriter:
             self.cregs = {}
             self.qregs = {}
 
-    def write_params(self, params: Optional[List[Union[float, Expr]]]) -> None:
+    def make_params_str(self, params: Optional[List[Union[float, Expr]]]) -> str:
+        s = ""
         if params is not None:
             n_params = len(params)
-            self.strings.add_string("(")
+            s += "("
             for i in range(n_params):
                 reduced = True
                 try:
@@ -1316,23 +1317,34 @@ class QasmWriter:
                     p = params[i]
                 if i < n_params - 1:
                     if reduced:
-                        self.strings.add_string("{}*pi,".format(p))
+                        s += "{}*pi,".format(p)
                     else:
-                        self.strings.add_string("({})*pi,".format(p))
+                        s += "({})*pi,".format(p)
                 else:
                     if reduced:
-                        self.strings.add_string("{}*pi)".format(p))
+                        s += "{}*pi)".format(p)
                     else:
-                        self.strings.add_string("({})*pi)".format(p))
-        self.strings.add_string(" ")
+                        s += "({})*pi)".format(p)
+        s += " "
+        return s
+
+    def write_params(self, params: Optional[List[Union[float, Expr]]]) -> None:
+        params_str = self.make_params_str(params)
+        self.strings.add_string(params_str)
+
+    def make_args_str(self, args: List[UnitID]):
+        s = ""
+        for i in range(len(args)):
+            s += f"{args[i]}"
+            if i < len(args) - 1:
+                s += ","
+            else:
+                s += ";\n"
+        return s
 
     def write_args(self, args: List[UnitID]) -> None:
-        for i in range(len(args)):
-            self.strings.add_string(f"{args[i]}")
-            if i < len(args) - 1:
-                self.strings.add_string(",")
-            else:
-                self.strings.add_string(";\n")
+        args_str = self.make_args_str(args)
+        self.strings.add_string(args_str)
 
     def make_gate_definition(
         self,

--- a/pytket/pytket/qasm/qasm.py
+++ b/pytket/pytket/qasm/qasm.py
@@ -1606,11 +1606,9 @@ class QasmWriter:
         if opstr not in self.added_gate_definitions:
             self.added_gate_definitions.add(opstr)
             gatedefstr = self.make_gate_definition(op.n_qubits, opstr, optype)
-        args_str = make_args_str(args)
+        mainstr = opstr + " " + make_args_str(args)
         self.strings.add_string(gatedefstr)
-        self.strings.add_string(opstr)
-        self.strings.add_string(" ")
-        self.strings.add_string(args_str)
+        self.strings.add_string(mainstr)
 
     def add_extra_params(self, op: Op, args: List[UnitID]) -> None:
         optype, params = _get_optype_and_params(op)
@@ -1622,12 +1620,9 @@ class QasmWriter:
             gatedefstr = self.make_gate_definition(
                 op.n_qubits, opstr, optype, len(params)
             )
-        params_str = make_params_str(params)
-        args_str = make_args_str(args)
+        mainstr = opstr + make_params_str(params) + make_args_str(args)
         self.strings.add_string(gatedefstr)
-        self.strings.add_string(opstr)
-        self.strings.add_string(params_str)
-        self.strings.add_string(args_str)
+        self.strings.add_string(mainstr)
 
     def add_op(self, op: Op, args: List[UnitID]) -> None:
         optype, _params = _get_optype_and_params(op)

--- a/pytket/tests/qasm_test.py
+++ b/pytket/tests/qasm_test.py
@@ -924,6 +924,14 @@ def test_nonstandard_gates() -> None:
     assert "gate csdg" in qasm
 
 
+def test_conditional_nonstandard_gates() -> None:
+    # https://github.com/CQCL/tket/issues/1301
+    circ = Circuit(2, 1)
+    circ.ZZMax(0, 1, condition=Bit(0))
+    qasm = circuit_to_qasm_str(circ)
+    assert "if(c==1) zzmax q[0],q[1];" in qasm
+
+
 if __name__ == "__main__":
     test_qasm_correct()
     test_qasm_qubit()


### PR DESCRIPTION
# Description

Instead of putting the gate definition immediately before the operation and after the "if", which is invalid, move all gate definitions to the top of the file (just below the header and include statements).

This necessitated some refactoring of the code: see commits.

# Related issues

Fixes #1301 .

# Checklist

- [x] I have performed a self-review of my code.
- [ ] I have commented hard-to-understand parts of my code.
- [ ] I have made corresponding changes to the public API documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have updated the changelog with any user-facing changes.
