### PR TITLE
Fix initialization of subcircuit in `GuidedPauliSimp` implementation

### DIFF
--- a/pytket/conanfile.py
+++ b/pytket/conanfile.py
@@ -38,7 +38,7 @@ class pytketRecipe(ConanFile):
         self.requires("pybind11_json/0.2.14")
         self.requires("symengine/0.12.0")
         self.requires("tkassert/0.3.4@tket/stable")
-        self.requires("tket/1.3.31@tket/stable")
+        self.requires("tket/1.3.32@tket/stable")
         self.requires("tklog/0.3.3@tket/stable")
         self.requires("tkrng/0.3.3@tket/stable")
         self.requires("tktokenswap/0.3.9@tket/stable")

--- a/pytket/docs/changelog.rst
+++ b/pytket/docs/changelog.rst
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+Unreleased
+----------
+
+Fixes:
+
+* Fix `GuidedPauliSimp` for circuits containing `CircBox` with classical wires.
+
 1.33.0 (October 2024)
 ---------------------
 

--- a/tket/conanfile.py
+++ b/tket/conanfile.py
@@ -23,7 +23,7 @@ from conan.errors import ConanInvalidConfiguration
 
 class TketConan(ConanFile):
     name = "tket"
-    version = "1.3.31"
+    version = "1.3.32"
     package_type = "library"
     license = "Apache 2"
     homepage = "https://github.com/CQCL/tket"

--- a/tket/src/Transformations/PauliOptimisation.cpp
+++ b/tket/src/Transformations/PauliOptimisation.cpp
@@ -16,6 +16,7 @@
 
 #include "tket/Circuit/CircUtils.hpp"
 #include "tket/Converters/Converters.hpp"
+#include "tket/OpType/EdgeType.hpp"
 #include "tket/OpType/OpType.hpp"
 #include "tket/OpType/OpTypeInfo.hpp"
 #include "tket/PauliGraph/PauliGraph.hpp"
@@ -238,7 +239,13 @@ Transform special_UCC_synthesis(PauliSynthStrat strat, CXConfigType cx_config) {
       Circuit inner_circ = *(box_ptr->to_circuit());
       synther.apply(inner_circ);
       decomp_boxes().apply(inner_circ);
-      Subcircuit sub = {circ.get_in_edges(v), circ.get_all_out_edges(v), {v}};
+      Subcircuit sub = {
+          circ.get_in_edges_of_type(v, EdgeType::Quantum),
+          circ.get_out_edges_of_type(v, EdgeType::Quantum),
+          circ.get_in_edges_of_type(v, EdgeType::Classical),
+          circ.get_out_edges_of_type(v, EdgeType::Classical),
+          circ.get_in_edges_of_type(v, EdgeType::Boolean),
+          {v}};
       circ.substitute(inner_circ, sub);
     }
     return !circbox_verts

--- a/tket/test/src/test_PauliGraph.cpp
+++ b/tket/test/src/test_PauliGraph.cpp
@@ -28,6 +28,7 @@
 #include "tket/PauliGraph/PauliGraph.hpp"
 #include "tket/Transformations/PauliOptimisation.hpp"
 #include "tket/Transformations/Rebase.hpp"
+#include "tket/Utils/UnitID.hpp"
 
 namespace tket {
 namespace test_PauliGraph {
@@ -692,6 +693,14 @@ SCENARIO("Test mutual diagonalisation of fully commuting sets") {
     test1.symbol_substitution(symbol_map);
     test2.symbol_substitution(symbol_map);
     REQUIRE(test_statevector_comparison(test1, test2));
+  }
+  GIVEN("A circuit with a classical bit") {
+    // https://github.com/CQCL/tket/issues/1578
+    Circuit c0(0, 1);
+    CircBox cbox(c0);
+    Circuit c(0, 1);
+    c.add_box<CircBox, Bit>(cbox, {Bit("c", 0)});
+    REQUIRE_NOTHROW(Transforms::special_UCC_synthesis().apply(c));
   }
   GIVEN(
       "Clifford merges requires removing from start line without segfault "


### PR DESCRIPTION
# Description

Subcircuit was being constructed assuming that all wires were quantum. Make it use classical wires as well.

# Related issues

Fixes #1578 .

# Checklist

- [x] I have performed a self-review of my code.
- [ ] I have commented hard-to-understand parts of my code.
- [ ] I have made corresponding changes to the public API documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have updated the changelog with any user-facing changes.
