### PR TITLE
remove support for multi return wasm functions

### DIFF
--- a/pytket/docs/changelog.rst
+++ b/pytket/docs/changelog.rst
@@ -31,6 +31,7 @@ Fixes:
 * When adding operations to a circuit, check for invalid wires before adding a
   vertex to the circuit.
 * Make ``RemoveRedundancies`` pass remove ``OpType.Phase`` gates.
+* Remove support for wasm functions with multiple return values.
 
 Deprecations:
 

--- a/pytket/pytket/wasm/wasm.py
+++ b/pytket/pytket/wasm/wasm.py
@@ -158,6 +158,12 @@ class WasmFileHandler:
                     if t != self._int_type:
                         supported_function = False
 
+                if (
+                    len(function_signatures[self._function_types[idx]]["return_types"])
+                    > 1
+                ):
+                    supported_function = False
+
                 if supported_function:
                     self._functions[x] = (
                         len(

--- a/pytket/tests/classical_test.py
+++ b/pytket/tests/classical_test.py
@@ -653,7 +653,7 @@ def test_wasmfilehandler_multivalue_clang() -> None:
         == """Functions in wasm file with the uid 6f821422038eec251d2f4e6bf2b9a5717b18b5c96a8a8e01fb49f080d9610f6e:
 function '__wasm_call_ctors' with 0 i32 parameter(s) and 0 i32 return value(s)
 function 'init' with 0 i32 parameter(s) and 0 i32 return value(s)
-function 'divmod' with 2 i32 parameter(s) and 2 i32 return value(s)
+unsupported function with invalid parameter or result type: 'divmod' 
 """
     )
 


### PR DESCRIPTION
# Description

Reject wasm functions with multiple return values

# Related issues

Please mention any github issues addressed by this PR.

# Checklist

- [x] I have performed a self-review of my code.
- [ ] I have commented hard-to-understand parts of my code.
- [ ] I have made corresponding changes to the public API documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have updated the changelog with any user-facing changes.
