### PR TITLE
Add "CANCELLING" and "RETRYING" statuses

### DIFF
--- a/pytket/docs/changelog.rst
+++ b/pytket/docs/changelog.rst
@@ -7,6 +7,7 @@ Unreleased
 Features:
 
 * Update to pytket-circuit-renderer 0.8.
+* Add two new status values for circuits on backends: "CANCELLING" and "RETRYING".
 
 1.27.0 (April 2024)
 -------------------

--- a/pytket/pytket/backends/status.py
+++ b/pytket/pytket/backends/status.py
@@ -26,6 +26,8 @@ class StatusEnum(Enum):
     QUEUED = "Circuit is queued."
     SUBMITTED = "Circuit has been submitted."
     RUNNING = "Circuit is running."
+    RETRYING = "Circuit is being retried."
+    CANCELLING = "Cancellation has been requested."
     CANCELLED = "Circuit has been cancelled."
     ERROR = "Circuit has errored. Check CircuitStatus.message for error message."
 


### PR DESCRIPTION
# Description

Add "CANCELLING" and "RETRYING" statuses to `pytket.backends.status.StatusEnum`

# Related issues

n/a

# Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented hard-to-understand parts of my code.
- [ ] I have made corresponding changes to the public API documentation. <- n/a
- [ ] I have added tests that prove my fix is effective or that my feature works. <- I haven't, but it should be covered by hypothesis in [test_status_serialization_basic](https://github.com/CQCL/tket/blob/develop/pytket/tests/backend_test.py#L427)
- [x] I have updated the changelog with any user-facing changes.
