### PR TITLE
fix: broken crosslinks to user guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,8 @@ patchy) is available
 The `pytket` (Python) API documentation is available
 [here](https://tket.quantinuum.com/api-docs).
 
-For getting started using pytket, check out the user manual and notebook examples.
+For getting started using pytket, check out the user manual and notebook examples -> https://tket.quantinuum.com/user-guide/
 
-- User manual - https://tket.quantinuum.com/user-manual/
-- Notebook examples - https://tket.quantinuum.com/examples/
 
 The source content for the manual and notebook examples can be found in the [pytket-docs repository](https://github.com/CQCL/pytket-docs).
 

--- a/pytket/docs/backends.rst
+++ b/pytket/docs/backends.rst
@@ -3,11 +3,11 @@ pytket.backends
 
 Contains :py:class:`Backend` abstract class and associated methods. In pytket a :py:class:`Backend` represents an interface between pytket and a quantum device or simulator. Different backends are defined in the various pytket extension modules and inherit from the core pytket :py:class:`Backend` class.
 
-There are several `example notebooks <https://tket.quantinuum.com/examples>`_ on pytket :py:class:`Backend`\s. If you are interested in developing your own :py:class:`Backend` or pytket extension then see the `creating backends <https://tket.quantinuum.com/examples/creating_backends.html>`_ tutorial.
+There are several `example notebooks <https://tket.quantinuum.com/examples>`_ on pytket :py:class:`Backend`\s. If you are interested in developing your own :py:class:`Backend` or pytket extension then see the `creating backends <https://tket.quantinuum.com/user-guide/examples/creating_backends.html>`_ tutorial.
 
 Notebook tutorials specific to the :py:class:`QuantinuumBackend` can be found `here <https://github.com/CQCL/pytket-quantinuum/tree/develop/examples>`_.
 
-See also the `Running on backends <https://tket.quantinuum.com/user-manual/manual_backend.html>`_ section of the pytket user manual.
+See also the `Running on backends <https://tket.quantinuum.com/user-guide/manual/manual_backend.html>`_ section of the pytket user manual.
 
 .. automodule:: pytket.backends
     :members: backend

--- a/pytket/docs/circuit_class.rst
+++ b/pytket/docs/circuit_class.rst
@@ -2,9 +2,9 @@ pytket.circuit.Circuit
 ======================
 :py:class:`Circuit` objects provide an abstraction of quantum circuits. They consist of a set of qubits/quantum wires and a collection of operations applied to them in a given order. These wires have open inputs and outputs, rather than assuming any fixed input state.
 
-See the `pytket User Manual <https://tket.quantinuum.com/user-manual/manual_circuit.html>`_ for a step-by-step tutorial on constructing circuits.
+See the `pytket User Manual <https://tket.quantinuum.com/user-guide/manual/manual_circuit.html>`_ for a step-by-step tutorial on constructing circuits.
 
-See also the notebook tutorials on `circuit generation <https://tket.quantinuum.com/examples/circuit_generation_example.html>`_ and `circuit analysis <https://tket.quantinuum.com/examples/circuit_analysis_example.html>`_.
+See also the notebook tutorials on `circuit generation <https://tket.quantinuum.com/user-guide/examples/circuit_construction/circuit_generation_example.html>`_ and `circuit analysis <https://tket.quantinuum.com/user-guide/examples/circuit_construction/circuit_analysis_example.html>`_.
 
 
 Many of the :py:class:`Circuit` methods described below append a gate or box to

--- a/pytket/docs/classical.rst
+++ b/pytket/docs/classical.rst
@@ -1,7 +1,7 @@
 pytket.circuit.logic_exp
 ========================
 
-For more discussion of classical logic in pytket see the `manual section <https://tket.quantinuum.com/user-manual/manual_circuit.html#classical-and-conditional-operations>`_.
+For more discussion of classical logic in pytket see the `manual section <https://tket.quantinuum.com/user-guide/manual/manual_circuit.html#classical-and-conditional-operations>`_.
 
 .. automodule:: pytket.circuit.logic_exp
     :members:

--- a/pytket/docs/faqs.rst
+++ b/pytket/docs/faqs.rst
@@ -14,7 +14,7 @@ There are two types of rebase
 2) :py:class:`RebaseCustom` - This can be used instead of `auto_rebase_pass` in cases where there is no hardcoded conversion available. 
 In this case the user will have to specify how to implement TKET's {TK1, CX} or {TK1, TK2} operations in terms of the target :py:class:`OpType` s. 
 
-See the manual section on `rebases <https://tket.quantinuum.com/user-manual/manual_compiler.html#rebases>`_ for examples.
+See the manual section on `rebases <https://tket.quantinuum.com/user-guide/manual/manual_compiler.html#rebases>`_ for examples.
 
 Unitary Synthesis
 -----------------
@@ -22,7 +22,7 @@ Q: Can TKET generate a circuit to implement a unitary operator of my choice?
 
 A: Yes but only up to three qubits at present. This can be done with :py:class:`Unitary3qBox`.
 
-See the manual section on `unitary synthesis <https://tket.quantinuum.com/user-manual/manual_circuit.html#boxes-for-unitary-synthesis>`_ .
+See the manual section on `unitary synthesis <https://tket.quantinuum.com/user-guide/manual/manual_circuit.html#boxes-for-unitary-synthesis>`_ .
 
 
 Qiskit to TKET Conversion

--- a/pytket/docs/getting_started.rst
+++ b/pytket/docs/getting_started.rst
@@ -67,7 +67,7 @@ Or, if an extension module like ``pytket-qiskit`` is installed:
     c = qiskit_to_tk(qc)
 
 See the
-`pytket user manual <https://tket.quantinuum.com/user-manual/index.html>`_
+`pytket user guide <https://tket.quantinuum.com/user-guide>`_
 for an extensive tutorial on pytket, providing a gentle introduction to its
 features and how to run circuits on backend devices, with worked examples.
 
@@ -109,4 +109,4 @@ The following code snippet will show how to compile a circuit to run on an IBM d
 Here the default compilation pass is applied by :py:meth:`IBMQBackend.get_compiled_circuit`. See `this page <https://tket.quantinuum.com/extensions/pytket-qiskit/#default-compilation>`_ for more details.
 
 As an alternative, We can experiment with constructing our own circuit compilation routines in pytket. Passes from the :py:mod:`pytket.passes` module can be applied individually or composed in sequence. 
-See the section of the user manual on `circuit compilation <https://tket.quantinuum.com/user-manual/manual_compiler.html>`_ and the corresponding `notebook example <https://tket.quantinuum.com/examples/compilation_example.html>`_ for more.
+See the section of the user manual on `circuit compilation <https://tket.quantinuum.com/user-guide/manual/manual_compiler.html>`_ and the corresponding `notebook example <https://tket.quantinuum.com/user-guide/examples/circuit_compilation/compilation_example.html>`_ for more.

--- a/pytket/docs/index.rst
+++ b/pytket/docs/index.rst
@@ -29,7 +29,7 @@ If you have issues installing ``pytket`` please visit the `installation troubles
 To use ``pytket``, you can simply import the appropriate modules into your python code or in an interactive Python notebook. We can build circuits directly using the ``pytket`` interface by creating a blank circuit and adding gates in the order we want to apply them.
 
 See the `Getting Started`_ page for a basic tutorial on using
-``pytket``. To get more in depth on features, see the `examples`_. See the `pytket user manual <https://tket.quantinuum.com/user-manual/index.html>`_ for an extensive introduction to ``pytket`` functionality and how to use it.
+``pytket``. To get more in depth on features, see the `examples`_. See the `pytket user guide <https://tket.quantinuum.com/user-guide/>`_ for an extensive introduction to ``pytket`` functionality and how to use it.
 
 Extensions
 ~~~~~~~~~~

--- a/pytket/docs/passes.rst
+++ b/pytket/docs/passes.rst
@@ -9,7 +9,7 @@ Also there are special purpose passes such as `OptimisePhaseGadgets <https://tke
 
 Rebase passes can be used to convert a circuit to a desired gateset. See `RebaseCustom <https://tket.quantinuum.com/api-docs/passes.html#pytket.passes.RebaseCustom>`_ and `auto_rebase_pass <https://tket.quantinuum.com/api-docs/passes.html#pytket.passes.auto_rebase.auto_rebase_pass>`_.
 
-For more on pytket passes see the `compilation <https://tket.quantinuum.com/user-manual/manual_compiler.html>`_ section of the user manual or the `notebook tutorials <https://tket.quantinuum.com/examples>`_
+For more on pytket passes see the `compilation <https://tket.quantinuum.com/user-guide/manual/manual_compiler.html>`_ section of the user manual or the `notebook tutorials <https://tket.quantinuum.com/examples>`_
 
 
 .. automodule:: pytket._tket.passes

--- a/pytket/docs/placement.rst
+++ b/pytket/docs/placement.rst
@@ -3,7 +3,7 @@ pytket.placement
 In order for the constraints of a :py:class:`Backend` to be solved we must first assign device qubits to device-independent (or program) qubits. 
 This module contains three placement methods to perform such an assignment. 
 
-For more on qubit placement (and routing in general) see the `qubit mapping and routing <https://tket.quantinuum.com/examples/mapping_example.html>`_ tutorial and the corresponding entry in the `user manual <https://tket.quantinuum.com/user-manual/manual_compiler.html#placement>`_.
+For more on qubit placement (and routing in general) see the `qubit mapping and routing <https://tket.quantinuum.com/user-guide/examples/circuit_compilation/mapping_example.html>`_ tutorial and the corresponding entry in the `user manual <https://tket.quantinuum.com/user-guide/manual/manual_compiler.html#placement>`_.
 
 .. automodule:: pytket._tket.placement
     :members:

--- a/pytket/docs/predicates.rst
+++ b/pytket/docs/predicates.rst
@@ -3,7 +3,7 @@ pytket.predicates
 
 In pytket, predicates enforce properties of circuits. Each pytket :py:class:`Backend` has its own set of predicates which must be satisfied before a quantum circuit can be executed. There are predicates that enforce restrictions including gateset, number of qubits and classical control.
 
-For more on predicates read the corresponding section of the `user manual <https://tket.quantinuum.com/user-manual/manual_compiler.html#predicates>`_. See also the `Compilation example <https://tket.quantinuum.com/examples/compilation_example.html>`_ notebook.
+For more on predicates read the corresponding section of the `user manual <https://tket.quantinuum.com/user-guide/manual/manual_compiler.html#compilation-predicates>`_. See also the `Compilation example <https://tket.quantinuum.com/user-guide/examples/circuit_compilation/compilation_example.html>`_ notebook.
 
 .. automodule:: pytket._tket.predicates
     :members:

--- a/pytket/docs/qasm.rst
+++ b/pytket/docs/qasm.rst
@@ -16,7 +16,7 @@ We can set the ``header`` argument in the qasm conversion functions as follows.
 
     qasm_str = circuit_to_qasm_str(circ, header="hqslib1")
 
-.. note:: Unlike pytket backends, the qasm converters do not handle `implicit qubit permutations <https://tket.quantinuum.com/user-manual/manual_circuit.html#implicit-qubit-permutations>`_. In other words if a circuit containing an implicit qubit permutation is converted to a qasm file the implicit permutation will not be accounted for and the circuit will be missing this permutation when reimported.
+.. note:: Unlike pytket backends, the qasm converters do not handle `implicit qubit permutations <https://tket.quantinuum.com/user-guide/manual/manual_circuit.html#implicit-qubit-permutations>`_. In other words if a circuit containing an implicit qubit permutation is converted to a qasm file the implicit permutation will not be accounted for and the circuit will be missing this permutation when reimported.
 
 .. automodule:: pytket.qasm
     :members: circuit_from_qasm, circuit_from_qasm_wasm, circuit_to_qasm, circuit_from_qasm_str, circuit_to_qasm_str, circuit_from_qasm_io, circuit_to_qasm_io

--- a/pytket/package.md
+++ b/pytket/package.md
@@ -27,9 +27,7 @@ official Python distribution instead.
 
 API reference: https://tket.quantinuum.com/api-docs/
 
-To get started using pytket see the [user manual](https://tket.quantinuum.com/user-manual/).
-
-For worked examples using TKET see our [notebook examples](https://tket.quantinuum.com/examples).
+To get started using pytket see the [user guide](https://tket.quantinuum.com/user-guide/).
 
 ## Support and Discussion
 


### PR DESCRIPTION
# Description

Fixed some broken links to the user guide. These were caused by the changes in https://github.com/CQCL/pytket-docs/pull/339

Not so happy with this fix as I'm still using the full URL links

It should be possible to link to subsections of the docs using intersphinx and [sphinx-autosectionlabel](https://www.sphinx-doc.org/en/master/usage/extensions/autosectionlabel.html) but I couldn't quite get it to work yet. This would mean that the full URL would only be written in the `conf.py` and it would be easy to get more robust linking. In the event of a URL change we could only update the link in a single place.

The autoforwarding from the old links also doesn't seem to be working properly so at least this PR addresses the link breakage for now.



# Related issues

Please mention any github issues addressed by this PR.

# Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have commented hard-to-understand parts of my code.
- [ ] I have made corresponding changes to the public API documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the changelog with any user-facing changes.
