### PR TITLE
Update `docmain` with missing `Circuit` methods

### DIFF
--- a/pytket/docs/circuit_class.rst
+++ b/pytket/docs/circuit_class.rst
@@ -327,6 +327,12 @@ condition on a specified set of bit values.)
 
    .. automethod:: ZZMax
 
+   .. automethod:: AAMS
+
+   .. automethod:: GPI
+
+   .. automethod:: GPI2
+
    Methods for appending circuit boxes
    -----------------------------------
 
@@ -347,6 +353,10 @@ condition on a specified set of bit values.)
 
    .. automethod:: add_circbox
 
+   .. automethod:: add_circbox_regwise
+
+   .. automethod:: add_circbox_with_regmap
+
    .. automethod:: add_unitary1qbox
    
    .. automethod:: add_unitary2qbox
@@ -360,6 +370,8 @@ condition on a specified set of bit values.)
    .. automethod:: add_pauliexppairbox
 
    .. automethod:: add_pauliexpcommutingsetbox
+
+   .. automethod:: add_termsequencebox
 
    .. automethod:: add_phasepolybox
 


### PR DESCRIPTION
# Description

Doing a cherry-pick to update with the changes in #1352 so we don't have to wait for the next pytket release for the updated docs.

# Related issues

Please mention any github issues addressed by this PR.

# Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have commented hard-to-understand parts of my code.
- [ ] I have made corresponding changes to the public API documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the changelog with any user-facing changes.
