### PR TITLE
fix: Handle classical control in PhasedXFrontier

### DIFF
--- a/pytket/conanfile.py
+++ b/pytket/conanfile.py
@@ -32,7 +32,7 @@ class pytketRecipe(ConanFile):
         cmake.install()
 
     def requirements(self):
-        self.requires("tket/1.2.114@tket/stable")
+        self.requires("tket/1.2.115@tket/stable")
         self.requires("tklog/0.3.3@tket/stable")
         self.requires("tkrng/0.3.3@tket/stable")
         self.requires("tkassert/0.3.4@tket/stable")

--- a/tket/conanfile.py
+++ b/tket/conanfile.py
@@ -23,7 +23,7 @@ from conan.errors import ConanInvalidConfiguration
 
 class TketConan(ConanFile):
     name = "tket"
-    version = "1.2.114"
+    version = "1.2.115"
     package_type = "library"
     license = "Apache 2"
     homepage = "https://github.com/CQCL/tket"

--- a/tket/include/tket/Transformations/PhasedXFrontier.hpp
+++ b/tket/include/tket/Transformations/PhasedXFrontier.hpp
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <cmath>
+#include <optional>
 #include <set>
 
 #include "SingleQubitSquash.hpp"
@@ -289,12 +290,44 @@ class PhasedXFrontier {
 
   // squasher to squash gates
   SingleQubitSquash squasher_;
+
+  // Access class attributes for testing
+  friend class PhasedXFrontierTester;
 };
 
 /**
  * @brief Whether all elements of `vec` are std::nullopt.
  */
 bool all_nullopt(const OptVertexVec& vec);
+
+/**
+ * @brief Testing class for the PhasedXFrontier class.
+ *
+ * Gives access to current interval start and end vertices.
+ */
+class PhasedXFrontierTester {
+ public:
+  PhasedXFrontierTester(PhasedXFrontier& frontier, Circuit& circ);
+
+  /**
+   * @brief Get the start of the interval on qubit `i`.
+   *
+   * @param i The qubit index.
+   * @return Vertex The gate before the current interval on qubit `i`.
+   */
+  Vertex get_interval_start(unsigned i);
+  /**
+   * @brief Get the end of the interval on qubit `i`.
+   *
+   * @param i The qubit index.
+   * @return Vertex The gate after the current interval on qubit `i`.
+   */
+  Vertex get_interval_end(unsigned i);
+
+ private:
+  PhasedXFrontier const& frontier_;
+  Circuit const& circ_;
+};
 
 }  // namespace Transforms
 


### PR DESCRIPTION
Closes #1306

This solves the issue by treating any classically controlled gate as a barrier when squashing and turning gates to global gates. This is the only simple solution I could think of, as squashing classically controlled operation is always a bit tricky and comes with many edge cases.