### PR TITLE
Update to catch2 3.7.1 and pybind11 2.13.6

### DIFF
--- a/.github/workflows/build-without-conan.yml
+++ b/.github/workflows/build-without-conan.yml
@@ -74,9 +74,9 @@ jobs:
     - name: Install catch2
       run: |
         cd ${TMP_DIR}
-        wget https://github.com/catchorg/Catch2/archive/refs/tags/v3.7.0.tar.gz
-        tar xzvf v3.7.0.tar.gz
-        cd Catch2-3.7.0/
+        wget https://github.com/catchorg/Catch2/archive/refs/tags/v3.7.1.tar.gz
+        tar xzvf v3.7.1.tar.gz
+        cd Catch2-3.7.1/
         mkdir build
         cd build
         cmake -GNinja -DCMAKE_INSTALL_PREFIX=${INSTALL_DIR} ..

--- a/.github/workflows/build-without-conan.yml
+++ b/.github/workflows/build-without-conan.yml
@@ -96,9 +96,9 @@ jobs:
     - name: Install pybind11
       run: |
         cd ${TMP_DIR}
-        wget https://github.com/pybind/pybind11/archive/refs/tags/v2.13.5.tar.gz
-        tar xzvf v2.13.5.tar.gz
-        cd pybind11-2.13.5/
+        wget https://github.com/pybind/pybind11/archive/refs/tags/v2.13.6.tar.gz
+        tar xzvf v2.13.6.tar.gz
+        cd pybind11-2.13.6/
         mkdir build
         cd build
         cmake -GNinja -DCMAKE_INSTALL_PREFIX=${INSTALL_DIR} -DPYBIND11_TEST=OFF ..

--- a/build-without-conan.md
+++ b/build-without-conan.md
@@ -119,9 +119,9 @@ cmake --install .
 
 ```
 cd ${TMP_DIR}
-wget https://github.com/pybind/pybind11/archive/refs/tags/v2.13.5.tar.gz
-tar xzvf v2.13.5.tar.gz
-cd pybind11-2.13.5/
+wget https://github.com/pybind/pybind11/archive/refs/tags/v2.13.6.tar.gz
+tar xzvf v2.13.6.tar.gz
+cd pybind11-2.13.6/
 mkdir build
 cd build
 cmake -DCMAKE_INSTALL_PREFIX=${INSTALL_DIR} -DPYBIND11_TEST=OFF ..

--- a/build-without-conan.md
+++ b/build-without-conan.md
@@ -91,9 +91,9 @@ cmake --install .
 
 ```
 cd ${TMP_DIR}
-wget https://github.com/catchorg/Catch2/archive/refs/tags/v3.7.0.tar.gz
-tar xzvf v3.7.0.tar.gz
-cd Catch2-3.7.0/
+wget https://github.com/catchorg/Catch2/archive/refs/tags/v3.7.1.tar.gz
+tar xzvf v3.7.1.tar.gz
+cd Catch2-3.7.1/
 mkdir build
 cd build
 cmake -DCMAKE_INSTALL_PREFIX=${INSTALL_DIR} ..

--- a/libs/tkassert/test/conanfile.py
+++ b/libs/tkassert/test/conanfile.py
@@ -60,4 +60,4 @@ class test_tkassertRecipe(ConanFile):
 
     def requirements(self):
         self.requires("tkassert/0.3.4")
-        self.requires("catch2/3.7.0")
+        self.requires("catch2/3.7.1")

--- a/libs/tklog/test/conanfile.py
+++ b/libs/tklog/test/conanfile.py
@@ -60,4 +60,4 @@ class test_tklogRecipe(ConanFile):
 
     def requirements(self):
         self.requires("tklog/0.3.3")
-        self.requires("catch2/3.7.0")
+        self.requires("catch2/3.7.1")

--- a/libs/tkrng/test/conanfile.py
+++ b/libs/tkrng/test/conanfile.py
@@ -60,4 +60,4 @@ class test_tkrngRecipe(ConanFile):
 
     def requirements(self):
         self.requires("tkrng/0.3.3")
-        self.requires("catch2/3.7.0")
+        self.requires("catch2/3.7.1")

--- a/libs/tktokenswap/test/conanfile.py
+++ b/libs/tktokenswap/test/conanfile.py
@@ -61,4 +61,4 @@ class test_tktokenswapRecipe(ConanFile):
     def requirements(self):
         self.requires("tktokenswap/0.3.9")
         self.requires("tkrng/0.3.3@tket/stable")
-        self.requires("catch2/3.7.0")
+        self.requires("catch2/3.7.1")

--- a/libs/tkwsm/test/conanfile.py
+++ b/libs/tkwsm/test/conanfile.py
@@ -62,4 +62,4 @@ class test_tkwsmRecipe(ConanFile):
         self.requires("tkwsm/0.3.9")
         self.requires("tkassert/0.3.4@tket/stable")
         self.requires("tkrng/0.3.3@tket/stable")
-        self.requires("catch2/3.7.0")
+        self.requires("catch2/3.7.1")

--- a/pytket/conanfile.py
+++ b/pytket/conanfile.py
@@ -40,6 +40,6 @@ class pytketRecipe(ConanFile):
         self.requires("tktokenswap/0.3.9@tket/stable")
         self.requires("symengine/0.12.0")
         self.requires("gmp/6.3.0")
-        self.requires("pybind11/2.13.5")
+        self.requires("pybind11/2.13.6")
         self.requires("nlohmann_json/3.11.3")
         self.requires("pybind11_json/0.2.14")

--- a/pytket/conanfile.py
+++ b/pytket/conanfile.py
@@ -32,7 +32,7 @@ class pytketRecipe(ConanFile):
         cmake.install()
 
     def requirements(self):
-        self.requires("tket/1.3.26@tket/stable")
+        self.requires("tket/1.3.27@tket/stable")
         self.requires("tklog/0.3.3@tket/stable")
         self.requires("tkrng/0.3.3@tket/stable")
         self.requires("tkassert/0.3.4@tket/stable")

--- a/pytket/pytket/_tket/architecture.pyi
+++ b/pytket/pytket/_tket/architecture.pyi
@@ -1,3 +1,4 @@
+from typing import Any
 from __future__ import annotations
 import pytket._tket.unit_id
 import typing
@@ -6,6 +7,9 @@ class Architecture:
     """
     Class describing the connectivity of qubits on a general device.
     """
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
     @staticmethod
     def from_dict(arg0: dict) -> Architecture:
         """
@@ -75,6 +79,9 @@ class FullyConnected:
     A specialised non-Architecture object emulating an architecture with all qubits connected. Not compatible with Routing or Placement methods.
     """
     @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
+    @staticmethod
     def from_dict(arg0: dict) -> FullyConnected:
         """
         Construct FullyConnected instance from dict representation.
@@ -111,6 +118,9 @@ class RingArch(Architecture):
     """
     Inherited Architecture class for number of qubits arranged in a ring.
     """
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
     def __deepcopy__(self, arg0: dict) -> RingArch:
         ...
     def __init__(self, nodes: int, label: str = 'ringNode') -> None:
@@ -132,6 +142,9 @@ class SquareGrid(Architecture):
     
      6 7 8
     """
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
     def __deepcopy__(self, arg0: dict) -> SquareGrid:
         ...
     @typing.overload

--- a/pytket/pytket/_tket/circuit.pyi
+++ b/pytket/pytket/_tket/circuit.pyi
@@ -16,6 +16,9 @@ class BarrierOp(Op):
     """
     Barrier operations.
     """
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
     def __init__(self, signature: typing.Sequence[EdgeType], data: str) -> None:
         """
         Construct BarrierOp with signature and additional data string
@@ -44,6 +47,9 @@ class BasisOrder:
     __members__: typing.ClassVar[dict[str, BasisOrder]]  # value = {'ilo': <BasisOrder.ilo: 0>, 'dlo': <BasisOrder.dlo: 1>}
     dlo: typing.ClassVar[BasisOrder]  # value = <BasisOrder.dlo: 1>
     ilo: typing.ClassVar[BasisOrder]  # value = <BasisOrder.ilo: 0>
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
     def __eq__(self, other: typing.Any) -> bool:
         ...
     def __getstate__(self) -> int:
@@ -89,6 +95,9 @@ class CXConfigType:
     Star: typing.ClassVar[CXConfigType]  # value = <CXConfigType.Star: 2>
     Tree: typing.ClassVar[CXConfigType]  # value = <CXConfigType.Tree: 1>
     __members__: typing.ClassVar[dict[str, CXConfigType]]  # value = {'Snake': <CXConfigType.Snake: 0>, 'Star': <CXConfigType.Star: 2>, 'Tree': <CXConfigType.Tree: 1>, 'MultiQGate': <CXConfigType.MultiQGate: 3>}
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
     def __eq__(self, other: typing.Any) -> bool:
         ...
     def __getstate__(self) -> int:
@@ -119,6 +128,9 @@ class CircBox(Op):
     """
     A user-defined operation specified by a :py:class:`Circuit`.
     """
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
     def __init__(self, circ: Circuit) -> None:
         """
         Construct from a :py:class:`Circuit`.
@@ -155,6 +167,9 @@ class Circuit:
     >>> c.Rx(0.5,1) # Angles of rotation are expressed in half-turns (i.e. 0.5 means PI/2)
     >>> c.Measure(1,0) # Measure qubit 1, saving result in bit 0
     """
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
     @staticmethod
     def from_dict(arg0: dict) -> Circuit:
         """
@@ -2529,10 +2544,16 @@ class ClassicalEvalOp(ClassicalOp):
     """
     Evaluatable classical operation.
     """
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
 class ClassicalExpBox(Op):
     """
     A box for holding classical expressions on Bits.
     """
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
     def __init__(self, n_i: int, n_io: int, n_o: int, exp: pytket.circuit.logic_exp.LogicExp) -> None:
         """
         Construct from signature (number of input, input/output, and output bits) and expression.
@@ -2561,6 +2582,9 @@ class ClassicalOp(Op):
     """
     Classical operation.
     """
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
     @property
     def n_input_outputs(self) -> int:
         """
@@ -2580,6 +2604,9 @@ class Command:
     """
     A single quantum command in the circuit, defined by the Op, the qubits it acts on, and the op group name if any.
     """
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
     def __eq__(self, arg0: typing.Any) -> bool:
         ...
     def __hash__(self) -> int:
@@ -2625,6 +2652,9 @@ class Conditional(Op):
     """
     A wrapper for an operation to be applied conditionally on the value of some classical bits (following the nature of conditional operations in the OpenQASM specification).
     """
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
     def __init__(self, op: Op, width: int, value: int) -> None:
         """
         Construct from operation, bit width and (little-endian) value
@@ -2648,6 +2678,9 @@ class ConjugationBox(Op):
     """
     A box to express computations that follow the compute-action-uncompute pattern.
     """
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
     def __init__(self, compute: Op, action: Op, uncompute: Op | None = None) -> None:
         """
         Construct from operations that perform compute, action, and uncompute. All three operations need to be quantum and have the same size.
@@ -2676,10 +2709,16 @@ class CopyBitsOp(ClassicalEvalOp):
     """
     An operation to copy the values of Bits to other Bits.
     """
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
 class CustomGate(Op):
     """
     A user-defined gate defined by a parametrised :py:class:`Circuit`.
     """
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
     def __init__(self, gatedef: CustomGateDef, params: typing.Sequence[sympy.Expr | float]) -> None:
         """
         Instantiate a custom gate.
@@ -2707,6 +2746,9 @@ class CustomGateDef:
     """
     A custom unitary gate definition, given as a composition of other gates
     """
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
     @staticmethod
     def define(name: str, circ: Circuit, args: typing.Sequence[sympy.Symbol]) -> CustomGateDef:
         """
@@ -2751,6 +2793,9 @@ class DiagonalBox(Op):
     """
     A box for synthesising a diagonal unitary matrix into a sequence of multiplexed-Rz gates. Implementation based on Theorem 7 of arxiv.org/abs/quant-ph/0406176. The decomposed circuit has at most 2^n-2 CX gates.
     """
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
     def __init__(self, diagonal: NDArray[numpy.complex128], upper_triangle: bool = True) -> None:
         """
         Construct from the diagonal entries of the unitary operator. The size of the vector must be 2^n where n is a positive integer.
@@ -2774,6 +2819,9 @@ class DummyBox(Op):
     """
     A placeholder operation that holds resource data. This box type cannot be decomposed into a circuit. It only serves to record resource data for a region of a circuit: for example, upper and lower bounds on gate counts and depth. A circuit containing such a box cannot be executed.
     """
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
     def __init__(self, n_qubits: int, n_bits: int, resource_data: ResourceData) -> None:
         """
         Construct a new instance from some resource data.
@@ -2809,6 +2857,9 @@ class EdgeType:
     Quantum: typing.ClassVar[EdgeType]  # value = <EdgeType.Quantum: 0>
     WASM: typing.ClassVar[EdgeType]  # value = <EdgeType.WASM: 3>
     __members__: typing.ClassVar[dict[str, EdgeType]]  # value = {'Boolean': <EdgeType.Boolean: 2>, 'Classical': <EdgeType.Classical: 1>, 'Quantum': <EdgeType.Quantum: 0>, 'WASM': <EdgeType.WASM: 3>}
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
     def __eq__(self, other: typing.Any) -> bool:
         ...
     def __getstate__(self) -> int:
@@ -2839,6 +2890,9 @@ class ExpBox(Op):
     """
     A user-defined two-qubit operation whose corresponding unitary matrix is the exponential of a user-defined hermitian matrix.
     """
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
     def __init__(self, A: NDArray[numpy.complex128], t: float, basis: BasisOrder = BasisOrder.ilo) -> None:
         """
         Construct :math:`e^{itA}` from a hermitian matrix :math:`A` and a parameter :math:`t`.
@@ -2855,6 +2909,9 @@ class MetaOp(Op):
     """
     Meta operation, such as input or output vertices.
     """
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
     def __init__(self, type: OpType, signature: typing.Sequence[EdgeType], data: str) -> None:
         """
         Construct MetaOp with optype, signature and additional data string
@@ -2872,6 +2929,9 @@ class MultiBitOp(ClassicalEvalOp):
     """
     An operation to apply a classical op multiple times in parallel.
     """
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
     def __init__(self, op: ClassicalEvalOp, multiplier: int) -> None:
         """
         Construct from a basic operation and a multiplier.
@@ -2885,6 +2945,9 @@ class MultiplexedRotationBox(Op):
     """
     A user-defined multiplexed rotation gate (i.e. uniformly controlled single-axis rotations) specified by a map from bitstrings to :py:class:`Op` sor a list of bitstring-:py:class:`Op` s pairs. Implementation based on arxiv.org/abs/quant-ph/0410066. The decomposed circuit has at most 2^k single-qubit rotations, 2^k CX gates, and two additional H gates if the rotation axis is X. k is the number of control qubits.
     """
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
     @typing.overload
     def __init__(self, bistring_to_op_list: typing.Sequence[tuple[typing.Sequence[bool], Op]]) -> None:
         """
@@ -2925,6 +2988,9 @@ class MultiplexedTensoredU2Box(Op):
     """
     A user-defined multiplexed tensor product of U2 gates specified by a map from bitstrings to lists of :py:class:`Op` sor a list of bitstring-list(:py:class:`Op` s) pairs. A box with k control qubits and t target qubits is implemented as t k-controlled multiplexed-U2 gates with their diagonal components merged and commuted to the end. The resulting circuit contains t non-diagonal components of the multiplexed-U2 decomposition, t k-controlled multiplexed-Rz boxes, and a k-qubit DiagonalBox at the end. The total CX count is at most 2^k(2t+1)-t-2.
     """
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
     @typing.overload
     def __init__(self, bistring_to_op_list: typing.Sequence[tuple[typing.Sequence[bool], typing.Sequence[Op]]]) -> None:
         """
@@ -2957,6 +3023,9 @@ class MultiplexedU2Box(Op):
     """
     A user-defined multiplexed U2 gate (i.e. uniformly controlled U2 gate) specified by a map from bitstrings to :py:class:`Op` sor a list of bitstring-:py:class:`Op` s pairsImplementation based on arxiv.org/abs/quant-ph/0410066. The decomposed circuit has at most 2^k single-qubit gates, 2^k -1 CX gates, and a k+1 qubit DiagonalBox at the end. k is the number of control qubits.
     """
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
     @typing.overload
     def __init__(self, bistring_to_op_list: typing.Sequence[tuple[typing.Sequence[bool], Op]], impl_diag: bool = True) -> None:
         """
@@ -2995,6 +3064,9 @@ class MultiplexorBox(Op):
     """
     A user-defined multiplexor (i.e. uniformly controlled operations) specified by a map from bitstrings to :py:class:`Op` sor a list of bitstring-:py:class:`Op` s pairs
     """
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
     @typing.overload
     def __init__(self, bistring_to_op_list: typing.Sequence[tuple[typing.Sequence[bool], Op]]) -> None:
         """
@@ -3025,6 +3097,9 @@ class Op:
     """
     Encapsulates operation information
     """
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
     @staticmethod
     @typing.overload
     def create(arg0: OpType) -> Op:
@@ -3408,6 +3483,9 @@ class OpType:
     __members__: typing.ClassVar[dict[str, OpType]]  # value = {'Phase': <OpType.Phase: 21>, 'Z': <OpType.Z: 22>, 'X': <OpType.X: 23>, 'Y': <OpType.Y: 24>, 'S': <OpType.S: 25>, 'Sdg': <OpType.Sdg: 26>, 'T': <OpType.T: 27>, 'Tdg': <OpType.Tdg: 28>, 'V': <OpType.V: 29>, 'Vdg': <OpType.Vdg: 30>, 'SX': <OpType.SX: 31>, 'SXdg': <OpType.SXdg: 32>, 'H': <OpType.H: 33>, 'Rx': <OpType.Rx: 34>, 'Ry': <OpType.Ry: 35>, 'Rz': <OpType.Rz: 36>, 'U1': <OpType.U1: 39>, 'U2': <OpType.U2: 38>, 'U3': <OpType.U3: 37>, 'GPI': <OpType.GPI: 40>, 'GPI2': <OpType.GPI2: 41>, 'AAMS': <OpType.AAMS: 42>, 'TK1': <OpType.TK1: 43>, 'TK2': <OpType.TK2: 44>, 'CX': <OpType.CX: 45>, 'CY': <OpType.CY: 46>, 'CZ': <OpType.CZ: 47>, 'CH': <OpType.CH: 48>, 'CV': <OpType.CV: 49>, 'CVdg': <OpType.CVdg: 50>, 'CSX': <OpType.CSX: 51>, 'CSXdg': <OpType.CSXdg: 52>, 'CS': <OpType.CS: 53>, 'CSdg': <OpType.CSdg: 54>, 'CRz': <OpType.CRz: 55>, 'CRx': <OpType.CRx: 56>, 'CRy': <OpType.CRy: 57>, 'CU1': <OpType.CU1: 58>, 'CU3': <OpType.CU3: 59>, 'CCX': <OpType.CCX: 61>, 'ECR': <OpType.ECR: 69>, 'SWAP': <OpType.SWAP: 62>, 'CSWAP': <OpType.CSWAP: 63>, 'noop': <OpType.noop: 65>, 'Barrier': <OpType.Barrier: 8>, 'Label': <OpType.Label: 9>, 'Branch': <OpType.Branch: 10>, 'Goto': <OpType.Goto: 11>, 'Stop': <OpType.Stop: 12>, 'BRIDGE': <OpType.BRIDGE: 64>, 'Measure': <OpType.Measure: 66>, 'Reset': <OpType.Reset: 68>, 'CircBox': <OpType.CircBox: 89>, 'PhasePolyBox': <OpType.PhasePolyBox: 100>, 'Unitary1qBox': <OpType.Unitary1qBox: 90>, 'Unitary2qBox': <OpType.Unitary2qBox: 91>, 'Unitary3qBox': <OpType.Unitary3qBox: 92>, 'ExpBox': <OpType.ExpBox: 93>, 'PauliExpBox': <OpType.PauliExpBox: 94>, 'PauliExpPairBox': <OpType.PauliExpPairBox: 95>, 'PauliExpCommutingSetBox': <OpType.PauliExpCommutingSetBox: 96>, 'TermSequenceBox': <OpType.TermSequenceBox: 97>, 'QControlBox': <OpType.QControlBox: 101>, 'ToffoliBox': <OpType.ToffoliBox: 113>, 'ConjugationBox': <OpType.ConjugationBox: 108>, 'DummyBox': <OpType.DummyBox: 115>, 'CustomGate': <OpType.CustomGate: 99>, 'Conditional': <OpType.Conditional: 110>, 'ISWAP': <OpType.ISWAP: 70>, 'PhasedISWAP': <OpType.PhasedISWAP: 82>, 'XXPhase': <OpType.XXPhase: 74>, 'YYPhase': <OpType.YYPhase: 75>, 'ZZPhase': <OpType.ZZPhase: 76>, 'XXPhase3': <OpType.XXPhase3: 77>, 'PhasedX': <OpType.PhasedX: 71>, 'NPhasedX': <OpType.NPhasedX: 72>, 'CnRx': <OpType.CnRx: 84>, 'CnRy': <OpType.CnRy: 83>, 'CnRz': <OpType.CnRz: 85>, 'CnX': <OpType.CnX: 86>, 'CnY': <OpType.CnY: 88>, 'CnZ': <OpType.CnZ: 87>, 'ZZMax': <OpType.ZZMax: 73>, 'ESWAP': <OpType.ESWAP: 78>, 'FSim': <OpType.FSim: 79>, 'Sycamore': <OpType.Sycamore: 80>, 'ISWAPMax': <OpType.ISWAPMax: 81>, 'ClassicalTransform': <OpType.ClassicalTransform: 13>, 'WASM': <OpType.WASM: 14>, 'SetBits': <OpType.SetBits: 15>, 'CopyBits': <OpType.CopyBits: 16>, 'RangePredicate': <OpType.RangePredicate: 17>, 'ExplicitPredicate': <OpType.ExplicitPredicate: 18>, 'ExplicitModifier': <OpType.ExplicitModifier: 19>, 'MultiBit': <OpType.MultiBit: 20>, 'ClassicalExpBox': <OpType.ClassicalExpBox: 109>, 'MultiplexorBox': <OpType.MultiplexorBox: 102>, 'MultiplexedRotationBox': <OpType.MultiplexedRotationBox: 103>, 'MultiplexedU2Box': <OpType.MultiplexedU2Box: 104>, 'MultiplexedTensoredU2Box': <OpType.MultiplexedTensoredU2Box: 105>, 'StatePreparationBox': <OpType.StatePreparationBox: 106>, 'DiagonalBox': <OpType.DiagonalBox: 107>}
     noop: typing.ClassVar[OpType]  # value = <OpType.noop: 65>
     @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
+    @staticmethod
     def from_name(arg0: str) -> OpType:
         """
         Construct from name
@@ -3450,6 +3528,9 @@ class PauliExpBox(Op):
     """
     An operation defined as the exponential of a tensor of Pauli operations and a (possibly symbolic) phase parameter.
     """
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
     def __init__(self, paulis: typing.Sequence[pytket._tket.pauli.Pauli], t: sympy.Expr | float, cx_config_type: CXConfigType = CXConfigType.Tree) -> None:
         """
         Construct :math:`e^{-\\frac12 i \\pi t \\sigma_0 \\otimes \\sigma_1 \\otimes \\cdots}` from Pauli operators :math:`\\sigma_i \\in \\{I,X,Y,Z\\}` and a parameter :math:`t`.
@@ -3474,6 +3555,9 @@ class PauliExpCommutingSetBox(Op):
     """
     An operation defined as a set of commuting of exponentials of atensor of Pauli operations and their (possibly symbolic) phase parameters.
     """
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
     def __init__(self, pauli_gadgets: typing.Sequence[tuple[typing.Sequence[pytket._tket.pauli.Pauli], sympy.Expr | float]], cx_config_type: CXConfigType = CXConfigType.Tree) -> None:
         """
         Construct a set of necessarily commuting Pauli exponentials of the form :math:`e^{-\\frac12 i \\pi t_j \\sigma_0 \\otimes \\sigma_1 \\otimes \\cdots}` from Pauli operator strings :math:`\\sigma_i \\in \\{I,X,Y,Z\\}` and parameters :math:`t_j, j \\in \\{0, 1, \\cdots \\}`.
@@ -3496,6 +3580,9 @@ class PauliExpPairBox(Op):
     Pairing up exponentials for synthesis can reduce gate costs of synthesis compared to synthesising individually, with the best reductions found when the Pauli tensors act on a large number of the same qubits.
     Phase parameters may be symbolic.
     """
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
     def __init__(self, paulis0: typing.Sequence[pytket._tket.pauli.Pauli], t0: sympy.Expr | float, paulis1: typing.Sequence[pytket._tket.pauli.Pauli], t1: sympy.Expr | float, cx_config_type: CXConfigType = CXConfigType.Tree) -> None:
         """
         Construct a pair of Pauli exponentials of the form :math:`e^{-\\frac12 i \\pi t_j \\sigma_0 \\otimes \\sigma_1 \\otimes \\cdots}` from Pauli operator strings :math:`\\sigma_i \\in \\{I,X,Y,Z\\}` and parameters :math:`t_j, j \\in \\{0,1\\}`.
@@ -3520,6 +3607,9 @@ class PhasePolyBox(Op):
     """
     Box encapsulating any Circuit made up of CNOT and RZ as a phase polynomial + linear transformation
     """
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
     @typing.overload
     def __init__(self, n_qubits: int, qubit_indices: dict[pytket._tket.unit_id.Qubit, int], phase_polynomial: dict[tuple[bool, ...], sympy.Expr | float], linear_transformation: NDArray[numpy.bool_]) -> None:
         """
@@ -3570,6 +3660,9 @@ class ProjectorAssertionBox(Op):
     """
     A user-defined assertion specified by a 2x2, 4x4, or 8x8 projector matrix.
     """
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
     def __init__(self, m: NDArray[numpy.complex128], basis: BasisOrder = BasisOrder.ilo) -> None:
         """
         Construct from a projector matrix.
@@ -3589,6 +3682,9 @@ class QControlBox(Op):
     """
     A user-defined controlled operation specified by an :py:class:`Op`, the number of quantum controls, and the control state expressed as an integer or a bit vector.
     """
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
     @typing.overload
     def __init__(self, op: Op, n_controls: int = 1, control_state: typing.Sequence[bool] = []) -> None:
         """
@@ -3636,6 +3732,9 @@ class RangePredicateOp(ClassicalEvalOp):
     """
     A predicate defined by a range of values in binary encoding.
     """
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
     def __init__(self, width: int, lower: int, upper: int) -> None:
         """
         Construct from a bit width, a lower bound and an upper bound.
@@ -3654,6 +3753,9 @@ class ResourceBounds:
     """
     Structure holding a minimum and maximum value of some resource, where both values are unsigned integers.
     """
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
     def __init__(self, min: int, max: int) -> None:
         """
         Constructs a ResourceBounds object.
@@ -3677,6 +3779,9 @@ class ResourceData:
     
     See :py:meth:`Circuit.get_resources` for how to use this data.
     """
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
     def __init__(self, op_type_count: dict[OpType, ResourceBounds], gate_depth: ResourceBounds, op_type_depth: dict[OpType, ResourceBounds], two_qubit_gate_depth: ResourceBounds) -> None:
         """
         Constructs a ResourceData object.
@@ -3708,6 +3813,9 @@ class SetBitsOp(ClassicalEvalOp):
     """
     An operation to set the values of Bits to some constants.
     """
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
     def __init__(self, values: typing.Sequence[bool]) -> None:
         """
         Construct from a table of values.
@@ -3721,6 +3829,9 @@ class StabiliserAssertionBox(Op):
     """
     A user-defined assertion specified by a list of Pauli stabilisers.
     """
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
     @typing.overload
     def __init__(self, stabilisers: typing.Sequence[pytket._tket.pauli.PauliStabiliser]) -> None:
         """
@@ -3747,6 +3858,9 @@ class StatePreparationBox(Op):
     """
     A box for preparing quantum states using multiplexed-Ry and multiplexed-Rz gates. Implementation based on Theorem 9 of arxiv.org/abs/quant-ph/0406176. The decomposed circuit has at most 2*(2^n-2) CX gates, and 2^n-2 CX gates if the coefficients are all real.
     """
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
     def __init__(self, statevector: NDArray[numpy.complex128], is_inverse: bool = False, with_initial_reset: bool = False) -> None:
         """
         Construct from a statevector
@@ -3775,6 +3889,9 @@ class TermSequenceBox(Op):
     """
     An unordered collection of Pauli exponentials that can be synthesised in any order, causing a change in the unitary operation. Synthesis order depends on the synthesis strategy chosen only.
     """
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
     def __init__(self, pauli_gadgets: typing.Sequence[tuple[typing.Sequence[pytket._tket.pauli.Pauli], sympy.Expr | float]], synthesis_strategy: pytket._tket.transform.PauliSynthStrat = pytket._tket.transform.PauliSynthStrat.Sets, partitioning_strategy: pytket._tket.partition.PauliPartitionStrat = pytket._tket.partition.PauliPartitionStrat.CommutingSets, graph_colouring: pytket._tket.partition.GraphColourMethod = pytket._tket.partition.GraphColourMethod.Lazy, cx_config_type: CXConfigType = CXConfigType.Tree, depth_weight: float = 0.3) -> None:
         """
         Construct a set of Pauli exponentials of the form :math:`e^{-\\frac12 i \\pi t_j \\sigma_0 \\otimes \\sigma_1 \\otimes \\cdots}` from Pauli operator strings :math:`\\sigma_i \\in \\{I,X,Y,Z\\}` and parameters :math:`t_j, j \\in \\{0, 1, \\cdots \\}`.
@@ -3812,6 +3929,9 @@ class ToffoliBox(Op):
     """
     An operation that constructs a circuit to implement the specified permutation of classical basis states.
     """
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
     @typing.overload
     def __init__(self, permutation: typing.Sequence[tuple[typing.Sequence[bool], typing.Sequence[bool]]], strat: ToffoliBoxSynthStrat, rotation_axis: OpType = OpType.Ry) -> None:
         """
@@ -3885,6 +4005,9 @@ class ToffoliBoxSynthStrat:
     Cycle: typing.ClassVar[ToffoliBoxSynthStrat]  # value = <ToffoliBoxSynthStrat.Cycle: 1>
     Matching: typing.ClassVar[ToffoliBoxSynthStrat]  # value = <ToffoliBoxSynthStrat.Matching: 0>
     __members__: typing.ClassVar[dict[str, ToffoliBoxSynthStrat]]  # value = {'Matching': <ToffoliBoxSynthStrat.Matching: 0>, 'Cycle': <ToffoliBoxSynthStrat.Cycle: 1>}
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
     def __eq__(self, other: typing.Any) -> bool:
         ...
     def __getstate__(self) -> int:
@@ -3915,6 +4038,9 @@ class Unitary1qBox(Op):
     """
     A user-defined one-qubit operation specified by a unitary matrix.
     """
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
     def __init__(self, m: NDArray[numpy.complex128]) -> None:
         """
         Construct from a unitary matrix.
@@ -3931,6 +4057,9 @@ class Unitary2qBox(Op):
     """
     A user-defined two-qubit operation specified by a unitary matrix.
     """
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
     def __init__(self, m: NDArray[numpy.complex128], basis: BasisOrder = BasisOrder.ilo) -> None:
         """
         Construct from a unitary matrix.
@@ -3950,6 +4079,9 @@ class Unitary3qBox(Op):
     """
     A user-defined three-qubit operation specified by a unitary matrix.
     """
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
     def __init__(self, m: NDArray[numpy.complex128], basis: BasisOrder = BasisOrder.ilo) -> None:
         """
         Construct from a unitary matrix.
@@ -3969,6 +4101,9 @@ class WASMOp(ClassicalOp):
     """
     An op holding an external classical call, defined by the external module id, the name of the function and the arguments. External calls can only act on entire registers (which will be interpreted as fixed-width integers).
     """
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
     def __init__(self, num_bits: int, num_w: int, n_inputs: typing.Sequence[int], n_outputs: typing.Sequence[int], func_name: str, wasm_uid: str) -> None:
         """
         Construct from number of bits, bitwidths of inputs and outputs, function name and module id.

--- a/pytket/pytket/_tket/logging.pyi
+++ b/pytket/pytket/_tket/logging.pyi
@@ -1,3 +1,4 @@
+from typing import Any
 from __future__ import annotations
 import typing
 __all__ = ['level', 'set_level']
@@ -27,6 +28,9 @@ class level:
     off: typing.ClassVar[level]  # value = <level.off: 6>
     trace: typing.ClassVar[level]  # value = <level.trace: 0>
     warn: typing.ClassVar[level]  # value = <level.warn: 3>
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
     def __eq__(self, other: typing.Any) -> bool:
         ...
     def __getstate__(self) -> int:

--- a/pytket/pytket/_tket/mapping.pyi
+++ b/pytket/pytket/_tket/mapping.pyi
@@ -1,3 +1,4 @@
+from typing import Any
 from __future__ import annotations
 import pytket._tket.architecture
 import pytket._tket.circuit
@@ -8,6 +9,9 @@ class AASLabellingMethod(RoutingMethod):
     """
     Defines a Labeling Method for aas for labelling all unplaced qubits in a circuit
     """
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
     def __init__(self) -> None:
         """
         AASLabellingMethod constructor.
@@ -16,6 +20,9 @@ class AASRouteRoutingMethod(RoutingMethod):
     """
     Defines a RoutingMethod object for mapping circuits that uses the architecture aware synthesis method implemented in tket.
     """
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
     def __init__(self, aaslookahead: int) -> None:
         """
         AASRouteRoutingMethod constructor.
@@ -26,6 +33,9 @@ class BoxDecompositionRoutingMethod(RoutingMethod):
     """
     Defines a RoutingMethod object for decomposing boxes.
     """
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
     def __init__(self) -> None:
         """
         BoxDecompositionRoutingMethod constructor.
@@ -34,6 +44,9 @@ class LexiLabellingMethod(RoutingMethod):
     """
     Defines a RoutingMethod for labelling Qubits that uses the Lexicographical Comparison approach outlined in arXiv:1902.08091.
     """
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
     def __init__(self) -> None:
         """
         LexiLabellingMethod constructor.
@@ -42,6 +55,9 @@ class LexiRouteRoutingMethod(RoutingMethod):
     """
     Defines a RoutingMethod object for mapping circuits that uses the Lexicographical Comparison approach outlined in arXiv:1902.08091.Only supports 1-qubit, 2-qubit and barrier gates.
     """
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
     def __init__(self, lookahead: int = 10) -> None:
         """
         LexiRoute constructor.
@@ -52,6 +68,9 @@ class MappingManager:
     """
     Defined by a pytket Architecture object, maps Circuit logical qubits to physically permitted Architecture qubits. Mapping is completed by sequential routing (full or partial) of subcircuits. A custom method for routing (full or partial) of subcircuits can be defined in Python.
     """
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
     def __init__(self, architecture: pytket._tket.architecture.Architecture) -> None:
         """
         MappingManager constructor.
@@ -69,6 +88,9 @@ class MultiGateReorderRoutingMethod(RoutingMethod):
     """
     Defines a RoutingMethod object for commuting physically permitted multi-qubit gates to the front of the subcircuit.
     """
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
     def __init__(self, max_depth: int = 10, max_size: int = 10) -> None:
         """
         MultiGateReorderRoutingMethod constructor.
@@ -80,12 +102,18 @@ class RoutingMethod:
     """
     Parent class for RoutingMethod, for inheritance purposes only, not for usage.
     """
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
     def __init__(self) -> None:
         ...
 class RoutingMethodCircuit(RoutingMethod):
     """
     The RoutingMethod class captures a method for partially mapping logical subcircuits to physical operations as permitted by some architecture. Ranked RoutingMethod objects are used by the MappingManager to route whole circuits.
     """
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
     def __init__(self, route_subcircuit: typing.Callable[[pytket._tket.circuit.Circuit, pytket._tket.architecture.Architecture], tuple[bool, pytket._tket.circuit.Circuit, dict[pytket._tket.unit_id.UnitID, pytket._tket.unit_id.UnitID], dict[pytket._tket.unit_id.UnitID, pytket._tket.unit_id.UnitID]]], max_size: int, max_depth: int) -> None:
         """
         Constructor for a routing method defined by partially routing subcircuits.

--- a/pytket/pytket/_tket/partition.pyi
+++ b/pytket/pytket/_tket/partition.pyi
@@ -1,3 +1,4 @@
+from typing import Any
 from __future__ import annotations
 import pytket._tket.circuit
 import pytket._tket.pauli
@@ -19,6 +20,9 @@ class GraphColourMethod:
     LargestFirst: typing.ClassVar[GraphColourMethod]  # value = <GraphColourMethod.LargestFirst: 1>
     Lazy: typing.ClassVar[GraphColourMethod]  # value = <GraphColourMethod.Lazy: 0>
     __members__: typing.ClassVar[dict[str, GraphColourMethod]]  # value = {'Lazy': <GraphColourMethod.Lazy: 0>, 'LargestFirst': <GraphColourMethod.LargestFirst: 1>, 'Exhaustive': <GraphColourMethod.Exhaustive: 2>}
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
     def __eq__(self, other: typing.Any) -> bool:
         ...
     def __getstate__(self) -> int:
@@ -49,6 +53,9 @@ class MeasurementBitMap:
     """
     Maps Pauli tensors to Clifford circuit indices and bits required for measurement. A MeasurementBitMap belongs to a MeasurementSetup object, and dictates which bits are to be included in the measurement. As Clifford circuits may flip the parity of the corresponding Pauli tensor, the MeasurementBitMap optionally inverts the result.
     """
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
     @staticmethod
     def from_dict(arg0: dict) -> MeasurementBitMap:
         """
@@ -89,6 +96,9 @@ class MeasurementSetup:
     """
     Encapsulates an experiment in which the expectation value of an operator is to be measured via decomposition into QubitPauliStrings. Each tensor expectation value can be measured using shots. These values are then summed together with some weights to retrieve the desired operator expctation value.
     """
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
     @staticmethod
     def from_dict(arg0: dict) -> MeasurementSetup:
         """
@@ -143,6 +153,9 @@ class PauliPartitionStrat:
     CommutingSets: typing.ClassVar[PauliPartitionStrat]  # value = <PauliPartitionStrat.CommutingSets: 1>
     NonConflictingSets: typing.ClassVar[PauliPartitionStrat]  # value = <PauliPartitionStrat.NonConflictingSets: 0>
     __members__: typing.ClassVar[dict[str, PauliPartitionStrat]]  # value = {'NonConflictingSets': <PauliPartitionStrat.NonConflictingSets: 0>, 'CommutingSets': <PauliPartitionStrat.CommutingSets: 1>}
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
     def __eq__(self, other: typing.Any) -> bool:
         ...
     def __getstate__(self) -> int:

--- a/pytket/pytket/_tket/passes.pyi
+++ b/pytket/pytket/_tket/passes.pyi
@@ -15,6 +15,9 @@ class BasePass:
     Base class for passes.
     """
     @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
+    @staticmethod
     def from_dict(arg0: dict) -> BasePass:
         """
         Construct a new Pass instance from a JSON serializable dictionary representation.
@@ -69,6 +72,9 @@ class CNotSynthType:
     Rec: typing.ClassVar[CNotSynthType]  # value = <CNotSynthType.Rec: 2>
     SWAP: typing.ClassVar[CNotSynthType]  # value = <CNotSynthType.SWAP: 0>
     __members__: typing.ClassVar[dict[str, CNotSynthType]]  # value = {'SWAP': <CNotSynthType.SWAP: 0>, 'HamPath': <CNotSynthType.HamPath: 1>, 'Rec': <CNotSynthType.Rec: 2>}
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
     def __eq__(self, other: typing.Any) -> bool:
         ...
     def __getstate__(self) -> int:
@@ -99,6 +105,9 @@ class RepeatPass(BasePass):
     """
     Repeat a pass until its `apply()` method returns False, or if `strict_check` is True until it stops modifying the circuit.
     """
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
     def __init__(self, compilation_pass: BasePass, strict_check: bool = False) -> None:
         """
         Construct from a compilation pass.
@@ -113,6 +122,9 @@ class RepeatUntilSatisfiedPass(BasePass):
     """
     Repeat a compilation pass until a predicate on the circuit is satisfied.
     """
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
     @typing.overload
     def __init__(self, compilation_pass: BasePass, predicate: pytket._tket.predicates.Predicate) -> None:
         """
@@ -137,6 +149,9 @@ class RepeatWithMetricPass(BasePass):
     """
     Repeat a compilation pass until the given metric stops decreasing.
     """
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
     def __init__(self, compilation_pass: BasePass, metric: typing.Callable[[pytket._tket.circuit.Circuit], int]) -> None:
         """
         Construct from a compilation pass and a metric function.
@@ -162,6 +177,9 @@ class SafetyMode:
     Audit: typing.ClassVar[SafetyMode]  # value = <SafetyMode.Audit: 0>
     Default: typing.ClassVar[SafetyMode]  # value = <SafetyMode.Default: 1>
     __members__: typing.ClassVar[dict[str, SafetyMode]]  # value = {'Audit': <SafetyMode.Audit: 0>, 'Default': <SafetyMode.Default: 1>}
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
     def __eq__(self, other: typing.Any) -> bool:
         ...
     def __getstate__(self) -> int:
@@ -192,6 +210,9 @@ class SequencePass(BasePass):
     """
     A sequence of compilation passes.
     """
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
     def __init__(self, pass_list: typing.Sequence[BasePass], strict: bool = True) -> None:
         """
         Construct from a list of compilation passes arranged in order of application.

--- a/pytket/pytket/_tket/pauli.pyi
+++ b/pytket/pytket/_tket/pauli.pyi
@@ -1,4 +1,5 @@
 from numpy.typing import NDArray
+from typing import Any
 from __future__ import annotations
 import numpy
 import pytket._tket.unit_id
@@ -22,6 +23,9 @@ class Pauli:
     Y: typing.ClassVar[Pauli]  # value = <Pauli.Y: 2>
     Z: typing.ClassVar[Pauli]  # value = <Pauli.Z: 3>
     __members__: typing.ClassVar[dict[str, Pauli]]  # value = {'I': <Pauli.I: 0>, 'X': <Pauli.X: 1>, 'Y': <Pauli.Y: 2>, 'Z': <Pauli.Z: 3>}
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
     def __eq__(self, other: typing.Any) -> bool:
         ...
     def __getstate__(self) -> int:
@@ -52,6 +56,9 @@ class PauliStabiliser:
     """
     A string of Pauli letters from the alphabet {I, X, Y, Z} with a +/- 1 coefficient.
     """
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
     def __eq__(self, arg0: typing.Any) -> bool:
         ...
     def __hash__(self) -> int:
@@ -84,6 +91,9 @@ class QubitPauliString:
     """
     A string of Pauli letters from the alphabet {I, X, Y, Z}, implemented as a sparse list, indexed by qubit.
     """
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
     @staticmethod
     def from_list(arg0: list) -> QubitPauliString:
         """
@@ -207,6 +217,9 @@ class QubitPauliTensor:
     """
     A tensor formed by Pauli terms, consisting of a sparse map from :py:class:`Qubit` to :py:class:`Pauli` (implemented as a :py:class:`QubitPauliString`) and a complex coefficient.
     """
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
     def __eq__(self, arg0: typing.Any) -> bool:
         ...
     def __getitem__(self, arg0: pytket._tket.unit_id.Qubit) -> Pauli:

--- a/pytket/pytket/_tket/placement.pyi
+++ b/pytket/pytket/_tket/placement.pyi
@@ -9,6 +9,9 @@ class GraphPlacement(Placement):
     """
     The GraphPlacement class, contains methods for getting maps between Circuit Qubits and Architecture Nodes and for relabelling Circuit Qubits.
     """
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
     def __init__(self, arc: pytket._tket.architecture.Architecture, maximum_matches: int = 1000, timeout: int = 1000, maximum_pattern_gates: int = 100, maximum_pattern_depth: int = 100) -> None:
         """
         The constructor for a GraphPlacement object. The Architecture object describes the connectivity between qubits. To find a qubit to node assignment, this method constructs a pattern graph where vertices are Circuit qubits and edges mean a pair of qubits have an interaction in the circuit, and then tries to find a weighted subgraph monomorphsim to the architecture connectivity, or target, graph. Edges in the pattern graph are weighted by the circuit depth at which the interaction between a pair of qubit occurs. The number of edges added to the pattern graph is effected by the maximum_pattern_gates and maximum_pattern_depth arguments. If no subgraph monomorphism can be found, lower edge weights are removed from the pattern graph, are more edges are added to the target graph. Edges added to the pattern graph are weighted lower to reflect what the distance between the Nodes they  are added between was on the original target graph. 
@@ -29,6 +32,9 @@ class LinePlacement(Placement):
     """
     The LinePlacement class, contains methods for getting maps between Circuit Qubits and Architecture Nodes and for relabelling Circuit Qubits.
     """
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
     def __init__(self, arc: pytket._tket.architecture.Architecture, maximum_line_gates: int = 100, maximum_line_depth: int = 100) -> None:
         """
         The constructor for a LinePlacement object. The Architecture object describes the connectivity between qubits. In this class, a reduced qubit interaction subgraph is constructed where each node has maximum outdegree 2 and does not construct a circle (i.e. lines). To place the Circuit, a Hamiltonian Path is found in the Architecture and this subgraph of lines is assigned along it.
@@ -43,6 +49,9 @@ class NoiseAwarePlacement(Placement):
     """
     The NoiseAwarePlacement class, contains methods for getting maps between Circuit Qubits and Architecture Nodes and for relabelling Circuit Qubits. It uses gate error rates and readout errors to find the best placement map.
     """
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
     def __init__(self, arc: pytket._tket.architecture.Architecture, node_errors: dict[pytket._tket.unit_id.Node, float] = {}, link_errors: dict[tuple[pytket._tket.unit_id.Node, pytket._tket.unit_id.Node], float] = {}, readout_errors: dict[pytket._tket.unit_id.Node, float] = {}, maximum_matches: int = 1000, timeout: int = 1000, maximum_pattern_gates: int = 100, maximum_pattern_depth: int = 100) -> None:
         """
         The constructor for a NoiseAwarePlacement object. The Architecture object describes the connectivity between qubits. The dictionaries passed as parameters indicate the average gate errors for single- and two-qubit gates as well as readouterrors.  If no error is given for a given node or pair of nodes,the fidelity is assumed to be 1.
@@ -66,6 +75,9 @@ class Placement:
     """
     The base Placement class, contains methods for getting maps between Circuit Qubits and Architecture Nodes and for relabelling Circuit Qubits.
     """
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
     @staticmethod
     def from_dict(arg0: dict) -> Placement:
         """

--- a/pytket/pytket/_tket/predicates.pyi
+++ b/pytket/pytket/_tket/predicates.pyi
@@ -1,3 +1,4 @@
+from typing import Any
 from __future__ import annotations
 import pytket._tket.architecture
 import pytket._tket.circuit
@@ -8,6 +9,9 @@ class CliffordCircuitPredicate(Predicate):
     """
     Predicate asserting that a circuit has only Clifford gates.
     """
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
     def __init__(self) -> None:
         """
         Constructor.
@@ -16,6 +20,9 @@ class CommutableMeasuresPredicate(Predicate):
     """
     Predicate asserting that all measurements can be delayed to the end of the circuit.
     """
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
     def __init__(self) -> None:
         """
         Constructor.
@@ -24,6 +31,9 @@ class CompilationUnit:
     """
     This class comprises a circuit and the predicates that the circuit is required to satisfy, for example to run on a backend.
     """
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
     @typing.overload
     def __init__(self, circuit: pytket._tket.circuit.Circuit) -> None:
         """
@@ -61,6 +71,9 @@ class ConnectivityPredicate(Predicate):
     """
     Predicate asserting that a circuit satisfies a given connectivity graph. The graph is always considered to be undirected.
     """
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
     def __init__(self, architecture: pytket._tket.architecture.Architecture) -> None:
         """
         Construct from an :py:class:`Architecture`.
@@ -69,6 +82,9 @@ class DefaultRegisterPredicate(Predicate):
     """
     Predicate asserting that a circuit only uses the default quantum and classical registers.
     """
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
     def __init__(self) -> None:
         """
         Constructor.
@@ -77,6 +93,9 @@ class DirectednessPredicate(Predicate):
     """
     Predicate asserting that a circuit satisfies a given connectivity graph. The graph is always considered to be directed.
     """
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
     def __init__(self, architecture: pytket._tket.architecture.Architecture) -> None:
         """
         Construct from an :py:class:`Architecture`.
@@ -92,6 +111,9 @@ class GateSetPredicate(Predicate):
     
     Classically conditioned operations are permitted provided that the conditioned operation is of a permitted type.
     """
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
     def __init__(self, allowed_types: set[pytket._tket.circuit.OpType]) -> None:
         """
         Construct from a set of gate types.
@@ -103,6 +125,9 @@ class MaxNClRegPredicate(Predicate):
     """
     Predicate asserting that a circuit has at most n classical registers.
     """
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
     def __init__(self, arg0: int) -> None:
         """
         Constructor.
@@ -111,6 +136,9 @@ class MaxNQubitsPredicate(Predicate):
     """
     Predicate asserting that a circuit has at most n qubits.
     """
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
     def __init__(self, arg0: int) -> None:
         """
         Constructor.
@@ -119,6 +147,9 @@ class MaxTwoQubitGatesPredicate(Predicate):
     """
     Predicate asserting that a circuit has no gates with more than two input wires.
     """
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
     def __init__(self) -> None:
         """
         Constructor.
@@ -127,6 +158,9 @@ class NoBarriersPredicate(Predicate):
     """
     Predicate asserting that a circuit contains no Barrier operations.
     """
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
     def __init__(self) -> None:
         """
         Constructor.
@@ -135,6 +169,9 @@ class NoClassicalBitsPredicate(Predicate):
     """
     Predicate asserting that a circuit has no classical wires.
     """
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
     def __init__(self) -> None:
         """
         Constructor.
@@ -143,6 +180,9 @@ class NoClassicalControlPredicate(Predicate):
     """
     Predicate asserting that a circuit has no classical controls.
     """
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
     def __init__(self) -> None:
         """
         Constructor.
@@ -151,6 +191,9 @@ class NoFastFeedforwardPredicate(Predicate):
     """
     Predicate asserting that a circuit has no fast feedforward.
     """
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
     def __init__(self) -> None:
         """
         Constructor.
@@ -159,6 +202,9 @@ class NoMidMeasurePredicate(Predicate):
     """
     Predicate asserting that all measurements occur at the end of the circuit.
     """
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
     def __init__(self) -> None:
         """
         Constructor.
@@ -167,6 +213,9 @@ class NoSymbolsPredicate(Predicate):
     """
     Predicate asserting that no gates in the circuit have symbolic parameters.
     """
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
     def __init__(self) -> None:
         """
         Constructor.
@@ -175,6 +224,9 @@ class NoWireSwapsPredicate(Predicate):
     """
     Predicate asserting that a circuit has no wire swaps.
     """
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
     def __init__(self) -> None:
         """
         Constructor.
@@ -188,6 +240,9 @@ class NormalisedTK2Predicate(Predicate):
      - If all expressions are non symbolic, then it must hold `0.5 ≥ a ≥ b ≥ |c|`.
      - In the ordering (a, b, c), any symbolic expression must appear before non-symbolic ones. The remaining non-symbolic expressions must still be ordered in non-increasing order and must be in the interval [0, 1/2], with the exception of the last one that may be in [-1/2, 1/2].
     """
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
     def __init__(self) -> None:
         """
         Constructor.
@@ -196,6 +251,9 @@ class PlacementPredicate(Predicate):
     """
     Predicate asserting that a circuit has been acted on by some Placement object.
     """
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
     @typing.overload
     def __init__(self, architecture: pytket._tket.architecture.Architecture) -> None:
         """
@@ -210,6 +268,9 @@ class Predicate:
     """
     A predicate that may be satisfied by a circuit.
     """
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
     @staticmethod
     def from_dict(arg0: dict) -> Predicate:
         """
@@ -237,6 +298,9 @@ class UserDefinedPredicate(Predicate):
     """
     User-defined predicate.
     """
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
     def __init__(self, check_function: typing.Callable[[pytket._tket.circuit.Circuit], bool]) -> None:
         """
         Construct from a user-defined function from :py:class:`Circuit` to `bool`.

--- a/pytket/pytket/_tket/tableau.pyi
+++ b/pytket/pytket/_tket/tableau.pyi
@@ -1,4 +1,5 @@
 from numpy.typing import NDArray
+from typing import Any
 from __future__ import annotations
 import numpy
 import pytket._tket.circuit
@@ -10,6 +11,9 @@ class UnitaryRevTableau:
     """
     Equivalent to the UnitaryTableau, except that the rows indicate the action at the input corresponding to either an X or a Z on a single output.
     """
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
     @typing.overload
     def __init__(self, nqb: int) -> None:
         """
@@ -81,6 +85,9 @@ class UnitaryTableau:
     """
     Stabilizer tableau for a unitary in the style of Aaronson&Gottesman "Improved Simulation of Stabilizer Circuits": rows indicate the action at the output corresponding to either an X or a Z on a single input.
     """
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
     @typing.overload
     def __init__(self, nqb: int) -> None:
         """
@@ -152,6 +159,9 @@ class UnitaryTableauBox(pytket._tket.circuit.Op):
     """
     A Clifford unitary specified by its actions on Paulis.
     """
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
     @typing.overload
     def __init__(self, tab: UnitaryTableau) -> None:
         """

--- a/pytket/pytket/_tket/tailoring.pyi
+++ b/pytket/pytket/_tket/tailoring.pyi
@@ -1,3 +1,4 @@
+from typing import Any
 """
 The tailoring module provides access to noise tailoring tools.
 """
@@ -9,6 +10,9 @@ class FrameRandomisation:
     """
     The base FrameRandomisation class. FrameRandomisation finds subcircuits (cycles) of a given circuit comprised of gates with OpType only from a specified set of OpType, and wires gates into the boundary (frame) of these cycles. Input frame gates are sampled from another set of OpType, and output frame gates deduced such that the circuit unitary doesn't change, achieved by computing the action of cycle gates on frame gates.
     """
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
     def __init__(self, arg0: set[pytket._tket.circuit.OpType], arg1: set[pytket._tket.circuit.OpType], arg2: dict[pytket._tket.circuit.OpType, dict[tuple, tuple]]) -> None:
         """
         Constructor for FrameRandomisation.
@@ -38,6 +42,9 @@ class PauliFrameRandomisation:
     """
     The PauliFrameRandomisation class. PauliFrameRandomisation finds subcircuits (cycles) of a given circuit comprised of gates with OpType::H, OpType::CX and OpType::S, and wires gates into the boundary (frame) of these cycles. Input frame gates are sampled from another set of OpType comprised of the Pauli gates, and output frame gates deduced such that the circuit unitary doesn't change, achieved by computing the action of cycle gates on frame gates.
     """
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
     def __init__(self) -> None:
         """
         Constructor for PauliFrameRandomisation.
@@ -63,6 +70,9 @@ class UniversalFrameRandomisation:
     """
     The UniversalFrameRandomisation class. UniversalFrameRandomisation finds subcircuits (cycles) of a given circuit comprised of gates with OpType::H, OpType::CX, and OpType::Rz, and wires gates into the boundary (frame) of these cycles. Input frame gates are sampled from another set of OpType comprised of the Pauli gates, and output frame gates deduced such that the circuit unitary doesn't change, achieved by computing the action of cycle gates on frame gates. Some gates with OpType::Rz may be substituted for their dagger to achieve this.
     """
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
     def __init__(self) -> None:
         """
         Constructor for UniversalFrameRandomisation.

--- a/pytket/pytket/_tket/transform.pyi
+++ b/pytket/pytket/_tket/transform.pyi
@@ -24,6 +24,9 @@ class PauliSynthStrat:
     Pairwise: typing.ClassVar[PauliSynthStrat]  # value = <PauliSynthStrat.Pairwise: 1>
     Sets: typing.ClassVar[PauliSynthStrat]  # value = <PauliSynthStrat.Sets: 2>
     __members__: typing.ClassVar[dict[str, PauliSynthStrat]]  # value = {'Individual': <PauliSynthStrat.Individual: 0>, 'Pairwise': <PauliSynthStrat.Pairwise: 1>, 'Sets': <PauliSynthStrat.Sets: 2>, 'Greedy': <PauliSynthStrat.Greedy: 3>}
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
     def __eq__(self, other: typing.Any) -> bool:
         ...
     def __getstate__(self) -> int:
@@ -309,6 +312,9 @@ class Transform:
         """
         Fixes all ZZPhase gate angles to [-1, 1) half turns.
         """
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
     @staticmethod
     def repeat(transform: Transform) -> Transform:
         """

--- a/pytket/pytket/_tket/unit_id.pyi
+++ b/pytket/pytket/_tket/unit_id.pyi
@@ -1,3 +1,4 @@
+from typing import Any
 from __future__ import annotations
 import pytket.circuit.logic_exp
 import typing
@@ -6,6 +7,9 @@ class Bit(UnitID):
     """
     A handle to a bit
     """
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
     @staticmethod
     def from_list(arg0: list) -> Bit:
         """
@@ -84,6 +88,9 @@ class BitRegister:
     """
     Linear register of UnitID types.
     """
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
     def __add__(self: typing.Union[pytket.circuit.logic_exp.LogicExp, pytket._tket.unit_id.BitRegister, int], other: typing.Union[pytket.circuit.logic_exp.LogicExp, pytket._tket.unit_id.BitRegister, int]) -> pytket.circuit.logic_exp.RegLogicExp:
         ...
     def __and__(self: typing.Union[pytket.circuit.logic_exp.LogicExp, pytket._tket.unit_id.BitRegister, int], other: typing.Union[pytket.circuit.logic_exp.LogicExp, pytket._tket.unit_id.BitRegister, int]) -> pytket.circuit.logic_exp.RegLogicExp:
@@ -172,6 +179,9 @@ class Node(Qubit):
     A handle to a device node
     """
     @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
+    @staticmethod
     def from_list(arg0: list) -> Node:
         """
         Construct Node instance from JSON serializable list representation of the Node.
@@ -230,6 +240,9 @@ class Qubit(UnitID):
     """
     A handle to a qubit
     """
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
     @staticmethod
     def from_list(arg0: list) -> Qubit:
         """
@@ -290,6 +303,9 @@ class QubitRegister:
     """
     Linear register of UnitID types.
     """
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
     def __contains__(self, arg0: Qubit) -> bool:
         ...
     def __copy__(self) -> QubitRegister:
@@ -351,6 +367,9 @@ class UnitID:
     """
     A handle to a computational unit (e.g. qubit, bit)
     """
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
     def __copy__(self) -> UnitID:
         ...
     def __deepcopy__(self, arg0: dict) -> UnitID:
@@ -393,6 +412,9 @@ class UnitType:
     __members__: typing.ClassVar[dict[str, UnitType]]  # value = {'qubit': <UnitType.qubit: 0>, 'bit': <UnitType.bit: 1>}
     bit: typing.ClassVar[UnitType]  # value = <UnitType.bit: 1>
     qubit: typing.ClassVar[UnitType]  # value = <UnitType.qubit: 0>
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
     def __eq__(self, other: typing.Any) -> bool:
         ...
     def __getstate__(self) -> int:

--- a/pytket/pytket/_tket/zx.pyi
+++ b/pytket/pytket/_tket/zx.pyi
@@ -1,3 +1,4 @@
+from typing import Any
 from __future__ import annotations
 import pytket._tket.circuit
 import pytket._tket.unit_id
@@ -8,6 +9,9 @@ class CliffordGen(ZXGen):
     """
     Specialisation of :py:class:`ZXGen` for arbitrary-arity, symmetric Clifford generators with a single boolean parameter.
     """
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
     def __init__(self, zxtype: ZXType, param: bool = False, qtype: QuantumType = QuantumType.Quantum) -> None:
         """
         Construct from a ZX type, parameter and quantum type.
@@ -21,6 +25,9 @@ class DirectedGen(ZXGen):
     """
     Specialisation of :py:class:`ZXGen` for asymmetric ZX generators which can be doubled to form a Quantum variant. Asymmetric effects handled by ports to distinguish operands.
     """
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
     def __init__(self, zxtype: ZXType, qtype: QuantumType) -> None:
         """
         Construct from a ZX type and quantum type.
@@ -39,6 +46,9 @@ class Flow:
     """
     Data structure for describing the Flow in a given MBQC-form :py:class:`ZXDiagram` object. Constructors are identification methods for different classes of Flow.
     """
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
     @staticmethod
     def identify_causal_flow(diag: ZXDiagram) -> Flow:
         """
@@ -84,6 +94,9 @@ class PhasedGen(ZXGen):
     """
     Specialisation of :py:class:`ZXGen` for arbitrary-arity, symmetric generators with a single continuous parameter.
     """
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
     def __init__(self, zxtype: ZXType, param: sympy.Expr | float = 0.0, qtype: QuantumType = QuantumType.Quantum) -> None:
         """
         Construct from a ZX type, parameter and quantum type.
@@ -106,6 +119,9 @@ class QuantumType:
     Classical: typing.ClassVar[QuantumType]  # value = <QuantumType.Classical: 1>
     Quantum: typing.ClassVar[QuantumType]  # value = <QuantumType.Quantum: 0>
     __members__: typing.ClassVar[dict[str, QuantumType]]  # value = {'Quantum': <QuantumType.Quantum: 0>, 'Classical': <QuantumType.Classical: 1>}
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
     def __eq__(self, other: typing.Any) -> bool:
         ...
     def __getstate__(self) -> int:
@@ -136,6 +152,9 @@ class Rewrite:
     """
     An in-place transformation of a ZXDiagram.
     """
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
     @staticmethod
     def basic_wires() -> Rewrite:
         """
@@ -263,6 +282,9 @@ class ZXBox(ZXGen):
     """
     Specialisation of :py:class:`ZXGen` for encapsulations of some other ZX diagrams. In general, arbitrary diagrams may be asymmetric tensors with both Quantum and Classical boundaries, so ports are used to distinguish each boundary.
     """
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
     def __init__(self, zxdiag: ZXDiagram) -> None:
         """
         Construct from a ZX diagram.
@@ -286,6 +308,9 @@ class ZXDiagram:
     """
     Undirected graphs for mixed process ZX diagrams. The boundary is an ordered list which may mix inputs, outputs, and "open" vertices (not specified to be inputs or outputs). Directed vertices (e.g. Boxes, Triangles, etc.) have numbered ports to distinguish different incident edges. The content of each vertex is given by a :py:class:`ZXGen` generator, describing the :py:class:`ZXType` (e.g. XSpider, Input, Triangle), the QuantumType for single/doubled versions of typical generators, and any parameters such as phase. Wires are undirected and have a :py:class:`ZXWireType` (e.g. Basic, Hadamard) and :py:class:`QuantumType` (a single wire or a doubled pair for a quantum system).
     """
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
     @typing.overload
     def __init__(self) -> None:
         """
@@ -534,6 +559,9 @@ class ZXGen:
     Encapsulates the information about the generator depicted by a given vertex in a :py:class:`ZXDiagram`.
     """
     @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
+    @staticmethod
     @typing.overload
     def create(type: ZXType, qtype: QuantumType = QuantumType.Quantum) -> ZXGen:
         """
@@ -612,6 +640,9 @@ class ZXType:
     ZSpider: typing.ClassVar[ZXType]  # value = <ZXType.ZSpider: 3>
     ZXBox: typing.ClassVar[ZXType]  # value = <ZXType.ZXBox: 13>
     __members__: typing.ClassVar[dict[str, ZXType]]  # value = {'Input': <ZXType.Input: 0>, 'Output': <ZXType.Output: 1>, 'Open': <ZXType.Open: 2>, 'ZSpider': <ZXType.ZSpider: 3>, 'XSpider': <ZXType.XSpider: 4>, 'Hbox': <ZXType.Hbox: 5>, 'XY': <ZXType.XY: 6>, 'XZ': <ZXType.XZ: 7>, 'YZ': <ZXType.YZ: 8>, 'PX': <ZXType.PX: 9>, 'PY': <ZXType.PY: 10>, 'PZ': <ZXType.PZ: 11>, 'Triangle': <ZXType.Triangle: 12>, 'ZXBox': <ZXType.ZXBox: 13>}
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
     def __eq__(self, other: typing.Any) -> bool:
         ...
     def __getstate__(self) -> int:
@@ -642,6 +673,9 @@ class ZXVert:
     """
     A handle to a vertex in a :py:class:`ZXDiagram`. Each instance is specific to a given :py:class:`ZXDiagram` instance and can be invalidated by rewrites. Exceptions or errors may occur if calling functions on a :py:class:`ZXVert` that is not present in the given :py:class:`ZXDiagram`.
     """
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
     def __eq__(self, arg0: typing.Any) -> bool:
         ...
     def __hash__(self) -> int:
@@ -652,6 +686,9 @@ class ZXWire:
     """
     A handle to a wire in a :py:class:`ZXDiagram`. Each instance is specific to a given :py:class:`ZXDiagram` instance and can be invalidated by rewrites. Exceptions or errors may occur if calling functions on a :py:class:`ZXWire` that is not present in the given :py:class:`ZXDiagram`.
     """
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
     def __eq__(self, arg0: typing.Any) -> bool:
         ...
     def __hash__(self) -> int:
@@ -669,6 +706,9 @@ class ZXWireType:
     Basic: typing.ClassVar[ZXWireType]  # value = <ZXWireType.Basic: 0>
     H: typing.ClassVar[ZXWireType]  # value = <ZXWireType.H: 1>
     __members__: typing.ClassVar[dict[str, ZXWireType]]  # value = {'Basic': <ZXWireType.Basic: 0>, 'H': <ZXWireType.H: 1>}
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
+        ...
     def __eq__(self, other: typing.Any) -> bool:
         ...
     def __getstate__(self) -> int:

--- a/pytket/stub_generation/regenerate_stubs
+++ b/pytket/stub_generation/regenerate_stubs
@@ -108,6 +108,13 @@ if __name__ == "__main__":
                 text = file.read()
                 text = stub_fixer.handle_args_kwargs_types(text)
                 text = stub_fixer.handle_numpy_stuff(text)
+                # Ignore types for the generated function _pybind11_conduit_v1_.
+                # Note that the annotations for args and kwargs were added by
+                # this script (above), so remove those too.
+                text = text.replace(
+                    "def _pybind11_conduit_v1_(*args: Any, **kwargs: Any):",
+                    "def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore",
+                )
 
             with path.open("w") as file:
                 file.write(text)

--- a/recipes/pybind11/conanfile.py
+++ b/recipes/pybind11/conanfile.py
@@ -21,7 +21,7 @@ import os
 
 class PyBind11Conan(ConanFile):
     name = "pybind11"
-    version = "2.13.5"
+    version = "2.13.6"
     description = "Seamless operability between C++11 and Python"
     topics = "pybind11", "python", "binding"
     homepage = "https://github.com/pybind/pybind11"

--- a/recipes/pybind11_json/all/conanfile.py
+++ b/recipes/pybind11_json/all/conanfile.py
@@ -29,7 +29,7 @@ class Pybind11JsonConan(ConanFile):
 
     def requirements(self):
         self.requires("nlohmann_json/3.11.3")
-        self.requires("pybind11/2.13.5")
+        self.requires("pybind11/2.13.6")
 
     def source(self):
         get(

--- a/tket/conanfile.py
+++ b/tket/conanfile.py
@@ -121,7 +121,7 @@ class TketConan(ConanFile):
         self.requires("tktokenswap/0.3.9@tket/stable")
         self.requires("tkwsm/0.3.9@tket/stable")
         if self.build_test():
-            self.test_requires("catch2/3.7.0")
+            self.test_requires("catch2/3.7.1")
         if self.build_proptest():
             self.test_requires("rapidcheck/cci.20230815")
 

--- a/tket/conanfile.py
+++ b/tket/conanfile.py
@@ -23,7 +23,7 @@ from conan.errors import ConanInvalidConfiguration
 
 class TketConan(ConanFile):
     name = "tket"
-    version = "1.3.26"
+    version = "1.3.27"
     package_type = "library"
     license = "Apache 2"
     homepage = "https://github.com/CQCL/tket"


### PR DESCRIPTION
With the pybind11 update, a new stub function is added in many places in the `.pyi` files generated by pybind11-stubgen. To avoid mypy errors I modified the stub-generation script to add a `# type: ignore` to this function (as I have no idea what the return type should be).