### PR TITLE
Prevent MultiplexedTensoredU2Box passing empty argument to MultiplexedRotationBox

### DIFF
--- a/pytket/conanfile.py
+++ b/pytket/conanfile.py
@@ -32,7 +32,7 @@ class pytketRecipe(ConanFile):
         cmake.install()
 
     def requirements(self):
-        self.requires("tket/1.3.16@tket/stable")
+        self.requires("tket/1.3.17@tket/stable")
         self.requires("tklog/0.3.3@tket/stable")
         self.requires("tkrng/0.3.3@tket/stable")
         self.requires("tkassert/0.3.4@tket/stable")

--- a/pytket/docs/changelog.rst
+++ b/pytket/docs/changelog.rst
@@ -7,6 +7,9 @@ Changelog
 * add scratch_reg_resize_pass for decomposing temp bit register
 * Update to pytket-circuit-renderer 0.9.
 
+Fixes:
+* Fix MultiplexedTensoredU2Box passing MultiplexedRotationBox an empty argument
+
 1.30.0 (July 2024)
 ------------------
 

--- a/tket/conanfile.py
+++ b/tket/conanfile.py
@@ -23,7 +23,7 @@ from conan.errors import ConanInvalidConfiguration
 
 class TketConan(ConanFile):
     name = "tket"
-    version = "1.3.16"
+    version = "1.3.17"
     package_type = "library"
     license = "Apache 2"
     homepage = "https://github.com/CQCL/tket"

--- a/tket/src/Circuit/Multiplexor.cpp
+++ b/tket/src/Circuit/Multiplexor.cpp
@@ -1005,9 +1005,6 @@ void add_multi_rz(
     } else {
       all_decomps.push_back({});
     }
-    // for the construction to work, we need to keep some semblance of ordering
-    // for the interleaving - so we return a bunch of "Identity" GateSpec N.B.
-    // it is not an expected circumstance for this to be empty!
   }
   TKET_ASSERT(!all_decomps.empty());
   unsigned reference_size = 0;

--- a/tket/src/Circuit/Multiplexor.cpp
+++ b/tket/src/Circuit/Multiplexor.cpp
@@ -998,37 +998,53 @@ void add_multi_rz(
   // First get all GateSpec by constructing and decomposing
   // MultiplexedRotationBox
   for (unsigned target = 0; target < n_targets_; target++) {
-    all_decomps.push_back(
-        MultiplexedRotationBox(all_multiplexed_rz[target]).decompose());
+    ctrl_op_map_t map = all_multiplexed_rz[target];
+    if (!map.empty()) {
+      all_decomps.push_back(
+          MultiplexedRotationBox(all_multiplexed_rz[target]).decompose());
+    } else {
+      all_decomps.push_back({});
+    }
+    // for the construction to work, we need to keep some semblance of ordering
+    // for the interleaving - so we return a bunch of "Identity" GateSpec N.B.
+    // it is not an expected circumstance for this to be empty!
   }
   TKET_ASSERT(!all_decomps.empty());
-  unsigned reference_size = all_decomps[0].size();
-  for (unsigned i = 1; i < all_decomps.size(); i++) {
+  unsigned reference_size = 0;
+  for (unsigned i = 0; i < all_decomps.size(); i++) {
+    if (!all_decomps[i].empty() && !reference_size) {
+      reference_size = all_decomps[i].size();
+    }
     TKET_ASSERT(reference_size == all_decomps[i].size());
   }
+
+  // => no MultiplexedRz so we can carry on
+  if (!reference_size) return;
 
   // Then iterate through all the commands, adding them to the circuit
   // in an interleaved manner
   for (unsigned i = 0; i < reference_size; i++) {
     for (unsigned target = 0; target < all_decomps.size(); target++) {
-      GateSpec gate = all_decomps[target][i];
-      unsigned rotated_index;
-      switch (gate.type) {
-        case OpType::CX:
-          // we also need to map gate.qubit to the correct qubit
-          // we know that the bitstrings for the "target"th target have been
-          // left rotated by "target", so:
-          rotated_index = (*gate.qubit + (target % n_targets_)) % n_controls_;
-          circ.add_op<unsigned>(
-              OpType::CX, {rotated_index, n_controls_ + target});
-          break;
-        case OpType::Rz:
-          circ.add_op<unsigned>(
-              OpType::Rz, *gate.angle, {n_controls_ + target});
-          break;
-        default:
-          // this should never be hit
-          TKET_ASSERT(false);
+      if (!all_decomps[target].empty()) {
+        GateSpec gate = all_decomps[target][i];
+        unsigned rotated_index;
+        switch (gate.type) {
+          case OpType::CX:
+            // we also need to map gate.qubit to the correct qubit
+            // we know that the bitstrings for the "target"th target have been
+            // left rotated by "target", so:
+            rotated_index = (*gate.qubit + (target % n_targets_)) % n_controls_;
+            circ.add_op<unsigned>(
+                OpType::CX, {rotated_index, n_controls_ + target});
+            break;
+          case OpType::Rz:
+            circ.add_op<unsigned>(
+                OpType::Rz, *gate.angle, {n_controls_ + target});
+            break;
+          default:
+            // this should never be hit
+            TKET_ASSERT(false);
+        }
       }
     }
   }

--- a/tket/test/src/Circuit/test_Multiplexor.cpp
+++ b/tket/test/src/Circuit/test_Multiplexor.cpp
@@ -812,5 +812,11 @@ SCENARIO("Test MultiplexedTensoredU2Box exceptions", "[boxes]") {
                         "single-qubit unitary gate types or Unitary1qBox"));
   }
 }
+SCENARIO("Test MultiplexedTensoredU2Box value error") {
+  ctrl_tensored_op_map_t op_map = {
+      {{0}, {get_op_ptr(OpType::X)}}, {{1}, {get_op_ptr(OpType::Y)}}};
+  MultiplexedTensoredU2Box box(op_map);
+  REQUIRE(box.to_circuit());
+}
 }  // namespace test_Multiplexor
 }  // namespace tket


### PR DESCRIPTION
# Related issues

https://github.com/CQCL/tket/issues/1459

# Checklist

- [x] I have performed a self-review of my code.
- [ ] I have commented hard-to-understand parts of my code.
- [ ] I have made corresponding changes to the public API documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have updated the changelog with any user-facing changes.
