### PR TITLE
Run ZX test with all Python versions

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -282,15 +282,9 @@ jobs:
       with:
         python-version: '3.12'
     - name: Build pytket
-      if: github.event_name != 'schedule'
       run: |
         cd pytket
         pip install -e .[ZX] -v
-    - name: Build pytket
-      if: github.event_name == 'schedule' # https://github.com/CQCL/tket/issues/1242
-      run: |
-        cd pytket
-        pip install -e . -v
     - name: Run doctests
       run: |
         cd pytket


### PR DESCRIPTION
# Description

Tested here: https://github.com/CQCL/tket/actions/runs/9396857013/job/25878869049

There was an issue with the ZX test running on Ubuntu with Python 3.12 but this seems to be working now.

# Related issues

Closes #1242 .

# Checklist

- [x] I have performed a self-review of my code.
- [ ] I have commented hard-to-understand parts of my code.
- [ ] I have made corresponding changes to the public API documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the changelog with any user-facing changes.
