### PR TITLE
Use clang-format 19.

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -88,7 +88,7 @@ jobs:
       - name: Check C++ code formatting
         run: |
           brew update
-          brew install clang-format@18
+          brew install clang-format@19
           git ls-files "*.cpp" "*.hpp" | xargs clang-format -style=file -i
           git diff --exit-code
 

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -82,7 +82,7 @@ jobs:
     name: Check C++ code formatting
     needs: check_changes
     if: needs.check_changes.outputs.tket_or_workflow_changed == 'true'
-    runs-on: 'macos-12'
+    runs-on: 'macos-14'
     steps:
       - uses: actions/checkout@v4
       - name: Check C++ code formatting

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ repo.
 C++20 features may be used whenever they are supported by all the compilers
 used on the CI (listed in the README).
 
-All C++ code should be formatted with `clang-format` (v18) using the
+All C++ code should be formatted with `clang-format` (v19) using the
 configuration file `.clang-format` in the root directory. This is checked on
 the CI. The script `do-clang-format` will run this over all C++ files in the
 repository and fix them up.

--- a/pytket/binders/pauli.cpp
+++ b/pytket/binders/pauli.cpp
@@ -100,8 +100,8 @@ PYBIND11_MODULE(pauli, m) {
           py::arg("other"))
       .def(
           "to_sparse_matrix",
-          (CmplxSpMat(SpPauliString::*)(void) const) &
-              SpPauliString::to_sparse_matrix,
+          (CmplxSpMat(SpPauliString::*)(void)
+               const)&SpPauliString::to_sparse_matrix,
           "Represents the sparse string as a dense string (without "
           "padding for extra qubits) and generates the matrix for the "
           "tensor. Uses the ILO-BE convention, so ``Qubit(\"a\", 0)`` "
@@ -110,8 +110,8 @@ PYBIND11_MODULE(pauli, m) {
           "\n\n:return: a sparse matrix corresponding to the operator")
       .def(
           "to_sparse_matrix",
-          (CmplxSpMat(SpPauliString::*)(const unsigned) const) &
-              SpPauliString::to_sparse_matrix,
+          (CmplxSpMat(SpPauliString::*)(const unsigned)
+               const)&SpPauliString::to_sparse_matrix,
           "Represents the sparse string as a dense string over "
           "`n_qubits` qubits (sequentially indexed from 0 in the "
           "default register) and generates the matrix for the tensor. "
@@ -137,8 +137,8 @@ PYBIND11_MODULE(pauli, m) {
           py::arg("qubits"))
       .def(
           "dot_state",
-          (Eigen::VectorXcd(SpPauliString::*)(const Eigen::VectorXcd &) const) &
-              SpPauliString::dot_state,
+          (Eigen::VectorXcd(SpPauliString::*)(const Eigen::VectorXcd &)
+               const)&SpPauliString::dot_state,
           "Performs the dot product of the state with the pauli string. "
           "Maps the qubits of the statevector with sequentially-indexed "
           "qubits in the default register, with ``Qubit(0)`` being the "

--- a/pytket/binders/zx/diagram.cpp
+++ b/pytket/binders/zx/diagram.cpp
@@ -278,7 +278,7 @@ void ZXDiagramPybind::init_zxdiagram(py::module& m) {
           py::arg("v"), py::arg("gen"))
       .def(
           "get_wire_qtype",
-          (QuantumType(ZXDiagram::*)(const Wire&) const) & ZXDiagram::get_qtype,
+          (QuantumType(ZXDiagram::*)(const Wire&) const)&ZXDiagram::get_qtype,
           "Returns the :py:class:`QuantumType` of the given wire.",
           py::arg("w"))
       .def(


### PR DESCRIPTION
Update to clang-format 19 as v18 is no longer available on homebrew.