### PR TITLE
Fix symbol substitution for classical operations

### DIFF
--- a/pytket/conanfile.py
+++ b/pytket/conanfile.py
@@ -32,7 +32,7 @@ class pytketRecipe(ConanFile):
         cmake.install()
 
     def requirements(self):
-        self.requires("tket/1.3.17@tket/stable")
+        self.requires("tket/1.3.18@tket/stable")
         self.requires("tklog/0.3.3@tket/stable")
         self.requires("tkrng/0.3.3@tket/stable")
         self.requires("tkassert/0.3.4@tket/stable")

--- a/pytket/docs/changelog.rst
+++ b/pytket/docs/changelog.rst
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+Unreleased
+----------
+
+* Fix symbol substitution for classical operations.
+
+
 1.31.1 (August 2024)
 --------------------
 

--- a/pytket/tests/classical_test.py
+++ b/pytket/tests/classical_test.py
@@ -72,6 +72,8 @@ from pytket.circuit.named_types import RenameUnitsMap
 
 from pytket.passes import DecomposeClassicalExp, FlattenRegisters
 
+from sympy import Symbol
+
 from strategies import reg_name_regex, binary_digits, uint32, uint64  # type: ignore
 
 curr_file_path = Path(__file__).resolve().parent
@@ -1479,6 +1481,15 @@ def test_box_equality_check() -> None:
     assert ceb1 != ceb2
     assert ceb1 == ceb1
     assert ceb1 == ClassicalExpBox(2, 0, 1, exp1)
+
+
+def test_sym_sub_range_pred() -> None:
+    c = Circuit(1, 2)
+    c.H(0, condition=reg_eq(BitRegister("c", 2), 3))
+    c1 = c.copy()
+    c.symbol_substitution({Symbol("a"): 0.5})
+
+    assert c == c1
 
 
 if __name__ == "__main__":

--- a/tket/conanfile.py
+++ b/tket/conanfile.py
@@ -23,7 +23,7 @@ from conan.errors import ConanInvalidConfiguration
 
 class TketConan(ConanFile):
     name = "tket"
-    version = "1.3.17"
+    version = "1.3.18"
     package_type = "library"
     license = "Apache 2"
     homepage = "https://github.com/CQCL/tket"

--- a/tket/include/tket/Ops/ClassicalOps.hpp
+++ b/tket/include/tket/Ops/ClassicalOps.hpp
@@ -22,6 +22,7 @@
 #include <memory>
 
 #include "Op.hpp"
+#include "OpPtr.hpp"
 #include "tket/Utils/Json.hpp"
 
 namespace tket {
@@ -47,11 +48,6 @@ class ClassicalOp : public Op {
       OpType type, unsigned n_i, unsigned n_io, unsigned n_o,
       const std::string &name = "");
 
-  // Trivial overrides
-  Op_ptr symbol_substitution(
-      const SymEngine::map_basic_basic &) const override {
-    return std::make_shared<ClassicalOp>(*this);
-  }
   SymSet free_symbols() const override { return {}; }
   unsigned n_qubits() const override { return 0; }
 
@@ -141,6 +137,11 @@ class ClassicalTransformOp : public ClassicalEvalOp {
       unsigned n, const std::vector<uint64_t> &values,
       const std::string &name = "ClassicalTransform");
 
+  Op_ptr symbol_substitution(
+      const SymEngine::map_basic_basic &) const override {
+    return std::make_shared<ClassicalTransformOp>(*this);
+  }
+
   std::vector<bool> eval(const std::vector<bool> &x) const override;
 
   std::vector<uint64_t> get_values() const { return values_; }
@@ -170,6 +171,11 @@ class WASMOp : public ClassicalOp {
       unsigned _n, unsigned _ww_n, std::vector<unsigned> _width_i_parameter,
       std::vector<unsigned> _width_o_parameter, const std::string &_func_name,
       const std::string &_wasm_uid);
+
+  Op_ptr symbol_substitution(
+      const SymEngine::map_basic_basic &) const override {
+    return std::make_shared<WASMOp>(*this);
+  }
 
   /**
    * return if the op is external
@@ -284,6 +290,11 @@ class SetBitsOp : public ClassicalEvalOp {
       : ClassicalEvalOp(OpType::SetBits, 0, 0, values.size(), "SetBits"),
         values_(values) {}
 
+  Op_ptr symbol_substitution(
+      const SymEngine::map_basic_basic &) const override {
+    return std::make_shared<SetBitsOp>(*this);
+  }
+
   std::string get_name(bool latex) const override;
 
   std::vector<bool> get_values() const { return values_; }
@@ -303,6 +314,11 @@ class CopyBitsOp : public ClassicalEvalOp {
  public:
   explicit CopyBitsOp(unsigned n)
       : ClassicalEvalOp(OpType::CopyBits, n, 0, n, "CopyBits") {}
+
+  Op_ptr symbol_substitution(
+      const SymEngine::map_basic_basic &) const override {
+    return std::make_shared<CopyBitsOp>(*this);
+  }
 
   std::vector<bool> eval(const std::vector<bool> &x) const override;
 };
@@ -345,6 +361,11 @@ class RangePredicateOp : public PredicateOp {
       uint64_t b = std::numeric_limits<uint64_t>::max())
       : PredicateOp(OpType::RangePredicate, n, "RangePredicate"), a(a), b(b) {}
 
+  Op_ptr symbol_substitution(
+      const SymEngine::map_basic_basic &) const override {
+    return std::make_shared<RangePredicateOp>(*this);
+  }
+
   std::string get_name(bool latex) const override;
 
   uint64_t upper() const { return b; }
@@ -383,6 +404,11 @@ class ExplicitPredicateOp : public PredicateOp {
   ExplicitPredicateOp(
       unsigned n, const std::vector<bool> &values,
       const std::string &name = "ExplicitPredicate");
+
+  Op_ptr symbol_substitution(
+      const SymEngine::map_basic_basic &) const override {
+    return std::make_shared<ExplicitPredicateOp>(*this);
+  }
 
   std::vector<bool> eval(const std::vector<bool> &x) const override;
 
@@ -430,6 +456,11 @@ class ExplicitModifierOp : public ModifyingOp {
       unsigned n, const std::vector<bool> &values,
       const std::string &name = "ExplicitModifier");
 
+  Op_ptr symbol_substitution(
+      const SymEngine::map_basic_basic &) const override {
+    return std::make_shared<ExplicitModifierOp>(*this);
+  }
+
   std::vector<bool> eval(const std::vector<bool> &x) const override;
 
   std::vector<bool> get_values() const { return values_; }
@@ -447,6 +478,11 @@ class ExplicitModifierOp : public ModifyingOp {
 class MultiBitOp : public ClassicalEvalOp {
  public:
   MultiBitOp(std::shared_ptr<const ClassicalEvalOp> op, unsigned n);
+
+  Op_ptr symbol_substitution(
+      const SymEngine::map_basic_basic &) const override {
+    return std::make_shared<MultiBitOp>(*this);
+  }
 
   std::string get_name(bool latex) const override;
 

--- a/tket/test/src/Circuit/test_Symbolic.cpp
+++ b/tket/test/src/Circuit/test_Symbolic.cpp
@@ -14,6 +14,7 @@
 
 #include <catch2/catch_test_macros.hpp>
 #include <tket/Circuit/Circuit.hpp>
+#include <tket/Ops/ClassicalOps.hpp>
 #include <tket/Transformations/BasicOptimisation.hpp>
 #include <tket/Transformations/CliffordOptimisation.hpp>
 #include <tket/Transformations/OptimisationPass.hpp>
@@ -257,6 +258,29 @@ SCENARIO("Symbolic GPI, GPI2, AAMS") {
       }
     }
   }
+}
+
+SCENARIO("Symbolic substitution for classical operations") {
+  std::vector<uint64_t> and_table = {0, 1, 2, 7, 0, 1, 2, 7};
+  std::shared_ptr<ClassicalTransformOp> and_ttop =
+      std::make_shared<ClassicalTransformOp>(3, and_table);
+  std::shared_ptr<RangePredicateOp> rpop =
+      std::make_shared<RangePredicateOp>(3, 2, 6);
+  Circuit circ(1, 4);
+  circ.add_op<unsigned>(OpType::H, {0});
+  circ.add_op<unsigned>(and_ttop, {0, 1, 2});
+  circ.add_op<unsigned>(and_ttop, {1, 2, 3});
+  circ.add_op<unsigned>(rpop, {0, 1, 2, 3});
+  circ.add_op<unsigned>(AndOp(), {2, 3, 0});
+  circ.add_op<unsigned>(OrOp(), {0, 1, 2});
+  circ.add_op<unsigned>(NotOp(), {2, 3});
+  circ.add_op<unsigned>(ClassicalX(), {1});
+  circ.add_op<unsigned>(ClassicalCX(), {0, 1});
+  circ.add_op<unsigned>(AndWithOp(), {2, 3});
+  Circuit circ1(circ);
+  symbol_map_t symmap;
+  circ1.symbol_substitution(symmap);
+  REQUIRE(circ == circ1);
 }
 
 }  // namespace test_Symbolic


### PR DESCRIPTION
# Description

The method, although trivial in all cases, needs to be defined on all the derived classes of `ClassicalOp`, in order to preserve the type information.

# Related issues

Fixes #1536 .

# Checklist

- [x] I have performed a self-review of my code.
- [ ] I have commented hard-to-understand parts of my code.
- [ ] I have made corresponding changes to the public API documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have updated the changelog with any user-facing changes.
