### PR TITLE
Run valgrind on ubuntu-24.04

### DIFF
--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -69,10 +69,10 @@ jobs:
         mkdir -p ~/texmf/tex/latex
         wget http://mirrors.ctan.org/graphics/pgf/contrib/quantikz/tikzlibraryquantikz.code.tex -P ~/texmf/tex/latex
         PKGPATH=`./rootpath tket.json tket`
-        cd ${PKGPATH}/bin && valgrind --error-exitcode=1 ./test-tket [long],~[long]
+        cd ${PKGPATH}/bin && valgrind --error-exitcode=1 --show-realloc-size-zero=no ./test-tket [long],~[long]
     - name: Run tests under valgrind (basic)
       if: github.event_name != 'schedule'
       run: |
         PKGPATH=`./rootpath tket.json tket`
-        cd ${PKGPATH}/bin && valgrind --error-exitcode=1 ./test-tket
+        cd ${PKGPATH}/bin && valgrind --error-exitcode=1 --show-realloc-size-zero=no ./test-tket
 

--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -28,7 +28,7 @@ jobs:
             - 'tket/**'
             - '.github/workflows/valgrind.yml'
   check:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: changes
     if: needs.changes.outputs.tket == 'true'
     steps:

--- a/pytket/conanfile.py
+++ b/pytket/conanfile.py
@@ -32,7 +32,7 @@ class pytketRecipe(ConanFile):
         cmake.install()
 
     def requirements(self):
-        self.requires("tket/1.3.20@tket/stable")
+        self.requires("tket/1.3.21@tket/stable")
         self.requires("tklog/0.3.3@tket/stable")
         self.requires("tkrng/0.3.3@tket/stable")
         self.requires("tkassert/0.3.4@tket/stable")

--- a/tket/conanfile.py
+++ b/tket/conanfile.py
@@ -23,7 +23,7 @@ from conan.errors import ConanInvalidConfiguration
 
 class TketConan(ConanFile):
     name = "tket"
-    version = "1.3.20"
+    version = "1.3.21"
     package_type = "library"
     license = "Apache 2"
     homepage = "https://github.com/CQCL/tket"

--- a/tket/test/src/Placement/test_NoiseAwarePlacement.cpp
+++ b/tket/test/src/Placement/test_NoiseAwarePlacement.cpp
@@ -352,7 +352,9 @@ SCENARIO("Base NoiseAwarePlacement class") {
     circuit.add_op<unsigned>(OpType::CX, {4, 3});
     circuit.add_op<unsigned>(OpType::CX, {0, 5});
 
-    NoiseAwarePlacement placement(architecture);
+    NoiseAwarePlacement placement(
+        architecture, std::nullopt, std::nullopt, std::nullopt, 2000,
+        1000 /*increase default timeout*/);
     // note we allow for more matches than should be returned
     // as noise aware placement returns equal best weighted results
     // as it does additional cost with device characteristics


### PR DESCRIPTION
Fixes #1402 .

Using the version of valgrind installed by default on ubuntu-24.04 we have to ignore "realloc() of size 0" warnings. It's not clear where these come from, but probably eigen.