### PR TITLE
Fix order of `lower` and `upper` in constructing `RangePredicateOp`

### DIFF
--- a/pytket/binders/circuit/classical.cpp
+++ b/pytket/binders/circuit/classical.cpp
@@ -123,12 +123,12 @@ void init_classical(py::module& m) {
       "A predicate defined by a range of values in binary encoding.")
       .def(
           py::init<unsigned, _tket_uint_t, _tket_uint_t>(),
-          "Construct from a bit width, an upper bound and a lower bound.",
-          py::arg("width"), py::arg("upper"), py::arg("lower"))
+          "Construct from a bit width, a lower bound and an upper bound.",
+          py::arg("width"), py::arg("lower"), py::arg("upper"))
       .def_property_readonly(
-          "upper", &RangePredicateOp::upper, "Inclusive upper bound.")
+          "lower", &RangePredicateOp::lower, "Inclusive lower bound.")
       .def_property_readonly(
-          "lower", &RangePredicateOp::lower, "Inclusive lower bound.");
+          "upper", &RangePredicateOp::upper, "Inclusive upper bound.");
   py::class_<
       ClassicalExpBox<py::tket_custom::LogicExpression>,
       std::shared_ptr<ClassicalExpBox<py::tket_custom::LogicExpression>>, Op>(

--- a/pytket/docs/changelog.rst
+++ b/pytket/docs/changelog.rst
@@ -6,6 +6,7 @@ Unreleased
 
 * Fix symbol substitution for classical operations.
 * Fix incorrect QASM conversion of conditional multi-line ops.
+* Fix incorrect order of `lower` and `upper` properties of `RangePredicateOp`.
 
 
 1.31.1 (August 2024)

--- a/pytket/pytket/_tket/circuit.pyi
+++ b/pytket/pytket/_tket/circuit.pyi
@@ -3636,9 +3636,9 @@ class RangePredicateOp(ClassicalEvalOp):
     """
     A predicate defined by a range of values in binary encoding.
     """
-    def __init__(self, width: int, upper: int, lower: int) -> None:
+    def __init__(self, width: int, lower: int, upper: int) -> None:
         """
-        Construct from a bit width, an upper bound and a lower bound.
+        Construct from a bit width, a lower bound and an upper bound.
         """
     @property
     def lower(self) -> int:

--- a/pytket/tests/classical_test.py
+++ b/pytket/tests/classical_test.py
@@ -1287,6 +1287,12 @@ def test_classical_ops() -> None:
     assert ceb.get_exp() == op2.get_exp()
 
 
+def test_range_predicate_properties() -> None:
+    range_predicate = RangePredicateOp(width=8, lower=3, upper=5)
+    assert range_predicate.lower == 3
+    assert range_predicate.upper == 5
+
+
 def test_add_expbox_bug() -> None:
     # previously a bug where if IO args weren't
     # at the back of the input iterator, the op signature


### PR DESCRIPTION
Previously if you constructed a `RangePredicateOp` from Python with named arguments they were interpreted in the wrong order.