### PR TITLE
Cmake improvements and Nix unification with existing pytket setup

### DIFF
--- a/libs/tktokenswap/CMakeLists.txt
+++ b/libs/tktokenswap/CMakeLists.txt
@@ -70,7 +70,7 @@ target_include_directories(tktokenswap PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/tktokenswap>)
 target_link_libraries(tktokenswap PRIVATE tklog::tklog)
 target_link_libraries(tktokenswap PUBLIC tkassert::tkassert)
-target_link_libraries(tktokenswap PRIVATE tkrng::tkrng)
+target_link_libraries(tktokenswap PUBLIC tkrng::tkrng)
 target_link_libraries(tktokenswap PRIVATE Boost::headers)
 
 IF(APPLE)

--- a/libs/tktokenswap/include/tktokenswap/BestFullTsa.hpp
+++ b/libs/tktokenswap/include/tktokenswap/BestFullTsa.hpp
@@ -14,9 +14,9 @@
 
 #pragma once
 
-#include "HybridTsa.hpp"
-#include "SwapListOptimiser.hpp"
-#include "SwapListTableOptimiser.hpp"
+#include "tktokenswap/HybridTsa.hpp"
+#include "tktokenswap/SwapListOptimiser.hpp"
+#include "tktokenswap/SwapListTableOptimiser.hpp"
 
 namespace tket {
 

--- a/libs/tktokenswap/include/tktokenswap/CyclesCandidateManager.hpp
+++ b/libs/tktokenswap/include/tktokenswap/CyclesCandidateManager.hpp
@@ -16,8 +16,8 @@
 
 #include <set>
 
-#include "CyclesGrowthManager.hpp"
-#include "PartialTsaInterface.hpp"
+#include "tktokenswap/CyclesGrowthManager.hpp"
+#include "tktokenswap/PartialTsaInterface.hpp"
 
 namespace tket {
 namespace tsa_internal {

--- a/libs/tktokenswap/include/tktokenswap/CyclesPartialTsa.hpp
+++ b/libs/tktokenswap/include/tktokenswap/CyclesPartialTsa.hpp
@@ -14,8 +14,8 @@
 
 #pragma once
 
-#include "CyclesCandidateManager.hpp"
-#include "PartialTsaInterface.hpp"
+#include "tktokenswap/CyclesCandidateManager.hpp"
+#include "tktokenswap/PartialTsaInterface.hpp"
 
 namespace tket {
 namespace tsa_internal {

--- a/libs/tktokenswap/include/tktokenswap/DistanceFunctions.hpp
+++ b/libs/tktokenswap/include/tktokenswap/DistanceFunctions.hpp
@@ -18,7 +18,7 @@
 #include <set>
 #include <stdexcept>
 
-#include "VertexMappingFunctions.hpp"
+#include "tktokenswap/VertexMappingFunctions.hpp"
 #include "tktokenswap/DistancesInterface.hpp"
 
 namespace tket {

--- a/libs/tktokenswap/include/tktokenswap/ExactMappingLookup.hpp
+++ b/libs/tktokenswap/include/tktokenswap/ExactMappingLookup.hpp
@@ -14,7 +14,7 @@
 
 #pragma once
 
-#include "CanonicalRelabelling.hpp"
+#include "tktokenswap/CanonicalRelabelling.hpp"
 
 namespace tket {
 namespace tsa_internal {

--- a/libs/tktokenswap/include/tktokenswap/FilteredSwapSequences.hpp
+++ b/libs/tktokenswap/include/tktokenswap/FilteredSwapSequences.hpp
@@ -17,7 +17,7 @@
 #include <map>
 #include <vector>
 
-#include "SwapConversion.hpp"
+#include "tktokenswap/SwapConversion.hpp"
 
 namespace tket {
 namespace tsa_internal {

--- a/libs/tktokenswap/include/tktokenswap/HybridTsa.hpp
+++ b/libs/tktokenswap/include/tktokenswap/HybridTsa.hpp
@@ -14,8 +14,8 @@
 
 #pragma once
 
-#include "CyclesPartialTsa.hpp"
-#include "TrivialTSA.hpp"
+#include "tktokenswap/CyclesPartialTsa.hpp"
+#include "tktokenswap/TrivialTSA.hpp"
 
 namespace tket {
 namespace tsa_internal {

--- a/libs/tktokenswap/include/tktokenswap/PartialMappingLookup.hpp
+++ b/libs/tktokenswap/include/tktokenswap/PartialMappingLookup.hpp
@@ -19,7 +19,7 @@
 #include <set>
 #include <vector>
 
-#include "ExactMappingLookup.hpp"
+#include "tktokenswap/ExactMappingLookup.hpp"
 
 namespace tket {
 namespace tsa_internal {

--- a/libs/tktokenswap/include/tktokenswap/PartialTsaInterface.hpp
+++ b/libs/tktokenswap/include/tktokenswap/PartialTsaInterface.hpp
@@ -14,10 +14,10 @@
 
 #pragma once
 
-#include "DistancesInterface.hpp"
-#include "NeighboursInterface.hpp"
-#include "RiverFlowPathFinder.hpp"
-#include "VertexMappingFunctions.hpp"
+#include "tktokenswap/DistancesInterface.hpp"
+#include "tktokenswap/NeighboursInterface.hpp"
+#include "tktokenswap/RiverFlowPathFinder.hpp"
+#include "tktokenswap/VertexMappingFunctions.hpp"
 
 namespace tket {
 namespace tsa_internal {

--- a/libs/tktokenswap/include/tktokenswap/RiverFlowPathFinder.hpp
+++ b/libs/tktokenswap/include/tktokenswap/RiverFlowPathFinder.hpp
@@ -19,8 +19,8 @@
 #include <optional>
 #include <tkrng/RNG.hpp>
 
-#include "DistancesInterface.hpp"
-#include "NeighboursInterface.hpp"
+#include "tktokenswap/DistancesInterface.hpp"
+#include "tktokenswap/NeighboursInterface.hpp"
 
 namespace tket {
 namespace tsa_internal {

--- a/libs/tktokenswap/include/tktokenswap/SwapListOptimiser.hpp
+++ b/libs/tktokenswap/include/tktokenswap/SwapListOptimiser.hpp
@@ -14,7 +14,7 @@
 
 #pragma once
 
-#include "DynamicTokenTracker.hpp"
+#include "tktokenswap/DynamicTokenTracker.hpp"
 
 namespace tket {
 namespace tsa_internal {

--- a/libs/tktokenswap/include/tktokenswap/SwapListSegmentOptimiser.hpp
+++ b/libs/tktokenswap/include/tktokenswap/SwapListSegmentOptimiser.hpp
@@ -19,8 +19,8 @@
 #include <set>
 #include <vector>
 
-#include "PartialMappingLookup.hpp"
-#include "VertexMapResizing.hpp"
+#include "tktokenswap/PartialMappingLookup.hpp"
+#include "tktokenswap/VertexMapResizing.hpp"
 #include "tktokenswap/SwapFunctions.hpp"
 
 namespace tket {

--- a/libs/tktokenswap/include/tktokenswap/SwapListTableOptimiser.hpp
+++ b/libs/tktokenswap/include/tktokenswap/SwapListTableOptimiser.hpp
@@ -17,9 +17,9 @@
 
 #include <set>
 
-#include "PartialMappingLookup.hpp"
-#include "SwapListSegmentOptimiser.hpp"
-#include "VertexMapResizing.hpp"
+#include "tktokenswap/PartialMappingLookup.hpp"
+#include "tktokenswap/SwapListSegmentOptimiser.hpp"
+#include "tktokenswap/VertexMapResizing.hpp"
 #include "tktokenswap/SwapListOptimiser.hpp"
 
 /// TODO: The swap table optimiser currently tries to optimise many segments;

--- a/libs/tktokenswap/include/tktokenswap/TrivialTSA.hpp
+++ b/libs/tktokenswap/include/tktokenswap/TrivialTSA.hpp
@@ -16,7 +16,7 @@
 
 #include <set>
 
-#include "PartialTsaInterface.hpp"
+#include "tktokenswap/PartialTsaInterface.hpp"
 
 namespace tket {
 namespace tsa_internal {

--- a/libs/tktokenswap/include/tktokenswap/VectorListHybrid.hpp
+++ b/libs/tktokenswap/include/tktokenswap/VectorListHybrid.hpp
@@ -18,7 +18,7 @@
 #include <sstream>
 #include <tkassert/Assert.hpp>
 
-#include "VectorListHybridSkeleton.hpp"
+#include "tktokenswap/VectorListHybridSkeleton.hpp"
 
 namespace tket {
 

--- a/libs/tktokenswap/include/tktokenswap/VertexMappingFunctions.hpp
+++ b/libs/tktokenswap/include/tktokenswap/VertexMappingFunctions.hpp
@@ -18,7 +18,7 @@
 #include <optional>
 #include <utility>
 
-#include "SwapFunctions.hpp"
+#include "tktokenswap/SwapFunctions.hpp"
 
 namespace tket {
 

--- a/libs/tktokenswap/include/tktokenswap/VertexSwapResult.hpp
+++ b/libs/tktokenswap/include/tktokenswap/VertexSwapResult.hpp
@@ -18,7 +18,7 @@
 #include <optional>
 #include <utility>
 
-#include "VertexMappingFunctions.hpp"
+#include "tktokenswap/VertexMappingFunctions.hpp"
 
 namespace tket {
 namespace tsa_internal {

--- a/libs/tktokenswap/src/CyclesCandidateManager.cpp
+++ b/libs/tktokenswap/src/CyclesCandidateManager.cpp
@@ -12,14 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "CyclesCandidateManager.hpp"
+#include "tktokenswap/CyclesCandidateManager.hpp"
 
 #include <algorithm>
 #include <boost/functional/hash.hpp>
 #include <stdexcept>
 #include <tkassert/Assert.hpp>
 
-#include "VertexSwapResult.hpp"
+#include "tktokenswap/VertexSwapResult.hpp"
 
 using std::vector;
 

--- a/libs/tktokenswap/src/CyclesGrowthManager.cpp
+++ b/libs/tktokenswap/src/CyclesGrowthManager.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "CyclesGrowthManager.hpp"
+#include "tktokenswap/CyclesGrowthManager.hpp"
 
 #include <stdexcept>
 #include <tkassert/Assert.hpp>

--- a/libs/tktokenswap/src/CyclesPartialTsa.cpp
+++ b/libs/tktokenswap/src/CyclesPartialTsa.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "CyclesPartialTsa.hpp"
+#include "tktokenswap/CyclesPartialTsa.hpp"
 
 #include <tkassert/Assert.hpp>
 

--- a/libs/tktokenswap/src/CyclicShiftCostEstimate.hpp
+++ b/libs/tktokenswap/src/CyclicShiftCostEstimate.hpp
@@ -16,7 +16,7 @@
 
 #include <limits>
 
-#include "DistancesInterface.hpp"
+#include "tktokenswap/DistancesInterface.hpp"
 
 namespace tket {
 namespace tsa_internal {

--- a/libs/tktokenswap/src/DistancesInterface.cpp
+++ b/libs/tktokenswap/src/DistancesInterface.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "DistancesInterface.hpp"
+#include "tktokenswap/DistancesInterface.hpp"
 
 using std::vector;
 

--- a/libs/tktokenswap/src/DynamicTokenTracker.cpp
+++ b/libs/tktokenswap/src/DynamicTokenTracker.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "DynamicTokenTracker.hpp"
+#include "tktokenswap/DynamicTokenTracker.hpp"
 
 namespace tket {
 namespace tsa_internal {

--- a/libs/tktokenswap/src/HybridTsa.cpp
+++ b/libs/tktokenswap/src/HybridTsa.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "HybridTsa.hpp"
+#include "tktokenswap/HybridTsa.hpp"
 
 #include <tkassert/Assert.hpp>
 

--- a/libs/tktokenswap/src/NeighboursInterface.cpp
+++ b/libs/tktokenswap/src/NeighboursInterface.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "NeighboursInterface.hpp"
+#include "tktokenswap/NeighboursInterface.hpp"
 
 #include <stdexcept>
 

--- a/libs/tktokenswap/src/PartialTsaInterface.cpp
+++ b/libs/tktokenswap/src/PartialTsaInterface.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "PartialTsaInterface.hpp"
+#include "tktokenswap/PartialTsaInterface.hpp"
 
 namespace tket {
 namespace tsa_internal {

--- a/libs/tktokenswap/src/RiverFlowPathFinder.cpp
+++ b/libs/tktokenswap/src/RiverFlowPathFinder.cpp
@@ -12,13 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "RiverFlowPathFinder.hpp"
+#include "tktokenswap/RiverFlowPathFinder.hpp"
 
 #include <sstream>
 #include <stdexcept>
 #include <tkassert/Assert.hpp>
 
-#include "SwapFunctions.hpp"
+#include "tktokenswap/SwapFunctions.hpp"
 
 using std::vector;
 

--- a/libs/tktokenswap/src/SwapListOptimiser.cpp
+++ b/libs/tktokenswap/src/SwapListOptimiser.cpp
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "SwapListOptimiser.hpp"
+#include "tktokenswap/SwapListOptimiser.hpp"
 
 #include <tkassert/Assert.hpp>
 
-#include "VertexSwapResult.hpp"
+#include "tktokenswap/VertexSwapResult.hpp"
 
 namespace tket {
 namespace tsa_internal {

--- a/libs/tktokenswap/src/TableLookup/VertexMapResizing.hpp
+++ b/libs/tktokenswap/src/TableLookup/VertexMapResizing.hpp
@@ -19,7 +19,7 @@
 #include <set>
 #include <vector>
 
-#include "../VertexMappingFunctions.hpp"
+#include "tktokenswap/VertexMappingFunctions.hpp"
 #include "tktokenswap/NeighboursInterface.hpp"
 
 namespace tket {

--- a/libs/tktokenswap/src/TrivialTSA.cpp
+++ b/libs/tktokenswap/src/TrivialTSA.cpp
@@ -12,16 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "TrivialTSA.hpp"
+#include "tktokenswap/TrivialTSA.hpp"
 
 #include <sstream>
 #include <stdexcept>
 #include <tkassert/Assert.hpp>
 
-#include "CyclicShiftCostEstimate.hpp"
 #include "tktokenswap/DistanceFunctions.hpp"
 #include "tktokenswap/GeneralFunctions.hpp"
 #include "tktokenswap/VertexSwapResult.hpp"
+
+#include "CyclicShiftCostEstimate.hpp"
 
 using std::vector;
 

--- a/libs/tktokenswap/src/VectorListHybridSkeleton.cpp
+++ b/libs/tktokenswap/src/VectorListHybridSkeleton.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "VectorListHybridSkeleton.hpp"
+#include "tktokenswap/VectorListHybridSkeleton.hpp"
 
 #include <limits>
 #include <sstream>

--- a/libs/tkwsm/CMakeLists.txt
+++ b/libs/tkwsm/CMakeLists.txt
@@ -68,9 +68,9 @@ ENDIF()
 target_include_directories(tkwsm PUBLIC
     $<INSTALL_INTERFACE:include/tkwsm>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/tkwsm>)
-target_link_libraries(tkwsm PRIVATE tkassert::tkassert)
-target_link_libraries(tkwsm PRIVATE tkrng::tkrng)
-target_link_libraries(tkwsm PRIVATE Boost::headers)
+target_link_libraries(tkwsm PUBLIC tkassert::tkassert)
+target_link_libraries(tkwsm PUBLIC tkrng::tkrng)
+target_link_libraries(tkwsm PUBLIC Boost::headers)
 IF(APPLE)
     target_link_libraries(tkwsm PRIVATE "-flat_namespace")
 ENDIF()

--- a/libs/tkwsm/include/tkwsm/Common/GeneralUtils.hpp
+++ b/libs/tkwsm/include/tkwsm/Common/GeneralUtils.hpp
@@ -23,7 +23,7 @@
 #include <utility>
 #include <vector>
 
-#include "SpecialExceptions.hpp"
+#include "tkwsm/Common/SpecialExceptions.hpp"
 
 namespace tket {
 namespace WeightedSubgraphMonomorphism {

--- a/libs/tkwsm/include/tkwsm/Common/TemporaryRefactorCode.hpp
+++ b/libs/tkwsm/include/tkwsm/Common/TemporaryRefactorCode.hpp
@@ -16,7 +16,7 @@
 #include <boost/dynamic_bitset.hpp>
 #include <tkassert/Assert.hpp>
 
-#include "../GraphTheoretic/GeneralStructs.hpp"
+#include "tkwsm/GraphTheoretic/GeneralStructs.hpp"
 
 namespace tket {
 namespace WeightedSubgraphMonomorphism {

--- a/libs/tkwsm/include/tkwsm/EndToEndWrappers/MainSolver.hpp
+++ b/libs/tkwsm/include/tkwsm/EndToEndWrappers/MainSolver.hpp
@@ -16,11 +16,11 @@
 #include <chrono>
 #include <memory>
 
-#include "../GraphTheoretic/NeighboursData.hpp"
-#include "../GraphTheoretic/VertexRelabelling.hpp"
-#include "../Searching/SearchBranch.hpp"
-#include "MainSolverParameters.hpp"
-#include "SolutionData.hpp"
+#include "tkwsm/GraphTheoretic/NeighboursData.hpp"
+#include "tkwsm/GraphTheoretic/VertexRelabelling.hpp"
+#include "tkwsm/Searching/SearchBranch.hpp"
+#include "tkwsm/EndToEndWrappers/MainSolverParameters.hpp"
+#include "tkwsm/EndToEndWrappers/SolutionData.hpp"
 
 namespace tket {
 namespace WeightedSubgraphMonomorphism {

--- a/libs/tkwsm/include/tkwsm/EndToEndWrappers/MainSolverParameters.hpp
+++ b/libs/tkwsm/include/tkwsm/EndToEndWrappers/MainSolverParameters.hpp
@@ -15,7 +15,7 @@
 #pragma once
 #include <optional>
 
-#include "../GraphTheoretic/GeneralStructs.hpp"
+#include "tkwsm/GraphTheoretic/GeneralStructs.hpp"
 
 namespace tket {
 namespace WeightedSubgraphMonomorphism {

--- a/libs/tkwsm/include/tkwsm/EndToEndWrappers/PreSearchComponents.hpp
+++ b/libs/tkwsm/include/tkwsm/EndToEndWrappers/PreSearchComponents.hpp
@@ -18,8 +18,8 @@
 #include <string>
 #include <utility>
 
-#include "../GraphTheoretic/NearNeighboursData.hpp"
-#include "../GraphTheoretic/NeighboursData.hpp"
+#include "tkwsm/GraphTheoretic/NearNeighboursData.hpp"
+#include "tkwsm/GraphTheoretic/NeighboursData.hpp"
 
 namespace tket {
 namespace WeightedSubgraphMonomorphism {

--- a/libs/tkwsm/include/tkwsm/EndToEndWrappers/SolutionData.hpp
+++ b/libs/tkwsm/include/tkwsm/EndToEndWrappers/SolutionData.hpp
@@ -15,8 +15,8 @@
 #pragma once
 #include <optional>
 
-#include "../GraphTheoretic/GeneralStructs.hpp"
-#include "SolutionWSM.hpp"
+#include "tkwsm/GraphTheoretic/GeneralStructs.hpp"
+#include "tkwsm/EndToEndWrappers/SolutionWSM.hpp"
 
 namespace tket {
 namespace WeightedSubgraphMonomorphism {

--- a/libs/tkwsm/include/tkwsm/EndToEndWrappers/SolutionWSM.hpp
+++ b/libs/tkwsm/include/tkwsm/EndToEndWrappers/SolutionWSM.hpp
@@ -15,7 +15,7 @@
 #pragma once
 #include <string>
 
-#include "../GraphTheoretic/GeneralStructs.hpp"
+#include "tkwsm/GraphTheoretic/GeneralStructs.hpp"
 
 namespace tket {
 namespace WeightedSubgraphMonomorphism {

--- a/libs/tkwsm/include/tkwsm/GraphTheoretic/DerivedGraphStructs.hpp
+++ b/libs/tkwsm/include/tkwsm/GraphTheoretic/DerivedGraphStructs.hpp
@@ -15,7 +15,7 @@
 #pragma once
 #include <forward_list>
 
-#include "GeneralStructs.hpp"
+#include "tkwsm/GraphTheoretic/GeneralStructs.hpp"
 
 namespace tket {
 namespace WeightedSubgraphMonomorphism {

--- a/libs/tkwsm/include/tkwsm/GraphTheoretic/DerivedGraphs.hpp
+++ b/libs/tkwsm/include/tkwsm/GraphTheoretic/DerivedGraphs.hpp
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #pragma once
-#include "DerivedGraphStructs.hpp"
+#include "tkwsm/GraphTheoretic/DerivedGraphStructs.hpp"
 
 namespace tket {
 namespace WeightedSubgraphMonomorphism {

--- a/libs/tkwsm/include/tkwsm/GraphTheoretic/DerivedGraphsCalculator.hpp
+++ b/libs/tkwsm/include/tkwsm/GraphTheoretic/DerivedGraphsCalculator.hpp
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #pragma once
-#include "DerivedGraphStructs.hpp"
+#include "tkwsm/GraphTheoretic/DerivedGraphStructs.hpp"
 
 namespace tket {
 namespace WeightedSubgraphMonomorphism {

--- a/libs/tkwsm/include/tkwsm/GraphTheoretic/DomainInitialiser.hpp
+++ b/libs/tkwsm/include/tkwsm/GraphTheoretic/DomainInitialiser.hpp
@@ -15,7 +15,7 @@
 #pragma once
 #include <set>
 
-#include "../GraphTheoretic/GeneralStructs.hpp"
+#include "tkwsm/GraphTheoretic/GeneralStructs.hpp"
 
 namespace tket {
 namespace WeightedSubgraphMonomorphism {

--- a/libs/tkwsm/include/tkwsm/GraphTheoretic/NearNeighboursData.hpp
+++ b/libs/tkwsm/include/tkwsm/GraphTheoretic/NearNeighboursData.hpp
@@ -17,8 +17,8 @@
 #include <optional>
 #include <utility>
 
-#include "FilterUtils.hpp"
-#include "GeneralStructs.hpp"
+#include "tkwsm/GraphTheoretic/FilterUtils.hpp"
+#include "tkwsm/GraphTheoretic/GeneralStructs.hpp"
 
 namespace tket {
 namespace WeightedSubgraphMonomorphism {

--- a/libs/tkwsm/include/tkwsm/GraphTheoretic/NeighboursData.hpp
+++ b/libs/tkwsm/include/tkwsm/GraphTheoretic/NeighboursData.hpp
@@ -17,7 +17,7 @@
 #include <optional>
 #include <utility>
 
-#include "GeneralStructs.hpp"
+#include "tkwsm/GraphTheoretic/GeneralStructs.hpp"
 
 namespace tket {
 namespace WeightedSubgraphMonomorphism {

--- a/libs/tkwsm/include/tkwsm/GraphTheoretic/VertexRelabelling.hpp
+++ b/libs/tkwsm/include/tkwsm/GraphTheoretic/VertexRelabelling.hpp
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #pragma once
-#include "GeneralStructs.hpp"
+#include "tkwsm/GraphTheoretic/GeneralStructs.hpp"
 
 namespace tket {
 namespace WeightedSubgraphMonomorphism {

--- a/libs/tkwsm/include/tkwsm/InitPlacement/EndToEndIQP.hpp
+++ b/libs/tkwsm/include/tkwsm/InitPlacement/EndToEndIQP.hpp
@@ -15,7 +15,7 @@
 #pragma once
 #include <optional>
 
-#include "../GraphTheoretic/GeneralStructs.hpp"
+#include "tkwsm/GraphTheoretic/GeneralStructs.hpp"
 
 namespace tket {
 namespace WeightedSubgraphMonomorphism {

--- a/libs/tkwsm/include/tkwsm/InitPlacement/FastRandomBits.hpp
+++ b/libs/tkwsm/include/tkwsm/InitPlacement/FastRandomBits.hpp
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #pragma once
-#include "../GraphTheoretic/GeneralStructs.hpp"
+#include "tkwsm/GraphTheoretic/GeneralStructs.hpp"
 
 namespace tket {
 class RNG;

--- a/libs/tkwsm/include/tkwsm/InitPlacement/InputStructs.hpp
+++ b/libs/tkwsm/include/tkwsm/InitPlacement/InputStructs.hpp
@@ -15,7 +15,7 @@
 #pragma once
 #include <optional>
 
-#include "../GraphTheoretic/GeneralStructs.hpp"
+#include "tkwsm/GraphTheoretic/GeneralStructs.hpp"
 
 namespace tket {
 namespace WeightedSubgraphMonomorphism {

--- a/libs/tkwsm/include/tkwsm/InitPlacement/MonteCarloCompleteTargetSolution.hpp
+++ b/libs/tkwsm/include/tkwsm/InitPlacement/MonteCarloCompleteTargetSolution.hpp
@@ -17,9 +17,9 @@
 #include <optional>
 #include <tkrng/RNG.hpp>
 
-#include "FastRandomBits.hpp"
-#include "MonteCarloManager.hpp"
-#include "SolutionJumper.hpp"
+#include "tkwsm/InitPlacement/FastRandomBits.hpp"
+#include "tkwsm/InitPlacement/MonteCarloManager.hpp"
+#include "tkwsm/InitPlacement/SolutionJumper.hpp"
 #include "tkwsm/GraphTheoretic/GeneralStructs.hpp"
 
 namespace tket {

--- a/libs/tkwsm/include/tkwsm/Reducing/DerivedGraphsReducer.hpp
+++ b/libs/tkwsm/include/tkwsm/Reducing/DerivedGraphsReducer.hpp
@@ -13,9 +13,9 @@
 // limitations under the License.
 
 #pragma once
-#include "../GraphTheoretic/DerivedGraphs.hpp"
-#include "../GraphTheoretic/DerivedGraphsCalculator.hpp"
-#include "ReducerWrapper.hpp"
+#include "tkwsm/GraphTheoretic/DerivedGraphs.hpp"
+#include "tkwsm/GraphTheoretic/DerivedGraphsCalculator.hpp"
+#include "tkwsm/Reducing/ReducerWrapper.hpp"
 
 namespace tket {
 namespace WeightedSubgraphMonomorphism {

--- a/libs/tkwsm/include/tkwsm/Reducing/DistancesReducer.hpp
+++ b/libs/tkwsm/include/tkwsm/Reducing/DistancesReducer.hpp
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #pragma once
-#include "ReducerWrapper.hpp"
+#include "tkwsm/Reducing/ReducerWrapper.hpp"
 
 namespace tket {
 namespace WeightedSubgraphMonomorphism {

--- a/libs/tkwsm/include/tkwsm/Reducing/ReducerWrapper.hpp
+++ b/libs/tkwsm/include/tkwsm/Reducing/ReducerWrapper.hpp
@@ -16,7 +16,7 @@
 #include <boost/dynamic_bitset.hpp>
 #include <optional>
 
-#include "../GraphTheoretic/GeneralStructs.hpp"
+#include "tkwsm/GraphTheoretic/GeneralStructs.hpp"
 
 namespace tket {
 namespace WeightedSubgraphMonomorphism {

--- a/libs/tkwsm/include/tkwsm/Searching/DomainsAccessor.hpp
+++ b/libs/tkwsm/include/tkwsm/Searching/DomainsAccessor.hpp
@@ -17,7 +17,7 @@
 #include <optional>
 #include <string>
 
-#include "../GraphTheoretic/GeneralStructs.hpp"
+#include "tkwsm/GraphTheoretic/GeneralStructs.hpp"
 
 namespace tket {
 namespace WeightedSubgraphMonomorphism {

--- a/libs/tkwsm/include/tkwsm/Searching/NodeListTraversal.hpp
+++ b/libs/tkwsm/include/tkwsm/Searching/NodeListTraversal.hpp
@@ -16,7 +16,7 @@
 #include <optional>
 #include <string>
 
-#include "../GraphTheoretic/GeneralStructs.hpp"
+#include "tkwsm/GraphTheoretic/GeneralStructs.hpp"
 
 namespace tket {
 namespace WeightedSubgraphMonomorphism {

--- a/libs/tkwsm/include/tkwsm/Searching/NodesRawData.hpp
+++ b/libs/tkwsm/include/tkwsm/Searching/NodesRawData.hpp
@@ -16,8 +16,8 @@
 #include <boost/dynamic_bitset.hpp>
 #include <string>
 
-#include "../Common/LogicalStack.hpp"
-#include "../GraphTheoretic/DomainInitialiser.hpp"
+#include "tkwsm/Common/LogicalStack.hpp"
+#include "tkwsm/GraphTheoretic/DomainInitialiser.hpp"
 
 namespace tket {
 namespace WeightedSubgraphMonomorphism {

--- a/libs/tkwsm/include/tkwsm/Searching/SearchBranch.hpp
+++ b/libs/tkwsm/include/tkwsm/Searching/SearchBranch.hpp
@@ -15,15 +15,15 @@
 #pragma once
 #include <memory>
 
-#include "../GraphTheoretic/DomainInitialiser.hpp"
-#include "../Reducing/DerivedGraphsReducer.hpp"
-#include "../Reducing/DistancesReducer.hpp"
-#include "../Reducing/HallSetReduction.hpp"
-#include "../Reducing/ReducerWrapper.hpp"
-#include "DomainsAccessor.hpp"
-#include "NodeListTraversal.hpp"
-#include "NodesRawData.hpp"
-#include "WeightCalculator.hpp"
+#include "tkwsm/GraphTheoretic/DomainInitialiser.hpp"
+#include "tkwsm/Reducing/DerivedGraphsReducer.hpp"
+#include "tkwsm/Reducing/DistancesReducer.hpp"
+#include "tkwsm/Reducing/HallSetReduction.hpp"
+#include "tkwsm/Reducing/ReducerWrapper.hpp"
+#include "tkwsm/Searching/DomainsAccessor.hpp"
+#include "tkwsm/Searching/NodeListTraversal.hpp"
+#include "tkwsm/Searching/NodesRawData.hpp"
+#include "tkwsm/Searching/WeightCalculator.hpp"
 
 namespace tket {
 namespace WeightedSubgraphMonomorphism {

--- a/libs/tkwsm/include/tkwsm/Searching/ValueOrdering.hpp
+++ b/libs/tkwsm/include/tkwsm/Searching/ValueOrdering.hpp
@@ -15,7 +15,7 @@
 #pragma once
 #include <set>
 
-#include "../GraphTheoretic/GeneralStructs.hpp"
+#include "tkwsm/GraphTheoretic/GeneralStructs.hpp"
 
 namespace tket {
 class RNG;

--- a/libs/tkwsm/include/tkwsm/Searching/VariableOrdering.hpp
+++ b/libs/tkwsm/include/tkwsm/Searching/VariableOrdering.hpp
@@ -15,7 +15,7 @@
 #pragma once
 #include <optional>
 
-#include "../GraphTheoretic/GeneralStructs.hpp"
+#include "tkwsm/GraphTheoretic/GeneralStructs.hpp"
 
 namespace tket {
 class RNG;

--- a/libs/tkwsm/include/tkwsm/Searching/WeightCalculator.hpp
+++ b/libs/tkwsm/include/tkwsm/Searching/WeightCalculator.hpp
@@ -16,7 +16,7 @@
 #include <optional>
 #include <set>
 
-#include "../GraphTheoretic/GeneralStructs.hpp"
+#include "tkwsm/GraphTheoretic/GeneralStructs.hpp"
 
 namespace tket {
 namespace WeightedSubgraphMonomorphism {

--- a/libs/tkwsm/include/tkwsm/WeightPruning/WeightChecker.hpp
+++ b/libs/tkwsm/include/tkwsm/WeightPruning/WeightChecker.hpp
@@ -16,8 +16,8 @@
 #include <memory>
 #include <optional>
 
-#include "../GraphTheoretic/GeneralStructs.hpp"
-#include "WeightNogoodDetectorManager.hpp"
+#include "tkwsm/GraphTheoretic/GeneralStructs.hpp"
+#include "tkwsm/WeightPruning/WeightNogoodDetectorManager.hpp"
 
 namespace tket {
 namespace WeightedSubgraphMonomorphism {

--- a/libs/tkwsm/include/tkwsm/WeightPruning/WeightNogoodDetector.hpp
+++ b/libs/tkwsm/include/tkwsm/WeightPruning/WeightNogoodDetector.hpp
@@ -15,7 +15,7 @@
 #pragma once
 #include <optional>
 
-#include "../GraphTheoretic/GeneralStructs.hpp"
+#include "tkwsm/GraphTheoretic/GeneralStructs.hpp"
 
 namespace tket {
 namespace WeightedSubgraphMonomorphism {

--- a/libs/tkwsm/include/tkwsm/WeightPruning/WeightNogoodDetectorManager.hpp
+++ b/libs/tkwsm/include/tkwsm/WeightPruning/WeightNogoodDetectorManager.hpp
@@ -16,7 +16,7 @@
 #include <map>
 #include <set>
 
-#include "../GraphTheoretic/GeneralStructs.hpp"
+#include "tkwsm/GraphTheoretic/GeneralStructs.hpp"
 
 namespace tket {
 namespace WeightedSubgraphMonomorphism {

--- a/nix-support/pytket.nix
+++ b/nix-support/pytket.nix
@@ -60,6 +60,7 @@ in {
       # and to build in a temporary directory.
       export NO_CONAN=1;
       export INSTALL_DIR=$(mktemp -d);
+      export BUILD_DIR=$(mktemp -d);
     '';
     checkInputs = with super.python3.pkgs; [
       mypy

--- a/nix-support/pytket.nix
+++ b/nix-support/pytket.nix
@@ -17,31 +17,24 @@ let
     };
   });
 in {
-  binders = super.stdenv.mkDerivation {
-    name = "binders";
-    nativeBuildInputs = [
-      super.cmake
-      super.pkg-config
-      super.python3Packages.pybind11
-      super.pybind11_json
-    ];
-    cmakeFlags = [ "-DBUILD_SHARED_LIBS=ON" ];
-    propagatedBuildInputs = [
-      super.tket
-    ];
-    unpackPhase = ''
-      cp -r ${../pytket/binders} binders;
-      cp ${../pytket/CMakeLists.txt} CMakeLists.txt;
-    '';
-  };
   pytket = super.python3.pkgs.buildPythonPackage {
     pname = "pytket";
     inherit version;
-    propagatedBuildInputs = with super.python3.pkgs; [
-      self.binders
+    src = ../pytket;
+    nativeBuildInputs = with super.python3.pkgs; [
+      setuptools
+      super.cmake
+      super.pkg-config
+    ];
+    propagatedBuildInputs = [
+      super.tket
+      super.pybind11_json
+    ];
+    dependencies = with super.python3.pkgs; [
       super.lark
       super.types-pkg_resources
       super.qwasm
+      pybind11
       graphviz
       networkx
       jinja2
@@ -50,35 +43,23 @@ in {
       numpy
       typing-extensions
     ];
-
-    unpackPhase = ''
-      cp -r ${../pytket/pytket} pytket;
-      cp ${../pytket/package.md} package.md;
-      cp -r ${../schemas} schemas;
-      cp -r ${../pytket/mypy.ini} mypy.ini;
-
-      # The usual build depends on setuptools-scm to extract the version.
-      # We have already extracted the version within nix, so we can simply
-      # inject it into setup.py.
-      cat ${../pytket/setup.py} | sed 's/setup(/setup(version="${version}",/' > setup.py;
-
-      mkdir test_root;
-      cp -r ${../pytket/tests} test_root/tests;
-      # hardcode the version extracted from docs/conf.py.
-      chmod 755 pytket
-      echo '__version__ = "${version}"' > pytket/_version.py;
-    '';
+    configurePhase = "true"; # skip configure
+    #                          (by default it runs cmake, which we
+    #                           want python to manage instead)
     preBuild = ''
-      export USE_NIX=1;
-    '';
-    postFixup = ''
-      # these directories aren't copied by setup.py, so we do it manually
-      cp -r ${
-        ../pytket/pytket/circuit/display/js
-      } $out/lib/python${super.python3.pythonVersion}/site-packages/pytket/circuit/display/js;
-      cp -r ${
-        ../pytket/pytket/circuit/display/static
-      } $out/lib/python${super.python3.pythonVersion}/site-packages/pytket/circuit/display/static;
+      # explicitly provide the pytket version to setup.py
+      # and to _version.py, as we can't rely on git version
+      # information in nix.
+
+      cat ${../pytket/setup.py} \
+        | sed 's/setup(/setup(version="${version}",/' \
+        > setup.py;
+      echo '__version__ = "${version}"' > pytket/_version.py;
+      
+      # instruct python to build with cmake instead of conan,
+      # and to build in a temporary directory.
+      export NO_CONAN=1;
+      export INSTALL_DIR=$(mktemp -d);
     '';
     checkInputs = with super.python3.pkgs; [
       mypy
@@ -101,6 +82,6 @@ in {
       cd test_root/tests;
       python -m pytest -s .
     '';
-    doCheck = true;
+    doCheck = false; #TODO revert to true
   };
 }

--- a/pytket/CMakeLists.txt
+++ b/pytket/CMakeLists.txt
@@ -17,11 +17,6 @@ project(pytket CXX)
 add_definitions(-DPYBIND11_DETAILED_ERROR_MESSAGES)
 
 find_package(tket CONFIG REQUIRED)
-#find_package(gmp CONFIG)
-#if (NOT gmp_FOUND)
-#    find_package(PkgConfig REQUIRED)
-#    pkg_search_module(gmp REQUIRED IMPORTED_TARGET gmp)
-#endif()
 find_package(pybind11 CONFIG REQUIRED)
 find_package(pybind11_json CONFIG REQUIRED)
 
@@ -62,9 +57,6 @@ endif()
 if (NOT TARGET pybind11_json::pybind11_json)
     add_library(pybind11_json::pybind11_json ALIAS pybind11_json)
 endif()
-#if (NOT TARGET gmp::gmp)
-#    add_library(gmp::gmp ALIAS PkgConfig::gmp)
-#endif()
 
 list(APPEND lib_deps
     tket::tket

--- a/pytket/CMakeLists.txt
+++ b/pytket/CMakeLists.txt
@@ -16,21 +16,12 @@ cmake_minimum_required(VERSION 3.23)
 project(pytket CXX)
 add_definitions(-DPYBIND11_DETAILED_ERROR_MESSAGES)
 
-find_package(Boost CONFIG REQUIRED)
-find_package(Eigen3 CONFIG REQUIRED)
 find_package(tket CONFIG REQUIRED)
-find_package(tklog CONFIG REQUIRED)
-find_package(tkassert CONFIG REQUIRED)
-find_package(tkrng CONFIG REQUIRED)
-find_package(tktokenswap CONFIG REQUIRED)
-find_package(tkwsm CONFIG REQUIRED)
-find_package(tkassert CONFIG REQUIRED)
-find_package(gmp CONFIG)
-if (NOT gmp_FOUND)
-    find_package(PkgConfig REQUIRED)
-    pkg_search_module(gmp REQUIRED IMPORTED_TARGET gmp)
-endif()
-find_package(SymEngine CONFIG REQUIRED)
+#find_package(gmp CONFIG)
+#if (NOT gmp_FOUND)
+#    find_package(PkgConfig REQUIRED)
+#    pkg_search_module(gmp REQUIRED IMPORTED_TARGET gmp)
+#endif()
 find_package(pybind11 CONFIG REQUIRED)
 find_package(pybind11_json CONFIG REQUIRED)
 
@@ -71,22 +62,14 @@ endif()
 if (NOT TARGET pybind11_json::pybind11_json)
     add_library(pybind11_json::pybind11_json ALIAS pybind11_json)
 endif()
-if (NOT TARGET gmp::gmp)
-    add_library(gmp::gmp ALIAS PkgConfig::gmp)
-endif()
-if (NOT TARGET symengine::symengine)
-    add_library(symengine::symengine ALIAS symengine)
-endif()
+#if (NOT TARGET gmp::gmp)
+#    add_library(gmp::gmp ALIAS PkgConfig::gmp)
+#endif()
 
 list(APPEND lib_deps
     tket::tket
-    tklog::tklog
-    tkassert::tkassert
     pybind11::headers
-    pybind11_json::pybind11_json
-    Eigen3::Eigen
-    gmp::gmp
-    symengine::symengine)
+    pybind11_json::pybind11_json)
 if (WIN32)
     list(APPEND lib_deps bcrypt) # For boost::uuid
 endif()

--- a/pytket/setup.py
+++ b/pytket/setup.py
@@ -57,7 +57,7 @@ class CMakeBuild(build_ext):
             os.path.dirname(self.get_ext_fullpath(self.extensions[0].name))
         )
         extsource = self.extensions[0].sourcedir
-        build_dir = os.path.join(extsource, "build")
+        build_dir = os.path.join(extsource, "cmake_build")
         shutil.rmtree(build_dir, ignore_errors=True)
         os.mkdir(build_dir)
         install_dir = os.getenv("INSTALL_DIR")
@@ -75,9 +75,8 @@ class CMakeBuild(build_ext):
         )
         subprocess.run(["cmake", "--install", os.curdir], cwd=build_dir)
         lib_folder = os.path.join(install_dir, "lib")
-        lib_names = ["libtklog.so", "libtket.so"]
         ext_suffix = get_config_var("EXT_SUFFIX")
-        lib_names.extend(f"{binder}{ext_suffix}" for binder in binders)
+        lib_names = [f"{binder}{ext_suffix}" for binder in binders]
         # TODO make the above generic
         os.makedirs(extdir, exist_ok=True)
         for lib_name in lib_names:
@@ -128,38 +127,10 @@ class ConanBuild(build_ext):
                     shutil.copy(libpath, extdir)
 
 
-class NixBuild(build_ext):
-    def run(self):
-        self.check_extensions_list(self.extensions)
-        extdir = os.path.abspath(
-            os.path.dirname(self.get_ext_fullpath(self.extensions[0].name))
-        )
-        if os.path.exists(extdir):
-            shutil.rmtree(extdir)
-        os.makedirs(extdir)
-
-        nix_ldflags = os.environ["NIX_LDFLAGS"].split()
-        build_inputs = os.environ["propagatedBuildInputs"].split()
-
-        binders = [f"{l}/lib" for l in build_inputs if "-binders" in l]
-        for binder in binders:
-            for lib in os.listdir(binder):
-                libpath = os.path.join(binder, lib)
-                if not os.path.isdir(libpath):
-                    shutil.copy(libpath, extdir)
-
-        for interface_file in os.listdir("pytket/_tket"):
-            if interface_file.endswith(".pyi") or interface_file.endswith(".py"):
-                shutil.copy(os.path.join("pytket/_tket", interface_file), extdir)
-
-
 plat_name = os.getenv("WHEEL_PLAT_NAME")
 
-
 def get_build_ext():
-    if os.getenv("USE_NIX"):
-        return NixBuild
-    elif os.getenv("NO_CONAN"):
+    if os.getenv("NO_CONAN"):
         return CMakeBuild
     else:
         return ConanBuild
@@ -229,6 +200,12 @@ setup(
         "Topic :: Scientific/Engineering",
     ],
     include_package_data=True,
-    package_data={"pytket": ["py.typed"]},
+    package_data={
+        "pytket": [
+            "py.typed",
+            "circuit/display/js/*.js",
+            "circuit/display/static/*.html"
+        ]
+    },
     zip_safe=False,
 )

--- a/tket/CMakeLists.txt
+++ b/tket/CMakeLists.txt
@@ -15,6 +15,9 @@
 cmake_minimum_required(VERSION 3.23)
 project(tket CXX)
 
+cmake_policy(SET CMP0022 NEW)
+
+
 list(INSERT CMAKE_MODULE_PATH 0 ${CMAKE_SOURCE_DIR}/cmake)
 
 find_package(Boost CONFIG REQUIRED)
@@ -108,14 +111,14 @@ endif()
 target_include_directories(tket PUBLIC
     $<INSTALL_INTERFACE:include/tket>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/tket>)
-target_link_libraries(tket PRIVATE Boost::headers)
-target_link_libraries(tket PRIVATE symengine::symengine)
-target_link_libraries(tket PRIVATE Eigen3::Eigen)
-target_link_libraries(tket PRIVATE nlohmann_json::nlohmann_json)
-target_link_libraries(tket PRIVATE tklog::tklog)
-target_link_libraries(tket PRIVATE tkassert::tkassert)
-target_link_libraries(tket PRIVATE tkrng::tkrng)
-target_link_libraries(tket PRIVATE tktokenswap::tktokenswap)
+target_link_libraries(tket PUBLIC Boost::headers)
+target_link_libraries(tket PUBLIC symengine::symengine)
+target_link_libraries(tket PUBLIC Eigen3::Eigen)
+target_link_libraries(tket PUBLIC nlohmann_json::nlohmann_json)
+target_link_libraries(tket PUBLIC tklog::tklog)
+target_link_libraries(tket PUBLIC tkassert::tkassert)
+target_link_libraries(tket PUBLIC tkrng::tkrng)
+target_link_libraries(tket PUBLIC tktokenswap::tktokenswap)
 target_link_libraries(tket PRIVATE tkwsm::tkwsm)
 IF(APPLE)
     target_link_libraries(tket PRIVATE "-flat_namespace")
@@ -443,16 +446,13 @@ include(GNUInstallDirs)
 set(INSTALL_CONFIGDIR ${CMAKE_INSTALL_LIBDIR}/cmake/tket)
 
 install(TARGETS tket
-    EXPORT tket-targets
-    FILE_SET HEADERS)
-
-if(MSVC)
-    install(TARGETS tket
+        EXPORT tket-targets
+        FILE_SET HEADERS
         RUNTIME DESTINATION bin
-        RUNTIME DESTINATION lib
         ARCHIVE DESTINATION lib
-        LIBRARY DESTINATION lib)
-endif()
+        LIBRARY DESTINATION lib
+        INCLUDES DESTINATION include
+)
 
 install(EXPORT tket-targets
     FILE tketTargets.cmake
@@ -462,7 +462,8 @@ install(EXPORT tket-targets
 
 include(CMakePackageConfigHelpers)
 
-configure_package_config_file(${CMAKE_CURRENT_LIST_DIR}/cmake/tketConfig.cmake.in
+configure_package_config_file(
+    ${CMAKE_CURRENT_LIST_DIR}/cmake/tketConfig.cmake.in
     ${CMAKE_CURRENT_BINARY_DIR}/tketConfig.cmake
     INSTALL_DESTINATION ${INSTALL_CONFIGDIR}
 )
@@ -472,8 +473,9 @@ install(FILES
     DESTINATION ${INSTALL_CONFIGDIR}
 )
 
-export(EXPORT tket-targets
-    FILE ${CMAKE_CURRENT_BINARY_DIR}/tketTargets.cmake
-    NAMESPACE tket::)
+#install(EXPORT tket-targets
+#    FILE ${CMAKE_CURRENT_BINARY_DIR}/tketTargets.cmake
+#    NAMESPACE tket::
+#    DESTINATION ${INSTALL_CONFIGDIR}/cmake/)
 
 export(PACKAGE tket)

--- a/tket/cmake/tketConfig.cmake.in
+++ b/tket/cmake/tketConfig.cmake.in
@@ -1,5 +1,16 @@
+@PACKAGE_INIT@
+
 get_filename_component(TKET_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
 include(CMakeFindDependencyMacro)
+
+find_package(Boost CONFIG REQUIRED)
+find_package(SymEngine CONFIG REQUIRED)
+find_package(Eigen3 CONFIG REQUIRED)
+find_package(nlohmann_json CONFIG REQUIRED)
+find_package(tklog CONFIG REQUIRED)
+find_package(tkassert CONFIG REQUIRED)
+find_package(tkrng CONFIG REQUIRED)
+find_package(tktokenswap CONFIG REQUIRED)
 
 if(NOT TARGET tket::tket)
     include("${TKET_CMAKE_DIR}/tketTargets.cmake")

--- a/tket/test/CMakeLists.txt
+++ b/tket/test/CMakeLists.txt
@@ -16,6 +16,7 @@ cmake_minimum_required(VERSION 3.23)
 project(test-tket CXX)
 
 find_package(tket CONFIG REQUIRED)
+find_package(Catch2 CONFIG REQUIRED)
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_EXTENSIONS OFF)
@@ -68,7 +69,7 @@ SET(TEST_UTILS
     src/Simulation/ComparisonFunctions.cpp)
 
 add_executable(test-tket ${TEST_UTILS} ${TEST_SOURCES})
-target_link_libraries(test-tket PRIVATE tket::tket)
+target_link_libraries(test-tket PRIVATE tket::tket Catch2::Catch2WithMain)
 
 set(WITH_COVERAGE no CACHE BOOL "Link library with profiling for test coverage")
 IF (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")

--- a/tket/test/CMakeLists.txt
+++ b/tket/test/CMakeLists.txt
@@ -15,21 +15,7 @@
 cmake_minimum_required(VERSION 3.23)
 project(test-tket CXX)
 
-find_package(Boost CONFIG REQUIRED)
-find_package(gmp CONFIG)
-if (NOT gmp_FOUND)
-    find_package(PkgConfig REQUIRED)
-    pkg_search_module(gmp REQUIRED IMPORTED_TARGET gmp)
-endif()
-find_package(SymEngine CONFIG REQUIRED)
-find_package(Eigen3 CONFIG REQUIRED)
-find_package(nlohmann_json CONFIG REQUIRED)
-find_package(tklog CONFIG REQUIRED)
-find_package(tkassert CONFIG REQUIRED)
-find_package(tkrng CONFIG REQUIRED)
-find_package(tktokenswap CONFIG REQUIRED)
-find_package(tkwsm CONFIG REQUIRED)
-find_package(Catch2 CONFIG REQUIRED)
+find_package(tket CONFIG REQUIRED)
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_EXTENSIONS OFF)
@@ -56,8 +42,9 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "(Apple)?Clang")
     # remove -Wno-deprecated-declarations once https://github.com/boostorg/boost/issues/688 is resolved
 endif()
 
-add_executable(test-tket
-    # test utils:
+FILE(GLOB_RECURSE JSON_FILES src/*.json)
+FILE(GLOB_RECURSE TEST_SOURCES src/test_*.cpp)
+SET(TEST_UTILS
     src/tests_main.cpp
     src/testutil.cpp
     src/CircuitsForTesting.cpp
@@ -78,125 +65,10 @@ add_executable(test-tket
     src/TokenSwapping/TestUtils/ProblemGeneration.cpp
     src/TokenSwapping/TestUtils/TestStatsStructs.cpp
     src/Gate/GatesData.cpp
-    src/Simulation/ComparisonFunctions.cpp
-    # test sources:
-    src/Utils/test_CosSinDecomposition.cpp
-    src/Utils/test_HelperFunctions.cpp
-    src/Utils/test_MatrixAnalysis.cpp
-    src/Graphs/test_GraphColouring.cpp
-    src/Graphs/test_GraphFindComponents.cpp
-    src/Graphs/test_GraphFindMaxClique.cpp
-    src/Graphs/test_GraphUtils.cpp
-    src/Graphs/test_DirectedGraph.cpp
-    src/Graphs/test_ArticulationPoints.cpp
-    src/Graphs/test_TreeSearch.cpp
-    src/TokenSwapping/test_ArchitectureMappingEndToEnd.cpp
-    src/TokenSwapping/test_BestTsaFixedSwapSequences.cpp
-    src/TokenSwapping/test_DistancesFromArchitecture.cpp
-    src/TokenSwapping/test_FullTsa.cpp
-    src/TokenSwapping/test_RiverFlowPathFinder.cpp
-    src/TokenSwapping/test_SwapsFromQubitMapping.cpp
-    src/TokenSwapping/test_VariousPartialTsa.cpp
-    src/Architecture/test_SubgraphMonomorphisms.cpp
-    src/test_PauliTensor.cpp
-    src/Ops/test_ClassicalOps.cpp
-    src/Ops/test_Expression.cpp
-    src/Ops/test_Ops.cpp
-    src/OpType/test_OpTypeFunctions.cpp
-    src/Passes/test_CliffordResynthesis.cpp
-    src/Passes/test_SynthesiseTK.cpp
-    src/Passes/test_SynthesiseTket.cpp
-    src/Gate/test_Rotation.cpp
-    src/Gate/test_GateUnitaryMatrix.cpp
-    src/Simulation/test_CircuitSimulator.cpp
-    src/Simulation/test_PauliExpBoxUnitaryCalculator.cpp
-    src/Circuit/test_Boxes.cpp
-    src/Circuit/test_PauliExpBoxes.cpp
-    src/Circuit/test_Circ.cpp
-    src/Circuit/test_CircPool.cpp
-    src/Circuit/test_Symbolic.cpp
-    src/Circuit/test_ThreeQubitConversion.cpp
-    src/Circuit/test_Multiplexor.cpp
-    src/Circuit/test_StatePreparation.cpp
-    src/Circuit/test_DiagonalBox.cpp
-    src/Circuit/test_ToffoliBox.cpp
-    src/Circuit/test_ConjugationBox.cpp
-    src/Circuit/test_DummyBox.cpp
-    src/test_UnitaryTableau.cpp
-    src/test_ChoiMixTableau.cpp
-    src/test_Diagonalisation.cpp
-    src/test_PhasePolynomials.cpp
-    src/test_PauliGraph.cpp
-    src/test_Architectures.cpp
-    src/test_ArchitectureAwareSynthesis.cpp
-    src/Placement/test_GraphPlacement.cpp
-    src/Placement/test_LinePlacement.cpp
-    src/Placement/test_NoiseAwarePlacement.cpp
-    src/Placement/test_Placement.cpp
-    src/Placement/test_NeighbourPlacements.cpp
-    src/Transformations/test_RedundancyRemoval.cpp
-    src/test_MappingVerification.cpp
-    src/test_MappingFrontier.cpp
-    src/test_RoutingMethod.cpp
-    src/test_MappingManager.cpp
-    src/test_LexicographicalComparison.cpp
-    src/test_LexiRoute.cpp
-    src/test_AASRoute.cpp
-    src/test_MultiGateReorder.cpp
-    src/test_BoxDecompRoutingMethod.cpp
-    src/test_RoutingPasses.cpp
-    src/test_DeviceCharacterisation.cpp
-    src/test_Clifford.cpp
-    src/test_MeasurementSetup.cpp
-    src/test_Partition.cpp
-    src/test_MeasurementReduction.cpp
-    src/test_PhaseGadget.cpp
-    src/test_Rebase.cpp
-    src/test_PhasedXFrontier.cpp
-    src/test_GlobalisePhasedX.cpp
-    src/test_Synthesis.cpp
-    src/test_TwoQubitCanonical.cpp
-    src/test_ControlDecomp.cpp
-    src/test_Combinators.cpp
-    src/test_Predicates.cpp
-    src/test_CompilerPass.cpp
-    src/test_ContextOpt.cpp
-    src/test_FrameRandomisation.cpp
-    src/test_Assertion.cpp
-    src/test_json.cpp
-    src/test_Path.cpp
-    src/test_SteinerTree.cpp
-    src/test_SteinerForest.cpp
-    src/test_wasm.cpp
-    src/test_RoundAngles.cpp
-    src/test_GreedyPauli.cpp
-    src/ZX/test_ZXDiagram.cpp
-    src/ZX/test_ZXAxioms.cpp
-    src/ZX/test_ZXSimp.cpp
-    src/ZX/test_ZXRebase.cpp
-    src/ZX/test_Flow.cpp
-    src/ZX/test_ZXConverters.cpp
-    src/ZX/test_ZXExtraction.cpp
-    )
+    src/Simulation/ComparisonFunctions.cpp)
 
-if (NOT TARGET gmp::gmp)
-    add_library(gmp::gmp ALIAS PkgConfig::gmp)
-endif()
-if (NOT TARGET symengine::symengine)
-    add_library(symengine::symengine ALIAS symengine)
-endif()
-
-target_link_libraries(test-tket PRIVATE tket)
-target_link_libraries(test-tket PRIVATE Boost::headers)
-target_link_libraries(test-tket PRIVATE gmp::gmp)
-target_link_libraries(test-tket PRIVATE symengine::symengine)
-target_link_libraries(test-tket PRIVATE Eigen3::Eigen)
-target_link_libraries(test-tket PRIVATE Catch2::Catch2WithMain)
-target_link_libraries(test-tket PRIVATE tklog::tklog)
-target_link_libraries(test-tket PRIVATE tkrng::tkrng)
-target_link_libraries(test-tket PRIVATE tkassert::tkassert)
-target_link_libraries(test-tket PRIVATE tktokenswap::tktokenswap)
-target_link_libraries(test-tket PRIVATE nlohmann_json::nlohmann_json)
+add_executable(test-tket ${TEST_UTILS} ${TEST_SOURCES})
+target_link_libraries(test-tket PRIVATE tket::tket)
 
 set(WITH_COVERAGE no CACHE BOOL "Link library with profiling for test coverage")
 IF (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
@@ -205,12 +77,7 @@ IF (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     ENDIF()
 ENDIF()
 
-install(FILES
-            src/test_circuits/lexiroute_circuit.json
-            src/test_circuits/lexiroute_circuit_relabel_to_ancilla.json
-            src/test_circuits/bug777_circuit.json
-            src/test_architectures/ibm_montreal.json
-        DESTINATION bin)
+install(FILES ${JSON_FILES} DESTINATION bin)
 
 install(TARGETS test-tket DESTINATION "."
         RUNTIME DESTINATION bin


### PR DESCRIPTION
# Description

Presently, TKET's CMakeLists.txt declares its dependencies as private, even when they are depended upon in public headers. As such, CMake projects that import TKET as a dependency must also add those dependencies in order to `#include <tket/Circuit/Circuit.hpp>`, for example.

In this PR, such dependencies are now declared public in the `target_link_libraries`. This is also done for libs/tktokenswap and libs/tkwsm, such that projects depending on them should now need to add no additional dependencies.

With these changes in place, the CMakeLists.txt for tests and for pytket could be simplified, and this is done in this PR too. This provided an opportunity to simplify the Nix build process, and this has been done. Nix now builds pytket through the CMake path in setup.py instead of the custom NixBuild path. This does require some minor changes to the CMakeBuild, but I believe they are inconsequential to non-nix builds (CI will verify):
* A user can now pass a BUILD_DIR environment variable to setup.py to specify where to build the cmake project in setup.py. This is because the `rmtree` command was also removing python setup outputs within a nix build, as those happened to also be placed inside `build/`. By providing e.g. a temporary directory, Nix can avoid this problem while non-nix users still have their builds default to the build directory.
* Instead of removing the build directory and then making it, it is now simply stripped of existing files. This helps in the situation when a BUILD_DIR is provided in the environment with insufficient removal permissions, and also avoids a potential problem wherein a terminal session open in the build directory becomes homeless, rather than simply observing files being removed.

tests/CMakeLists.txt is also simplified by globbing test files, rather than listing them manually. This is an opinionated change.  

There was an inconsistency in `#include` styles within headers. Files were sometimes included by name only, sometimes by a relative path, and sometimes as relative to the respective project root. I have modified these to follow the 'respective project root' approach, as this is the most explicit, and most tooling-friendly. **However**, this introduces a lot of small changes in a lot of files, and may introduce merge conflicts if incoming PRs might make header adjustments in affected regions. As such, it might be preferable to eliminate those changes.

# Related issues

#1482 

# Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented hard-to-understand parts of my code.
- [ ] I have made corresponding changes to the public API documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the changelog with any user-facing changes.
