### PR TITLE
Correct phase handling on ChoiMixTableau constructor

### DIFF
--- a/pytket/conanfile.py
+++ b/pytket/conanfile.py
@@ -32,7 +32,7 @@ class pytketRecipe(ConanFile):
         cmake.install()
 
     def requirements(self):
-        self.requires("tket/1.2.109@tket/stable")
+        self.requires("tket/1.2.110@tket/stable")
         self.requires("tklog/0.3.3@tket/stable")
         self.requires("tkrng/0.3.3@tket/stable")
         self.requires("tkassert/0.3.4@tket/stable")

--- a/tket/conanfile.py
+++ b/tket/conanfile.py
@@ -23,7 +23,7 @@ from conan.errors import ConanInvalidConfiguration
 
 class TketConan(ConanFile):
     name = "tket"
-    version = "1.2.109"
+    version = "1.2.110"
     package_type = "library"
     license = "Apache 2"
     homepage = "https://github.com/CQCL/tket"

--- a/tket/src/Clifford/ChoiMixTableau.cpp
+++ b/tket/src/Clifford/ChoiMixTableau.cpp
@@ -102,8 +102,8 @@ ChoiMixTableau::ChoiMixTableau(const std::list<row_tensor_t>& rows)
   MatrixXb zmat = MatrixXb::Zero(n_rows, n_qbs);
   VectorXb phase = VectorXb::Zero(n_rows);
   unsigned r = 0;
-  unsigned n_ys = 0;
   for (const row_tensor_t& row : rows) {
+    unsigned n_ys = 0;
     for (const std::pair<const Qubit, Pauli>& qb : row.first.string) {
       unsigned c =
           col_index_.left.at(col_key_t{qb.first, TableauSegment::Input});

--- a/tket/test/src/test_ChoiMixTableau.cpp
+++ b/tket/test/src/test_ChoiMixTableau.cpp
@@ -877,6 +877,10 @@ SCENARIO("Synthesis of circuits from ChoiMixTableaus") {
          SpPauliStabiliser({Pauli::I, Pauli::I, Pauli::X})},
     };
     ChoiMixTableau tab(rows);
+    // Check the row constructor gets the right phases after internally
+    // transposing Ys
+    CHECK(tab.get_row(1).second.coeff == 0);
+    CHECK(tab.get_row(2).second.coeff == 0);
     REQUIRE_THROWS(cm_tableau_to_unitary_extension_circuit(tab));
     std::pair<Circuit, qubit_map_t> res_uni =
         cm_tableau_to_unitary_extension_circuit(


### PR DESCRIPTION
# Description

I spotted a v minor error in how the ChoiMixTableau constructor from rows handled the internal transposing of the input segment. This can lead to phase errors in constructed tableaux. This constructor is currently not used internally or externally available so this is not a user facing bug, just bad code (my bad).

# Related issues

N/A

# Checklist

- [x] I have performed a self-review of my code.
- [ ] I have commented hard-to-understand parts of my code.
- [ ] I have made corresponding changes to the public API documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the changelog with any user-facing changes.
