### PR TITLE
Remove unused "include" directives and "using" statements

### DIFF
--- a/pytket/conanfile.py
+++ b/pytket/conanfile.py
@@ -32,7 +32,7 @@ class pytketRecipe(ConanFile):
         cmake.install()
 
     def requirements(self):
-        self.requires("tket/1.3.23@tket/stable")
+        self.requires("tket/1.3.24@tket/stable")
         self.requires("tklog/0.3.3@tket/stable")
         self.requires("tkrng/0.3.3@tket/stable")
         self.requires("tkassert/0.3.4@tket/stable")

--- a/tket/conanfile.py
+++ b/tket/conanfile.py
@@ -23,7 +23,7 @@ from conan.errors import ConanInvalidConfiguration
 
 class TketConan(ConanFile):
     name = "tket"
-    version = "1.3.23"
+    version = "1.3.24"
     package_type = "library"
     license = "Apache 2"
     homepage = "https://github.com/CQCL/tket"

--- a/tket/proptest/src/ComparisonFunctions.cpp
+++ b/tket/proptest/src/ComparisonFunctions.cpp
@@ -17,6 +17,8 @@
 #include <sstream>
 #include <stdexcept>
 
+#include "tket/Utils/MatrixAnalysis.hpp"
+
 // NOTE: this is an identical copy of a file in tket-tests, in the Simulation
 // folder. This is deliberate! Please keep both in sync!
 // See the tket-tests file for a mathematical discussion.

--- a/tket/proptest/src/ComparisonFunctions.hpp
+++ b/tket/proptest/src/ComparisonFunctions.hpp
@@ -14,7 +14,7 @@
 
 #pragma once
 
-#include "tket/Utils/MatrixAnalysis.hpp"
+#include "tket/Utils/EigenConfig.hpp"
 
 namespace tket {
 namespace tket_sim {

--- a/tket/src/Architecture/Architecture.cpp
+++ b/tket/src/Architecture/Architecture.cpp
@@ -16,11 +16,9 @@
 
 #include <boost/graph/biconnected_components.hpp>
 #include <tkassert/Assert.hpp>
-#include <unordered_set>
 #include <vector>
 
 #include "tket/Graphs/ArticulationPoints.hpp"
-#include "tket/Utils/Json.hpp"
 #include "tket/Utils/UnitID.hpp"
 
 namespace tket {

--- a/tket/src/Architecture/ArchitectureMapping.cpp
+++ b/tket/src/Architecture/ArchitectureMapping.cpp
@@ -14,8 +14,6 @@
 
 #include "tket/Architecture/ArchitectureMapping.hpp"
 
-#include <sstream>
-#include <stdexcept>
 #include <tkassert/Assert.hpp>
 
 namespace tket {

--- a/tket/src/Architecture/DistancesFromArchitecture.cpp
+++ b/tket/src/Architecture/DistancesFromArchitecture.cpp
@@ -14,9 +14,6 @@
 
 #include "tket/Architecture/DistancesFromArchitecture.hpp"
 
-#include <sstream>
-#include <stdexcept>
-
 namespace tket {
 
 DistancesFromArchitecture::DistancesFromArchitecture(

--- a/tket/src/Architecture/NeighboursFromArchitecture.cpp
+++ b/tket/src/Architecture/NeighboursFromArchitecture.cpp
@@ -15,8 +15,6 @@
 #include "tket/Architecture/NeighboursFromArchitecture.hpp"
 
 #include <algorithm>
-#include <sstream>
-#include <stdexcept>
 
 namespace tket {
 

--- a/tket/src/Circuit/AssertionSynthesis.cpp
+++ b/tket/src/Circuit/AssertionSynthesis.cpp
@@ -16,17 +16,12 @@
 
 #include <array>
 #include <cmath>
-#include <complex>
-#include <optional>
 #include <stdexcept>
 #include <tkassert/Assert.hpp>
 
-#include "tket/Circuit/CircUtils.hpp"
 #include "tket/Circuit/Circuit.hpp"
 #include "tket/OpType/OpType.hpp"
 #include "tket/Utils/Constants.hpp"
-#include "tket/Utils/CosSinDecomposition.hpp"
-#include "tket/Utils/EigenConfig.hpp"
 #include "tket/Utils/MatrixAnalysis.hpp"
 #include "tket/Utils/UnitID.hpp"
 

--- a/tket/src/Circuit/Boxes.cpp
+++ b/tket/src/Circuit/Boxes.cpp
@@ -29,10 +29,8 @@
 #include "tket/OpType/OpTypeInfo.hpp"
 #include "tket/Ops/OpJsonFactory.hpp"
 #include "tket/Ops/OpPtr.hpp"
-#include "tket/Utils/EigenConfig.hpp"
 #include "tket/Utils/Expression.hpp"
 #include "tket/Utils/HelperFunctions.hpp"
-#include "tket/Utils/Json.hpp"
 #include "tket/Utils/PauliTensor.hpp"
 
 namespace tket {

--- a/tket/src/Circuit/CircPool.cpp
+++ b/tket/src/Circuit/CircPool.cpp
@@ -18,11 +18,9 @@
 
 #include "tket/Circuit/CircUtils.hpp"
 #include "tket/Circuit/Circuit.hpp"
-#include "tket/Gate/Rotation.hpp"
 #include "tket/OpType/OpType.hpp"
 #include "tket/Transformations/BasicOptimisation.hpp"
 #include "tket/Utils/Expression.hpp"
-#include "tket/Utils/MatrixAnalysis.hpp"
 
 namespace tket {
 

--- a/tket/src/Circuit/CircUtils.cpp
+++ b/tket/src/Circuit/CircUtils.cpp
@@ -27,8 +27,6 @@
 #include "tket/Gate/GateUnitaryMatrixImplementations.hpp"
 #include "tket/Gate/Rotation.hpp"
 #include "tket/OpType/OpType.hpp"
-#include "tket/Ops/Op.hpp"
-#include "tket/Utils/EigenConfig.hpp"
 #include "tket/Utils/Expression.hpp"
 #include "tket/Utils/MatrixAnalysis.hpp"
 #include "tket/Utils/UnitID.hpp"

--- a/tket/src/Circuit/Circuit.cpp
+++ b/tket/src/Circuit/Circuit.cpp
@@ -17,7 +17,6 @@
 #include <algorithm>
 #include <cstddef>
 #include <fstream>
-#include <numeric>
 #include <optional>
 #include <set>
 #include <string>
@@ -32,7 +31,6 @@
 #include "tket/OpType/OpType.hpp"
 #include "tket/OpType/OpTypeFunctions.hpp"
 #include "tket/Utils/Expression.hpp"
-#include "tket/Utils/GraphHeaders.hpp"
 #include "tket/Utils/HelperFunctions.hpp"
 
 namespace tket {

--- a/tket/src/Circuit/CircuitJson.cpp
+++ b/tket/src/Circuit/CircuitJson.cpp
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include "tket/Circuit/Circuit.hpp"
-#include "tket/Utils/Json.hpp"
 
 namespace tket {
 

--- a/tket/src/Circuit/ConjugationBox.cpp
+++ b/tket/src/Circuit/ConjugationBox.cpp
@@ -20,8 +20,6 @@
 #include "Utils/Expression.hpp"
 #include "tket/Circuit/Circuit.hpp"
 #include "tket/Ops/OpJsonFactory.hpp"
-#include "tket/Utils/HelperFunctions.hpp"
-#include "tket/Utils/Json.hpp"
 
 namespace tket {
 

--- a/tket/src/Circuit/ControlledGates.cpp
+++ b/tket/src/Circuit/ControlledGates.cpp
@@ -23,7 +23,6 @@
 #include "tket/Gate/GatePtr.hpp"
 #include "tket/Gate/Rotation.hpp"
 #include "tket/OpType/OpType.hpp"
-#include "tket/Utils/EigenConfig.hpp"
 #include "tket/Utils/HelperFunctions.hpp"
 
 namespace tket {

--- a/tket/src/Circuit/DAGProperties.cpp
+++ b/tket/src/Circuit/DAGProperties.cpp
@@ -15,11 +15,10 @@
 #include "DAGProperties.hpp"
 
 #include <algorithm>
+#include <tkassert/Assert.hpp>
 #include <tklog/TketLog.hpp>
 
-#include "tket/Circuit/Circuit.hpp"
 #include "tket/OpType/EdgeType.hpp"
-#include "tket/Utils/GraphHeaders.hpp"
 
 namespace tket {
 

--- a/tket/src/Circuit/DiagonalBox.cpp
+++ b/tket/src/Circuit/DiagonalBox.cpp
@@ -16,10 +16,8 @@
 
 #include "tket/Circuit/Circuit.hpp"
 #include "tket/Circuit/Multiplexor.hpp"
-#include "tket/Gate/Rotation.hpp"
 #include "tket/Ops/OpJsonFactory.hpp"
 #include "tket/Utils/HelperFunctions.hpp"
-#include "tket/Utils/Json.hpp"
 
 namespace tket {
 

--- a/tket/src/Circuit/Multiplexor.cpp
+++ b/tket/src/Circuit/Multiplexor.cpp
@@ -24,7 +24,6 @@
 #include "tket/Ops/OpJsonFactory.hpp"
 #include "tket/Utils/Constants.hpp"
 #include "tket/Utils/HelperFunctions.hpp"
-#include "tket/Utils/Json.hpp"
 
 namespace tket {
 

--- a/tket/src/Circuit/OpJson.cpp
+++ b/tket/src/Circuit/OpJson.cpp
@@ -19,7 +19,6 @@
 #include "tket/OpType/OpTypeFunctions.hpp"
 #include "tket/Ops/BarrierOp.hpp"
 #include "tket/Ops/ClassicalOps.hpp"
-#include "tket/Ops/MetaOp.hpp"
 #include "tket/Ops/OpPtr.hpp"
 #include "tket/Utils/Json.hpp"
 

--- a/tket/src/Circuit/PauliExpBoxes.cpp
+++ b/tket/src/Circuit/PauliExpBoxes.cpp
@@ -14,8 +14,6 @@
 
 #include "tket/Circuit/PauliExpBoxes.hpp"
 
-#include <iostream>
-
 #include "tket/Circuit/CircUtils.hpp"
 #include "tket/Circuit/ConjugationBox.hpp"
 #include "tket/Converters/PhasePoly.hpp"

--- a/tket/src/Circuit/ResourceData.cpp
+++ b/tket/src/Circuit/ResourceData.cpp
@@ -14,8 +14,6 @@
 
 #include "tket/Circuit/ResourceData.hpp"
 
-#include "tket/Utils/Json.hpp"
-
 namespace tket {
 
 bool ResourceData::operator==(const ResourceData& other) const {

--- a/tket/src/Circuit/Simulation/BitOperations.cpp
+++ b/tket/src/Circuit/Simulation/BitOperations.cpp
@@ -14,7 +14,6 @@
 
 #include "BitOperations.hpp"
 
-#include <stdexcept>
 #include <tkassert/Assert.hpp>
 
 namespace tket {

--- a/tket/src/Circuit/Simulation/DecomposeCircuit.cpp
+++ b/tket/src/Circuit/Simulation/DecomposeCircuit.cpp
@@ -20,8 +20,6 @@
 #include "GateNodesBuffer.hpp"
 #include "tket/Circuit/Boxes.hpp"
 #include "tket/Circuit/Circuit.hpp"
-#include "tket/Circuit/PauliExpBoxes.hpp"
-#include "tket/Circuit/Simulation/PauliExpBoxUnitaryCalculator.hpp"
 #include "tket/Gate/Gate.hpp"
 #include "tket/Gate/GateUnitaryMatrix.hpp"
 #include "tket/Gate/GateUnitaryMatrixError.hpp"

--- a/tket/src/Circuit/Simulation/DecomposeCircuit.hpp
+++ b/tket/src/Circuit/Simulation/DecomposeCircuit.hpp
@@ -14,8 +14,6 @@
 
 #pragma once
 
-#include "tket/Utils/MatrixAnalysis.hpp"
-
 namespace tket {
 class Circuit;
 namespace tket_sim {

--- a/tket/src/Circuit/Simulation/GateNodesBuffer.hpp
+++ b/tket/src/Circuit/Simulation/GateNodesBuffer.hpp
@@ -17,7 +17,6 @@
 #include <memory>
 
 #include "GateNode.hpp"
-#include "tket/Utils/MatrixAnalysis.hpp"
 
 namespace tket {
 namespace tket_sim {

--- a/tket/src/Circuit/StatePreparation.cpp
+++ b/tket/src/Circuit/StatePreparation.cpp
@@ -22,7 +22,6 @@
 #include "tket/Gate/Rotation.hpp"
 #include "tket/Ops/OpJsonFactory.hpp"
 #include "tket/Utils/HelperFunctions.hpp"
-#include "tket/Utils/Json.hpp"
 
 namespace tket {
 

--- a/tket/src/Circuit/SubcircuitFinder.cpp
+++ b/tket/src/Circuit/SubcircuitFinder.cpp
@@ -16,7 +16,6 @@
 #include <boost/graph/transitive_closure.hpp>
 #include <cstddef>
 #include <iterator>
-#include <memory>
 #include <optional>
 #include <tkassert/Assert.hpp>
 #include <vector>

--- a/tket/src/Circuit/ThreeQubitConversion.cpp
+++ b/tket/src/Circuit/ThreeQubitConversion.cpp
@@ -30,8 +30,6 @@
 #include "tket/OpType/OpType.hpp"
 #include "tket/Utils/Constants.hpp"
 #include "tket/Utils/CosSinDecomposition.hpp"
-#include "tket/Utils/EigenConfig.hpp"
-#include "tket/Utils/MatrixAnalysis.hpp"
 #include "tket/Utils/UnitID.hpp"
 
 namespace tket {

--- a/tket/src/Circuit/ToffoliBox.cpp
+++ b/tket/src/Circuit/ToffoliBox.cpp
@@ -20,10 +20,8 @@
 #include "tket/Circuit/Circuit.hpp"
 #include "tket/Circuit/DiagonalBox.hpp"
 #include "tket/Circuit/Multiplexor.hpp"
-#include "tket/Gate/Rotation.hpp"
 #include "tket/Ops/OpJsonFactory.hpp"
 #include "tket/Utils/HelperFunctions.hpp"
-#include "tket/Utils/Json.hpp"
 
 namespace tket {
 

--- a/tket/src/Circuit/macro_circ_info.cpp
+++ b/tket/src/Circuit/macro_circ_info.cpp
@@ -23,7 +23,6 @@
 #include "tket/OpType/EdgeType.hpp"
 #include "tket/OpType/OpType.hpp"
 #include "tket/Ops/OpPtr.hpp"
-#include "tket/Utils/GraphHeaders.hpp"
 
 namespace tket {
 

--- a/tket/src/Circuit/setters_and_getters.cpp
+++ b/tket/src/Circuit/setters_and_getters.cpp
@@ -26,7 +26,6 @@
 #include "tket/OpType/OpDesc.hpp"
 #include "tket/OpType/OpType.hpp"
 #include "tket/Ops/OpPtr.hpp"
-#include "tket/Utils/GraphHeaders.hpp"
 
 namespace tket {
 

--- a/tket/src/Converters/PauliGraphConverters.cpp
+++ b/tket/src/Converters/PauliGraphConverters.cpp
@@ -15,8 +15,6 @@
 #include "tket/Circuit/Boxes.hpp"
 #include "tket/Circuit/PauliExpBoxes.hpp"
 #include "tket/Converters/Converters.hpp"
-#include "tket/Converters/PhasePoly.hpp"
-#include "tket/Diagonalisation/Diagonalisation.hpp"
 #include "tket/Gate/Gate.hpp"
 
 namespace tket {

--- a/tket/src/Converters/PhasePoly.cpp
+++ b/tket/src/Converters/PhasePoly.cpp
@@ -26,8 +26,6 @@
 #include "tket/OpType/OpType.hpp"
 #include "tket/Ops/OpJsonFactory.hpp"
 #include "tket/Ops/OpPtr.hpp"
-#include "tket/Utils/GraphHeaders.hpp"
-#include "tket/Utils/Json.hpp"
 
 namespace tket {
 

--- a/tket/src/Converters/ZXConverters.cpp
+++ b/tket/src/Converters/ZXConverters.cpp
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "tket/Circuit/CircPool.hpp"
 #include "tket/Converters/Converters.hpp"
 #include "tket/ZX/Flow.hpp"
 #include "tket/ZX/ZXDiagram.hpp"

--- a/tket/src/Diagonalisation/Diagonalisation.cpp
+++ b/tket/src/Diagonalisation/Diagonalisation.cpp
@@ -16,7 +16,6 @@
 
 #include <tkassert/Assert.hpp>
 
-#include "tket/Ops/Op.hpp"
 #include "tket/PauliGraph/ConjugatePauliFunctions.hpp"
 #include "tket/Utils/UnitID.hpp"
 

--- a/tket/src/Diagonalisation/PauliPartition.cpp
+++ b/tket/src/Diagonalisation/PauliPartition.cpp
@@ -19,7 +19,6 @@
 
 #include "tket/Graphs/AdjacencyData.hpp"
 #include "tket/Graphs/GraphColouring.hpp"
-#include "tket/Utils/GraphHeaders.hpp"
 
 namespace tket {
 

--- a/tket/src/Gate/GateUnitaryMatrixVariableQubits.hpp
+++ b/tket/src/Gate/GateUnitaryMatrixVariableQubits.hpp
@@ -15,7 +15,7 @@
 #pragma once
 
 #include "tket/OpType/OpType.hpp"
-#include "tket/Utils/MatrixAnalysis.hpp"
+#include "tket/Utils/EigenConfig.hpp"
 
 namespace tket {
 namespace internal {

--- a/tket/src/Gate/Rotation.cpp
+++ b/tket/src/Gate/Rotation.cpp
@@ -21,7 +21,6 @@
 #include "tket/OpType/OpDesc.hpp"
 #include "tket/OpType/OpType.hpp"
 #include "tket/Utils/Expression.hpp"
-#include "tket/Utils/Symbols.hpp"
 
 namespace tket {
 

--- a/tket/src/Graphs/AdjacencyData.cpp
+++ b/tket/src/Graphs/AdjacencyData.cpp
@@ -17,12 +17,9 @@
 #include <algorithm>
 #include <set>
 #include <sstream>
-#include <stdexcept>
 #include <tkassert/Assert.hpp>
 
-using std::exception;
 using std::map;
-using std::runtime_error;
 using std::set;
 using std::string;
 using std::stringstream;

--- a/tket/src/Graphs/ArticulationPoints.cpp
+++ b/tket/src/Graphs/ArticulationPoints.cpp
@@ -23,7 +23,6 @@
 #include <vector>
 
 #include "tket/Graphs/Utils.hpp"
-#include "tket/Utils/GraphHeaders.hpp"
 
 namespace tket::graphs {
 

--- a/tket/src/Graphs/BruteForceColouring.cpp
+++ b/tket/src/Graphs/BruteForceColouring.cpp
@@ -15,7 +15,6 @@
 #include "BruteForceColouring.hpp"
 
 #include <set>
-#include <sstream>
 #include <stdexcept>
 #include <tkassert/Assert.hpp>
 

--- a/tket/src/Graphs/GraphColouring.cpp
+++ b/tket/src/Graphs/GraphColouring.cpp
@@ -28,7 +28,6 @@
 #include "tket/Graphs/LargeCliquesResult.hpp"
 
 using std::exception;
-using std::map;
 using std::runtime_error;
 using std::set;
 using std::string;

--- a/tket/src/Graphs/GraphRoutines.cpp
+++ b/tket/src/Graphs/GraphRoutines.cpp
@@ -18,7 +18,6 @@
 
 #include "tket/Graphs/AdjacencyData.hpp"
 
-using std::map;
 using std::set;
 using std::size_t;
 using std::vector;

--- a/tket/src/Mapping/LexiRoute.cpp
+++ b/tket/src/Mapping/LexiRoute.cpp
@@ -15,7 +15,6 @@
 #include "tket/Mapping/LexiRoute.hpp"
 
 #include "tket/Mapping/MappingFrontier.hpp"
-#include "tket/Utils/Json.hpp"
 
 namespace tket {
 

--- a/tket/src/Ops/BarrierOp.cpp
+++ b/tket/src/Ops/BarrierOp.cpp
@@ -14,11 +14,8 @@
 
 #include "tket/Ops/BarrierOp.hpp"
 
-#include <typeinfo>
-
 #include "tket/OpType/EdgeType.hpp"
 #include "tket/OpType/OpType.hpp"
-#include "tket/Utils/Json.hpp"
 
 namespace tket {
 

--- a/tket/src/Ops/MetaOp.cpp
+++ b/tket/src/Ops/MetaOp.cpp
@@ -15,11 +15,9 @@
 #include "tket/Ops/MetaOp.hpp"
 
 #include <memory>
-#include <typeinfo>
 
 #include "tket/OpType/EdgeType.hpp"
 #include "tket/OpType/OpType.hpp"
-#include "tket/Utils/Json.hpp"
 
 namespace tket {
 

--- a/tket/src/Ops/Op.cpp
+++ b/tket/src/Ops/Op.cpp
@@ -17,7 +17,6 @@
 #include <sstream>
 
 #include "tket/Ops/OpPtr.hpp"
-#include "tket/Utils/Json.hpp"
 
 namespace tket {
 

--- a/tket/src/PauliGraph/ConjugatePauliFunctions.cpp
+++ b/tket/src/PauliGraph/ConjugatePauliFunctions.cpp
@@ -17,7 +17,6 @@
 #include <tkassert/Assert.hpp>
 
 #include "tket/OpType/OpTypeInfo.hpp"
-#include "tket/PauliGraph/PauliGraph.hpp"
 
 namespace tket {
 

--- a/tket/src/PauliGraph/PauliGraph.cpp
+++ b/tket/src/PauliGraph/PauliGraph.cpp
@@ -18,7 +18,6 @@
 
 #include "tket/Gate/Gate.hpp"
 #include "tket/OpType/OpType.hpp"
-#include "tket/Utils/GraphHeaders.hpp"
 #include "tket/Utils/PauliTensor.hpp"
 
 namespace tket {

--- a/tket/src/Placement/GraphPlacement.cpp
+++ b/tket/src/Placement/GraphPlacement.cpp
@@ -15,7 +15,6 @@
 #include <chrono>
 
 #include "tket/Placement/Placement.hpp"
-#include "tket/Utils/HelperFunctions.hpp"
 
 typedef std::chrono::steady_clock Clock;
 

--- a/tket/src/Placement/LinePlacement.cpp
+++ b/tket/src/Placement/LinePlacement.cpp
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include "tket/Placement/Placement.hpp"
-#include "tket/Utils/HelperFunctions.hpp"
 
 namespace tket {
 

--- a/tket/src/Placement/NeighbourPlacements.cpp
+++ b/tket/src/Placement/NeighbourPlacements.cpp
@@ -16,7 +16,6 @@
 
 #include <cstdlib>
 #include <sstream>
-#include <string>
 #include <tklog/TketLog.hpp>
 #include <tktokenswap/SwapListOptimiser.hpp>
 

--- a/tket/src/Placement/NoiseAwarePlacement.cpp
+++ b/tket/src/Placement/NoiseAwarePlacement.cpp
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include "tket/Placement/Placement.hpp"
-#include "tket/Utils/HelperFunctions.hpp"
 
 namespace tket {
 

--- a/tket/src/Placement/Placement.cpp
+++ b/tket/src/Placement/Placement.cpp
@@ -14,8 +14,6 @@
 
 #include "tket/Placement/Placement.hpp"
 
-#include "tket/Utils/HelperFunctions.hpp"
-
 namespace tket {
 
 const std::string& Placement::unplaced_reg() {

--- a/tket/src/Placement/RelabelledGraphWSM.hpp
+++ b/tket/src/Placement/RelabelledGraphWSM.hpp
@@ -13,12 +13,11 @@
 // limitations under the License.
 
 #pragma once
+#include <boost/graph/adjacency_list.hpp>
 #include <stdexcept>
 #include <tkassert/Assert.hpp>
 #include <tkwsm/Common/GeneralUtils.hpp>
 #include <tkwsm/GraphTheoretic/GeneralStructs.hpp>
-
-#include "tket/Placement/Placement.hpp"
 
 namespace tket {
 namespace WeightedSubgraphMonomorphism {

--- a/tket/src/Predicates/CompilerPass.cpp
+++ b/tket/src/Predicates/CompilerPass.cpp
@@ -18,7 +18,6 @@
 #include <optional>
 #include <tklog/TketLog.hpp>
 
-#include "tket/Mapping/RoutingMethodJson.hpp"
 #include "tket/Predicates/PassGenerators.hpp"
 #include "tket/Predicates/PassLibrary.hpp"
 #include "tket/Transformations/ContextualReduction.hpp"

--- a/tket/src/Predicates/PassGenerators.cpp
+++ b/tket/src/Predicates/PassGenerators.cpp
@@ -24,7 +24,6 @@
 #include "tket/Circuit/Circuit.hpp"
 #include "tket/Converters/PhasePoly.hpp"
 #include "tket/Mapping/LexiLabelling.hpp"
-#include "tket/Mapping/LexiRoute.hpp"
 #include "tket/Mapping/MappingManager.hpp"
 #include "tket/OpType/OpType.hpp"
 #include "tket/Placement/Placement.hpp"
@@ -43,7 +42,6 @@
 #include "tket/Transformations/Rebase.hpp"
 #include "tket/Transformations/ThreeQubitSquash.hpp"
 #include "tket/Transformations/Transform.hpp"
-#include "tket/Utils/Json.hpp"
 
 namespace tket {
 

--- a/tket/src/Predicates/PassLibrary.cpp
+++ b/tket/src/Predicates/PassLibrary.cpp
@@ -16,19 +16,17 @@
 
 #include <memory>
 
-#include "tket/Circuit/CircPool.hpp"
 #include "tket/Converters/Converters.hpp"
 #include "tket/Predicates/CompilationUnit.hpp"
 #include "tket/Predicates/CompilerPass.hpp"
-#include "tket/Predicates/PassGenerators.hpp"
 #include "tket/Predicates/Predicates.hpp"
 #include "tket/Transformations/BasicOptimisation.hpp"
+#include "tket/Transformations/ContextualReduction.hpp"
 #include "tket/Transformations/Decomposition.hpp"
 #include "tket/Transformations/MeasurePass.hpp"
 #include "tket/Transformations/OptimisationPass.hpp"
 #include "tket/Transformations/Rebase.hpp"
 #include "tket/Transformations/Transform.hpp"
-#include "tket/Utils/Json.hpp"
 #include "tket/ZX/Rewrite.hpp"
 
 namespace tket {

--- a/tket/src/Predicates/Predicates.cpp
+++ b/tket/src/Predicates/Predicates.cpp
@@ -14,7 +14,6 @@
 
 #include "tket/Predicates/Predicates.hpp"
 
-#include "tket/Gate/Gate.hpp"
 #include "tket/Mapping/Verification.hpp"
 #include "tket/OpType/OpTypeFunctions.hpp"
 #include "tket/Placement/Placement.hpp"

--- a/tket/src/Transformations/BasicOptimisation.cpp
+++ b/tket/src/Transformations/BasicOptimisation.cpp
@@ -26,7 +26,6 @@
 #include "tket/Circuit/DAGDefs.hpp"
 #include "tket/Transformations/Decomposition.hpp"
 #include "tket/Transformations/Transform.hpp"
-#include "tket/Utils/EigenConfig.hpp"
 #include "tket/Utils/Expression.hpp"
 #include "tket/Utils/MatrixAnalysis.hpp"
 #include "tket/Utils/UnitID.hpp"

--- a/tket/src/Transformations/Decomposition.cpp
+++ b/tket/src/Transformations/Decomposition.cpp
@@ -29,7 +29,6 @@
 #include "tket/OpType/OpTypeInfo.hpp"
 #include "tket/Ops/OpPtr.hpp"
 #include "tket/Transformations/BasicOptimisation.hpp"
-#include "tket/Transformations/OptimisationPass.hpp"
 #include "tket/Transformations/PhasedXFrontier.hpp"
 #include "tket/Transformations/Rebase.hpp"
 #include "tket/Transformations/Replacement.hpp"

--- a/tket/src/Transformations/GreedyPauliOptimisation.cpp
+++ b/tket/src/Transformations/GreedyPauliOptimisation.cpp
@@ -19,8 +19,6 @@
 #include "tket/Circuit/PauliExpBoxes.hpp"
 #include "tket/Converters/Converters.hpp"
 #include "tket/OpType/OpType.hpp"
-#include "tket/OpType/OpTypeInfo.hpp"
-#include "tket/Ops/Op.hpp"
 #include "tket/PauliGraph/PauliGraph.hpp"
 #include "tket/Transformations/CliffordOptimisation.hpp"
 #include "tket/Transformations/GreedyPauliOptimisationLookupTables.hpp"

--- a/tket/src/Transformations/MeasurePass.cpp
+++ b/tket/src/Transformations/MeasurePass.cpp
@@ -15,12 +15,10 @@
 #include "tket/Transformations/MeasurePass.hpp"
 
 #include <optional>
-#include <tuple>
 
 #include "tket/Circuit/DAGDefs.hpp"
 #include "tket/OpType/EdgeType.hpp"
 #include "tket/OpType/OpTypeFunctions.hpp"
-#include "tket/Ops/Op.hpp"
 #include "tket/Ops/OpPtr.hpp"
 #include "tket/Transformations/Transform.hpp"
 

--- a/tket/src/Transformations/PQPSquash.cpp
+++ b/tket/src/Transformations/PQPSquash.cpp
@@ -16,7 +16,6 @@
 
 #include <memory>
 
-#include "tket/Circuit/DAGDefs.hpp"
 #include "tket/Gate/Rotation.hpp"
 #include "tket/OpType/OpTypeInfo.hpp"
 #include "tket/Transformations/BasicOptimisation.hpp"

--- a/tket/src/Transformations/PauliOptimisation.cpp
+++ b/tket/src/Transformations/PauliOptimisation.cpp
@@ -18,7 +18,6 @@
 #include "tket/Converters/Converters.hpp"
 #include "tket/OpType/OpType.hpp"
 #include "tket/OpType/OpTypeInfo.hpp"
-#include "tket/Ops/Op.hpp"
 #include "tket/PauliGraph/PauliGraph.hpp"
 #include "tket/Transformations/Decomposition.hpp"
 #include "tket/Transformations/OptimisationPass.hpp"

--- a/tket/src/Transformations/PhasedXFrontier.cpp
+++ b/tket/src/Transformations/PhasedXFrontier.cpp
@@ -17,7 +17,6 @@
 #include <string>
 
 #include "tket/Circuit/CircPool.hpp"
-#include "tket/Circuit/CircUtils.hpp"
 #include "tket/Circuit/Circuit.hpp"
 #include "tket/OpType/OpType.hpp"
 #include "tket/OpType/OpTypeInfo.hpp"

--- a/tket/src/Transformations/Rebase.cpp
+++ b/tket/src/Transformations/Rebase.cpp
@@ -18,12 +18,10 @@
 #include <tklog/TketLog.hpp>
 
 #include "tket/Circuit/CircPool.hpp"
-#include "tket/Circuit/CircUtils.hpp"
 #include "tket/Circuit/Circuit.hpp"
 #include "tket/Gate/GatePtr.hpp"
 #include "tket/OpType/OpType.hpp"
 #include "tket/OpType/OpTypeFunctions.hpp"
-#include "tket/Ops/Op.hpp"
 #include "tket/Transformations/BasicOptimisation.hpp"
 #include "tket/Transformations/Replacement.hpp"
 #include "tket/Transformations/Transform.hpp"

--- a/tket/src/Transformations/RedundancyRemoval.cpp
+++ b/tket/src/Transformations/RedundancyRemoval.cpp
@@ -15,7 +15,6 @@
 #include <optional>
 
 #include "tket/Circuit/DAGDefs.hpp"
-#include "tket/Gate/Gate.hpp"
 #include "tket/Transformations/BasicOptimisation.hpp"
 #include "tket/Transformations/Transform.hpp"
 

--- a/tket/src/Transformations/SingleQubitSquash.cpp
+++ b/tket/src/Transformations/SingleQubitSquash.cpp
@@ -21,7 +21,6 @@
 #include "Gate/GatePtr.hpp"
 #include "tket/Circuit/Circuit.hpp"
 #include "tket/Circuit/DAGDefs.hpp"
-#include "tket/Gate/Gate.hpp"
 
 namespace tket {
 

--- a/tket/src/Transformations/ThreeQubitSquash.cpp
+++ b/tket/src/Transformations/ThreeQubitSquash.cpp
@@ -16,12 +16,8 @@
 
 #include <algorithm>
 #include <array>
-#include <iostream>
-#include <iterator>
 #include <memory>
-#include <numeric>
 #include <set>
-#include <string>
 #include <tkassert/Assert.hpp>
 
 #include "tket/Circuit/CircUtils.hpp"
@@ -34,7 +30,6 @@
 #include "tket/Transformations/Decomposition.hpp"
 #include "tket/Transformations/OptimisationPass.hpp"
 #include "tket/Transformations/Transform.hpp"
-#include "tket/Utils/GraphHeaders.hpp"
 
 namespace tket {
 

--- a/tket/src/Utils/CosSinDecomposition.cpp
+++ b/tket/src/Utils/CosSinDecomposition.cpp
@@ -18,7 +18,6 @@
 #include <tklog/TketLog.hpp>
 
 #include "tket/Utils/Constants.hpp"
-#include "tket/Utils/EigenConfig.hpp"
 #include "tket/Utils/MatrixAnalysis.hpp"
 
 namespace tket {

--- a/tket/src/Utils/Expression.cpp
+++ b/tket/src/Utils/Expression.cpp
@@ -18,7 +18,6 @@
 
 #include "symengine/symengine_exception.h"
 #include "tket/Utils/Constants.hpp"
-#include "tket/Utils/Symbols.hpp"
 
 namespace tket {
 

--- a/tket/src/Utils/MatrixAnalysis.cpp
+++ b/tket/src/Utils/MatrixAnalysis.cpp
@@ -14,7 +14,6 @@
 
 #include "tket/Utils/MatrixAnalysis.hpp"
 
-#include <fstream>
 #include <iostream>
 #include <limits>
 #include <map>
@@ -23,8 +22,6 @@
 #include <tkassert/Assert.hpp>
 #include <utility>
 #include <vector>
-
-#include "tket/Utils/EigenConfig.hpp"
 
 namespace tket {
 

--- a/tket/src/Utils/UnitID.cpp
+++ b/tket/src/Utils/UnitID.cpp
@@ -16,8 +16,6 @@
 
 #include <sstream>
 
-#include "tket/Utils/Json.hpp"
-
 namespace tket {
 
 std::string UnitID::repr() const {

--- a/tket/test/src/Circuit/test_Circ.cpp
+++ b/tket/test/src/Circuit/test_Circ.cpp
@@ -20,7 +20,6 @@
 #include <vector>
 
 #include "../testutil.hpp"
-#include "tket/Circuit/CircUtils.hpp"
 #include "tket/Circuit/Circuit.hpp"
 #include "tket/Circuit/DAGDefs.hpp"
 #include "tket/Circuit/Simulation/CircuitSimulator.hpp"
@@ -30,13 +29,11 @@
 #include "tket/OpType/OpType.hpp"
 #include "tket/OpType/OpTypeFunctions.hpp"
 #include "tket/Ops/ClassicalOps.hpp"
-#include "tket/Ops/Op.hpp"
 #include "tket/Ops/OpPtr.hpp"
 #include "tket/Transformations/Decomposition.hpp"
 #include "tket/Transformations/OptimisationPass.hpp"
 #include "tket/Transformations/Replacement.hpp"
 #include "tket/Transformations/Transform.hpp"
-#include "tket/Utils/MatrixAnalysis.hpp"
 #include "tket/Utils/UnitID.hpp"
 
 namespace tket {

--- a/tket/test/src/Circuit/test_CircPool.cpp
+++ b/tket/test/src/Circuit/test_CircPool.cpp
@@ -15,7 +15,6 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include "tket/Circuit/CircPool.hpp"
-#include "tket/Circuit/CircUtils.hpp"
 #include "tket/Circuit/Simulation/CircuitSimulator.hpp"
 #include "tket/Predicates/Predicates.hpp"
 

--- a/tket/test/src/Circuit/test_ConjugationBox.cpp
+++ b/tket/test/src/Circuit/test_ConjugationBox.cpp
@@ -16,15 +16,12 @@
 #include <boost/dynamic_bitset.hpp>
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
-#include <random>
 
 #include "../testutil.hpp"
 #include "tket/Circuit/Boxes.hpp"
-#include "tket/Circuit/CircUtils.hpp"
 #include "tket/Circuit/Circuit.hpp"
 #include "tket/Circuit/ConjugationBox.hpp"
 #include "tket/Circuit/Simulation/CircuitSimulator.hpp"
-#include "tket/Gate/Rotation.hpp"
 
 namespace tket {
 namespace test_ConjugationBox {

--- a/tket/test/src/Circuit/test_DiagonalBox.cpp
+++ b/tket/test/src/Circuit/test_DiagonalBox.cpp
@@ -20,11 +20,9 @@
 
 #include "../testutil.hpp"
 #include "tket/Circuit/Boxes.hpp"
-#include "tket/Circuit/CircUtils.hpp"
 #include "tket/Circuit/Circuit.hpp"
 #include "tket/Circuit/DiagonalBox.hpp"
 #include "tket/Circuit/Simulation/CircuitSimulator.hpp"
-#include "tket/Gate/Rotation.hpp"
 
 namespace tket {
 namespace test_DiagonalBox {

--- a/tket/test/src/Circuit/test_Multiplexor.cpp
+++ b/tket/test/src/Circuit/test_Multiplexor.cpp
@@ -18,7 +18,6 @@
 
 #include "../testutil.hpp"
 #include "tket/Circuit/Boxes.hpp"
-#include "tket/Circuit/CircUtils.hpp"
 #include "tket/Circuit/Circuit.hpp"
 #include "tket/Circuit/Multiplexor.hpp"
 #include "tket/Circuit/Simulation/CircuitSimulator.hpp"

--- a/tket/test/src/Circuit/test_StatePreparation.cpp
+++ b/tket/test/src/Circuit/test_StatePreparation.cpp
@@ -20,7 +20,6 @@
 
 #include "../testutil.hpp"
 #include "tket/Circuit/Boxes.hpp"
-#include "tket/Circuit/CircUtils.hpp"
 #include "tket/Circuit/Circuit.hpp"
 #include "tket/Circuit/Simulation/CircuitSimulator.hpp"
 #include "tket/Circuit/StatePreparation.hpp"

--- a/tket/test/src/Circuit/test_ThreeQubitConversion.cpp
+++ b/tket/test/src/Circuit/test_ThreeQubitConversion.cpp
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <array>
 #include <catch2/catch_test_macros.hpp>
 #include <cmath>
 
@@ -26,8 +25,6 @@
 #include "tket/Transformations/Decomposition.hpp"
 #include "tket/Transformations/ThreeQubitSquash.hpp"
 #include "tket/Transformations/Transform.hpp"
-#include "tket/Utils/Constants.hpp"
-#include "tket/Utils/EigenConfig.hpp"
 #include "tket/Utils/UnitID.hpp"
 
 namespace tket {

--- a/tket/test/src/Circuit/test_ToffoliBox.cpp
+++ b/tket/test/src/Circuit/test_ToffoliBox.cpp
@@ -21,11 +21,9 @@
 
 #include "../testutil.hpp"
 #include "tket/Circuit/Boxes.hpp"
-#include "tket/Circuit/CircUtils.hpp"
 #include "tket/Circuit/Circuit.hpp"
 #include "tket/Circuit/Simulation/CircuitSimulator.hpp"
 #include "tket/Circuit/ToffoliBox.hpp"
-#include "tket/Gate/Rotation.hpp"
 #include "tket/Utils/HelperFunctions.hpp"
 
 namespace tket {

--- a/tket/test/src/Gate/test_GateUnitaryMatrix.cpp
+++ b/tket/test/src/Gate/test_GateUnitaryMatrix.cpp
@@ -20,7 +20,6 @@
 
 #include "../testutil.hpp"
 #include "GatesData.hpp"
-#include "tket/Circuit/CircUtils.hpp"
 #include "tket/Circuit/Circuit.hpp"
 #include "tket/Circuit/Simulation/CircuitSimulator.hpp"
 #include "tket/Gate/Gate.hpp"

--- a/tket/test/src/Graphs/test_ArticulationPoints.cpp
+++ b/tket/test/src/Graphs/test_ArticulationPoints.cpp
@@ -15,7 +15,6 @@
 #include <algorithm>
 #include <boost/graph/adjacency_list.hpp>
 #include <catch2/catch_test_macros.hpp>
-#include <iostream>
 #include <vector>
 
 #include "tket/Architecture/Architecture.hpp"

--- a/tket/test/src/Graphs/test_DirectedGraph.cpp
+++ b/tket/test/src/Graphs/test_DirectedGraph.cpp
@@ -14,10 +14,8 @@
 
 #include <boost/graph/adjacency_list.hpp>
 #include <catch2/catch_test_macros.hpp>
-#include <iostream>
 #include <vector>
 
-#include "boost/range/iterator_range_core.hpp"
 #include "tket/Graphs/DirectedGraph.hpp"
 #include "tket/Utils/UnitID.hpp"
 

--- a/tket/test/src/Graphs/test_GraphUtils.cpp
+++ b/tket/test/src/Graphs/test_GraphUtils.cpp
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <algorithm>
 #include <boost/graph/adjacency_list.hpp>
 #include <boost/range/iterator_range_core.hpp>
 #include <catch2/catch_test_macros.hpp>

--- a/tket/test/src/Ops/test_Ops.cpp
+++ b/tket/test/src/Ops/test_Ops.cpp
@@ -19,7 +19,6 @@
 
 #include "../testutil.hpp"
 #include "tket/Circuit/Boxes.hpp"
-#include "tket/Circuit/CircUtils.hpp"
 #include "tket/Circuit/Circuit.hpp"
 #include "tket/Circuit/PauliExpBoxes.hpp"
 #include "tket/Circuit/Simulation/CircuitSimulator.hpp"
@@ -27,7 +26,6 @@
 #include "tket/Gate/SymTable.hpp"
 #include "tket/OpType/OpType.hpp"
 #include "tket/Ops/OpPtr.hpp"
-#include "tket/Predicates/CompilerPass.hpp"
 #include "tket/Predicates/PassLibrary.hpp"
 #include "tket/Transformations/OptimisationPass.hpp"
 #include "tket/Utils/Constants.hpp"

--- a/tket/test/src/Placement/test_GraphPlacement.cpp
+++ b/tket/test/src/Placement/test_GraphPlacement.cpp
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include <catch2/catch_test_macros.hpp>
-#include <random>
 
 #include "../testutil.hpp"
 #include "tket/Placement/Placement.hpp"

--- a/tket/test/src/Placement/test_LinePlacement.cpp
+++ b/tket/test/src/Placement/test_LinePlacement.cpp
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include <catch2/catch_test_macros.hpp>
-#include <random>
 
 #include "../testutil.hpp"
 #include "tket/Placement/Placement.hpp"

--- a/tket/test/src/Placement/test_NeighbourPlacements.cpp
+++ b/tket/test/src/Placement/test_NeighbourPlacements.cpp
@@ -13,11 +13,8 @@
 // limitations under the License.
 
 #include <catch2/catch_test_macros.hpp>
-#include <random>
 #include <tket/Placement/NeighbourPlacements.hpp>
 #include <utility>
-
-#include "../testutil.hpp"
 
 namespace tket {
 namespace test_NeighbourPlacements {

--- a/tket/test/src/Placement/test_NoiseAwarePlacement.cpp
+++ b/tket/test/src/Placement/test_NoiseAwarePlacement.cpp
@@ -13,9 +13,7 @@
 // limitations under the License.
 
 #include <catch2/catch_test_macros.hpp>
-#include <random>
 
-#include "../testutil.hpp"
 #include "tket/Placement/Placement.hpp"
 
 namespace tket {

--- a/tket/test/src/Placement/test_Placement.cpp
+++ b/tket/test/src/Placement/test_Placement.cpp
@@ -13,9 +13,7 @@
 // limitations under the License.
 
 #include <catch2/catch_test_macros.hpp>
-#include <random>
 
-#include "../testutil.hpp"
 #include "tket/Placement/Placement.hpp"
 
 namespace tket {

--- a/tket/test/src/Simulation/ComparisonFunctions.cpp
+++ b/tket/test/src/Simulation/ComparisonFunctions.cpp
@@ -17,6 +17,8 @@
 #include <sstream>
 #include <stdexcept>
 
+#include "tket/Utils/MatrixAnalysis.hpp"
+
 // NOTE: this is used by both tket-proptests and tket-tests.
 // Since it's test-only code, it is NOT placed in tket.
 // However, we don't want to make proptests depend on tket-tests,

--- a/tket/test/src/Simulation/ComparisonFunctions.hpp
+++ b/tket/test/src/Simulation/ComparisonFunctions.hpp
@@ -14,7 +14,7 @@
 
 #pragma once
 
-#include "tket/Utils/MatrixAnalysis.hpp"
+#include "tket/Utils/EigenConfig.hpp"
 
 // NOTE: an identical copy also exists in proptests. This is deliberate.
 // Please ensure you update BOTH if you update either one of them!

--- a/tket/test/src/Simulation/test_PauliExpBoxUnitaryCalculator.cpp
+++ b/tket/test/src/Simulation/test_PauliExpBoxUnitaryCalculator.cpp
@@ -15,7 +15,6 @@
 #include <catch2/catch_test_macros.hpp>
 #include <stack>
 
-#include "tket/Circuit/Boxes.hpp"
 #include "tket/Circuit/PauliExpBoxes.hpp"
 #include "tket/Circuit/Simulation/PauliExpBoxUnitaryCalculator.hpp"
 #include "tket/Gate/GateUnitaryMatrix.hpp"

--- a/tket/test/src/TokenSwapping/TestUtils/TestStatsStructs.hpp
+++ b/tket/test/src/TokenSwapping/TestUtils/TestStatsStructs.hpp
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <cstdint>
 #include <limits>
 #include <string>
 

--- a/tket/test/src/TokenSwapping/test_DistancesFromArchitecture.cpp
+++ b/tket/test/src/TokenSwapping/test_DistancesFromArchitecture.cpp
@@ -15,7 +15,6 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_string.hpp>
 #include <sstream>
-#include <stdexcept>
 
 #include "tket/Architecture/DistancesFromArchitecture.hpp"
 

--- a/tket/test/src/TokenSwapping/test_SwapsFromQubitMapping.cpp
+++ b/tket/test/src/TokenSwapping/test_SwapsFromQubitMapping.cpp
@@ -18,8 +18,6 @@
 
 #include "tket/Architecture/BestTsaWithArch.hpp"
 
-using std::vector;
-
 // Detailed algorithmic checks with quantitative benchmarks
 // are done elsewhere, so this is really just checking conversion.
 

--- a/tket/test/src/TokenSwapping/test_VariousPartialTsa.cpp
+++ b/tket/test/src/TokenSwapping/test_VariousPartialTsa.cpp
@@ -19,7 +19,6 @@
 #include <tktokenswap/TrivialTSA.hpp>
 
 #include "TestUtils/ArchitectureEdgesReimplementation.hpp"
-#include "TestUtils/DebugFunctions.hpp"
 #include "TestUtils/PartialTsaTesting.hpp"
 #include "TestUtils/ProblemGeneration.hpp"
 

--- a/tket/test/src/Transformations/test_RedundancyRemoval.cpp
+++ b/tket/test/src/Transformations/test_RedundancyRemoval.cpp
@@ -14,11 +14,9 @@
 
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/generators/catch_generators.hpp>
-#include <iostream>
 
 #include "tket/Circuit/Circuit.hpp"
 #include "tket/Transformations/BasicOptimisation.hpp"
-#include "tket/Transformations/PQPSquash.hpp"
 
 namespace tket {
 namespace test_RedundancyRemoval {

--- a/tket/test/src/Utils/test_CosSinDecomposition.cpp
+++ b/tket/test/src/Utils/test_CosSinDecomposition.cpp
@@ -16,7 +16,6 @@
 #include <cstdlib>
 
 #include "../testutil.hpp"
-#include "tket/Utils/Constants.hpp"
 #include "tket/Utils/CosSinDecomposition.hpp"
 #include "tket/Utils/MatrixAnalysis.hpp"
 

--- a/tket/test/src/test_AASRoute.cpp
+++ b/tket/test/src/test_AASRoute.cpp
@@ -1,22 +1,14 @@
-#include <algorithm>
 #include <catch2/catch_test_macros.hpp>
 
-#include "Simulation/ComparisonFunctions.hpp"
 #include "testutil.hpp"
 #include "tket/Circuit/Circuit.hpp"
 #include "tket/Circuit/Simulation/CircuitSimulator.hpp"
 #include "tket/Mapping/AASLabelling.hpp"
 #include "tket/Mapping/AASRoute.hpp"
 #include "tket/Mapping/LexiLabelling.hpp"
-#include "tket/Mapping/LexiRoute.hpp"
 #include "tket/Mapping/MappingManager.hpp"
 #include "tket/OpType/OpType.hpp"
-#include "tket/OpType/OpTypeFunctions.hpp"
 #include "tket/Predicates/CompilationUnit.hpp"
-#include "tket/Predicates/CompilerPass.hpp"
-#include "tket/Predicates/PassGenerators.hpp"
-#include "tket/Predicates/PassLibrary.hpp"
-#include "tket/Transformations/ContextualReduction.hpp"
 
 namespace tket {
 SCENARIO("Test aas route in RV3") {

--- a/tket/test/src/test_Architectures.cpp
+++ b/tket/test/src/test_Architectures.cpp
@@ -12,15 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <algorithm>
 #include <boost/graph/adjacency_list.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <cmath>
-#include <iostream>
 #include <vector>
 
 #include "tket/Architecture/Architecture.hpp"
-#include "tket/Graphs/ArticulationPoints.hpp"
 
 namespace tket {
 namespace graphs {

--- a/tket/test/src/test_Assertion.cpp
+++ b/tket/test/src/test_Assertion.cpp
@@ -15,12 +15,10 @@
 #include <catch2/catch_test_macros.hpp>
 #include <stdexcept>
 
-#include "testutil.hpp"
 #include "tket/Circuit/AssertionSynthesis.hpp"
 #include "tket/Circuit/Circuit.hpp"
 #include "tket/Predicates/CompilationUnit.hpp"
 #include "tket/Predicates/PassLibrary.hpp"
-#include "tket/Utils/MatrixAnalysis.hpp"
 namespace tket {
 
 SCENARIO("Testing projector based assertion synthesis") {

--- a/tket/test/src/test_BoxDecompRoutingMethod.cpp
+++ b/tket/test/src/test_BoxDecompRoutingMethod.cpp
@@ -16,7 +16,7 @@
 #include "Simulation/ComparisonFunctions.hpp"
 #include "tket/Circuit/Simulation/CircuitSimulator.hpp"
 #include "tket/Mapping/BoxDecomposition.hpp"
-#include "tket/Mapping/LexiRoute.hpp"
+#include "tket/Mapping/LexiRouteRoutingMethod.hpp"
 #include "tket/Mapping/MappingManager.hpp"
 #include "tket/Predicates/Predicates.hpp"
 

--- a/tket/test/src/test_Combinators.cpp
+++ b/tket/test/src/test_Combinators.cpp
@@ -17,7 +17,6 @@
 #include "CircuitsForTesting.hpp"
 #include "Simulation/ComparisonFunctions.hpp"
 #include "tket/Circuit/Simulation/CircuitSimulator.hpp"
-#include "tket/Predicates/PassGenerators.hpp"
 #include "tket/Transformations/Combinator.hpp"
 #include "tket/Transformations/OptimisationPass.hpp"
 #include "tket/Transformations/Rebase.hpp"

--- a/tket/test/src/test_CompilerPass.cpp
+++ b/tket/test/src/test_CompilerPass.cpp
@@ -18,7 +18,6 @@
 #include <tkrng/RNG.hpp>
 #include <vector>
 
-#include "Simulation/ComparisonFunctions.hpp"
 #include "testutil.hpp"
 #include "tket/Circuit/CircPool.hpp"
 #include "tket/Circuit/Circuit.hpp"
@@ -35,7 +34,6 @@
 #include "tket/Predicates/CompilerPass.hpp"
 #include "tket/Predicates/PassGenerators.hpp"
 #include "tket/Predicates/PassLibrary.hpp"
-#include "tket/Transformations/ContextualReduction.hpp"
 #include "tket/Transformations/MeasurePass.hpp"
 #include "tket/Transformations/OptimisationPass.hpp"
 #include "tket/Transformations/PauliOptimisation.hpp"

--- a/tket/test/src/test_ContextOpt.cpp
+++ b/tket/test/src/test_ContextOpt.cpp
@@ -22,7 +22,6 @@
 #include "tket/Predicates/PassGenerators.hpp"
 #include "tket/Transformations/ContextualReduction.hpp"
 #include "tket/Transformations/Transform.hpp"
-#include "tket/Utils/EigenConfig.hpp"
 
 namespace tket {
 namespace test_ContextOpt {

--- a/tket/test/src/test_ControlDecomp.cpp
+++ b/tket/test/src/test_ControlDecomp.cpp
@@ -22,7 +22,6 @@
 #include "tket/Circuit/Simulation/CircuitSimulator.hpp"
 #include "tket/Gate/GateUnitaryMatrix.hpp"
 #include "tket/Gate/SymTable.hpp"
-#include "tket/Transformations/CliffordReductionPass.hpp"
 #include "tket/Transformations/Decomposition.hpp"
 #include "tket/Transformations/OptimisationPass.hpp"
 #include "tket/Transformations/Replacement.hpp"

--- a/tket/test/src/test_DeviceCharacterisation.cpp
+++ b/tket/test/src/test_DeviceCharacterisation.cpp
@@ -15,7 +15,6 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include "tket/Characterisation/DeviceCharacterisation.hpp"
-#include "tket/OpType/OpDesc.hpp"
 
 namespace tket {
 namespace test_DeviceCharacterisation {

--- a/tket/test/src/test_GlobalisePhasedX.cpp
+++ b/tket/test/src/test_GlobalisePhasedX.cpp
@@ -14,7 +14,6 @@
 
 #include <catch2/catch_test_macros.hpp>
 
-#include "testutil.hpp"
 #include "tket/Circuit/Circuit.hpp"
 #include "tket/Circuit/Simulation/CircuitSimulator.hpp"
 #include "tket/Transformations/Decomposition.hpp"

--- a/tket/test/src/test_GreedyPauli.cpp
+++ b/tket/test/src/test_GreedyPauli.cpp
@@ -14,7 +14,6 @@
 
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
-#include <optional>
 
 #include "testutil.hpp"
 #include "tket/Circuit/Circuit.hpp"
@@ -23,7 +22,6 @@
 #include "tket/Gate/SymTable.hpp"
 #include "tket/PauliGraph/PauliGraph.hpp"
 #include "tket/Predicates/PassGenerators.hpp"
-#include "tket/Transformations/Decomposition.hpp"
 #include "tket/Transformations/GreedyPauliOptimisation.hpp"
 #include "tket/Utils/Expression.hpp"
 

--- a/tket/test/src/test_LexiRoute.cpp
+++ b/tket/test/src/test_LexiRoute.cpp
@@ -25,9 +25,7 @@
 #include "tket/Predicates/CompilationUnit.hpp"
 #include "tket/Predicates/CompilerPass.hpp"
 #include "tket/Predicates/PassGenerators.hpp"
-#include "tket/Predicates/PassLibrary.hpp"
 #include "tket/Transformations/Decomposition.hpp"
-#include "tket/Utils/Json.hpp"
 
 namespace tket {
 

--- a/tket/test/src/test_LexicographicalComparison.cpp
+++ b/tket/test/src/test_LexicographicalComparison.cpp
@@ -14,8 +14,6 @@
 
 #include <catch2/catch_test_macros.hpp>
 #include <cstdlib>
-#include <fstream>
-#include <iostream>
 
 #include "tket/Mapping/LexicographicalComparison.hpp"
 

--- a/tket/test/src/test_MappingFrontier.cpp
+++ b/tket/test/src/test_MappingFrontier.cpp
@@ -14,11 +14,11 @@
 
 #include <catch2/catch_test_macros.hpp>
 #include <cstdlib>
-#include <fstream>
-#include <iostream>
 
-#include "tket/Circuit/ClassicalExpBox.hpp"
-#include "tket/Mapping/MappingManager.hpp"
+#include "tket/Architecture/Architecture.hpp"
+#include "tket/Circuit/Circuit.hpp"
+#include "tket/Mapping/MappingFrontier.hpp"
+#include "tket/Utils/UnitID.hpp"
 
 namespace tket {
 

--- a/tket/test/src/test_MappingManager.cpp
+++ b/tket/test/src/test_MappingManager.cpp
@@ -14,8 +14,6 @@
 
 #include <catch2/catch_test_macros.hpp>
 #include <cstdlib>
-#include <fstream>
-#include <iostream>
 
 #include "tket/Mapping/MappingManager.hpp"
 

--- a/tket/test/src/test_MappingVerification.cpp
+++ b/tket/test/src/test_MappingVerification.cpp
@@ -15,7 +15,7 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include "testutil.hpp"
-#include "tket/Mapping/LexiRoute.hpp"
+#include "tket/Mapping/LexiRouteRoutingMethod.hpp"
 #include "tket/Mapping/MappingManager.hpp"
 #include "tket/Mapping/Verification.hpp"
 #include "tket/Placement/Placement.hpp"

--- a/tket/test/src/test_MultiGateReorder.cpp
+++ b/tket/test/src/test_MultiGateReorder.cpp
@@ -15,7 +15,7 @@
 
 #include "Simulation/ComparisonFunctions.hpp"
 #include "tket/Circuit/Simulation/CircuitSimulator.hpp"
-#include "tket/Mapping/LexiRoute.hpp"
+#include "tket/Mapping/LexiRouteRoutingMethod.hpp"
 #include "tket/Mapping/MappingManager.hpp"
 #include "tket/Mapping/MultiGateReorder.hpp"
 #include "tket/Predicates/Predicates.hpp"

--- a/tket/test/src/test_Partition.cpp
+++ b/tket/test/src/test_Partition.cpp
@@ -14,7 +14,6 @@
 
 #include <catch2/catch_test_macros.hpp>
 
-#include "testutil.hpp"
 #include "tket/Diagonalisation/PauliPartition.hpp"
 
 namespace tket {

--- a/tket/test/src/test_PhaseGadget.cpp
+++ b/tket/test/src/test_PhaseGadget.cpp
@@ -26,7 +26,6 @@
 #include "tket/Transformations/PauliOptimisation.hpp"
 #include "tket/Transformations/PhaseOptimisation.hpp"
 #include "tket/Transformations/Transform.hpp"
-#include "tket/Utils/EigenConfig.hpp"
 
 namespace tket {
 namespace test_PhaseGadget {

--- a/tket/test/src/test_PhasePolynomials.cpp
+++ b/tket/test/src/test_PhasePolynomials.cpp
@@ -17,14 +17,11 @@
 #include "CircuitsForTesting.hpp"
 #include "testutil.hpp"
 #include "tket/Circuit/Boxes.hpp"
-#include "tket/Circuit/CircUtils.hpp"
 #include "tket/Converters/PhasePoly.hpp"
-#include "tket/Predicates/CompilerPass.hpp"
 #include "tket/Predicates/PassLibrary.hpp"
 #include "tket/Transformations/Decomposition.hpp"
 #include "tket/Transformations/Rebase.hpp"
 #include "tket/Transformations/Transform.hpp"
-#include "tket/Utils/HelperFunctions.hpp"
 #include "tket/Utils/MatrixAnalysis.hpp"
 
 namespace tket {

--- a/tket/test/src/test_PhasedXFrontier.cpp
+++ b/tket/test/src/test_PhasedXFrontier.cpp
@@ -15,10 +15,8 @@
 #include <catch2/catch_test_macros.hpp>
 #include <optional>
 
-#include "testutil.hpp"
 #include "tket/Circuit/Circuit.hpp"
 #include "tket/Circuit/Simulation/CircuitSimulator.hpp"
-#include "tket/Transformations/Decomposition.hpp"
 #include "tket/Transformations/PhasedXFrontier.hpp"
 #include "tket/Utils/Expression.hpp"
 

--- a/tket/test/src/test_Rebase.cpp
+++ b/tket/test/src/test_Rebase.cpp
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include <catch2/catch_test_macros.hpp>
-#include <numeric>
 
 #include "CircuitsForTesting.hpp"
 #include "Simulation/ComparisonFunctions.hpp"
@@ -25,7 +24,6 @@
 #include "tket/Transformations/Decomposition.hpp"
 #include "tket/Transformations/Rebase.hpp"
 #include "tket/Transformations/Transform.hpp"
-#include "tket/Utils/MatrixAnalysis.hpp"
 
 namespace tket {
 namespace test_Rebase {

--- a/tket/test/src/test_RoutingMethod.cpp
+++ b/tket/test/src/test_RoutingMethod.cpp
@@ -1,7 +1,5 @@
 #include <catch2/catch_test_macros.hpp>
 #include <cstdlib>
-#include <fstream>
-#include <iostream>
 
 #include "tket/Mapping/MappingFrontier.hpp"
 #include "tket/Mapping/RoutingMethodCircuit.hpp"

--- a/tket/test/src/test_RoutingPasses.cpp
+++ b/tket/test/src/test_RoutingPasses.cpp
@@ -14,27 +14,19 @@
 
 #include <catch2/catch_test_macros.hpp>
 #include <numeric>
-#include <optional>
 
-#include "Simulation/ComparisonFunctions.hpp"
 #include "testutil.hpp"
-#include "tket/Characterisation/DeviceCharacterisation.hpp"
 #include "tket/Circuit/Circuit.hpp"
 #include "tket/Circuit/Simulation/CircuitSimulator.hpp"
 #include "tket/Mapping/LexiLabelling.hpp"
-#include "tket/Mapping/LexiRoute.hpp"
 #include "tket/Mapping/MappingManager.hpp"
 #include "tket/Mapping/Verification.hpp"
 #include "tket/OpType/OpType.hpp"
 #include "tket/Predicates/CompilerPass.hpp"
 #include "tket/Predicates/PassGenerators.hpp"
 #include "tket/Predicates/Predicates.hpp"
-#include "tket/Transformations/BasicOptimisation.hpp"
 #include "tket/Transformations/Decomposition.hpp"
-#include "tket/Transformations/OptimisationPass.hpp"
-#include "tket/Transformations/Rebase.hpp"
 #include "tket/Transformations/Transform.hpp"
-#include "tket/Utils/HelperFunctions.hpp"
 
 namespace tket {
 

--- a/tket/test/src/test_Synthesis.cpp
+++ b/tket/test/src/test_Synthesis.cpp
@@ -22,7 +22,6 @@
 #include "Simulation/ComparisonFunctions.hpp"
 #include "testutil.hpp"
 #include "tket/Circuit/CircPool.hpp"
-#include "tket/Circuit/CircUtils.hpp"
 #include "tket/Circuit/Simulation/CircuitSimulator.hpp"
 #include "tket/Gate/Rotation.hpp"
 #include "tket/OpType/OpType.hpp"

--- a/tket/test/src/test_TwoQubitCanonical.cpp
+++ b/tket/test/src/test_TwoQubitCanonical.cpp
@@ -26,7 +26,6 @@
 #include "tket/Transformations/BasicOptimisation.hpp"
 #include "tket/Transformations/Decomposition.hpp"
 #include "tket/Transformations/Transform.hpp"
-#include "tket/Utils/EigenConfig.hpp"
 #include "tket/Utils/MatrixAnalysis.hpp"
 
 namespace tket {

--- a/tket/test/src/test_json.cpp
+++ b/tket/test/src/test_json.cpp
@@ -14,7 +14,6 @@
 
 #include <boost/range/join.hpp>
 #include <catch2/catch_test_macros.hpp>
-#include <iostream>
 
 #include "CircuitsForTesting.hpp"
 #include "testutil.hpp"
@@ -34,7 +33,6 @@
 #include "tket/Converters/PhasePoly.hpp"
 #include "tket/Gate/SymTable.hpp"
 #include "tket/Mapping/LexiLabelling.hpp"
-#include "tket/Mapping/LexiRoute.hpp"
 #include "tket/Mapping/RoutingMethod.hpp"
 #include "tket/MeasurementSetup/MeasurementSetup.hpp"
 #include "tket/OpType/OpType.hpp"

--- a/tket/test/src/test_wasm.cpp
+++ b/tket/test/src/test_wasm.cpp
@@ -15,11 +15,8 @@
 #include <Eigen/Core>
 #include <catch2/catch_test_macros.hpp>
 
-#include "testutil.hpp"
-#include "tket/Circuit/CircUtils.hpp"
 #include "tket/Circuit/Circuit.hpp"
 #include "tket/Circuit/Simulation/CircuitSimulator.hpp"
-#include "tket/Converters/PhasePoly.hpp"
 #include "tket/Ops/ClassicalOps.hpp"
 
 namespace tket {

--- a/tket/test/src/testutil.cpp
+++ b/tket/test/src/testutil.cpp
@@ -19,8 +19,6 @@
 #include "Simulation/ComparisonFunctions.hpp"
 #include "tket/Circuit/Circuit.hpp"
 #include "tket/Circuit/Simulation/CircuitSimulator.hpp"
-#include "tket/Utils/EigenConfig.hpp"
-#include "tket/Utils/MatrixAnalysis.hpp"
 
 namespace tket {
 

--- a/tket/test/src/testutil.hpp
+++ b/tket/test/src/testutil.hpp
@@ -23,7 +23,6 @@
 #include <cstdlib>
 
 #include "tket/Circuit/Circuit.hpp"
-#include "tket/Utils/EigenConfig.hpp"
 
 namespace tket {
 


### PR DESCRIPTION
Remove includes not directly used, as detected by clangd. In a few cases, add directly-used includes to replace them.