### PR TITLE
Update `docmain` with link to pytket-azure docs

### DIFF
--- a/pytket/docs/extensions.rst
+++ b/pytket/docs/extensions.rst
@@ -121,6 +121,7 @@ Other
    :maxdepth: 0
 
    pytket-aqt <https://cqcl.github.io/pytket-aqt/api/index.html>
+   pytket-azure <https://tket.quantinuum.com/extensions/pytket-azure>
    pytket-braket <https://tket.quantinuum.com/extensions/pytket-braket>
    pytket-cirq <https://tket.quantinuum.com/extensions/pytket-cirq>
    pytket-iqm <https://tket.quantinuum.com/extensions/pytket-iqm>


### PR DESCRIPTION
# Description

Cherry picking the commit from #1540 to make sure the link to the pytket-azure docs is visible
