### PR TITLE
Changed the link to old pytket-cutensornet docs

### DIFF
--- a/pytket/docs/extensions.rst
+++ b/pytket/docs/extensions.rst
@@ -132,7 +132,7 @@ Other
    pytket-qir <https://tket.quantinuum.com/extensions/pytket-qir>
    pytket-qiskit <https://tket.quantinuum.com/extensions/pytket-qiskit>
    pytket-quantinuum <https://tket.quantinuum.com/extensions/pytket-quantinuum>
-   pytket-cutensornet <https://tket.quantinuum.com/extensions/pytket-cutensornet> 
+   pytket-cutensornet <https://cqcl.github.io/pytket-cutensornet/api/index.html> 
    pytket-qulacs <https://tket.quantinuum.com/extensions/pytket-qulacs>
    pytket-qujax <https://tket.quantinuum.com/extensions/pytket-qujax>
    pytket-stim <https://tket.quantinuum.com/extensions/pytket-stim>


### PR DESCRIPTION
# Description

Changing the link for the docs of pytket-cutensornet to the old version of the docs (which is still maintained for pytket-cutensornet) since there are some problems with the new docs (see issue linked below).

NOTE: This is a temporary solution.

# Related issues

https://github.com/CQCL/pytket-cutensornet/issues/139

# Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have commented hard-to-understand parts of my code.
- [ ] I have made corresponding changes to the public API documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the changelog with any user-facing changes.
