### PR TITLE
Switch workflows to target `main` only

### DIFF
--- a/.github/workflows/build-with-nix.yml
+++ b/.github/workflows/build-with-nix.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
     branches:
       - main
-      - develop
   schedule:
     # 01:00 every Sunday morning
     - cron: '0 1 * * 0'

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -4,10 +4,9 @@ on:
   pull_request:
     branches:
       - main
-      - develop
   push:
     branches:
-      - develop
+      - main
   schedule:
     # 03:00 every Saturday morning
     - cron: '0 3 * * 6'
@@ -63,7 +62,7 @@ jobs:
         tket_package_exists=`conan search -r tket-libs "tket/${{ steps.tket_ver.outputs.tket_ver }}@tket/stable" | grep "not found" > /dev/null 2>&1 && echo false || echo true`
         echo "tket_package_exists=${tket_package_exists}" >> $GITHUB_OUTPUT
     - name: Check tket version bump
-      if: github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'develop' && steps.filter.outputs.tket == 'true' && steps.test_package_exists.outputs.tket_package_exists == 'true'
+      if: github.event_name == 'pull_request' && steps.filter.outputs.tket == 'true' && steps.test_package_exists.outputs.tket_package_exists == 'true'
       run: exit 1
 
   check_docs_tket:
@@ -138,7 +137,7 @@ jobs:
     - name: Build tket
       run: conan create tket -s build_type=Release --user=tket --channel=stable -o boost/*:header_only=True -o with_all_tests=True
     - name: Upload package
-      if: github.event_name == 'push' && github.ref == 'refs/heads/develop'
+      if: github.event_name == 'push'
       run: |
         ccache --set-config namespace=WITHOUT_TESTS
         conan create tket --user=tket --channel=stable -o boost/*:header_only=True
@@ -207,7 +206,7 @@ jobs:
           conan build tket --user=tket --channel=stable -o boost/*:header_only=True -o with_all_tests=True -c tools.cmake.cmaketoolchain:generator=Ninja
           conan export-pkg tket --user=tket --channel=stable -o boost/*:header_only=True -o with_all_tests=True -c tools.cmake.cmaketoolchain:generator=Ninja
       - name: Upload package
-        if: github.event_name == 'push' && github.ref == 'refs/heads/develop'
+        if: github.event_name == 'push'
         run: |
           ccache --set-config namespace=WITHOUT_TESTS
           conan build tket --user=tket --channel=stable -o boost/*:header_only=True
@@ -319,7 +318,7 @@ jobs:
         name: pytket_test_coverage
         path: pytket/tests/htmlcov
     - name: Upload package
-      if: github.event_name == 'push' && github.ref == 'refs/heads/develop' && needs.check_changes.outputs.tket_changed == 'true'
+      if: github.event_name == 'push && needs.check_changes.outputs.tket_changed == 'true'
       run: |
         conan remote login -p ${{ secrets.JFROG_ARTIFACTORY_TOKEN_3 }} tket-libs ${{ secrets.JFROG_ARTIFACTORY_USER_3 }}
         conan upload tket/${{ needs.check_changes.outputs.tket_ver }}@tket/stable -r=tket-libs
@@ -409,7 +408,7 @@ jobs:
         git diff --quiet pytket/_tket && echo "Stubs are up-to-date" || exit 1  # fail if stubs change after regeneration
         python -m mypy --config-file=mypy.ini --no-incremental -p pytket -p tests
     - name: Upload package
-      if: github.event_name == 'push' && github.ref == 'refs/heads/develop' && needs.check_changes.outputs.tket_changed == 'true'
+      if: github.event_name == 'push' && needs.check_changes.outputs.tket_changed == 'true'
       run: |
         conan remote login -p ${{ secrets.JFROG_ARTIFACTORY_TOKEN_3 }} tket-libs ${{ secrets.JFROG_ARTIFACTORY_USER_3 }}
         conan upload tket/${{ needs.check_changes.outputs.tket_ver }}@tket/stable -r=tket-libs
@@ -521,7 +520,7 @@ jobs:
         pip install -r requirements.txt
         pytest --ignore=simulator/
     - name: Upload package
-      if: github.event_name == 'push' && github.ref == 'refs/heads/develop' && needs.check_changes.outputs.tket_changed == 'true'
+      if: github.event_name == 'push' && needs.check_changes.outputs.tket_changed == 'true'
       run: |
         conan remote login -p ${{ secrets.JFROG_ARTIFACTORY_TOKEN_3 }} tket-libs ${{ secrets.JFROG_ARTIFACTORY_USER_3 }}
         conan upload tket/${{ needs.check_changes.outputs.tket_ver }}@tket/stable -r=tket-libs
@@ -534,7 +533,7 @@ jobs:
     name: Publish pytket coverage
     needs: build_test_pytket_ubuntu
     concurrency: gh_pages
-    if: github.event_name == 'push' && github.ref == 'refs/heads/develop'
+    if: github.event_name == 'push'
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
@@ -562,7 +561,7 @@ jobs:
   check_pytket_coverage:
     name: Check pytket line and branch coverage
     needs: build_test_pytket_ubuntu
-    if: (github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'develop') || github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
@@ -571,7 +570,7 @@ jobs:
       with:
         name: pytket_test_coverage
         path: pytket-test-coverage/
-    - name: Compare with latest report from develop
+    - name: Compare with latest report from main
       run: |
         wget https://cqcl.github.io/tket/pytket/test-coverage/cov.xml -O oldcov.xml
         ./.github/workflows/compare-pytket-coverage oldcov.xml pytket-test-coverage/cov.xml

--- a/.github/workflows/build_libs.yml
+++ b/.github/workflows/build_libs.yml
@@ -2,10 +2,10 @@ name: build libraries
 on:
   push:
     branches:
-      - develop
+      - main
   pull_request:
     branches:
-      - develop
+      - main
   workflow_dispatch: {}
 
 jobs:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -3,10 +3,10 @@ name: Analyse tket C++ test coverage
 on:
   pull_request:
     branches:
-      - develop
+      - main
   push:
     branches:
-      - develop
+      - main
   schedule:
     # 03:00 every Saturday morning
     - cron: '0 3 * * 6'
@@ -99,12 +99,12 @@ jobs:
       with:
         name: test_coverage
         path: test-coverage/
-    - name: Compare with latest report from develop (short tests)
+    - name: Compare with latest report from main (short tests)
       if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
       run: |
         wget https://cqcl.github.io/tket/tket/test-coverage-short/summary.txt
         ./.github/workflows/compare-coverage summary.txt test-coverage/summary.txt
-    - name: Compare with latest report from develop (full suite)
+    - name: Compare with latest report from main (full suite)
       if: github.event_name == 'schedule'
       run: |
         wget https://cqcl.github.io/tket/tket/test-coverage/summary.txt

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,7 +3,7 @@ name: Deploy tket C++ documentation
 on:
   push:
     branches:
-      - develop
+      - main
     paths:
       - 'tket/src/**'
 

--- a/.github/workflows/pytket_benchmarking.yml
+++ b/.github/workflows/pytket_benchmarking.yml
@@ -3,7 +3,7 @@ name: Automated Benchmarks
 on:
   pull_request:
     branches:
-      - develop
+      - main
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/test_libs.yml
+++ b/.github/workflows/test_libs.yml
@@ -2,10 +2,10 @@ name: test libraries
 on:
   push:
     branches:
-      - develop
+      - main
   pull_request:
     branches:
-      - develop
+      - main
   workflow_dispatch: {}
 
 env:
@@ -135,7 +135,7 @@ jobs:
       with:
         name: ${{ matrix.lib }}_coverage
         path: ${{ matrix.lib }}-coverage/
-    - name: check coverage against latest published data from develop
+    - name: check coverage against latest published data from main
       if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
       run: |
         # File may not exist if this is the very first time, so don't error.
@@ -146,7 +146,7 @@ jobs:
   publish_coverage:
     name: Publish coverage
     needs: [set_libs_matrix, generate_coverage]
-    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/develop' && needs.set_libs_matrix.outputs.libs != '[]' && needs.set_libs_matrix.outputs.libs != '' }}
+    if: ${{ github.event_name == 'push' && needs.set_libs_matrix.outputs.libs != '[]' && needs.set_libs_matrix.outputs.libs != '' }}
     strategy:
       matrix:
         lib: ${{ fromJson(needs.set_libs_matrix.outputs.libs) }}

--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -2,7 +2,7 @@ name: valgrind check
 on:
   pull_request:
     branches:
-      - develop
+      - main
   workflow_dispatch: {}
 
   schedule:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Contributing to TKET
 
 Pull requests are welcome. To make a PR, first fork the repo, make your proposed
-changes on the `develop` branch, and open a PR from your fork. If it passes
+changes on the `main` branch, and open a PR from your fork. If it passes
 tests and is accepted after review, it will be merged in.
 
 When adding a new feature, please add tests for it. When fixing a bug, please
@@ -9,11 +9,11 @@ add a test that demonstrates the fix.
 
 If you make a change to one of the libraries in the `libs` directory, please
 increase the version number and make a PR with that change only: the component
-will then be tested on the CI, and on merge to `develop` the new version will be
+will then be tested on the CI, and on merge to `main` the new version will be
 uploaded. Then it will be possible to update conan requirements to use the new
 version.
 
-A new version of TKET is uploaded to our conan repo with each push to `develop`
+A new version of TKET is uploaded to our conan repo with each push to `main`
 that changes the core library. This process is managed by CI workflows. If you
 are making changes only to TKET tests or pytket, you do not need to build TKET
 locally: the right version should be downloaded automatically from the conan
@@ -80,7 +80,7 @@ If you make any changes in `tket/src`, you should bump the version number of
 `tket` in `recipes/tket/conanfile.py`, and also the `tket` versions in the
 `requires` field in `recipes/tket-test/conanfile.py`,
 `recipes/tket-proptests/conanfile.py` and `pytket/conanfile.txt` so that they
-match the new version. (This is checked on the CI for all PRs to `develop`.)
+match the new version. (This is checked on the CI for all PRs to `main`.)
 Follow the "semantic versioning" convention: any backwards-incompatible changes
 to the C++ API require a major version bump; new API features that maintain
 backwards compatibility require a minor version bump; internal improvements and
@@ -92,21 +92,21 @@ bugfixes require a patch version bump.
 
 The code coverage of the `tket` tests is reported
 [here](https://cqcl.github.io/tket/tket/test-coverage/index.html). This report
-is generated weekly from the `develop` branch.
+is generated weekly from the `main` branch.
 
 The libraries' coverage (from their own unit tests) is also reported: for
 example [tklog](https://cqcl.github.io/tket/tket/tklog-coverage/index.html).
 (For other libraries, just replace "tklog" with the library name in the URL.)
 
-In both cases, PRs to `develop` check that the coverage has not decreased, and
+In both cases, PRs to `main` check that the coverage has not decreased, and
 merging is blocked until the coverage is at least as good as before.
 
 ### pytket
 
 The code coverage of the `pytket` tests is reported
 [here](https://cqcl.github.io/tket/pytket/test-coverage/index.html). This report
-reflects the coverage of the `develop` branch, and is updated with every push.
+reflects the coverage of the `main` branch, and is updated with every push.
 The same report can be found in XML format
 [here](https://cqcl.github.io/tket/pytket/test-coverage/cov.xml).
 
-Lines and branch coverage results are also checked with every PR to `develop`.
+Lines and branch coverage results are also checked with every PR to `main`.

--- a/pytket/docs/backends.rst
+++ b/pytket/docs/backends.rst
@@ -5,7 +5,7 @@ Contains :py:class:`Backend` abstract class and associated methods. In pytket a 
 
 There are several `example notebooks <https://tket.quantinuum.com/examples>`_ on pytket :py:class:`Backend`\s. If you are interested in developing your own :py:class:`Backend` or pytket extension then see the `creating backends <https://tket.quantinuum.com/examples/creating_backends.html>`_ tutorial.
 
-Notebook tutorials specific to the :py:class:`QuantinuumBackend` can be found `here <https://github.com/CQCL/pytket-quantinuum/tree/main/examples>`_.
+Notebook tutorials specific to the :py:class:`QuantinuumBackend` can be found `here <https://github.com/CQCL/pytket-quantinuum/tree/develop/examples>`_.
 
 See also the `Running on backends <https://tket.quantinuum.com/user-manual/manual_backend.html>`_ section of the pytket user manual.
 

--- a/pytket/docs/backends.rst
+++ b/pytket/docs/backends.rst
@@ -5,7 +5,7 @@ Contains :py:class:`Backend` abstract class and associated methods. In pytket a 
 
 There are several `example notebooks <https://tket.quantinuum.com/examples>`_ on pytket :py:class:`Backend`\s. If you are interested in developing your own :py:class:`Backend` or pytket extension then see the `creating backends <https://tket.quantinuum.com/examples/creating_backends.html>`_ tutorial.
 
-Notebook tutorials specific to the :py:class:`QuantinuumBackend` can be found `here <https://github.com/CQCL/pytket-quantinuum/tree/develop/examples>`_.
+Notebook tutorials specific to the :py:class:`QuantinuumBackend` can be found `here <https://github.com/CQCL/pytket-quantinuum/tree/main/examples>`_.
 
 See also the `Running on backends <https://tket.quantinuum.com/user-manual/manual_backend.html>`_ section of the pytket user manual.
 


### PR DESCRIPTION
# Description

Update CI workflows to run on push and PR to `main` instead of `develop`.

Once approved, I would:
- change the branch protection rules on the repo (note that some of the "Required" checks below will not run on this PR);
- merge this into `develop`;
- make `main` the default branch;
- make a PR from `develop` into `main`;
- merge that.

We will also need to update the workflows on `tket-site`, so that they only publish released versions (which will be identifiable by tag).

# Checklist

- [x] I have performed a self-review of my code.
- [ ] I have commented hard-to-understand parts of my code.
- [ ] I have made corresponding changes to the public API documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the changelog with any user-facing changes.
