### PR TITLE
Feature/add cachix

### DIFF
--- a/.github/workflows/build-with-nix.yml
+++ b/.github/workflows/build-with-nix.yml
@@ -16,5 +16,9 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: cachix/install-nix-action@v26
+    - uses: cachix/cachix-action@v14
+      with:
+        name: tket
+        authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
     - name: Build and test tket
       run: nix flake check -L

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ pytket/tests/qasm_test_files/testout6.qasm
 
 #nix
 result
+.envrc
+.direnv/

--- a/README.md
+++ b/README.md
@@ -153,3 +153,13 @@ building and testing pytket.
 Tket and pytket are available as a Nix flake, with support for Linux and Apple Silicon systems.
 See the [README](nix-support/README.md) in the `nix-support` directory for instructions
 on building and testing tket and pytket through Nix, and on how to use it within a Nix project.
+
+To launch into a tket environment, you can use
+
+```
+nix develop github:CQCL/tket
+```
+
+We use Cachix to cache pre-built artifacts, which provides a faster install time for nix users.
+To make use of this cache, enable our cachix substituter with `cachix use tket`, or enter a
+tket nix environment from a trusted user and confirm the use of the tket.cachix.org substituter.

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1694529238,
-        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1700484102,
-        "narHash": "sha256-yGPHhYBH8KZu70gZvHRBvIzN0Z9dlwXX7u3hFFiGevA=",
+        "lastModified": 1712940319,
+        "narHash": "sha256-QN9FhrpcHQLfc6CJmgNOD2vXz9/aGTEqDYTWtdc/mi0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "48a753219ede79d448cd0aa3bbf29d29fcbab8c9",
+        "rev": "623ac957cb99a5647c9cf127ed6b5b9edfbba087",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,10 @@
 {
   description = "Tket Quantum SDK";
-  nixConfig.extra-substituters = "https://tket.cachix.org";
-  nixConfig.trusted-public-keys = "tket.cachix.org-1:ACdm5Zg19qPL0PpvUwTPPiIx8SEUy+D/uqa9vKJFwh0=";
+  nixConfig.extra-substituters = "https://tket.cachix.org https://cache.nixos.org";
+  nixConfig.trusted-public-keys = ''
+    tket.cachix.org-1:ACdm5Zg19qPL0PpvUwTPPiIx8SEUy+D/uqa9vKJFwh0=
+    cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
+  '';
   inputs.nixpkgs.url = "github:nixos/nixpkgs";
   inputs.flake-utils.url = "github:numtide/flake-utils";
   outputs = { self, nixpkgs, flake-utils }:

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,7 @@
 {
   description = "Tket Quantum SDK";
+  nixConfig.extra-substituters = "https://tket.cachix.org";
+  nixConfig.trusted-public-keys = "tket.cachix.org-1:ACdm5Zg19qPL0PpvUwTPPiIx8SEUy+D/uqa9vKJFwh0=";
   inputs.nixpkgs.url = "github:nixos/nixpkgs";
   inputs.flake-utils.url = "github:numtide/flake-utils";
   outputs = { self, nixpkgs, flake-utils }:


### PR DESCRIPTION
# Description

Adds tket.cachix.org as a substituter within the tket nix flake, a github action to push to the binary cache when nix builds are triggered, and instructions on using the tket cache in the README. Also updated nix flake dependencies (e.g. nixpkgs) and tested their outputs.

I have confirmed that the git action to push to cachix works by running the nix build workflow manually on the feature branch.

I have also confirmed that the resulting derivation is provided through downloads from the cache rather than through compilation on the destination machine with MacOS and linux.

The end results:
- Entering a tket environment from any machine with Nix installed is considerably faster with cached artifacts, which will be useful for quick installs, live demonstrations, and entering development environments quickly.
- Only modified subtrees of the build DAG are rebuilt in CI. For example, commits that touch pytket (but not tket itself) will not rebuild tket in CI, as it is already cached. Custom dependencies (such as the modified symengine) won't be rebuilt unless they are changed.
- TKET extensions will have these benefits too, which will make them easier to work with and add less pressure to CI.

# Related issues

N/A

# Checklist

- [✓] I have performed a self-review of my code.
- [N/A] I have commented hard-to-understand parts of my code.
- [✓] I have made corresponding changes to the public API documentation.
- [N/A] I have added tests that prove my fix is effective or that my feature works.
- [N/A ] I have updated the changelog with any user-facing changes.
