### PR TITLE
Cherry-pick docs theme upgrade to `docmain`

### DIFF
--- a/pytket/docs/requirements.txt
+++ b/pytket/docs/requirements.txt
@@ -1,6 +1,6 @@
 sphinx >= 4.5, <7
 sphinx_autodoc_annotation >= 1.0
-sphinx_book_theme ~= 1.0.1
+sphinx_book_theme ~= 1.1.2
 sphinx-copybutton
 jupyter-sphinx
 ipykernel


### PR DESCRIPTION
# Description

Doing a cherry pick of the theme version bump in #1334 to the `docmain` branch. 

This means we can get the upgraded theme into the website build without waiting for a new release of pytket

# Related issues

Please mention any github issues addressed by this PR.

# Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have commented hard-to-understand parts of my code.
- [ ] I have made corresponding changes to the public API documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the changelog with any user-facing changes.
