### PR TITLE
Escape underscores when converting to latex

### DIFF
--- a/pytket/conanfile.py
+++ b/pytket/conanfile.py
@@ -32,7 +32,7 @@ class pytketRecipe(ConanFile):
         cmake.install()
 
     def requirements(self):
-        self.requires("tket/1.2.122@tket/stable")
+        self.requires("tket/1.2.123@tket/stable")
         self.requires("tklog/0.3.3@tket/stable")
         self.requires("tkrng/0.3.3@tket/stable")
         self.requires("tkassert/0.3.4@tket/stable")

--- a/pytket/docs/changelog.rst
+++ b/pytket/docs/changelog.rst
@@ -9,6 +9,10 @@ Features:
 * Update to pytket-circuit-renderer 0.8.
 * Add two new status values for circuits on backends: "CANCELLING" and "RETRYING".
 
+Fixes:
+
+* Escape underscores in qubit and bit names when converting to latex.
+
 1.27.0 (April 2024)
 -------------------
 

--- a/tket/conanfile.py
+++ b/tket/conanfile.py
@@ -23,7 +23,7 @@ from conan.errors import ConanInvalidConfiguration
 
 class TketConan(ConanFile):
     name = "tket"
-    version = "1.2.122"
+    version = "1.2.123"
     package_type = "library"
     license = "Apache 2"
     homepage = "https://github.com/CQCL/tket"

--- a/tket/src/Circuit/latex_drawing.cpp
+++ b/tket/src/Circuit/latex_drawing.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <boost/algorithm/string/replace.hpp>
 #include <limits>
 
 #include "tket/Circuit/Boxes.hpp"
@@ -287,14 +288,16 @@ std::string Circuit::to_latex_str() const {
     unsigned n_lines = lines.size();
     line_ids.insert({qb, n_lines});
     LineBufferInfo& line = *lines.emplace(lines.end());
-    line.buffer << "\\lstick{" + qb.repr() + "} & ";
+    line.buffer << "\\lstick{" +
+                       boost::replace_all_copy(qb.repr(), "_", "\\_") + "} & ";
     line.is_quantum = true;
   }
   for (const Bit& cb : this->all_bits()) {
     unsigned n_lines = lines.size();
     line_ids.insert({cb, n_lines});
     LineBufferInfo& line = *lines.emplace(lines.end());
-    line.buffer << "\\lstick{" + cb.repr() + "} & ";
+    line.buffer << "\\lstick{" +
+                       boost::replace_all_copy(cb.repr(), "_", "\\_") + "} & ";
     line.is_quantum = false;
   }
 

--- a/tket/test/src/Circuit/test_Circ.cpp
+++ b/tket/test/src/Circuit/test_Circ.cpp
@@ -37,6 +37,7 @@
 #include "tket/Transformations/Replacement.hpp"
 #include "tket/Transformations/Transform.hpp"
 #include "tket/Utils/MatrixAnalysis.hpp"
+#include "tket/Utils/UnitID.hpp"
 
 namespace tket {
 namespace test_Circ {
@@ -2693,6 +2694,13 @@ SCENARIO("Confirm that LaTeX output compiles", "[latex][.long]") {
   c.add_conditional_gate<unsigned>(OpType::CU1, {0.02}, {4, 3}, {}, 0);
   c.add_conditional_gate<unsigned>(
       OpType::CU3, {1.04, 0.36, -0.36}, {0, 4}, {}, 0);
+
+  // https://github.com/CQCL/tket/issues/1363
+  Qubit q1("q_1", 0);
+  Bit c1("c_1", 0);
+  c.add_qubit(q1);
+  c.add_bit(c1);
+  c.add_measure(q1, c1);
 
   c.to_latex_file("circ.tex");
   int response = std::system("latexmk -pdf circ.tex -quiet");


### PR DESCRIPTION
# Description

Note that this is the only character we need to worry about, since `UnitID` names are restricted to `"[a-z][A-Za-z0-9_]*"`.

# Related issues

Fixes #1363 .

# Checklist

- [x] I have performed a self-review of my code.
- [ ] I have commented hard-to-understand parts of my code.
- [ ] I have made corresponding changes to the public API documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have updated the changelog with any user-facing changes.
