### PR TITLE
Docs/add decomposition complexities to several multiplexor based boxes

### DIFF
--- a/pytket/binders/circuit/boxes.cpp
+++ b/pytket/binders/circuit/boxes.cpp
@@ -982,9 +982,9 @@ void init_boxes(py::module &m) {
       "uniformly controlled single-axis rotations) specified by "
       "a map from bitstrings to " CLSOBJS(Op)
       "or a list of bitstring-" CLSOBJS(Op) " pairs. "
-      "Implamentation based on https://arxiv.org/abs/quant-ph/0410066. "
+      "Implementation based on arxiv.org/abs/quant-ph/0410066. "
       "The decomposed circuit has at most 2^k single-qubit rotations, "
-      "2^k CX gates, and 2 H gates if it's X-axis. "
+      "2^k CX gates, and two additional H gates if the rotation axis is X. "
       "k is the number of control qubits.")
       .def(
               py::init([](const py_ctrl_op_map_t_alt & bitstring_op_pairs){
@@ -1053,7 +1053,7 @@ void init_boxes(py::module &m) {
       "gate) specified by a "
       "map from bitstrings to " CLSOBJS(Op)
       "or a list of bitstring-" CLSOBJS(Op) " pairs"
-      "Implamentation based on https://arxiv.org/abs/quant-ph/0410066. "
+      "Implementation based on arxiv.org/abs/quant-ph/0410066. "
       "The decomposed circuit has at most 2^k single-qubit gates, 2^k -1 CX gates, "
       "and a k+1 qubit DiagonalBox at the end. "
       "k is the number of control qubits.")
@@ -1149,13 +1149,9 @@ void init_boxes(py::module &m) {
       "A box for preparing quantum states using multiplexed-Ry and "
       "multiplexed-Rz gates. "
       "Implementation based on Theorem 9 of "
-      "https://arxiv.org/abs/quant-ph/0406176. "
+      "arxiv.org/abs/quant-ph/0406176. "
       "The decomposed circuit has at most 2*(2^n-2) CX gates, and "
-      "2^n-2 CX gates if the coefficients are all real. "
-      "Note that by decomposing each multiplexed-Ry(Rz) as its dagger can lead "
-      "to a CX cancellation with its adjacent multiplexed-Rz(Ry), "
-      "which leads to an improved CX count of 2^(n+1)-2n. "
-      "However, this is currently not automatically done in tket.")
+      "2^n-2 CX gates if the coefficients are all real.")
       .def(
           py::init<const Eigen::VectorXcd &, bool, bool>(),
           "Construct from a statevector\n\n"
@@ -1187,7 +1183,7 @@ void init_boxes(py::module &m) {
       "A box for synthesising a diagonal unitary matrix into a sequence of "
       "multiplexed-Rz gates. "
       "Implementation based on Theorem 7 of "
-      "https://arxiv.org/abs/quant-ph/0406176. "
+      "arxiv.org/abs/quant-ph/0406176. "
       "The decomposed circuit has at most 2^n-2 CX gates.")
       .def(
           py::init<const Eigen::VectorXcd &, bool>(),

--- a/pytket/binders/circuit/boxes.cpp
+++ b/pytket/binders/circuit/boxes.cpp
@@ -981,7 +981,11 @@ void init_boxes(py::module &m) {
       "A user-defined multiplexed rotation gate (i.e. "
       "uniformly controlled single-axis rotations) specified by "
       "a map from bitstrings to " CLSOBJS(Op)
-      "or a list of bitstring-" CLSOBJS(Op) " pairs")
+      "or a list of bitstring-" CLSOBJS(Op) " pairs. "
+      "Implamentation based on https://arxiv.org/abs/quant-ph/0410066. "
+      "The decomposed circuit has at most 2^k single-qubit rotations, "
+      "2^k CX gates, and 2 H gates if it's X-axis. "
+      "k is the number of control qubits.")
       .def(
               py::init([](const py_ctrl_op_map_t_alt & bitstring_op_pairs){
           return MultiplexedRotationBox(to_cpp_ctrl_op_map_t(bitstring_op_pairs));}),
@@ -1048,7 +1052,11 @@ void init_boxes(py::module &m) {
       "A user-defined multiplexed U2 gate (i.e. uniformly controlled U2 "
       "gate) specified by a "
       "map from bitstrings to " CLSOBJS(Op)
-      "or a list of bitstring-" CLSOBJS(Op) " pairs")
+      "or a list of bitstring-" CLSOBJS(Op) " pairs"
+      "Implamentation based on https://arxiv.org/abs/quant-ph/0410066. "
+      "The decomposed circuit has at most 2^k single-qubit gates, 2^k -1 CX gates, "
+      "and a k+1 qubit DiagonalBox at the end. "
+      "k is the number of control qubits.")
       .def(
               py::init([](const py_ctrl_op_map_t_alt & bitstring_op_pairs, bool impl_diag){
           return MultiplexedU2Box(to_cpp_ctrl_op_map_t(bitstring_op_pairs), impl_diag);}),
@@ -1095,7 +1103,14 @@ void init_boxes(py::module &m) {
       m, "MultiplexedTensoredU2Box",
       "A user-defined multiplexed tensor product of U2 gates specified by a "
       "map from bitstrings to lists of " CLSOBJS(Op)
-      "or a list of bitstring-list(" CLSOBJS(Op) ") pairs")
+      "or a list of bitstring-list(" CLSOBJS(Op) ") pairs. "
+      "A box with k control qubits and t target qubits is implemented as t "
+      "k-controlled multiplexed-U2 gates with their diagonal "
+      "components merged and commuted to the end. The resulting circuit contains "
+      "t non-diagonal components of the multiplexed-U2 decomposition, t k-controlled "
+      "multiplexed-Rz boxes, and a k-qubit DiagonalBox at the end. "
+      "The total CX count is at most 2^k(2t+1)-t-2."
+      )
       .def(
               py::init([](const py_ctrl_tensored_op_map_t_alt & bitstring_op_pairs){
           return MultiplexedTensoredU2Box(to_cpp_ctrl_op_map_t(bitstring_op_pairs));}),
@@ -1132,7 +1147,15 @@ void init_boxes(py::module &m) {
   py::class_<StatePreparationBox, std::shared_ptr<StatePreparationBox>, Op>(
       m, "StatePreparationBox",
       "A box for preparing quantum states using multiplexed-Ry and "
-      "multiplexed-Rz gates")
+      "multiplexed-Rz gates. "
+      "Implementation based on Theorem 9 of "
+      "https://arxiv.org/abs/quant-ph/0406176. "
+      "The decomposed circuit has at most 2*(2^n-2) CX gates, and "
+      "2^n-2 CX gates if the coefficients are all real. "
+      "Note that by decomposing each multiplexed-Ry(Rz) as its dagger can lead "
+      "to a CX cancellation with its adjacent multiplexed-Rz(Ry), "
+      "which leads to an improved CX count of 2^(n+1)-2n. "
+      "However, this is currently not automatically done in tket.")
       .def(
           py::init<const Eigen::VectorXcd &, bool, bool>(),
           "Construct from a statevector\n\n"
@@ -1162,7 +1185,10 @@ void init_boxes(py::module &m) {
   py::class_<DiagonalBox, std::shared_ptr<DiagonalBox>, Op>(
       m, "DiagonalBox",
       "A box for synthesising a diagonal unitary matrix into a sequence of "
-      "multiplexed-Rz gates.")
+      "multiplexed-Rz gates. "
+      "Implementation based on Theorem 7 of "
+      "https://arxiv.org/abs/quant-ph/0406176. "
+      "The decomposed circuit has at most 2^n-2 CX gates.")
       .def(
           py::init<const Eigen::VectorXcd &, bool>(),
           "Construct from the diagonal entries of the unitary operator. The "

--- a/pytket/pytket/_tket/circuit.pyi
+++ b/pytket/pytket/_tket/circuit.pyi
@@ -2705,7 +2705,7 @@ class CustomGateDef:
         """
 class DiagonalBox(Op):
     """
-    A box for synthesising a diagonal unitary matrix into a sequence of multiplexed-Rz gates. Implementation based on Theorem 7 of https://arxiv.org/abs/quant-ph/0406176. The decomposed circuit has at most 2^n-2 CX gates.
+    A box for synthesising a diagonal unitary matrix into a sequence of multiplexed-Rz gates. Implementation based on Theorem 7 of arxiv.org/abs/quant-ph/0406176. The decomposed circuit has at most 2^n-2 CX gates.
     """
     def __init__(self, diagonal: NDArray[numpy.complex128], upper_triangle: bool = True) -> None:
         """
@@ -2839,7 +2839,7 @@ class MultiBitOp(ClassicalEvalOp):
         """
 class MultiplexedRotationBox(Op):
     """
-    A user-defined multiplexed rotation gate (i.e. uniformly controlled single-axis rotations) specified by a map from bitstrings to :py:class:`Op` sor a list of bitstring-:py:class:`Op` s pairs. Implamentation based on https://arxiv.org/abs/quant-ph/0410066. The decomposed circuit has at most 2^k single-qubit rotations, 2^k CX gates, and 2 H gates if it's X-axis. k is the number of control qubits.
+    A user-defined multiplexed rotation gate (i.e. uniformly controlled single-axis rotations) specified by a map from bitstrings to :py:class:`Op` sor a list of bitstring-:py:class:`Op` s pairs. Implementation based on arxiv.org/abs/quant-ph/0410066. The decomposed circuit has at most 2^k single-qubit rotations, 2^k CX gates, and two additional H gates if the rotation axis is X. k is the number of control qubits.
     """
     @typing.overload
     def __init__(self, bistring_to_op_list: typing.Sequence[tuple[typing.Sequence[bool], Op]]) -> None:
@@ -2911,7 +2911,7 @@ class MultiplexedTensoredU2Box(Op):
         """
 class MultiplexedU2Box(Op):
     """
-    A user-defined multiplexed U2 gate (i.e. uniformly controlled U2 gate) specified by a map from bitstrings to :py:class:`Op` sor a list of bitstring-:py:class:`Op` s pairsImplamentation based on https://arxiv.org/abs/quant-ph/0410066. The decomposed circuit has at most 2^k single-qubit gates, 2^k -1 CX gates, and a k+1 qubit DiagonalBox at the end. k is the number of control qubits.
+    A user-defined multiplexed U2 gate (i.e. uniformly controlled U2 gate) specified by a map from bitstrings to :py:class:`Op` sor a list of bitstring-:py:class:`Op` s pairsImplementation based on arxiv.org/abs/quant-ph/0410066. The decomposed circuit has at most 2^k single-qubit gates, 2^k -1 CX gates, and a k+1 qubit DiagonalBox at the end. k is the number of control qubits.
     """
     @typing.overload
     def __init__(self, bistring_to_op_list: typing.Sequence[tuple[typing.Sequence[bool], Op]], impl_diag: bool = True) -> None:
@@ -3686,7 +3686,7 @@ class StabiliserAssertionBox(Op):
         """
 class StatePreparationBox(Op):
     """
-    A box for preparing quantum states using multiplexed-Ry and multiplexed-Rz gates. Implementation based on Theorem 9 of https://arxiv.org/abs/quant-ph/0406176. The decomposed circuit has at most 2*(2^n-2) CX gates, and 2^n-2 CX gates if the coefficients are all real. Note that by decomposing each multiplexed-Ry(Rz) as its dagger can lead to a CX cancellation with its adjacent multiplexed-Rz(Ry), which leads to an improved CX count of 2^(n+1)-2n. However, this is currently not automatically done in tket.
+    A box for preparing quantum states using multiplexed-Ry and multiplexed-Rz gates. Implementation based on Theorem 9 of arxiv.org/abs/quant-ph/0406176. The decomposed circuit has at most 2*(2^n-2) CX gates, and 2^n-2 CX gates if the coefficients are all real.
     """
     def __init__(self, statevector: NDArray[numpy.complex128], is_inverse: bool = False, with_initial_reset: bool = False) -> None:
         """

--- a/pytket/pytket/_tket/circuit.pyi
+++ b/pytket/pytket/_tket/circuit.pyi
@@ -2705,7 +2705,7 @@ class CustomGateDef:
         """
 class DiagonalBox(Op):
     """
-    A box for synthesising a diagonal unitary matrix into a sequence of multiplexed-Rz gates.
+    A box for synthesising a diagonal unitary matrix into a sequence of multiplexed-Rz gates. Implementation based on Theorem 7 of https://arxiv.org/abs/quant-ph/0406176. The decomposed circuit has at most 2^n-2 CX gates.
     """
     def __init__(self, diagonal: NDArray[numpy.complex128], upper_triangle: bool = True) -> None:
         """
@@ -2839,7 +2839,7 @@ class MultiBitOp(ClassicalEvalOp):
         """
 class MultiplexedRotationBox(Op):
     """
-    A user-defined multiplexed rotation gate (i.e. uniformly controlled single-axis rotations) specified by a map from bitstrings to :py:class:`Op` sor a list of bitstring-:py:class:`Op` s pairs
+    A user-defined multiplexed rotation gate (i.e. uniformly controlled single-axis rotations) specified by a map from bitstrings to :py:class:`Op` sor a list of bitstring-:py:class:`Op` s pairs. Implamentation based on https://arxiv.org/abs/quant-ph/0410066. The decomposed circuit has at most 2^k single-qubit rotations, 2^k CX gates, and 2 H gates if it's X-axis. k is the number of control qubits.
     """
     @typing.overload
     def __init__(self, bistring_to_op_list: typing.Sequence[tuple[typing.Sequence[bool], Op]]) -> None:
@@ -2879,7 +2879,7 @@ class MultiplexedRotationBox(Op):
         """
 class MultiplexedTensoredU2Box(Op):
     """
-    A user-defined multiplexed tensor product of U2 gates specified by a map from bitstrings to lists of :py:class:`Op` sor a list of bitstring-list(:py:class:`Op` s) pairs
+    A user-defined multiplexed tensor product of U2 gates specified by a map from bitstrings to lists of :py:class:`Op` sor a list of bitstring-list(:py:class:`Op` s) pairs. A box with k control qubits and t target qubits is implemented as t k-controlled multiplexed-U2 gates with their diagonal components merged and commuted to the end. The resulting circuit contains t non-diagonal components of the multiplexed-U2 decomposition, t k-controlled multiplexed-Rz boxes, and a k-qubit DiagonalBox at the end. The total CX count is at most 2^k(2t+1)-t-2.
     """
     @typing.overload
     def __init__(self, bistring_to_op_list: typing.Sequence[tuple[typing.Sequence[bool], typing.Sequence[Op]]]) -> None:
@@ -2911,7 +2911,7 @@ class MultiplexedTensoredU2Box(Op):
         """
 class MultiplexedU2Box(Op):
     """
-    A user-defined multiplexed U2 gate (i.e. uniformly controlled U2 gate) specified by a map from bitstrings to :py:class:`Op` sor a list of bitstring-:py:class:`Op` s pairs
+    A user-defined multiplexed U2 gate (i.e. uniformly controlled U2 gate) specified by a map from bitstrings to :py:class:`Op` sor a list of bitstring-:py:class:`Op` s pairsImplamentation based on https://arxiv.org/abs/quant-ph/0410066. The decomposed circuit has at most 2^k single-qubit gates, 2^k -1 CX gates, and a k+1 qubit DiagonalBox at the end. k is the number of control qubits.
     """
     @typing.overload
     def __init__(self, bistring_to_op_list: typing.Sequence[tuple[typing.Sequence[bool], Op]], impl_diag: bool = True) -> None:
@@ -3686,7 +3686,7 @@ class StabiliserAssertionBox(Op):
         """
 class StatePreparationBox(Op):
     """
-    A box for preparing quantum states using multiplexed-Ry and multiplexed-Rz gates
+    A box for preparing quantum states using multiplexed-Ry and multiplexed-Rz gates. Implementation based on Theorem 9 of https://arxiv.org/abs/quant-ph/0406176. The decomposed circuit has at most 2*(2^n-2) CX gates, and 2^n-2 CX gates if the coefficients are all real. Note that by decomposing each multiplexed-Ry(Rz) as its dagger can lead to a CX cancellation with its adjacent multiplexed-Rz(Ry), which leads to an improved CX count of 2^(n+1)-2n. However, this is currently not automatically done in tket.
     """
     def __init__(self, statevector: NDArray[numpy.complex128], is_inverse: bool = False, with_initial_reset: bool = False) -> None:
         """


### PR DESCRIPTION
# Description

Add gate complexities to all the `Multiplexed*Boxes `, `StatePreparationBox`, and `DiagonalBox`

# Related issues

Please mention any github issues addressed by this PR.

# Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have commented hard-to-understand parts of my code.
- [x] I have made corresponding changes to the public API documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the changelog with any user-facing changes.
