### PR TITLE
Relax scipy constraint and require latest quimb

### DIFF
--- a/pytket/docs/changelog.rst
+++ b/pytket/docs/changelog.rst
@@ -28,7 +28,6 @@ Fixes:
   targets.
 * When adding operations to a circuit, check for invalid wires before adding a
   vertex to the circuit.
-* Restrict scipy version to 1.12.x to avoid quimb-related errors from zx module.
 * Make ``RemoveRedundancies`` pass remove ``OpType.Phase`` gates.
 
 Deprecations:

--- a/pytket/docs/changelog.rst
+++ b/pytket/docs/changelog.rst
@@ -58,6 +58,7 @@ Fixes:
 
 * Add missing op types to methods for converting Clifford circuits to unitary
   tableaux.
+* Require scipy >= 1.13 and quimb >= 1.8 for ZX module.
 
 1.25.0 (February 2024)
 ----------------------

--- a/pytket/setup.py
+++ b/pytket/setup.py
@@ -194,7 +194,7 @@ setup(
         "sympy ~=1.6",
         "numpy >=1.21.4, <2.0",
         "lark-parser ~=0.7",
-        "scipy ~=1.12.0",
+        "scipy ~=1.13.0",
         "networkx >= 2.8.8",
         "graphviz ~= 0.14",
         "jinja2 ~= 3.0",
@@ -204,7 +204,7 @@ setup(
     ],
     extras_require={
         "ZX": [
-            "quimb ~= 1.5",
+            "quimb ~= 1.8",
             "autoray >= 0.6.1",
         ],
     },

--- a/pytket/setup.py
+++ b/pytket/setup.py
@@ -194,7 +194,7 @@ setup(
         "sympy ~=1.6",
         "numpy >=1.21.4, <2.0",
         "lark-parser ~=0.7",
-        "scipy ~=1.13.0",
+        "scipy ~=1.13",
         "networkx >= 2.8.8",
         "graphviz ~= 0.14",
         "jinja2 ~= 3.0",


### PR DESCRIPTION
The quimb 1.8.0 release fixes the issue with scipy 1.13 so we don't need to pin to scipy 1.12 anymore.
