### PR TITLE
Use `lark` package instead of deprecated `lark-parser`

### DIFF
--- a/nix-support/pytket.nix
+++ b/nix-support/pytket.nix
@@ -39,7 +39,7 @@ in {
     inherit version;
     propagatedBuildInputs = with super.python3.pkgs; [
       self.binders
-      super.lark-parser
+      super.lark
       super.types-pkg_resources
       super.qwasm
       graphviz

--- a/nix-support/third-party-python-packages.nix
+++ b/nix-support/third-party-python-packages.nix
@@ -19,15 +19,17 @@ self: super: {
       sha256 = "sha256:g/QA5CpAR3exRDgVQMnXGIH8bEGtwGFBjjSblbdXRkU=";
     };
   };
-  lark-parser = super.python3.pkgs.buildPythonPackage {
-    pname = "lark-parser";
-    version = "0.12.0";
+  lark = super.python3.pkgs.buildPythonPackage {
+    pname = "lark";
+    version = "1.1.9";
+    format = "pyproject";
     src = super.fetchFromGitHub {
       owner = "lark-parser";
       repo = "lark";
-      rev = "refs/tags/0.12.0";
-      hash = "sha256-zcMGCn3ixD3dJg3GlC/ijs+U1JN1BodHLTXZc/5UR7Y=";
+      rev = "refs/tags/1.1.9";
+      hash = "sha256:pWLKjELy10VNumpBHjBYCO2TltKsZx1GhQcGMHsYJNk=";
     };
+    nativeBuildInputs = with super.python3Packages; [ setuptools ];
     doCheck = false;
   };
   types-pkg_resources = let

--- a/pytket/docs/changelog.rst
+++ b/pytket/docs/changelog.rst
@@ -8,6 +8,7 @@ Features:
 
 * Update to pytket-circuit-renderer 0.8.
 * Add two new status values for circuits on backends: "CANCELLING" and "RETRYING".
+* Use `lark` package instead of deprecated `lark-parser`.
 
 1.27.0 (April 2024)
 -------------------

--- a/pytket/pytket/qasm/qasm.py
+++ b/pytket/pytket/qasm/qasm.py
@@ -793,7 +793,7 @@ class CircuitTransformer(Transformer):
             else:
                 raise QASMParseError(f"Unexpected expression in assignment {exp}", line)
 
-    def extern(self, tree: List[Any]) -> Type[Discard]:
+    def extern(self, tree: List[Any]) -> Any:
         # TODO parse extern defs
         return Discard
 
@@ -899,7 +899,7 @@ class CircuitTransformer(Transformer):
 
     opaq = gdef
 
-    def oqasm(self, tree: List) -> Type[Discard]:
+    def oqasm(self, tree: List) -> Any:
         return Discard
 
     def incl(self, tree: List[Token]) -> None:

--- a/pytket/pytket/quipper/quipper.py
+++ b/pytket/pytket/quipper/quipper.py
@@ -183,6 +183,7 @@ Subroutine = NamedTuple(
 )
 Start = NamedTuple("Start", [("circuit", Program), ("subroutines", List[Subroutine])])
 
+
 # Transformer
 class QuipperTransformer(Transformer):
     def int(self, t: List) -> int:
@@ -284,18 +285,20 @@ class QuipperTransformer(Transformer):
         return CDiscard(wire=t[0])
 
     def subroutine_call(self, t: List) -> SubroutineCall:
+        for i, ti in enumerate(t):
+            print(f"t[{i}] = {ti}")
         repetitions = 1
-        if isinstance(t[0], int):
+        if t[0] is not None:
+            assert isinstance(t[0], int)
             repetitions = t[0]
-            t.pop(0)
         return SubroutineCall(
             repetitions=repetitions,
-            name=t[0],
-            shape=t[1],
-            inverted=len(t[2].children) > 0,
-            inputs=t[3],
-            outputs=t[4],
-            control=t[5],
+            name=t[1],
+            shape=t[2],
+            inverted=len(t[3].children) > 0,
+            inputs=t[4],
+            outputs=t[5],
+            control=t[6],
         )
 
     def comment(self, t: List) -> Comment:

--- a/pytket/setup.py
+++ b/pytket/setup.py
@@ -192,7 +192,7 @@ setup(
     install_requires=[
         "sympy ~=1.6",
         "numpy >=1.21.4, <2.0",
-        "lark-parser ~=0.7",
+        "lark ~=1.1",
         "scipy ~=1.13",
         "networkx >= 2.8.8",
         "graphviz ~= 0.14",


### PR DESCRIPTION
# Description

Needs a couple of small tweaks to the qasm and quipper parsers.

# Related issues

Closes #1356 .

# Checklist

- [x] I have performed a self-review of my code.
- [ ] I have commented hard-to-understand parts of my code.
- [ ] I have made corresponding changes to the public API documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have updated the changelog with any user-facing changes.
