### PR TITLE
Don't add a vertex to the circuit when an operation is added with invalid arguments

### DIFF
--- a/pytket/conanfile.py
+++ b/pytket/conanfile.py
@@ -32,7 +32,7 @@ class pytketRecipe(ConanFile):
         cmake.install()
 
     def requirements(self):
-        self.requires("tket/1.2.106@tket/stable")
+        self.requires("tket/1.2.107@tket/stable")
         self.requires("tklog/0.3.3@tket/stable")
         self.requires("tkrng/0.3.3@tket/stable")
         self.requires("tkassert/0.3.4@tket/stable")

--- a/pytket/docs/changelog.rst
+++ b/pytket/docs/changelog.rst
@@ -22,6 +22,8 @@ Fixes:
   in QASM conversion.
 * Fix ``DelayMeasures()`` pass for circuits where bits are reused as measurement
   targets.
+* When adding operations to a circuit, check for invalid wires before adding a
+  vertex to the circuit.
 
 1.26.0 (March 2024)
 -------------------

--- a/tket/conanfile.py
+++ b/tket/conanfile.py
@@ -23,7 +23,7 @@ from conan.errors import ConanInvalidConfiguration
 
 class TketConan(ConanFile):
     name = "tket"
-    version = "1.2.106"
+    version = "1.2.107"
     package_type = "library"
     license = "Apache 2"
     homepage = "https://github.com/CQCL/tket"

--- a/tket/include/tket/Circuit/Circuit.hpp
+++ b/tket/include/tket/Circuit/Circuit.hpp
@@ -1821,7 +1821,6 @@ Vertex Circuit::add_op(
 
   add_wasm_register(count_wasm_sig);
 
-  Vertex new_v = add_vertex(op, opgroup);
   unit_set_t write_arg_set;
   EdgeVec preds;
   for (unsigned i = 0; i < args.size(); ++i) {
@@ -1837,6 +1836,7 @@ Vertex Circuit::add_op(
     preds.push_back(pred_out_e);
   }
 
+  Vertex new_v = add_vertex(op, opgroup);
   rewire(new_v, preds, sig);
   return new_v;
 }

--- a/tket/test/src/Circuit/test_Circ.cpp
+++ b/tket/test/src/Circuit/test_Circ.cpp
@@ -2800,11 +2800,20 @@ SCENARIO("(qu)bit_readout/mapping for a circuit") {
   REQUIRE(qb_map.at(Qubit(qreg[2])) == creg[2]);
 }
 
-SCENARIO("Trying to add a Measure gate with no classical output") {
-  Circuit circ(2);
-  circ.add_op<unsigned>(OpType::CX, {0, 1});
-  REQUIRE_THROWS_AS(
-      circ.add_op<unsigned>(OpType::Measure, {0}), CircuitInvalidity);
+SCENARIO("Invalid Measure operations") {
+  GIVEN("Trying to add a Measure gate with no classical output") {
+    Circuit circ(2);
+    circ.add_op<unsigned>(OpType::CX, {0, 1});
+    REQUIRE_THROWS_AS(
+        circ.add_op<unsigned>(OpType::Measure, {0}), CircuitInvalidity);
+  }
+  GIVEN("Trying to add a Measure on non-existent wires") {
+    // https://github.com/CQCL/tket/issues/979
+    Circuit circ;
+    REQUIRE_THROWS(circ.add_measure(0, 0));
+    std::vector<Command> cmds = circ.get_commands();
+    REQUIRE(cmds.empty());
+  }
 }
 
 SCENARIO("Testing add_op with Barrier type and add_barrier") {


### PR DESCRIPTION
# Description

Check for invalid arguments before adding a vertex to (thus potentially invalidating) the circuit.

# Related issues

Fixes #979 .

# Checklist

- [x] I have performed a self-review of my code.
- [ ] I have commented hard-to-understand parts of my code.
- [ ] I have made corresponding changes to the public API documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have updated the changelog with any user-facing changes.
