### PR TITLE
Set Nix workflow to run on PRs and commits (not just weekly)

### DIFF
--- a/.github/workflows/build-with-nix.yml
+++ b/.github/workflows/build-with-nix.yml
@@ -5,9 +5,6 @@ on:
     branches:
       - main
       - develop
-  push:
-    branches:
-      - develop
   schedule:
     # 01:00 every Sunday morning
     - cron: '0 1 * * 0'

--- a/.github/workflows/build-with-nix.yml
+++ b/.github/workflows/build-with-nix.yml
@@ -1,9 +1,18 @@
 name: build with nix
+
 on:
+  pull_request:
+    branches:
+      - main
+      - develop
+  push:
+    branches:
+      - develop
   schedule:
     # 01:00 every Sunday morning
     - cron: '0 1 * * 0'
   workflow_dispatch: {}
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Previously this was run only once per week due to the time taken to build via Nix (most dependencies had to be compiled, then tket, etc).

However, with Cachix, build times have decreased dramatically, and I propose we keep the cache hot so that running on the latest commit remains fast.