### PR TITLE
Use delocate 0.10.x when building pytket wheels on `macos-13-xlarge`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,7 +138,8 @@ jobs:
         cd pytket
         # Ensure wheels are compatible with MacOS 12.0 and later:
         export WHEEL_PLAT_NAME=macosx_12_0_arm64
-        python${{ matrix.python-version }} -m pip install -U pip build delocate
+        python${{ matrix.python-version }} -m pip install -U pip build
+        python${{ matrix.python-version }} -m pip install delocate ~= 0.10.7
         python${{ matrix.python-version }} -m build
         delocate-wheel -v -w "$GITHUB_WORKSPACE/wheelhouse/" "dist/pytket-"*".whl"
     - uses: actions/upload-artifact@v4


### PR DESCRIPTION
# Description

Ensure we use a version of `delocate` that does not rename the wheel.

I have checked that the wheels produced do have `macosx_12_0_arm64` in their name.

We should also investigate whether there really is a compatibility issue here, as `delocate` 0.11 would seem to indicate. I'll raise a new issue for that (and if possible reverting this change).

# Related issues

Fixes #1341 .

# Checklist

- [x] I have performed a self-review of my code.
- [ ] I have commented hard-to-understand parts of my code.
- [ ] I have made corresponding changes to the public API documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the changelog with any user-facing changes.
