### PR TITLE
Fix name for consistency and to match reference in `publish_to_pypi`.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -217,7 +217,7 @@ jobs:
       - name: Run tests
         run: cd tket/pytket/tests && pytest --ignore=simulator/
 
-  test_Linux_aarch64_wheels:
+  test_linux_aarch64_wheels:
     name: Test linux aarch64 wheels
     needs: build_Linux_aarch64_wheels
     runs-on: 'buildjet-4vcpu-ubuntu-2204-arm'


### PR DESCRIPTION
I don't know if this was why https://github.com/CQCL/tket/actions/runs/9109560293/workflow skipped the `publish_to_pypi` step; it seems possible, but as far as I can see this inconsistency has been there for a while, so I'm not sure.