### PR TITLE
Updated flake.lock to bring symengine-0.12.0 into nix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,16 +20,15 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1720386169,
-        "narHash": "sha256-NGKVY4PjzwAa4upkGtAMz1npHGoRzWotlSnVlqI40mo=",
+        "lastModified": 1721812269,
+        "narHash": "sha256-qcI00YJBrLMmyPktlTS0UUvX/qGA7tVp73K6lJpRdy4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "194846768975b7ad2c4988bdb82572c00222c0d7",
+        "rev": "5c31ee6b23a06da40bf2dfc9017a60308a4adc53",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-24.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,7 @@
     tket.cachix.org-1:ACdm5Zg19qPL0PpvUwTPPiIx8SEUy+D/uqa9vKJFwh0=
     cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
   '';
-  inputs.nixpkgs.url = "github:nixos/nixpkgs/nixos-24.05";
+  inputs.nixpkgs.url = "github:nixos/nixpkgs";
   inputs.flake-utils.url = "github:numtide/flake-utils";
   outputs = { self, nixpkgs, flake-utils }:
     flake-utils.lib.eachDefaultSystem (system:

--- a/nix-support/symengine.patch
+++ b/nix-support/symengine.patch
@@ -2,7 +2,7 @@ diff --git a/cmake/SymEngineConfig.cmake.in b/cmake/SymEngineConfig.cmake.in
 index dbfc80ba..d3a390b8 100644
 --- a/cmake/SymEngineConfig.cmake.in
 +++ b/cmake/SymEngineConfig.cmake.in
-@@ -107,11 +107,11 @@ endif()
+@@ -109,11 +109,11 @@ endif()
 
  list(REMOVE_DUPLICATES SYMENGINE_INCLUDE_DIRS)
 


### PR DESCRIPTION
… the patch file to fit

# Description

To keep the nix build in sync, symengine needed updating. Fortunately the flake tracks nixpkgs' master branch, which has had symengine 0.12 for a week. So a `nix flake update` handled that.

Additionally, as we patch symengine to have it expose symengine libraries through INTERFACE_LINK_LIBRARIES, the patch file needed adjusting to take into account the new symengine's `cmake/SymEngineConfig.cmake.in` file.

I have run the tests on my local linux machine.

# Related issues

N/A

# Checklist

- [x] I have performed a self-review of my code.
- [-] I have commented hard-to-understand parts of my code.
- [-] I have made corresponding changes to the public API documentation.
- [-] I have added tests that prove my fix is effective or that my feature works.
- [-] I have updated the changelog with any user-facing changes.
