### PR TITLE
fix: Add copy implementations for Unit IDs

### DIFF
--- a/pytket/binders/unitid.cpp
+++ b/pytket/binders/unitid.cpp
@@ -119,6 +119,10 @@ PYBIND11_MODULE(unit_id, m) {
           "``UnitType.bit``");
 
   py::class_<Qubit, UnitID>(m, "Qubit", "A handle to a qubit")
+      .def("__copy__", [](const Qubit &id) { return Qubit(id); })
+      .def(
+          "__deepcopy__",
+          [](const Qubit &id, const py::dict &) { return Qubit(id); })
       .def(
           py::init<unsigned>(),
           "Constructs an id for some index in the default qubit "
@@ -172,6 +176,10 @@ PYBIND11_MODULE(unit_id, m) {
           "list representation of the Qubit.");
 
   py::class_<Bit, UnitID>(m, "Bit", "A handle to a bit")
+      .def("__copy__", [](const Bit &id) { return Bit(id); })
+      .def(
+          "__deepcopy__",
+          [](const Bit &id, const py::dict &) { return Bit(id); })
       .def(
           py::init<unsigned>(),
           "Constructs an id for some index in the default classical "
@@ -226,6 +234,10 @@ PYBIND11_MODULE(unit_id, m) {
           "list representation of the Bit.");
 
   py::class_<Node, Qubit>(m, "Node", "A handle to a device node")
+      .def("__copy__", [](const Node &id) { return Node(id); })
+      .def(
+          "__deepcopy__",
+          [](const Node &id, const py::dict &) { return Node(id); })
       .def(
           py::init<unsigned>(),
           "Constructs an id for some index in the default physical "

--- a/pytket/tests/unit_id/copy_test.py
+++ b/pytket/tests/unit_id/copy_test.py
@@ -1,0 +1,49 @@
+# Copyright 2019-2024 Cambridge Quantum Computing
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from copy import copy, deepcopy
+
+from pytket.unit_id import Bit, Qubit, Node
+
+
+def test_copying_qubits():
+    q = Qubit(0)
+
+    q1 = copy(q)
+    q2 = deepcopy(q)
+
+    assert type(q) is Qubit
+    assert type(q1) is Qubit
+    assert type(q2) is Qubit
+
+
+def test_copying_bits():
+    b = Bit(0)
+
+    b1 = copy(b)
+    b2 = deepcopy(b)
+
+    assert type(b) is Qubit
+    assert type(b1) is Qubit
+    assert type(b2) is Qubit
+
+
+def test_copying_nodes():
+    n = Node(0)
+
+    n1 = copy(n)
+    n2 = deepcopy(n)
+
+    assert type(n) is Node
+    assert type(n1) is Node
+    assert type(n2) is Node


### PR DESCRIPTION
Prevent a bug where the wrong instance would be returned when copying or deep copying some of the unit id classes.

# Description

Please summarise the changes.

# Related issues

Please mention any github issues addressed by this PR.

# Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have commented hard-to-understand parts of my code.
- [ ] I have made corresponding changes to the public API documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the changelog with any user-facing changes.
