### PR TITLE
fix: correct navbar links to work on subpath

### DIFF
--- a/pytket/docs/_static/nav-config.js
+++ b/pytket/docs/_static/nav-config.js
@@ -3,17 +3,17 @@ const navConfig = {
     "navTextLinks": [
         {
             "title": "API Docs",
-            "href": "../../api-docs",
+            "href": "../api-docs",
             "pathMatch": "somewhere",
         },
         {
             "title": "Blog",
-            "href": "../../blog/",
+            "href": "../blog/",
             "pathMatch": "somewhere",
         },
         {
             "title": "User Guide",
-            "href": "../../user-guide",
+            "href": "../user-guide",
             "pathMatch": "somewhere",
         },
     ],
@@ -23,19 +23,19 @@ const navConfig = {
             "title": "TKET Github",
             "href": "https://github.com/CQCL/tket",
             "pathMatch": "somewhere",
-            "iconImageURL": "/_static/assets/github.svg",
+            "iconImageURL": "_static/assets/github.svg",
         },
         {
             "title": "TKET Slack Channel",
             "href": "https://tketusers.slack.com/",
             "pathMatch": "somewhere",
-            "iconImageURL": "/_static/assets/slack.svg",
+            "iconImageURL": "_static/assets/slack.svg",
         },
         {
             "title": "TKET Stack Exchange",
             "href": "https://quantumcomputing.stackexchange.com/questions/tagged/pytket",
             "pathMatch": "somewhere",
-            "iconImageURL": "/_static/assets/stack.svg",
+            "iconImageURL": "_static/assets/stack.svg",
         },
     ],
 }


### PR DESCRIPTION
Should enable the links to work on both `tket.quantinuum.com` and `docs.quantinuum.com/tket`
