### PR TITLE
using types-setuptools instead

### DIFF
--- a/pytket/setup.py
+++ b/pytket/setup.py
@@ -197,7 +197,7 @@ setup(
         "networkx >= 2.8.8",
         "graphviz >= 0.20.3",
         "jinja2 >= 3.1.4",
-        "types-pkg_resources >= 0.1.3",
+        "types-setuptools",
         "typing-extensions >= 4.12.2",
         "qwasm >= 1.0.1",
     ],


### PR DESCRIPTION
# Description

```
ERROR: Ignored the following yanked versions: 0.1.0, 0.1.1, 0.1.2, 0.1.3
ERROR: Could not find a version that satisfies the requirement types-pkg-resources>=0.1.3 (from pytket) (from versions: none)
ERROR: No matching distribution found for types-pkg-resources>=0.1.3
```

# Related issues

Please mention any github issues addressed by this PR.

# Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have commented hard-to-understand parts of my code.
- [ ] I have made corresponding changes to the public API documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the changelog with any user-facing changes.
