### PR TITLE
Revert to removing blank classical wires in `FlattenRelabelRegistersPass`

### DIFF
--- a/pytket/conanfile.py
+++ b/pytket/conanfile.py
@@ -32,7 +32,7 @@ class pytketRecipe(ConanFile):
         cmake.install()
 
     def requirements(self):
-        self.requires("tket/1.3.9@tket/stable")
+        self.requires("tket/1.3.10@tket/stable")
         self.requires("tklog/0.3.3@tket/stable")
         self.requires("tkrng/0.3.3@tket/stable")
         self.requires("tkassert/0.3.4@tket/stable")

--- a/pytket/docs/changelog.rst
+++ b/pytket/docs/changelog.rst
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+Unreleased
+----------
+
+Feature:
+
+* Revert keeping of blank classical wires when running
+  ``FlattenRelabelRegistersPass``.
+
 1.29.1 (June 2024)
 ------------------
 

--- a/pytket/tests/predicates_test.py
+++ b/pytket/tests/predicates_test.py
@@ -24,7 +24,6 @@ from pytket.circuit import (
     Unitary2qBox,
     Node,
     Qubit,
-    Bit,
     UnitID,
     Conditional,
 )
@@ -886,10 +885,7 @@ def test_conditional_phase() -> None:
 
 
 def test_flatten_relabel_pass() -> None:
-    c = Circuit(3, 3)
-    c.add_bit(Bit("d", 0))
-    c.add_bit(Bit("d", 1))
-    c.add_c_register("e", 5)
+    c = Circuit(3)
     c.H(1).H(2)
     rename_map: RenameUnitsMap = dict()
     rename_map[Qubit(0)] = Qubit("a", 4)
@@ -905,10 +901,6 @@ def test_flatten_relabel_pass() -> None:
     assert cu.initial_map[Qubit("a", 4)] == Qubit("a", 4)
     assert cu.initial_map[Qubit("b", 7)] == Qubit("a", 1)
     assert cu.circuit.qubits == [Qubit("a", 0), Qubit("a", 1)]
-    assert cu.circuit.n_bits == 10
-    assert cu.circuit.get_c_register("c").size == 3
-    assert cu.circuit.get_c_register("d").size == 2
-    assert cu.circuit.get_c_register("e").size == 5
 
     # test default argument
     c = Circuit()

--- a/tket/conanfile.py
+++ b/tket/conanfile.py
@@ -23,7 +23,7 @@ from conan.errors import ConanInvalidConfiguration
 
 class TketConan(ConanFile):
     name = "tket"
-    version = "1.3.9"
+    version = "1.3.10"
     package_type = "library"
     license = "Apache 2"
     homepage = "https://github.com/CQCL/tket"

--- a/tket/src/Predicates/PassGenerators.cpp
+++ b/tket/src/Predicates/PassGenerators.cpp
@@ -357,7 +357,7 @@ PassPtr gen_flatten_relabel_registers_pass(const std::string& label) {
   Transform t =
       Transform([=](Circuit& circuit, std::shared_ptr<unit_bimaps_t> maps) {
         unsigned n_qubits = circuit.n_qubits();
-        circuit.remove_blank_wires(true);
+        circuit.remove_blank_wires(false);
         bool changed = circuit.n_qubits() < n_qubits;
         std::map<Qubit, Qubit> relabelling_map;
         std::vector<Qubit> all_qubits = circuit.all_qubits();


### PR DESCRIPTION
The change in #1441 causes test failures in dependent packages; revert for now.

I've checked that the pytket-quantinuum tests all pass with a wheel built from this branch.
