### PR TITLE
Handle `NPhasedX` gates in `decompose_cliffords_std()`

### DIFF
--- a/pytket/conanfile.py
+++ b/pytket/conanfile.py
@@ -32,7 +32,7 @@ class pytketRecipe(ConanFile):
         cmake.install()
 
     def requirements(self):
-        self.requires("tket/1.3.2@tket/stable")
+        self.requires("tket/1.3.3@tket/stable")
         self.requires("tklog/0.3.3@tket/stable")
         self.requires("tkrng/0.3.3@tket/stable")
         self.requires("tkassert/0.3.4@tket/stable")

--- a/pytket/docs/changelog.rst
+++ b/pytket/docs/changelog.rst
@@ -13,6 +13,7 @@ Features:
 Fixes:
 
 * Allow barriers when dagger or transpose a circuit.
+* Handle Clifford-angle ``NPhasedX`` gates in Clifford resynthesis.
 
 
 1.28.0 (May 2024)

--- a/tket/conanfile.py
+++ b/tket/conanfile.py
@@ -23,7 +23,7 @@ from conan.errors import ConanInvalidConfiguration
 
 class TketConan(ConanFile):
     name = "tket"
-    version = "1.3.2"
+    version = "1.3.3"
     package_type = "library"
     license = "Apache 2"
     homepage = "https://github.com/CQCL/tket"

--- a/tket/src/Transformations/Decomposition.cpp
+++ b/tket/src/Transformations/Decomposition.cpp
@@ -1141,16 +1141,23 @@ Transform decompose_cliffords_std() {
           circ.substitute(replacement, sub, Circuit::VertexDeletion::No);
           circ.add_phase(tk1_param_exprs[3]);
           success = true;
-        } else if (type == OpType::TK2) {
-          auto params = op->get_params();
-          TKET_ASSERT(params.size() == 3);
-          // TODO: Maybe handle TK2 gates natively within clifford_simp?
-          Circuit replacement =
-              CircPool::TK2_using_CX(params[0], params[1], params[2]);
-          decompose_cliffords_std().apply(replacement);
-          bin.push_back(v);
-          circ.substitute(replacement, v, Circuit::VertexDeletion::No);
-          success = true;
+        } else {
+          switch (type) {
+            case OpType::TK2: {
+              auto params = op->get_params();
+              TKET_ASSERT(params.size() == 3);
+              // TODO: Maybe handle TK2 gates natively within clifford_simp?
+              Circuit replacement =
+                  CircPool::TK2_using_CX(params[0], params[1], params[2]);
+              decompose_cliffords_std().apply(replacement);
+              bin.push_back(v);
+              circ.substitute(replacement, v, Circuit::VertexDeletion::No);
+              success = true;
+              break;
+            }
+            default:
+              break;
+          }
         }
       }
     }

--- a/tket/src/Transformations/Decomposition.cpp
+++ b/tket/src/Transformations/Decomposition.cpp
@@ -1111,45 +1111,47 @@ Transform decompose_cliffords_std() {
     BGL_FORALL_VERTICES(v, circ.dag, DAG) {
       Op_ptr op = circ.get_Op_ptr_from_Vertex(v);
       OpType type = op->get_type();
-      if (type != OpType::V && type != OpType::S && type != OpType::X &&
-          type != OpType::Z && is_single_qubit_unitary_type(type) &&
-          op->is_clifford()) {
-        std::vector<Expr> tk1_param_exprs = as_gate_ptr(op)->get_tk1_angles();
-        bool all_reduced = true;
-        bool all_roundable = true;
-        std::vector<int> iangles(3);
-        for (int i = 0; i < 3; i++) {
-          std::optional<double> reduced = eval_expr_mod(tk1_param_exprs[i], 4);
-          if (!reduced)
-            all_reduced = false;
-          else {
-            double angle = 2 * reduced.value();  // > 0
-            iangles[i] = int(angle + 0.5);       // nearest integer
-            if (std::abs(angle - iangles[i]) >= EPS) {
-              all_roundable = false;
+      if (op->is_clifford()) {
+        if (type != OpType::V && type != OpType::S && type != OpType::X &&
+            type != OpType::Z && is_single_qubit_unitary_type(type)) {
+          std::vector<Expr> tk1_param_exprs = as_gate_ptr(op)->get_tk1_angles();
+          bool all_reduced = true;
+          bool all_roundable = true;
+          std::vector<int> iangles(3);
+          for (int i = 0; i < 3; i++) {
+            std::optional<double> reduced =
+                eval_expr_mod(tk1_param_exprs[i], 4);
+            if (!reduced)
+              all_reduced = false;
+            else {
+              double angle = 2 * reduced.value();  // > 0
+              iangles[i] = int(angle + 0.5);       // nearest integer
+              if (std::abs(angle - iangles[i]) >= EPS) {
+                all_roundable = false;
+              }
+              iangles[i] %= 8;  // 8 --> 0
             }
-            iangles[i] %= 8;  // 8 --> 0
           }
+          if (!(all_reduced && all_roundable)) continue;
+          Circuit replacement =
+              clifford_from_tk1(iangles[0], iangles[1], iangles[2]);
+          Subcircuit sub = {
+              {circ.get_in_edges(v)}, {circ.get_all_out_edges(v)}, {v}};
+          bin.push_back(v);
+          circ.substitute(replacement, sub, Circuit::VertexDeletion::No);
+          circ.add_phase(tk1_param_exprs[3]);
+          success = true;
+        } else if (type == OpType::TK2) {
+          auto params = op->get_params();
+          TKET_ASSERT(params.size() == 3);
+          // TODO: Maybe handle TK2 gates natively within clifford_simp?
+          Circuit replacement =
+              CircPool::TK2_using_CX(params[0], params[1], params[2]);
+          decompose_cliffords_std().apply(replacement);
+          bin.push_back(v);
+          circ.substitute(replacement, v, Circuit::VertexDeletion::No);
+          success = true;
         }
-        if (!(all_reduced && all_roundable)) continue;
-        Circuit replacement =
-            clifford_from_tk1(iangles[0], iangles[1], iangles[2]);
-        Subcircuit sub = {
-            {circ.get_in_edges(v)}, {circ.get_all_out_edges(v)}, {v}};
-        bin.push_back(v);
-        circ.substitute(replacement, sub, Circuit::VertexDeletion::No);
-        circ.add_phase(tk1_param_exprs[3]);
-        success = true;
-      } else if (type == OpType::TK2 && op->is_clifford()) {
-        auto params = op->get_params();
-        TKET_ASSERT(params.size() == 3);
-        // TODO: Maybe handle TK2 gates natively within clifford_simp?
-        Circuit replacement =
-            CircPool::TK2_using_CX(params[0], params[1], params[2]);
-        decompose_cliffords_std().apply(replacement);
-        bin.push_back(v);
-        circ.substitute(replacement, v, Circuit::VertexDeletion::No);
-        success = true;
       }
     }
     circ.remove_vertices(

--- a/tket/src/Transformations/Decomposition.cpp
+++ b/tket/src/Transformations/Decomposition.cpp
@@ -1155,6 +1155,19 @@ Transform decompose_cliffords_std() {
               success = true;
               break;
             }
+            case OpType::NPhasedX: {
+              auto params = op->get_params();
+              unsigned n = circ.n_out_edges(v);
+              Circuit replacement(n);
+              for (unsigned i = 0; i < n; i++) {
+                replacement.add_op<Qubit>(OpType::PhasedX, params, {Qubit(i)});
+              }
+              decompose_cliffords_std().apply(replacement);
+              bin.push_back(v);
+              circ.substitute(replacement, v, Circuit::VertexDeletion::No);
+              success = true;
+              break;
+            }
             default:
               break;
           }

--- a/tket/test/src/Passes/test_CliffordResynthesis.cpp
+++ b/tket/test/src/Passes/test_CliffordResynthesis.cpp
@@ -109,6 +109,17 @@ SCENARIO("SynthesiseCliffordResynthesis correctness") {
     c.add_op<unsigned>(OpType::CY, {1, 0});
     check_clifford_resynthesis(c);
   }
+  GIVEN("A Clifford-angle NPhasedX on 1 qubit") {
+    // https://github.com/CQCL/tket/issues/1408
+    Circuit c(1);
+    c.add_op<unsigned>(OpType::NPhasedX, {0.5, 0.0}, {0});
+    check_clifford_resynthesis(c);
+  }
+  GIVEN("A Clifford-angle NPhasedX on 2 qubits") {
+    Circuit c(2);
+    c.add_op<unsigned>(OpType::NPhasedX, {0.5, 0.0}, {0, 1});
+    check_clifford_resynthesis(c);
+  }
 }
 
 }  // namespace test_CliffordResynthesis


### PR DESCRIPTION
# Description

Add special-case handling of `NPhasedX` so that gates recognized as Clifford actually get decomposed.

# Related issues

Fixes #1408 .

# Checklist

- [x] I have performed a self-review of my code.
- [ ] I have commented hard-to-understand parts of my code.
- [ ] I have made corresponding changes to the public API documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have updated the changelog with any user-facing changes.
