### PR TITLE
Use float not int for QPO coefficient.

### DIFF
--- a/pytket/mypy.ini
+++ b/pytket/mypy.ini
@@ -33,3 +33,6 @@ ignore_errors = True
 [mypy-IPython.*]
 ignore_missing_imports = True
 ignore_errors = True
+
+[mypy-sympy.*]
+ignore_missing_imports = True

--- a/pytket/pytket/qasm/qasm.py
+++ b/pytket/pytket/qasm/qasm.py
@@ -875,9 +875,7 @@ class CircuitTransformer(Transformer):
             comparison_circ = _get_gate_circuit(
                 PARAM_EXTRA_COMMANDS[gate],
                 qubit_args,
-                [
-                    Symbol("param" + str(index) + "/pi") for index in range(len(symbols))  # type: ignore
-                ],
+                [Symbol("param" + str(index) + "/pi") for index in range(len(symbols))],
             )
             # checks that each command has same string
             existing_op = all(
@@ -1203,7 +1201,7 @@ def _get_gate_circuit(
     for q in qubits:
         gate_circ.add_qubit(q)
     if symbols:
-        exprs = [symbol.as_expr() for symbol in symbols]  # type: ignore
+        exprs = [symbol.as_expr() for symbol in symbols]
         gate_circ.add_gate(optype, exprs, unitids)
     else:
         gate_circ.add_gate(optype, unitids)
@@ -1370,8 +1368,10 @@ class QasmWriter:
         if n_params is not None:
             # need to add parameters to gate definition
             s += "("
-            symbols = [Symbol("param" + str(index) + "/pi") for index in range(n_params)]  # type: ignore
-            symbols_header = [Symbol("param" + str(index)) for index in range(n_params)]  # type: ignore
+            symbols = [
+                Symbol("param" + str(index) + "/pi") for index in range(n_params)
+            ]
+            symbols_header = [Symbol("param" + str(index)) for index in range(n_params)]
             for symbol in symbols_header[:-1]:
                 s += symbol.name + ", "
             s += symbols_header[-1].name + ") "
@@ -1580,7 +1580,7 @@ class QasmWriter:
         # that 0 <= param < 4
         if param > 1:
             # first get in to 0 <= param < 2 range
-            param = Decimal(str(param)) % Decimal("2")  # type: ignore
+            param = Decimal(str(param)) % Decimal("2")
             # then flip 1 <= param < 2  range into
             # -1 <= param < 0
             if param > 1:

--- a/pytket/pytket/utils/symbolic.py
+++ b/pytket/pytket/utils/symbolic.py
@@ -64,11 +64,11 @@ SymGateMap = Dict[OpType, SymGateFunc]
 
 
 def symb_controlled(target: SymGateFunc) -> SymGateFunc:
-    return lambda x: ImmutableMatrix(BlockDiagMatrix(Identity(2), target(x)))  # type: ignore
+    return lambda x: ImmutableMatrix(BlockDiagMatrix(Identity(2), target(x)))
 
 
 def symb_rz(params: ParamsType) -> ImmutableMatrix:
-    return ImmutableMatrix(  # type: ignore
+    return ImmutableMatrix(
         [
             [sympy.exp(-I * (sympy.pi / 2) * params[0]), 0],
             [0, sympy.exp(I * (sympy.pi / 2) * params[0])],
@@ -79,7 +79,7 @@ def symb_rz(params: ParamsType) -> ImmutableMatrix:
 def symb_rx(params: ParamsType) -> ImmutableMatrix:
     costerm = sympy.cos((sympy.pi / 2) * params[0])
     sinterm = -I * sympy.sin((sympy.pi / 2) * params[0])
-    return ImmutableMatrix(  # type: ignore
+    return ImmutableMatrix(
         [
             [costerm, sinterm],
             [sinterm, costerm],
@@ -90,7 +90,7 @@ def symb_rx(params: ParamsType) -> ImmutableMatrix:
 def symb_ry(params: ParamsType) -> ImmutableMatrix:
     costerm = sympy.cos((sympy.pi / 2) * params[0])
     sinterm = sympy.sin((sympy.pi / 2) * params[0])
-    return ImmutableMatrix(  # type: ignore
+    return ImmutableMatrix(
         [
             [costerm, -sinterm],
             [sinterm, costerm],
@@ -102,7 +102,7 @@ def symb_u3(params: ParamsType) -> ImmutableMatrix:
     theta, phi, lam = params
     costerm = sympy.cos((sympy.pi / 2) * theta)
     sinterm = sympy.sin((sympy.pi / 2) * theta)
-    return ImmutableMatrix(  # type: ignore
+    return ImmutableMatrix(
         [
             [costerm, -sinterm * sympy.exp(I * sympy.pi * lam)],
             [
@@ -114,19 +114,19 @@ def symb_u3(params: ParamsType) -> ImmutableMatrix:
 
 
 def symb_u2(params: ParamsType) -> ImmutableMatrix:
-    return symb_u3([0.5] + params)  # type: ignore
+    return symb_u3([0.5] + params)
 
 
 def symb_u1(params: ParamsType) -> ImmutableMatrix:
-    return symb_u3([0.0, 0.0] + params)  # type: ignore
+    return symb_u3([0.0, 0.0] + params)
 
 
 def symb_tk1(params: ParamsType) -> ImmutableMatrix:
-    return symb_rz([params[0]]) * symb_rx([params[1]]) * symb_rz([params[2]])  # type: ignore
+    return symb_rz([params[0]]) * symb_rx([params[1]]) * symb_rz([params[2]])
 
 
 def symb_tk2(params: ParamsType) -> ImmutableMatrix:
-    return (  # type: ignore
+    return (
         symb_xxphase([params[0]])
         * symb_yyphase([params[1]])
         * symb_zzphase([params[2]])
@@ -137,7 +137,7 @@ def symb_iswap(params: ParamsType) -> ImmutableMatrix:
     alpha = params[0]
     costerm = sympy.cos((sympy.pi / 2) * alpha)
     sinterm = sympy.sin((sympy.pi / 2) * alpha)
-    return ImmutableMatrix(  # type: ignore
+    return ImmutableMatrix(
         [
             [1, 0, 0, 0],
             [0, costerm, I * sinterm, 0],
@@ -152,7 +152,7 @@ def symb_phasediswap(params: ParamsType) -> ImmutableMatrix:
     costerm = sympy.cos((sympy.pi / 2) * alpha)
     sinterm = I * sympy.sin((sympy.pi / 2) * alpha)
     phase = sympy.exp(2 * I * sympy.pi * p)
-    return ImmutableMatrix(  # type: ignore
+    return ImmutableMatrix(
         [
             [1, 0, 0, 0],
             [0, costerm, sinterm * phase, 0],
@@ -166,7 +166,7 @@ def symb_xxphase(params: ParamsType) -> ImmutableMatrix:
     alpha = params[0]
     c = sympy.cos((sympy.pi / 2) * alpha)
     s = -I * sympy.sin((sympy.pi / 2) * alpha)
-    return ImmutableMatrix(  # type: ignore
+    return ImmutableMatrix(
         [
             [c, 0, 0, s],
             [0, c, s, 0],
@@ -180,7 +180,7 @@ def symb_yyphase(params: ParamsType) -> ImmutableMatrix:
     alpha = params[0]
     c = sympy.cos((sympy.pi / 2) * alpha)
     s = I * sympy.sin((sympy.pi / 2) * alpha)
-    return ImmutableMatrix(  # type: ignore
+    return ImmutableMatrix(
         [
             [c, 0, 0, s],
             [0, c, -s, 0],
@@ -193,31 +193,31 @@ def symb_yyphase(params: ParamsType) -> ImmutableMatrix:
 def symb_zzphase(params: ParamsType) -> ImmutableMatrix:
     alpha = params[0]
     t = sympy.exp(I * (sympy.pi / 2) * alpha)
-    return ImmutableMatrix(diag(1 / t, t, t, 1 / t))  # type: ignore
+    return ImmutableMatrix(diag(1 / t, t, t, 1 / t))
 
 
 def symb_xxphase3(params: ParamsType) -> ImmutableMatrix:
     xxphase2 = symb_xxphase(params)
-    res1 = matrix_tensor_product(xxphase2, eye(2))  # type: ignore
+    res1 = matrix_tensor_product(xxphase2, eye(2))
     res2 = Matrix(
-        BlockMatrix(  # type: ignore
+        BlockMatrix(
             [
-                [xxphase2[:2, :2], zeros(2), xxphase2[:2, 2:], zeros(2)],  # type: ignore
-                [zeros(2), xxphase2[:2, :2], zeros(2), xxphase2[:2, 2:]],  # type: ignore
-                [xxphase2[2:, :2], zeros(2), xxphase2[2:, 2:], zeros(2)],  # type: ignore
-                [zeros(2), xxphase2[2:, :2], zeros(2), xxphase2[2:, 2:]],  # type: ignore
+                [xxphase2[:2, :2], zeros(2), xxphase2[:2, 2:], zeros(2)],
+                [zeros(2), xxphase2[:2, :2], zeros(2), xxphase2[:2, 2:]],
+                [xxphase2[2:, :2], zeros(2), xxphase2[2:, 2:], zeros(2)],
+                [zeros(2), xxphase2[2:, :2], zeros(2), xxphase2[2:, 2:]],
             ]
         )
     )
-    res3 = matrix_tensor_product(eye(2), xxphase2)  # type: ignore
-    res = ImmutableMatrix(res1 * res2 * res3)  # type: ignore
+    res3 = matrix_tensor_product(eye(2), xxphase2)
+    res = ImmutableMatrix(res1 * res2 * res3)
     return res
 
 
 def symb_phasedx(params: ParamsType) -> ImmutableMatrix:
     alpha, beta = params
 
-    return symb_rz([beta]) * symb_rx([alpha]) * symb_rz([-beta])  # type: ignore
+    return symb_rz([beta]) * symb_rx([alpha]) * symb_rz([-beta])
 
 
 def symb_eswap(params: ParamsType) -> ImmutableMatrix:
@@ -226,7 +226,7 @@ def symb_eswap(params: ParamsType) -> ImmutableMatrix:
     s = -I * sympy.sin((sympy.pi / 2) * alpha)
     t = sympy.exp(-I * (sympy.pi / 2) * alpha)
 
-    return ImmutableMatrix(  # type: ignore
+    return ImmutableMatrix(
         [
             [t, 0, 0, 0],
             [0, c, s, 0],
@@ -242,7 +242,7 @@ def symb_fsim(params: ParamsType) -> ImmutableMatrix:
     s = -I * sympy.sin(sympy.pi * alpha)
     t = sympy.exp(-I * sympy.pi * beta)
 
-    return ImmutableMatrix(  # type: ignore
+    return ImmutableMatrix(
         [
             [1, 0, 0, 0],
             [0, c, s, 0],
@@ -255,7 +255,7 @@ def symb_fsim(params: ParamsType) -> ImmutableMatrix:
 def symb_gpi(params: ParamsType) -> ImmutableMatrix:
     t = sympy.exp(I * sympy.pi * params[0])
 
-    return ImmutableMatrix(  # type: ignore
+    return ImmutableMatrix(
         [
             [0, 1 / t],
             [t, 0],
@@ -265,9 +265,9 @@ def symb_gpi(params: ParamsType) -> ImmutableMatrix:
 
 def symb_gpi2(params: ParamsType) -> ImmutableMatrix:
     t = sympy.exp(I * sympy.pi * params[0])
-    c = 1 / sympy.sqrt(2)  # type: ignore
+    c = 1 / sympy.sqrt(2)
 
-    return c * ImmutableMatrix(  # type: ignore
+    return c * ImmutableMatrix(
         [
             [1, -I / t],
             [-I * t, 1],
@@ -284,7 +284,7 @@ def symb_aams(params: ParamsType) -> ImmutableMatrix:
     s3 = -I * sympy.exp(I * sympy.pi * (beta - gamma)) * s
     s4 = -I * sympy.exp(I * sympy.pi * (beta + gamma)) * s
 
-    return ImmutableMatrix(  # type: ignore
+    return ImmutableMatrix(
         [
             [c, 0, 0, s1],
             [0, c, s2, 0],
@@ -373,7 +373,7 @@ def _op_to_sympy_gate(op: Op, targets: List[int]) -> symgate.Gate:
     else:
         try:
             # use internal tket unitary definition
-            u_mat = ImmutableMatrix(op.get_unitary())  # type: ignore
+            u_mat = ImmutableMatrix(op.get_unitary())
         except RuntimeError as e:
             # to catch tket failure to get Op unitary
             # most likely due to symbolic parameters.
@@ -382,7 +382,7 @@ def _op_to_sympy_gate(op: Op, targets: List[int]) -> symgate.Gate:
                 " Try registering your own symbolic matrix representation"
                 " with SymGateRegister.func."
             ) from e
-    gate = symgate.UGate(targets, u_mat)  # type: ignore
+    gate = symgate.UGate(targets, u_mat)
     return gate
 
 
@@ -395,7 +395,7 @@ def circuit_to_symbolic_gates(circ: Circuit) -> Mul:
     :return: Symbolic gate multiplication expression.
     :rtype: Mul
     """
-    outmat = symgate.IdentityGate(0)  # type: ignore
+    outmat = symgate.IdentityGate(0)
     nqb = circ.n_qubits
     qubit_map = {qb: nqb - 1 - i for i, qb in enumerate(circ.qubits)}
     for com in circ:
@@ -414,9 +414,9 @@ def circuit_to_symbolic_gates(circ: Circuit) -> Mul:
         outmat = gate * outmat
 
     for i in range(len(qubit_map)):
-        outmat = symgate.IdentityGate(i) * outmat  # type: ignore
+        outmat = symgate.IdentityGate(i) * outmat
 
-    return outmat * sympy.exp((circ.phase * sympy.pi * I))  # type: ignore
+    return outmat * sympy.exp((circ.phase * sympy.pi * I))
 
 
 def circuit_to_symbolic_unitary(circ: Circuit) -> ImmutableMatrix:
@@ -432,18 +432,18 @@ def circuit_to_symbolic_unitary(circ: Circuit) -> ImmutableMatrix:
     gates = circuit_to_symbolic_gates(circ)
     nqb = circ.n_qubits
     try:
-        return cast(ImmutableMatrix, represent(gates, nqubits=circ.n_qubits))  # type: ignore
+        return cast(ImmutableMatrix, represent(gates, nqubits=circ.n_qubits))
     except NotImplementedError:
         # sympy can't represent n>1 qubit unitaries very well
         # so if it fails we will just calculate columns using the statevectors
         # for all possible input basis states
         matrix_dim = 1 << nqb
-        input_states = (Qubit(f"{i:0{nqb}b}") for i in range(matrix_dim))  # type: ignore
-        outmat = Matrix([])  # type: ignore
+        input_states = (Qubit(f"{i:0{nqb}b}") for i in range(matrix_dim))
+        outmat = Matrix([])
         for col, input_state in enumerate(input_states):
-            outmat = outmat.col_insert(col, represent(qapply(gates * input_state)))  # type: ignore
+            outmat = outmat.col_insert(col, represent(qapply(gates * input_state)))
 
-        return ImmutableMatrix(outmat)  # type: ignore
+        return ImmutableMatrix(outmat)
 
 
 def circuit_apply_symbolic_qubit(circ: Circuit, input_qb: Expr) -> Qubit:
@@ -458,7 +458,7 @@ def circuit_apply_symbolic_qubit(circ: Circuit, input_qb: Expr) -> Qubit:
     """
     gates = circuit_to_symbolic_gates(circ)
 
-    return cast(Qubit, qapply(gates * input_qb))  # type: ignore
+    return cast(Qubit, qapply(gates * input_qb))
 
 
 def circuit_apply_symbolic_statevector(
@@ -477,10 +477,10 @@ def circuit_apply_symbolic_statevector(
     :rtype: ImmutableMatrix
     """
     if input_state:
-        input_qb = matrix_to_qubit(input_state)  # type: ignore
+        input_qb = matrix_to_qubit(input_state)
     else:
-        input_qb = Qubit("0" * circ.n_qubits)  # type: ignore
+        input_qb = Qubit("0" * circ.n_qubits)
     return cast(
         ImmutableMatrix,
-        represent(circuit_apply_symbolic_qubit(circ, cast(Qubit, input_qb))),  # type: ignore
+        represent(circuit_apply_symbolic_qubit(circ, cast(Qubit, input_qb))),
     )

--- a/pytket/pytket/zx/tensor_eval.py
+++ b/pytket/pytket/zx/tensor_eval.py
@@ -222,7 +222,7 @@ def tensor_from_quantum_diagram(diag: ZXDiagram) -> np.ndarray:
                 "supports diagrams consisting of only quantum components"
             )
     diag_copy = ZXDiagram(diag)
-    diag_copy.multiply_scalar(1 / sympy.sqrt(diag.scalar))  # type: ignore
+    diag_copy.multiply_scalar(1 / sympy.sqrt(diag.scalar))
     Rewrite.basic_wires().apply(diag_copy)
     return _tensor_from_basic_diagram(diag_copy)
 

--- a/pytket/tests/circuit_test.py
+++ b/pytket/tests/circuit_test.py
@@ -106,7 +106,7 @@ def test_op_free_symbols() -> None:
     c.add_barrier([0, 1])
     op = c.get_commands()[0].op
     assert op.free_symbols() == set()
-    alpha = Symbol("alpha")  # type: ignore
+    alpha = Symbol("alpha")
     c.Rx(alpha, 0)
     op = c.get_commands()[1].op
     assert op.free_symbols() == {alpha}
@@ -293,11 +293,11 @@ def test_circuit_gen_ids() -> None:
 
 def test_symbolic_ops() -> None:
     c = Circuit(2)
-    alpha = Symbol("alpha")  # type: ignore
+    alpha = Symbol("alpha")
     c.Rx(alpha, 0)
     beta = fresh_symbol("alpha")
     c.CRz(beta * 2, 1, 0)
-    gamma = Symbol("gamma")  # type: ignore
+    gamma = Symbol("gamma")
     # https://github.com/CQCL/tket/issues/1068
     c.Rz(exp(gamma), 1)
     s_map = {alpha: 0.5, beta: 3.2, gamma: 1}
@@ -307,7 +307,7 @@ def test_symbolic_ops() -> None:
     assert not c.is_symbolic()
 
     commands = c.get_commands()
-    assert beta.__str__() == "alpha_1"  # type: ignore
+    assert beta.__str__() == "alpha_1"
     assert np.allclose(np.asarray(commands[0].op.params), [0.5], atol=1e-10)
     assert np.allclose(np.asarray(commands[1].op.params), [2.4], atol=1e-10)
     assert np.allclose(np.asarray(commands[2].op.params), [math.e], atol=1e-10)
@@ -316,7 +316,7 @@ def test_symbolic_ops() -> None:
 def test_symbolic_circbox() -> None:
     c = Circuit(2)
     c_outer = Circuit(2)
-    alpha = Symbol("alpha")  # type: ignore
+    alpha = Symbol("alpha")
     c.Rx(alpha, 0)
     beta = fresh_symbol("alpha")
     c.CRz(beta * 2, 1, 0)
@@ -359,7 +359,7 @@ def test_sympy_conversion() -> None:
         tree_str = str(type(expr)).rsplit(".", 1)[-1].split("'")[0]
         if len(expr.args) != 0:
             tree_str += " ("
-            tree_str += ", ".join([get_type_tree(a) for a in expr.args])  # type: ignore
+            tree_str += ", ".join([get_type_tree(a) for a in expr.args])
             tree_str += ")"
         return tree_str
 
@@ -375,7 +375,7 @@ def test_sympy_conversion() -> None:
     }
     for expr_string, type_tree in test_dict.items():
         c = Circuit(1)
-        c.Rz(sympify(expr_string), 0)  # type: ignore
+        c.Rz(sympify(expr_string), 0)
         com = c.get_commands()[0]
         param0 = com.op.params[0]
         assert isinstance(param0, Expr)
@@ -505,24 +505,24 @@ def test_boxes() -> None:
     d.add_expbox(ebox, 3, 2)
 
     paulis = [Pauli.X, Pauli.Z, Pauli.X]
-    pbox = PauliExpBox(paulis, Symbol("alpha"))  # type: ignore
+    pbox = PauliExpBox(paulis, Symbol("alpha"))
     assert pbox.type == OpType.PauliExpBox
     d.add_pauliexpbox(pbox, [3, 2, 1])
 
     ppairbox = PauliExpPairBox(
         [Pauli.I, Pauli.X, Pauli.Y, Pauli.Z],
-        Symbol("alpha"),  # type: ignore
+        Symbol("alpha"),
         [Pauli.Y, Pauli.I, Pauli.I, Pauli.X],
-        Symbol("beta"),  # type: ignore
+        Symbol("beta"),
     )
     assert ppairbox.type == OpType.PauliExpPairBox
     d.add_pauliexppairbox(ppairbox, [3, 2, 1, 0])
 
     psetbox = PauliExpCommutingSetBox(
         [
-            ([Pauli.X, Pauli.X, Pauli.X, Pauli.Y], Symbol("alpha")),  # type: ignore
-            ([Pauli.X, Pauli.X, Pauli.Y, Pauli.X], Symbol("beta")),  # type: ignore
-            ([Pauli.X, Pauli.Y, Pauli.X, Pauli.X], Symbol("gamma")),  # type: ignore
+            ([Pauli.X, Pauli.X, Pauli.X, Pauli.Y], Symbol("alpha")),
+            ([Pauli.X, Pauli.X, Pauli.Y, Pauli.X], Symbol("beta")),
+            ([Pauli.X, Pauli.Y, Pauli.X, Pauli.X], Symbol("gamma")),
         ]
     )
     assert psetbox.type == OpType.PauliExpCommutingSetBox
@@ -530,9 +530,9 @@ def test_boxes() -> None:
 
     tseqbox = TermSequenceBox(
         [
-            ([Pauli.X, Pauli.X, Pauli.X, Pauli.Y], Symbol("alpha")),  # type: ignore
-            ([Pauli.X, Pauli.X, Pauli.Y, Pauli.X], Symbol("beta")),  # type: ignore
-            ([Pauli.X, Pauli.Y, Pauli.X, Pauli.X], Symbol("gamma")),  # type: ignore
+            ([Pauli.X, Pauli.X, Pauli.X, Pauli.Y], Symbol("alpha")),
+            ([Pauli.X, Pauli.X, Pauli.Y, Pauli.X], Symbol("beta")),
+            ([Pauli.X, Pauli.Y, Pauli.X, Pauli.X], Symbol("gamma")),
         ]
     )
     assert tseqbox.type == OpType.TermSequenceBox
@@ -550,7 +550,7 @@ def test_boxes() -> None:
     pauli_exp = pauli_exps[0]
     assert isinstance(pauli_exp, PauliExpBox)
     assert pauli_exp.get_paulis() == paulis
-    assert pauli_exp.get_phase() == Symbol("alpha")  # type: ignore
+    assert pauli_exp.get_phase() == Symbol("alpha")
 
     boxes = (cbox, mbox, u2qbox, u3qbox, ebox, pbox, qcbox)
     assert all(box == box for box in boxes)
@@ -770,8 +770,8 @@ def test_u1q_stability() -> None:
 
 
 def test_custom_gates() -> None:
-    a = Symbol("a")  # type: ignore
-    b = Symbol("b")  # type: ignore
+    a = Symbol("a")
+    b = Symbol("b")
     setup = Circuit(3)
     setup.CX(0, 1)
     setup.Rz(a + 0.5, 2)
@@ -798,7 +798,7 @@ def test_custom_gates() -> None:
 def test_errors() -> None:
     # TKET-289
     c = Circuit(1)
-    a = Symbol("a")  # type: ignore
+    a = Symbol("a")
     c.Rz(a, 0)
     c.Rz(0.5, 0)
     c.Rz(0, 0)

--- a/pytket/tests/predicates_test.py
+++ b/pytket/tests/predicates_test.py
@@ -767,7 +767,7 @@ def test_simplify_initial_symbolic() -> None:
     # Symbolic circuits should be left alone, no error
     c = Circuit(1)
     c.qubit_create(Qubit(0))
-    c.Rx(Symbol("a"), 0)  # type: ignore
+    c.Rx(Symbol("a"), 0)
     c.measure_all()
     c1 = c.copy()
     SimplifyInitial(allow_classical=False).apply(c)

--- a/pytket/tests/qubitpaulioperator_test.py
+++ b/pytket/tests/qubitpaulioperator_test.py
@@ -29,7 +29,7 @@ import strategies as st  # type: ignore
 
 
 def test_QubitPauliOperator_addition() -> None:
-    x = Symbol("x")  # type: ignore
+    x = Symbol("x")
     qpo = QubitPauliOperator()
     qpo += QubitPauliOperator(
         {
@@ -49,9 +49,9 @@ def test_QubitPauliOperator_addition() -> None:
 
 
 def test_QubitPauliOperator_scalarmult() -> None:
-    y = Symbol("y")  # type: ignore
+    y = Symbol("y")
     qpo = QubitPauliOperator({QubitPauliString(Qubit("q"), Pauli.X): y})
-    x = Symbol("x")  # type: ignore
+    x = Symbol("x")
     qpo2 = x * qpo
     qpo3 = qpo * x
     assert qpo2 == qpo3
@@ -61,9 +61,9 @@ def test_QubitPauliOperator_scalarmult() -> None:
 
 
 def test_QubitPauliOperator_opmult() -> None:
-    y = Symbol("y")  # type: ignore
+    y = Symbol("y")
     qpo = QubitPauliOperator({QubitPauliString(Qubit(0), Pauli.Z): y})
-    x = Symbol("x")  # type: ignore
+    x = Symbol("x")
     qpo2 = QubitPauliOperator({QubitPauliString(Qubit(0), Pauli.X): x})
     qpo3 = qpo * qpo2  # order matters!
     assert qpo3._dict[QubitPauliString(Qubit(0), Pauli.Y)] == 1j * x * y
@@ -73,7 +73,7 @@ def test_QubitPauliOperator_opmult() -> None:
 
 def test_QubitPauliOperator_substitution() -> None:
     qps = QubitPauliString(Qubit(0), Pauli.X)
-    e = Symbol("e")  # type: ignore
+    e = Symbol("e")
     exp = e + 5
     qpo = QubitPauliOperator({qps: exp})
     qpo.subs({e: 1})
@@ -91,7 +91,7 @@ def test_QubitPauliOperator_io() -> None:
     qps1 = pickle.loads(string_data)
     assert qps0 == qps1
     qps2 = QubitPauliString(Qubit(2), Pauli.Z)
-    a = Symbol("a")  # type: ignore
+    a = Symbol("a")
     op = QubitPauliOperator({qps1: a, qps2: 3.1})
     op_data = pickle.dumps(op)
     op2 = pickle.loads(op_data)
@@ -146,7 +146,7 @@ def test_QubitPauliOperator_compression() -> None:
     qpsXY = QubitPauliString(qbs, [Pauli.X, Pauli.Y])
     qpsZI = QubitPauliString(qbs, [Pauli.Z, Pauli.I])
     qpsYY = QubitPauliString(qbs, [Pauli.Y, Pauli.Y])
-    x = Symbol("x")  # type: ignore
+    x = Symbol("x")
     op = QubitPauliOperator({qpsXY: 2, qpsZI: 1e-11j * x, qpsYY: 1e-11 * x + 1j})
     op.compress()
     with pytest.raises(KeyError) as errorinfo:
@@ -155,8 +155,8 @@ def test_QubitPauliOperator_compression() -> None:
     assert op[qpsXY] == 2
     assert re(op[qpsYY]) == 0
     assert im(op[qpsYY])
-    assert op[qpsYY].subs({x: 0.001}).equals(1.0j)  # type: ignore
-    assert op[qpsYY].subs({x: 10}).equals(1.0j)  # type: ignore
+    assert op[qpsYY].subs({x: 0.001}).equals(1.0j)
+    assert op[qpsYY].subs({x: 10}).equals(1.0j)
 
 
 if __name__ == "__main__":
@@ -197,7 +197,7 @@ def test_QubitPauliOperator_serialization_symbolic() -> None:
     qps = [Qubit(i) for i in range(2)]
     qpsXY = QubitPauliString(qps, [Pauli.X, Pauli.Y])
     qpsZI = QubitPauliString(qps, [Pauli.Z, Pauli.I])
-    x = Symbol("x")  # type: ignore
+    x = Symbol("x")
     op = QubitPauliOperator({qpsXY: 2 * x, qpsZI: 1j})
 
     serializable = op.to_list()

--- a/pytket/tests/qubitpaulioperator_test.py
+++ b/pytket/tests/qubitpaulioperator_test.py
@@ -185,7 +185,7 @@ def test_QubitPauliOperator_serialization() -> None:
     qps = [Qubit(i) for i in range(2)]
     qpsXY = QubitPauliString(qps, [Pauli.X, Pauli.Y])
     qpsZI = QubitPauliString(qps, [Pauli.Z, Pauli.I])
-    op = QubitPauliOperator({qpsXY: 2, qpsZI: 1j})
+    op = QubitPauliOperator({qpsXY: 2.0, qpsZI: 1j})
 
     serializable = op.to_list()
     assert QubitPauliOperator.from_list(serializable) == op

--- a/pytket/tests/transform_test.py
+++ b/pytket/tests/transform_test.py
@@ -717,7 +717,7 @@ def test_cu3_removal() -> None:
 
 def test_symbol_squash() -> None:
     # Test simplification of symbolic angles when squashing.
-    a = Symbol("a")  # type: ignore
+    a = Symbol("a")
     circ = Circuit(1)
     circ.Ry(0.5, 0).Rz(a, 0).Ry(0.5, 0)
     circ1 = circ.copy()
@@ -741,7 +741,7 @@ def test_symbol_squash() -> None:
 
 
 def symbolic_test_circ(n: int) -> Circuit:
-    a = Symbol("a")  # type: ignore
+    a = Symbol("a")
     circ = Circuit(n)
     for i in range(n - 1, 0, -1):
         circ.CX(i, i - 1)
@@ -762,7 +762,7 @@ def test_symbol_pauli_squash_1() -> None:
     circ1 = circ.copy()
     assert PauliSquash().apply(circ1)
     for x in np.arange(0.0, 4.0, 0.4):
-        smap = {Symbol("a"): x}  # type: ignore
+        smap = {Symbol("a"): x}
         c = circ.copy()
         c.symbol_substitution(smap)
         u = c.get_unitary()
@@ -780,7 +780,7 @@ def test_symbol_pauli_squash_2() -> None:
     circ1 = circ.copy()
     assert PauliSquash().apply(circ1)
     for x in np.arange(0.0, 4.0, 0.4):
-        smap = {Symbol("a"): x}  # type: ignore
+        smap = {Symbol("a"): x}
         c = circ.copy()
         c.symbol_substitution(smap)
         u = c.get_unitary()

--- a/pytket/tests/utils_test.py
+++ b/pytket/tests/utils_test.py
@@ -648,8 +648,8 @@ def test_symbolic_conversion(circ: Circuit) -> None:
 
     substitutions = [(sym, val) for sym, val in zip(free_symbs, bind_vals)]
     circ.symbol_substitution(dict(substitutions))
-    sym_unitary = sym_unitary.subs(substitutions)  # type: ignore
-    sym_state = sym_state.subs(substitutions)  # type: ignore
+    sym_unitary = sym_unitary.subs(substitutions)
+    sym_state = sym_state.subs(substitutions)
 
     numeric_unitary = np.array(sym_unitary).astype(np.complex128)
     numeric_state = np.array(sym_state).astype(np.complex128)

--- a/pytket/tests/zx_diagram_test.py
+++ b/pytket/tests/zx_diagram_test.py
@@ -486,7 +486,7 @@ def test_classical_and_cptp() -> None:
 def test_tensor_errors() -> None:
     # A symbolic generator
     diag = ZXDiagram(0, 1, 0, 0)
-    v = diag.add_vertex(ZXType.XSpider, sympify("2*a"))  # type: ignore
+    v = diag.add_vertex(ZXType.XSpider, sympify("2*a"))
     diag.add_wire(v, diag.get_boundary()[0])
     with pytest.raises(ValueError) as exc_info:
         tensor_from_quantum_diagram(diag)
@@ -494,7 +494,7 @@ def test_tensor_errors() -> None:
 
     # A symbolic scalar
     diag.set_vertex_ZXGen(v, PhasedGen(ZXType.XSpider, 0.5))
-    diag.multiply_scalar(sympify("2*a"))  # type: ignore
+    diag.multiply_scalar(sympify("2*a"))
     with pytest.raises(ValueError) as exc_info:
         tensor_from_quantum_diagram(diag)
     assert "symbolic scalar" in exc_info.value.args[0]


### PR DESCRIPTION
Fixes #1486 .

Also a bunch of mypy fixes.

The nix failure is expected because it's using the older sympy which has different mypy requirements. (Will make a separate issue for that.)