### PR TITLE
Update flake inputs, use custom sympy 1.13 derivation

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,15 +20,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1712940319,
-        "narHash": "sha256-QN9FhrpcHQLfc6CJmgNOD2vXz9/aGTEqDYTWtdc/mi0=",
+        "lastModified": 1720386169,
+        "narHash": "sha256-NGKVY4PjzwAa4upkGtAMz1npHGoRzWotlSnVlqI40mo=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "623ac957cb99a5647c9cf127ed6b5b9edfbba087",
+        "rev": "194846768975b7ad2c4988bdb82572c00222c0d7",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
+        "ref": "nixos-24.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,7 @@
     tket.cachix.org-1:ACdm5Zg19qPL0PpvUwTPPiIx8SEUy+D/uqa9vKJFwh0=
     cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
   '';
-  inputs.nixpkgs.url = "github:nixos/nixpkgs";
+  inputs.nixpkgs.url = "github:nixos/nixpkgs/nixos-24.05";
   inputs.flake-utils.url = "github:numtide/flake-utils";
   outputs = { self, nixpkgs, flake-utils }:
     flake-utils.lib.eachDefaultSystem (system:

--- a/nix-support/pytket.nix
+++ b/nix-support/pytket.nix
@@ -45,7 +45,7 @@ in {
       graphviz
       networkx
       jinja2
-      sympy
+      super.sympy'
       scipy
       numpy
       typing-extensions

--- a/nix-support/third-party-python-packages.nix
+++ b/nix-support/third-party-python-packages.nix
@@ -43,4 +43,22 @@ self: super: {
     };
     doCheck = false;
   };
+  sympy' = super.python3.pkgs.buildPythonPackage rec{
+    # version bump - nixpkgs' version is 1.12 at the time of writing
+    pname = "sympy";
+    version = "1.13.0";
+    format = "setuptools";
+    src = super.python3Packages.fetchPypi {
+      inherit pname version;
+      sha256 = "sha256:O2r49NAIuaGmpCaLM1uYSyODXybR1gsFJuvHHUiiX1c=";
+    };
+    nativeCheckInputs = [ super.glibcLocales ];
+    propagatedBuildInputs = [ super.python3Packages.mpmath ];
+    # tests take ~1h
+    doCheck = false;
+    pythonImportsCheck = [ "sympy" ];
+    preCheck = ''
+      export LANG="en_US.UTF-8"
+    '';
+  };
 }


### PR DESCRIPTION
# Description

I updated nixpkgs to get everything else up to date too, but sympy 1.13 is too new to have found its way into nixpkgs yet, so I added a custom derivation for it based on the existing one in nixpkgs.

# Related issues

Resolves #1488 

# Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented hard-to-understand parts of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.