### PR TITLE
Show diff from clang-format.

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -88,7 +88,8 @@ jobs:
         run: |
           brew update
           brew install clang-format@18
-          git ls-files "*.cpp" "*.hpp" | xargs clang-format -style=file --dry-run --Werror
+          git ls-files "*.cpp" "*.hpp" | xargs clang-format -style=file -i
+          git diff --exit-code
 
   build_test_tket:
     name: Build and test (tket)

--- a/libs/tklog/src/TketLog.cpp
+++ b/libs/tklog/src/TketLog.cpp
@@ -63,8 +63,8 @@ void Logger::log(const char *levstr, const std::string &s, std::ostream &os) {
 #else
   plt = std::localtime(&t);
 #endif
-  os << "[" << std::put_time(plt, "%Y-%m-%d %H:%M:%S") << "]" << " [tket] ["
-     << levstr << "] " << s << std::endl;
+  os << "[" << std::put_time(plt, "%Y-%m-%d %H:%M:%S") << "]"
+     << " [tket] [" << levstr << "] " << s << std::endl;
 }
 
 void Logger::set_level(LogLevel lev) { level = lev; }

--- a/pytket/conanfile.py
+++ b/pytket/conanfile.py
@@ -32,7 +32,7 @@ class pytketRecipe(ConanFile):
         cmake.install()
 
     def requirements(self):
-        self.requires("tket/1.2.119@tket/stable")
+        self.requires("tket/1.2.120@tket/stable")
         self.requires("tklog/0.3.3@tket/stable")
         self.requires("tkrng/0.3.3@tket/stable")
         self.requires("tkassert/0.3.4@tket/stable")

--- a/tket/conanfile.py
+++ b/tket/conanfile.py
@@ -23,7 +23,7 @@ from conan.errors import ConanInvalidConfiguration
 
 class TketConan(ConanFile):
     name = "tket"
-    version = "1.2.119"
+    version = "1.2.120"
     package_type = "library"
     license = "Apache 2"
     homepage = "https://github.com/CQCL/tket"

--- a/tket/src/Architecture/DistancesFromArchitecture.cpp
+++ b/tket/src/Architecture/DistancesFromArchitecture.cpp
@@ -80,8 +80,8 @@ std::size_t DistancesFromArchitecture::operator()(
         distance_entry > 0 ||
         AssertMessage() << "DistancesFromArchitecture: architecture has "
                         << arch.n_nodes() << " vertices, "
-                        << arch.n_connections() << " edges; " << " and d("
-                        << vertex1 << "," << vertex2
+                        << arch.n_connections() << " edges; "
+                        << " and d(" << vertex1 << "," << vertex2
                         << ")=0. "
                            "Is the graph connected?");
     // GCOVR_EXCL_STOP

--- a/tket/src/Clifford/UnitaryTableau.cpp
+++ b/tket/src/Clifford/UnitaryTableau.cpp
@@ -715,16 +715,16 @@ std::ostream& operator<<(std::ostream& os, const UnitaryRevTableau& tab) {
   for (unsigned i = 0; i < nqs; ++i) {
     Qubit qi = tab.tab_.qubits_.right.at(i);
     os << tab.tab_.tab_.xmat.row(i) << "   " << tab.tab_.tab_.zmat.row(i)
-       << "   " << tab.tab_.tab_.phase(i) << "\t->\t" << "X@" << qi.repr()
-       << std::endl;
+       << "   " << tab.tab_.tab_.phase(i) << "\t->\t"
+       << "X@" << qi.repr() << std::endl;
   }
   os << "--" << std::endl;
   for (unsigned i = 0; i < nqs; ++i) {
     Qubit qi = tab.tab_.qubits_.right.at(i);
     os << tab.tab_.tab_.xmat.row(i + nqs) << "   "
        << tab.tab_.tab_.zmat.row(i + nqs) << "   "
-       << tab.tab_.tab_.phase(i + nqs) << "\t->\t" << "Z@" << qi.repr()
-       << std::endl;
+       << tab.tab_.tab_.phase(i + nqs) << "\t->\t"
+       << "Z@" << qi.repr() << std::endl;
   }
   return os;
 }

--- a/tket/src/Predicates/Predicates.cpp
+++ b/tket/src/Predicates/Predicates.cpp
@@ -52,8 +52,7 @@ static std::string auto_name(const T&) {
   return predicate_name(typeid(T));
 }
 
-#define SET_PRED_NAME(a) \
-  { typeid(a), #a }
+#define SET_PRED_NAME(a) {typeid(a), #a}
 
 const std::string& predicate_name(std::type_index idx) {
   static const std::map<std::type_index, std::string> predicate_names = {


### PR DESCRIPTION
# Description

Previously the formatting check would fail without indicating exactly what was wrong. This PR makes it print a diff which the developer can then apply to their branch to fix the issues.

This became necessary since clang-format began changing its rules on updates to minor versions that are not easily available on all platforms.

Also actually fix the latest formatting errors.

# Checklist

- [x] I have performed a self-review of my code.
- [ ] I have commented hard-to-understand parts of my code.
- [ ] I have made corresponding changes to the public API documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the changelog with any user-facing changes.
