### PR TITLE
Allow any kwarg type.

### DIFF
--- a/pytket/pytket/utils/results.py
+++ b/pytket/pytket/utils/results.py
@@ -12,14 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Dict, List, Tuple, Union
+from typing import Any, Dict, List, Tuple, Union
 
 import numpy as np
 from pytket.circuit import BasisOrder
 
 StateTuple = Tuple[int, ...]
 CountsDict = Dict[StateTuple, Union[int, float]]
-KwargTypes = Union[int, float, str, None]
+KwargTypes = Any
 
 
 class BitPermuter:


### PR DESCRIPTION
Closes #868 .

I don't see a good reason for the restriction, and extensions sometimes want to pass other types such as dictionaries.