### PR TITLE
Ensure `CXMappingPass` works on circuits containing barriers or wire swaps

### DIFF
--- a/pytket/conanfile.py
+++ b/pytket/conanfile.py
@@ -38,7 +38,7 @@ class pytketRecipe(ConanFile):
         self.requires("pybind11_json/0.2.14")
         self.requires("symengine/0.12.0")
         self.requires("tkassert/0.3.4@tket/stable")
-        self.requires("tket/1.3.29@tket/stable")
+        self.requires("tket/1.3.30@tket/stable")
         self.requires("tklog/0.3.3@tket/stable")
         self.requires("tkrng/0.3.3@tket/stable")
         self.requires("tktokenswap/0.3.9@tket/stable")

--- a/pytket/docs/changelog.rst
+++ b/pytket/docs/changelog.rst
@@ -17,6 +17,7 @@ Fixes:
 
 * Fix QASM conversion of non-register-aligned `MultiBitOp`.
 * Fix `DecomposeClassicalExp()` when target occurs in expression.
+* Allow barriers and wire swaps in `DecomposeSwapsToCXs()`.
 
 1.32.0 (September 2024)
 -----------------------

--- a/tket/conanfile.py
+++ b/tket/conanfile.py
@@ -23,7 +23,7 @@ from conan.errors import ConanInvalidConfiguration
 
 class TketConan(ConanFile):
     name = "tket"
-    version = "1.3.29"
+    version = "1.3.30"
     package_type = "library"
     license = "Apache 2"
     homepage = "https://github.com/CQCL/tket"

--- a/tket/src/Predicates/PassGenerators.cpp
+++ b/tket/src/Predicates/PassGenerators.cpp
@@ -780,6 +780,7 @@ PassPtr gen_decompose_routing_gates_to_cxs_pass(
     OpTypeSet in_optypes = out_optypes;
     in_optypes.insert(OpType::SWAP);
     in_optypes.insert(OpType::BRIDGE);
+    in_optypes.insert(OpType::Barrier);
     PredicatePtr twoqbpred = std::make_shared<MaxTwoQubitGatesPredicate>();
     PredicatePtr connected = std::make_shared<ConnectivityPredicate>(arc);
     PredicatePtr wireswaps = std::make_shared<NoWireSwapsPredicate>();

--- a/tket/src/Predicates/PassGenerators.cpp
+++ b/tket/src/Predicates/PassGenerators.cpp
@@ -783,13 +783,11 @@ PassPtr gen_decompose_routing_gates_to_cxs_pass(
     in_optypes.insert(OpType::Barrier);
     PredicatePtr twoqbpred = std::make_shared<MaxTwoQubitGatesPredicate>();
     PredicatePtr connected = std::make_shared<ConnectivityPredicate>(arc);
-    PredicatePtr wireswaps = std::make_shared<NoWireSwapsPredicate>();
     PredicatePtr directedpred = std::make_shared<DirectednessPredicate>(arc);
     PredicatePtr ingates = std::make_shared<GateSetPredicate>(in_optypes);
     PredicatePtr outgates = std::make_shared<GateSetPredicate>(out_optypes);
     precons = {
         CompilationUnit::make_type_pair(connected),
-        CompilationUnit::make_type_pair(wireswaps),
         CompilationUnit::make_type_pair(ingates)};
     s_postcons = {
         CompilationUnit::make_type_pair(directedpred),


### PR DESCRIPTION
# Description

Allow barriers and wireswaps in `DecomposeSwapsToCXs`.

# Related issues

Fixes #1597 .

# Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented hard-to-understand parts of my code.
- [ ] I have made corresponding changes to the public API documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the changelog with any user-facing changes.
