### PR TITLE
Multi circuit display

### DIFF
--- a/pytket/docs/changelog.rst
+++ b/pytket/docs/changelog.rst
@@ -16,6 +16,8 @@ Features:
 * Fix symbol substitution for classical operations.
 * Fix incorrect QASM conversion of conditional multi-line ops.
 * Fix incorrect order of `lower` and `upper` properties of `RangePredicateOp`.
+* Add support for rendering multiple circuits at once.
+* Add option to save circuit renderer options to pytket config.
 
 
 1.31.1 (August 2024)

--- a/pytket/docs/display.rst
+++ b/pytket/docs/display.rst
@@ -33,8 +33,8 @@ Example usage:
 
     circuit_renderer.render_circuit_jupyter(circ) # Render interactive display
 
-If you are happy with the default render options, you can import the render
-functions directly:
+You can save the render options to the pytket config via ``circuit_renderer.save_render_options()``.
+You can then import the render functions directly with your config already applied:
 
 .. jupyter-execute::
 
@@ -44,7 +44,7 @@ functions directly:
         circ = Circuit(2,2) # Define Circuit
         circ.H(0).H(1).CX(0, 1).Rz(0.4, 1).CX(0, 1).H(0).H(1).measure_all()
 
-        render_circuit_jupyter(circ) # Render with default options
+        render_circuit_jupyter(circ) # Render with default/saved options
 
 This same diagram can be rendered with the offline renderer as follows
  

--- a/pytket/pytket/circuit/display/__init__.py
+++ b/pytket/pytket/circuit/display/__init__.py
@@ -132,9 +132,9 @@ class CircuitDisplayConfig(PytketExtConfig):
     @classmethod
     def from_extension_dict(cls, ext_dict: Dict[str, Any]) -> "CircuitDisplayConfig":
         return CircuitDisplayConfig(
-            min_height=ext_dict["min_height"] if "min_height" in ext_dict else None,
-            min_width=ext_dict["min_width"] if "min_width" in ext_dict else None,
-            orient=ext_dict["orient"] if "orient" in ext_dict else None,
+            min_height=ext_dict.get("min_height"),
+            min_width=ext_dict.get("min_width"),
+            orient=ext_dict.get("orient"),
             render_options=RenderOptions(
                 **(ext_dict["render_options"] if "render_options" in ext_dict else {})
             ),

--- a/pytket/pytket/circuit/display/__init__.py
+++ b/pytket/pytket/circuit/display/__init__.py
@@ -21,7 +21,7 @@ import time
 import uuid
 import webbrowser
 from dataclasses import dataclass, field
-from typing import List, Dict, Optional, Union, Literal, cast, Any
+from typing import Literal, cast, Any
 
 from jinja2 import Environment, PrefixLoader, FileSystemLoader, nodes
 from jinja2.ext import Extension
@@ -67,25 +67,21 @@ loader = PrefixLoader(
 
 jinja_env = Environment(loader=loader, extensions=[IncludeRawExtension])
 
-RenderCircuit = Union[Dict[str, Union[str, float, dict]], Circuit]
+RenderCircuit = dict[str, str | float | dict] | Circuit
 Orientation = Literal["row"] | Literal["column"]
 
 
 @dataclass(kw_only=True)
 class RenderOptions:
-    zx_style: Optional[bool] = None  # display zx style gates where possible.
-    condense_c_bits: Optional[bool] = (
-        None  # collapse classical bits into a single wire.
-    )
-    recursive: Optional[bool] = None  # display nested circuits inline.
-    condensed: Optional[bool] = None  # display circuit on one line only.
-    dark_theme: Optional[bool] = None  # use dark mode.
-    system_theme: Optional[bool] = (
-        None  # use the system theme mode (overrides dark mode).
-    )
-    transparent_bg: Optional[bool] = None  # transparent circuit background.
-    crop_params: Optional[bool] = None  # shorten parameter expressions for display.
-    interpret_math: Optional[bool] = (
+    zx_style: bool | None = None  # display zx style gates where possible.
+    condense_c_bits: bool | None = None  # collapse classical bits into a single wire.
+    recursive: bool | None = None  # display nested circuits inline.
+    condensed: bool | None = None  # display circuit on one line only.
+    dark_theme: bool | None = None  # use dark mode.
+    system_theme: bool | None = None  # use the system theme mode (overrides dark mode).
+    transparent_bg: bool | None = None  # transparent circuit background.
+    crop_params: bool | None = None  # shorten parameter expressions for display.
+    interpret_math: bool | None = (
         None  # try to display parameters and box names as math.
     )
 
@@ -104,7 +100,7 @@ class RenderOptions:
 
     def get_render_options(
         self, full: bool = False, _for_js: bool = False
-    ) -> Dict[str, bool]:
+    ) -> dict[str, bool]:
         """
         Get a dict of the current render options.
 
@@ -130,10 +126,10 @@ class CircuitDisplayConfig(PytketExtConfig):
     render_options: RenderOptions = field(default_factory=RenderOptions)
 
     @classmethod
-    def from_extension_dict(cls, ext_dict: Dict[str, Any]) -> "CircuitDisplayConfig":
+    def from_extension_dict(cls, ext_dict: dict[str, Any]) -> "CircuitDisplayConfig":
         return CircuitDisplayConfig(
-            min_height=ext_dict.get("min_height"),
-            min_width=ext_dict.get("min_width"),
+            min_height=str(ext_dict.get("min_height")),
+            min_width=str(ext_dict.get("min_width")),
             orient=ext_dict.get("orient"),
             render_options=RenderOptions(
                 **(ext_dict["render_options"] if "render_options" in ext_dict else {})
@@ -150,7 +146,7 @@ class CircuitRenderer:
         self.env = env
         self.config = config
 
-    def set_render_options(self, **kwargs: Union[bool, str]) -> None:
+    def set_render_options(self, **kwargs: bool | str) -> None:
         """
         Set rendering defaults.
 
@@ -177,7 +173,7 @@ class CircuitRenderer:
 
     def get_render_options(
         self, full: bool = False, _for_js: bool = False
-    ) -> Dict[str, bool]:
+    ) -> dict[str, bool]:
         """
         Get a dict of the current render options.
 
@@ -193,18 +189,19 @@ class CircuitRenderer:
 
     def render_circuit_as_html(
         self,
-        circuit: RenderCircuit | List[RenderCircuit],
+        circuit: RenderCircuit | list[RenderCircuit],
         jupyter: bool = False,
         orient: Orientation | None = None,
-    ) -> Optional[str]:
+    ) -> str | None:
         """
         Render a circuit as HTML for inline display.
 
         :param circuit: the circuit(s) to render.
         :param jupyter: set to true to render generated HTML in cell output.
         :param orient: the direction in which to stack circuits if multiple are present.
+            One of 'row' or 'column'.
         """
-        circuit_dict: dict | List[dict]
+        circuit_dict: dict | list[dict]
         if isinstance(circuit, list):
             circuit_dict = [
                 (
@@ -248,7 +245,7 @@ class CircuitRenderer:
 
     def render_circuit_jupyter(
         self,
-        circuit: RenderCircuit | List[RenderCircuit],
+        circuit: RenderCircuit | list[RenderCircuit],
         orient: Orientation | None = None,
     ) -> None:
         """Render a circuit as jupyter cell output.
@@ -260,7 +257,7 @@ class CircuitRenderer:
 
     def view_browser(
         self,
-        circuit: RenderCircuit | List[RenderCircuit],
+        circuit: RenderCircuit | list[RenderCircuit],
         browser_new: int = 2,
         sleep: int = 5,
     ) -> None:

--- a/pytket/pytket/circuit/display/__init__.py
+++ b/pytket/pytket/circuit/display/__init__.py
@@ -268,7 +268,7 @@ class CircuitRenderer:
 
         Waits for some time for browser to load then deletes tempfile.
 
-        :param circuit: the Circuit or serialized Circuit to render.
+        :param circuit: the Circuit(s) or serialized Circuit(s) to render.
             Either a single circuit or a list of circuits to compare.
         :param browser_new: ``new`` parameter to ``webbrowser.open``, default 2.
         :param sleep: Number of seconds to sleep before deleting file, default 5.

--- a/pytket/pytket/circuit/display/static/circuit.html
+++ b/pytket/pytket/circuit/display/static/circuit.html
@@ -1,6 +1,6 @@
 
 
-{% macro show_circuit_page(display_options, circuit_json, uid, min_width, min_height) %}
+{% macro show_circuit_page(display_options, circuit_json, uid, min_width, min_height, view_format) %}
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -19,7 +19,6 @@
     max-width:100%;
     max-height:100%;">
 {% endif %}
-
     <div id="circuit-display-vue-container-{{uid}}" class="pytket-circuit-display-container">
         <div style="display: none">
             <div id="circuit-json-to-display">{{ circuit_json }}</div>
@@ -27,6 +26,7 @@
         <circuit-display-container
                 :circuit-element-str="'#circuit-json-to-display'"
                 :init-render-options="initRenderOptions"
+                view-format="{{view_format}}"
         ></circuit-display-container>
     </div>
     <script type="application/javascript">
@@ -47,13 +47,13 @@
 {% if jupyter %}
 
 <div style="resize: vertical; overflow: auto; height: {{ min_height }}; display: block">
-    <iframe srcdoc="{{ show_circuit_page(display_options, circuit_json, uid)|escape }}"
+    <iframe srcdoc="{{ show_circuit_page(display_options, circuit_json, uid, min_width, min_height, view_format)|escape }}"
             width="100%" height="100%"
             style="border: none; outline: none; overflow: auto"></iframe>
 </div>
 
 {% else %}
 
-{{ show_circuit_page(display_options, circuit_json, uid, min_width, min_height) }}
+{{ show_circuit_page(display_options, circuit_json, uid, min_width, min_height, view_format) }}
 
 {% endif %}

--- a/pytket/pytket/circuit/display/static/head_imports.html
+++ b/pytket/pytket/circuit/display/static/head_imports.html
@@ -1,5 +1,5 @@
 <!-- Download Vue 3-->
 <script type="application/javascript" src="https://cdn.jsdelivr.net/npm/vue@3"></script>
 <!-- Download Circuit Renderer with styles -->
-<script type="application/javascript" src="https://unpkg.com/pytket-circuit-renderer@0.9/dist/pytket-circuit-renderer.umd.js"></script>
-<link rel="stylesheet" href="https://unpkg.com/pytket-circuit-renderer@0.9/dist/pytket-circuit-renderer.css">
+<script type="application/javascript" src="https://unpkg.com/pytket-circuit-renderer@0.10/dist/pytket-circuit-renderer.umd.js"></script>
+<link rel="stylesheet" href="https://unpkg.com/pytket-circuit-renderer@0.10/dist/pytket-circuit-renderer.css">

--- a/pytket/tests/circuit_test.py
+++ b/pytket/tests/circuit_test.py
@@ -932,6 +932,17 @@ def test_circuit_display(circuit: Circuit) -> None:
 
 @given(st.circuits())
 @settings(deadline=None)
+def test_circuit_display_multiple(circuit: Circuit) -> None:
+    html_str_circ = render_circuit_as_html([circuit, circuit], jupyter=False)
+    html_str_dict = render_circuit_as_html(
+        [circuit.to_dict(), circuit.to_dict()], jupyter=False
+    )
+    assert isinstance(html_str_circ, str)
+    assert isinstance(html_str_dict, str)
+
+
+@given(st.circuits())
+@settings(deadline=None)
 def test_circuit_display_with_options(circuit: Circuit) -> None:
     circuit_renderer = get_circuit_renderer()
     circuit_renderer.set_render_options(zx_style=False)


### PR DESCRIPTION
# Description

- Update circuit renderer link to use v0.10 (includes support for displaying multiple circuits next to each other.)
- Refactor display class to allow saving and loading render options from the pytket config

# Related issues

[Save render options to config](https://github.com/CQCL/pytket-circuit-renderer/issues/44)

# Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented hard-to-understand parts of my code.
- [x] I have made corresponding changes to the public API documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have updated the changelog with any user-facing changes.
