### PR TITLE
Fix `DelayMeasures()` pass when two measurements target the same bit

### DIFF
--- a/pytket/conanfile.py
+++ b/pytket/conanfile.py
@@ -32,7 +32,7 @@ class pytketRecipe(ConanFile):
         cmake.install()
 
     def requirements(self):
-        self.requires("tket/1.2.105@tket/stable")
+        self.requires("tket/1.2.106@tket/stable")
         self.requires("tklog/0.3.3@tket/stable")
         self.requires("tkrng/0.3.3@tket/stable")
         self.requires("tkassert/0.3.4@tket/stable")

--- a/pytket/docs/changelog.rst
+++ b/pytket/docs/changelog.rst
@@ -20,6 +20,8 @@ Fixes:
   conversion.
 * Correct position of custom gate definitions needed for conditional operations
   in QASM conversion.
+* Fix ``DelayMeasures()`` pass for circuits where bits are reused as measurement
+  targets.
 
 1.26.0 (March 2024)
 -------------------

--- a/tket/conanfile.py
+++ b/tket/conanfile.py
@@ -23,7 +23,7 @@ from conan.errors import ConanInvalidConfiguration
 
 class TketConan(ConanFile):
     name = "tket"
-    version = "1.2.105"
+    version = "1.2.106"
     package_type = "library"
     license = "Apache 2"
     homepage = "https://github.com/CQCL/tket"

--- a/tket/src/Transformations/MeasurePass.cpp
+++ b/tket/src/Transformations/MeasurePass.cpp
@@ -191,9 +191,12 @@ std::pair<bool, bool> run_delay_measures(
     Vertex v = com.get_vertex();
     OpType optype = com.get_op_ptr()->get_type();
     if (optype == OpType::Measure) {
-      if (!allow_partial) {
-        Edge c_out_edge = circ.get_nth_out_edge(v, 1);
-        if (!circ.detect_final_Op(circ.target(c_out_edge)) ||
+      Edge c_out_edge = circ.get_nth_out_edge(v, 1);
+      bool measurement_is_final = circ.detect_final_Op(circ.target(c_out_edge));
+      if (allow_partial) {
+        if (!measurement_is_final) continue;
+      } else {
+        if (!measurement_is_final ||
             circ.n_out_edges_of_type(v, EdgeType::Boolean) != 0) {
           if (dry_run) return {false, false};
           throw CircuitInvalidity(

--- a/tket/src/Transformations/MeasurePass.cpp
+++ b/tket/src/Transformations/MeasurePass.cpp
@@ -105,7 +105,7 @@ static Edge follow_until_noncommuting(
  * through SWAPs, gates that commute on the Pauli Z basis, and recursively
  * checks inside boxes and conditional operations.
  * @param circ The circuit containing the operation.
- * @param v The vertex of the operation.
+ * @param op The operation.
  * @param in_port The input port of the operation to check.
  * @param only_boxes Whether to only commute through straight wires in boxes or
  * conditional operations.

--- a/tket/test/src/test_CompilerPass.cpp
+++ b/tket/test/src/test_CompilerPass.cpp
@@ -1388,6 +1388,17 @@ SCENARIO("Commute measurements to the end of a circuit") {
     REQUIRE(type == OpType::Measure);
     // REQUIRE(final_command.get_args().front() == Node(3));
   }
+  GIVEN("Measures targeting the same bit") {
+    // https://github.com/CQCL/tket/issues/1305
+    Circuit c(4, 1);
+    c.add_op<unsigned>(OpType::CX, {0, 1});
+    c.add_measure(3, 0);
+    c.add_measure(1, 0);
+    c.add_op<unsigned>(OpType::X, {1});
+    c.add_op<unsigned>(OpType::CCX, {1, 3, 2});
+    CompilationUnit cu(c);
+    CHECK_FALSE(try_delay_pass->apply(cu));
+  }
 }
 
 SCENARIO("RemoveRedundancies and phase") {


### PR DESCRIPTION
# Description

When `allow_partial` is `false` we were allowing measurements to commute past succeeding gates even when their target bit was later written to by another measurement. This is invalid and also invalidates the DAG.

# Related issues

Fixes #1305 .

# Checklist

- [x] I have performed a self-review of my code.
- [ ] I have commented hard-to-understand parts of my code.
- [ ] I have made corresponding changes to the public API documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have updated the changelog with any user-facing changes.
