### PR TITLE
Revert to using ubuntu-22.04 runner for valgrind checks.

### DIFF
--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -28,7 +28,7 @@ jobs:
             - 'tket/**'
             - '.github/workflows/valgrind.yml'
   check:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     needs: changes
     if: needs.changes.outputs.tket == 'true'
     steps:
@@ -45,7 +45,7 @@ jobs:
       run: |
         conan profile detect
         DEFAULT_PROFILE_PATH=`conan profile path default`
-        PROFILE_PATH=./conan-profiles/ubuntu-24.04
+        PROFILE_PATH=./conan-profiles/ubuntu-22.04
         diff ${DEFAULT_PROFILE_PATH} ${PROFILE_PATH} || true
         cp ${PROFILE_PATH} ${DEFAULT_PROFILE_PATH}
         conan remote add tket-libs https://quantinuumsw.jfrog.io/artifactory/api/conan/tket1-libs --index 0
@@ -69,12 +69,10 @@ jobs:
         mkdir -p ~/texmf/tex/latex
         wget http://mirrors.ctan.org/graphics/pgf/contrib/quantikz/tikzlibraryquantikz.code.tex -P ~/texmf/tex/latex
         PKGPATH=`./rootpath tket.json tket`
-        # realloc of size 0 used (intentionally?) in eigen
-        cd ${PKGPATH}/bin && valgrind --error-exitcode=1 --show-realloc-size-zero=no ./test-tket [long],~[long]
+        cd ${PKGPATH}/bin && valgrind --error-exitcode=1 ./test-tket [long],~[long]
     - name: Run tests under valgrind (basic)
       if: github.event_name != 'schedule'
       run: |
         PKGPATH=`./rootpath tket.json tket`
-        # realloc of size 0 used (intentionally?) in eigen
-        cd ${PKGPATH}/bin && valgrind --error-exitcode=1 --show-realloc-size-zero=no ./test-tket
+        cd ${PKGPATH}/bin && valgrind --error-exitcode=1 ./test-tket
 


### PR DESCRIPTION
# Description

For some reason the valgrind CI runs have started to [fail](https://github.com/CQCL/tket/actions/runs/9343595071/job/25721020802) on the `ubuntu-24.04` runners during valgrind installation, the run being abruptly cancelled.

Revert to using `ubuntu-22.04` until this issue is resolved.

# Related issues

Fixes #1433 .

# Checklist

- [x] I have performed a self-review of my code.
- [ ] I have commented hard-to-understand parts of my code.
- [ ] I have made corresponding changes to the public API documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the changelog with any user-facing changes.
