### PR TITLE
ci: Add automated benchmarking workflow

### DIFF
--- a/.github/workflows/pytket_benchmarking.yml
+++ b/.github/workflows/pytket_benchmarking.yml
@@ -78,11 +78,6 @@ jobs:
           pip install pytket-*.whl
           pip install --pre --index-url https://github_actions:${{ secrets.PRIVATE_PYPI_PASS }}@cqcpythonrepository.azurewebsites.net/simple/ pytket_benchmarking
 
-      - name: Checkout tket
-        uses: actions/checkout@v4
-        with:
-          path: tket
-
       - name: Checkout pytket-benchmarking-store
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/pytket_benchmarking.yml
+++ b/.github/workflows/pytket_benchmarking.yml
@@ -56,8 +56,8 @@ jobs:
         name: pytket_wheel
         path: wheelhouse/
 
-  Write-Env-Var:
-    name: Write Env Var
+  compile-and-compare:
+    name: Compile and compare
     runs-on: macos-14
     needs: build_wheels
 
@@ -68,7 +68,7 @@ jobs:
         with:
           python-version: '3.11'
 
-      - name: Download Wheel
+      - name: Download wheel
         uses: actions/download-artifact@v4
         with:
           name: pytket_wheel
@@ -77,7 +77,6 @@ jobs:
         run: |
           pip install pytket-*.whl
           pip install --pre --index-url https://github_actions:${{ secrets.PRIVATE_PYPI_PASS }}@cqcpythonrepository.azurewebsites.net/simple/ pytket_benchmarking
-          pip list
 
       - name: Checkout tket
         uses: actions/checkout@v4
@@ -95,13 +94,13 @@ jobs:
           pytket_benchmarking compile QiskitIBMQ pytket-benchmarking-store/benchmarking_circuits/quantum_volume automated_benchmarks_compiled
           pytket_benchmarking compile PytketIBMQ pytket-benchmarking-store/benchmarking_circuits/quantum_volume automated_benchmarks_compiled
 
-      - name: Save Compiled Circuits
+      - name: Save compiled circuits
         uses: actions/upload-artifact@v4
         with:
           name: automated_benchmarks_compiled
           path: automated_benchmarks_compiled/
 
-      - name: Percentage better
+      - name: Calculate percentage better
         run: echo "RETURN_TEST=$(pytket_benchmarking percentage-better pytket-benchmarking-store/benchmarking_circuits/quantum_volume automated_benchmarks_compiled PytketIBMQ)" >> $GITHUB_ENV
 
       - name: Create comment

--- a/.github/workflows/pytket_benchmarking.yml
+++ b/.github/workflows/pytket_benchmarking.yml
@@ -44,6 +44,8 @@ jobs:
         conan create recipes/pybind11
         conan create recipes/pybind11_json/all --version 0.2.13
         cd pytket
+        # Ensure wheels are compatible with MacOS 12.0 and later:
+        export WHEEL_PLAT_NAME=macosx_12_0_arm64
         python3.11 -m pip install -U pip build delocate
         python3.11 -m build
         delocate-wheel -v -w "$GITHUB_WORKSPACE/wheelhouse/" "dist/pytket-"*".whl"

--- a/.github/workflows/pytket_benchmarking.yml
+++ b/.github/workflows/pytket_benchmarking.yml
@@ -44,8 +44,6 @@ jobs:
         conan create recipes/pybind11
         conan create recipes/pybind11_json/all --version 0.2.13
         cd pytket
-        # Ensure wheels are compatible with MacOS 12.0 and later:
-        export WHEEL_PLAT_NAME=macosx_12_0_arm64
         python3.11 -m pip install -U pip build delocate
         python3.11 -m build
         delocate-wheel -v -w "$GITHUB_WORKSPACE/wheelhouse/" "dist/pytket-"*".whl"

--- a/.github/workflows/pytket_benchmarking.yml
+++ b/.github/workflows/pytket_benchmarking.yml
@@ -1,0 +1,113 @@
+name: Automated Benchmarks
+
+on:
+  pull_request:
+    branches:
+      - develop
+  workflow_dispatch:
+
+jobs:
+
+  build_wheels:
+    name: Build macos wheels
+    runs-on: macos-14
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: '0'
+
+    - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
+
+    - name: Set up Python 3.11
+      uses: actions/setup-python@v5
+      with:
+        python-version: 3.11
+
+    - name: Install conan
+      uses: turtlebrowser/get-conan@v1.2
+
+    - name: Set up conan
+      run: |
+        conan profile detect
+        DEFAULT_PROFILE_PATH=`conan profile path default`
+        PROFILE_PATH=./conan-profiles/macos-14
+        diff ${DEFAULT_PROFILE_PATH} ${PROFILE_PATH} || true
+        cp ${PROFILE_PATH} ${DEFAULT_PROFILE_PATH}
+        conan remote add tket-libs https://quantinuumsw.jfrog.io/artifactory/api/conan/tket1-libs --index 0
+
+    - name: Build tket C++
+      run: conan create tket --user tket --channel stable --build=missing -o boost/*:header_only=True -o tklog/*:shared=True -o tket/*:shared=True -tf ""
+
+    - name: Build wheel
+      run: |
+        conan create recipes/pybind11
+        conan create recipes/pybind11_json/all --version 0.2.13
+        cd pytket
+        # Ensure wheels are compatible with MacOS 12.0 and later:
+        export WHEEL_PLAT_NAME=macosx_12_0_arm64
+        python3.11 -m pip install -U pip build delocate
+        python3.11 -m build
+        delocate-wheel -v -w "$GITHUB_WORKSPACE/wheelhouse/" "dist/pytket-"*".whl"
+
+    - name: Save Wheel
+      uses: actions/upload-artifact@v4
+      with:
+        name: pytket_wheel
+        path: wheelhouse/
+
+  Write-Env-Var:
+    name: Write Env Var
+    runs-on: macos-14
+    needs: build_wheels
+
+    steps:
+      
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Download Wheel
+        uses: actions/download-artifact@v4
+        with:
+          name: pytket_wheel
+
+      - name: Install dependencies
+        run: |
+          pip install pytket-*.whl
+          pip install --pre --index-url https://github_actions:${{ secrets.PRIVATE_PYPI_PASS }}@cqcpythonrepository.azurewebsites.net/simple/ pytket_benchmarking
+          pip list
+
+      - name: Checkout tket
+        uses: actions/checkout@v4
+        with:
+          path: tket
+
+      - name: Checkout pytket-benchmarking-store
+        uses: actions/checkout@v4
+        with:
+          repository: CQCL/pytket-benchmarking-store
+          path: pytket-benchmarking-store
+
+      - name: Perform Compilation
+        run: |
+          pytket_benchmarking compile QiskitIBMQ pytket-benchmarking-store/benchmarking_circuits/quantum_volume automated_benchmarks_compiled
+          pytket_benchmarking compile PytketIBMQ pytket-benchmarking-store/benchmarking_circuits/quantum_volume automated_benchmarks_compiled
+
+      - name: Save Compiled Circuits
+        uses: actions/upload-artifact@v4
+        with:
+          name: automated_benchmarks_compiled
+          path: automated_benchmarks_compiled/
+
+      - name: Percentage better
+        run: echo "RETURN_TEST=$(pytket_benchmarking percentage-better pytket-benchmarking-store/benchmarking_circuits/quantum_volume automated_benchmarks_compiled PytketIBMQ)" >> $GITHUB_ENV
+
+      - name: Create comment
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body: '${{ env.RETURN_TEST }}'
+        env:
+          RETURN_TEST: ${{ env.RETURN_TEST }}


### PR DESCRIPTION
# Description

Adds a workflow to run benchmarks on each new PR. The version of pytket built from the PR is used in the benchmarks. At the moment this is a simple comparison to Qiskit on quantum volume circuits.

I would like to have a wider conversation about the compilers to compare agains, and the circuits to compile. The outcome of those conversation would feature in later PRs.

I also note that the benchmarks are quite slow. I will experiment with parallelisation in future PRs.

# Related issues

N/A

# Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented hard-to-understand parts of my code.
- [x] I have made corresponding changes to the public API documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have updated the changelog with any user-facing changes.
