### PR TITLE
Let `RemoveRedundancies` remove `Phase` gates

### DIFF
--- a/pytket/conanfile.py
+++ b/pytket/conanfile.py
@@ -32,7 +32,7 @@ class pytketRecipe(ConanFile):
         cmake.install()
 
     def requirements(self):
-        self.requires("tket/1.2.111@tket/stable")
+        self.requires("tket/1.2.112@tket/stable")
         self.requires("tklog/0.3.3@tket/stable")
         self.requires("tkrng/0.3.3@tket/stable")
         self.requires("tkassert/0.3.4@tket/stable")

--- a/pytket/docs/changelog.rst
+++ b/pytket/docs/changelog.rst
@@ -29,6 +29,7 @@ Fixes:
 * When adding operations to a circuit, check for invalid wires before adding a
   vertex to the circuit.
 * Restrict scipy version to 1.12.x to avoid quimb-related errors from zx module.
+* Make ``RemoveRedundancies`` pass remove ``OpType.Phase`` gates.
 
 1.26.0 (March 2024)
 -------------------

--- a/tket/conanfile.py
+++ b/tket/conanfile.py
@@ -23,7 +23,7 @@ from conan.errors import ConanInvalidConfiguration
 
 class TketConan(ConanFile):
     name = "tket"
-    version = "1.2.111"
+    version = "1.2.112"
     package_type = "library"
     license = "Apache 2"
     homepage = "https://github.com/CQCL/tket"

--- a/tket/src/Transformations/RedundancyRemoval.cpp
+++ b/tket/src/Transformations/RedundancyRemoval.cpp
@@ -214,10 +214,12 @@ static bool is_apriori_not_detachable(
   const OpDesc op_descriptor =
       circuit.get_Op_ptr_from_Vertex(vertex)->get_desc();
 
-  return (not op_descriptor.is_gate()) or  // not a gate
-         circuit.n_out_edges(vertex) ==
-             0 or  // vertex is boundary or already detached
-         circuit.n_in_edges(vertex) == 0;  // vertex is boundary
+  if (!op_descriptor.is_gate()) return true;
+  if (op_descriptor.type() == OpType::Phase) return false;
+  if (circuit.n_out_edges(vertex) == 0 || circuit.n_in_edges(vertex) == 0) {
+    return true;  // vertex is boundary or already detached
+  }
+  return false;
 }
 
 static bool try_detach_vertex(

--- a/tket/test/src/test_CompilerPass.cpp
+++ b/tket/test/src/test_CompilerPass.cpp
@@ -1431,6 +1431,15 @@ SCENARIO("RemoveRedundancies and phase") {
     REQUIRE(c1.get_commands().size() == 0);
     REQUIRE(equiv_val(c1.get_phase(), 1.));
   }
+  GIVEN("A circuit with a Phase gate") {
+    Circuit c(2);
+    c.add_op<unsigned>(OpType::H, {0});
+    c.add_op<unsigned>(OpType::Phase, 0.25, {});
+    c.add_op<unsigned>(OpType::CX, {0, 1});
+    CompilationUnit cu(c);
+    REQUIRE(RemoveRedundancies()->apply(cu));
+    REQUIRE(cu.get_circ_ref().n_gates() == 2);
+  }
 }
 
 // Check whether a circuit maps all basis states to basis states.


### PR DESCRIPTION
# Description

Fixes a "bug" in `RemoveRedundancies` that caused it to ignore `Phase` gates.

# Related issues

Closes #1316 .

# Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented hard-to-understand parts of my code.
- [ ] I have made corresponding changes to the public API documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have updated the changelog with any user-facing changes.
