### PR TITLE
docs: cherry-pick navbar fixes to `docmain`

### DIFF
--- a/pytket/docs/_static/nav-config.js
+++ b/pytket/docs/_static/nav-config.js
@@ -1,46 +1,41 @@
-const navConfig = { 
-    
+const navConfig = {
+
     "navTextLinks": [
-    {
-        "title": "API Docs",
-        "href": "../api-docs",
-        "pathMatch": "somewhere",
-    },
-    {
-        "title": "Examples",
-        "href": "../examples",
-        "pathMatch": "somewhere",
-    },
-    {
-        "title": "Blog",
-        "href": "../blog/",
-        "pathMatch": "somewhere",
-    },
-    {
-        "title": "User Manual",
-        "href": "../user-manual",
-        "pathMatch": "somewhere",
-    },
-],
-"navProductName": "TKET",
-"navIconLinks": [
-    {
-        "title": "TKET Github",
-        "href": "https://github.com/CQCL/tket",
-        "pathMatch": "somewhere",
-        "iconImageURL": "_static/assets/github.svg",
-    },
-    {
-        "title": "TKET Slack Channel",
-        "href": "https://tketusers.slack.com/",
-        "pathMatch": "somewhere",
-        "iconImageURL": "_static/assets/slack.svg",
-    },
-    {
-        "title": "TKET Stack Exchange",
-        "href": "https://quantumcomputing.stackexchange.com/questions/tagged/pytket",
-        "pathMatch": "somewhere",
-        "iconImageURL": "_static/assets/stack.svg",
-    },
-],
+        {
+            "title": "API Docs",
+            "href": "../../api-docs",
+            "pathMatch": "somewhere",
+        },
+        {
+            "title": "Blog",
+            "href": "../../blog/",
+            "pathMatch": "somewhere",
+        },
+        {
+            "title": "User Guide",
+            "href": "../../user-guide",
+            "pathMatch": "somewhere",
+        },
+    ],
+    "navProductName": "TKET",
+    "navIconLinks": [
+        {
+            "title": "TKET Github",
+            "href": "https://github.com/CQCL/tket",
+            "pathMatch": "somewhere",
+            "iconImageURL": "/_static/assets/github.svg",
+        },
+        {
+            "title": "TKET Slack Channel",
+            "href": "https://tketusers.slack.com/",
+            "pathMatch": "somewhere",
+            "iconImageURL": "/_static/assets/slack.svg",
+        },
+        {
+            "title": "TKET Stack Exchange",
+            "href": "https://quantumcomputing.stackexchange.com/questions/tagged/pytket",
+            "pathMatch": "somewhere",
+            "iconImageURL": "/_static/assets/stack.svg",
+        },
+    ],
 }

--- a/pytket/docs/conf.py
+++ b/pytket/docs/conf.py
@@ -96,6 +96,9 @@ html_static_path = ["./quantinuum-sphinx/_static/", "_static/"]
 # documentation.
 #
 
+
+exclude_patterns = ["build/jupyter_execute/*", ".venv/*"]
+
 html_theme_options = {}
 
 # Custom sidebar templates, must be a dictionary that maps document names


### PR DESCRIPTION
# Description

cherry-picking the commit from https://github.com/CQCL/tket/pull/1523 onto `docmain` so it will be cloned by the website.

Would be good to retire the `docmain` branch soon.
