### PR TITLE
fix: update wasm functions to accept `WasmModuleHandler`

### DIFF
--- a/pytket/pytket/_tket/circuit.pyi
+++ b/pytket/pytket/_tket/circuit.pyi
@@ -37,11 +37,11 @@ class BasisOrder:
     For statevector and unitaries, the string abc is interpreted as an index in a big-endian (BE) fashion. e.g. the statevector :math:`(a_{00}, a_{01}, a_{10}, a_{11})`
     Some backends (Qiskit, ProjectQ, etc.) use a DLO-BE (decreasing lexicographic order, big-endian) convention. This is the same as ILO-LE (little-endian) for statevectors and unitaries, but gives shot tables/readouts in a counter-intuitive manner.
     Every backend and matrix-based box has a BasisOrder option which can toggle between ILO-BE (ilo) and DLO-BE (dlo).
-    
+
     Members:
-    
+
       ilo : Increasing Lexicographic Order of UnitID, big-endian
-    
+
       dlo : Decreasing Lexicographic Order of UnitID, big-endian
     """
     __members__: typing.ClassVar[dict[str, BasisOrder]]  # value = {'ilo': <BasisOrder.ilo: 0>, 'dlo': <BasisOrder.dlo: 1>}
@@ -79,15 +79,15 @@ class BasisOrder:
 class CXConfigType:
     """
     Enum for available configurations for CXs upon decompose phase gadgets
-    
+
     Members:
-    
+
       Snake : linear nearest neighbour CX sequence. Linear depth.
-    
+
       Star : Every CX has same target, linear depth, good for gate cancellation.
-    
+
       Tree : Balanced tree: logarithmic depth, harder to route.
-    
+
       MultiQGate : Support for multi-qubit architectures, decomposing to 3-qubit XXPhase3 gates instead of CXs where possible.
     """
     MultiQGate: typing.ClassVar[CXConfigType]  # value = <CXConfigType.MultiQGate: 3>
@@ -141,17 +141,17 @@ class CircBox(Op):
         """
     def symbol_substitution(self, symbol_map: dict[sympy.Symbol, sympy.Expr | float]) -> None:
         """
-        In-place substitution of symbolic expressions within underlying circuit; iterates through each parameterised gate/box within the circuit and performs the substitution. 
-        
-         WARNING: This method potentially mutates the CircBox and any changes are propagated to any Circuit that the CircBox has been added to (via Circuit.add_circbox). 
-        
+        In-place substitution of symbolic expressions within underlying circuit; iterates through each parameterised gate/box within the circuit and performs the substitution.
+
+         WARNING: This method potentially mutates the CircBox and any changes are propagated to any Circuit that the CircBox has been added to (via Circuit.add_circbox).
+
         :param symbol_map: A map from SymPy symbols to SymPy expressions
         """
     @property
     def circuit_name(self) -> str | None:
         """
-        :return: the name of the contained circuit. 
-        
+        :return: the name of the contained circuit.
+
          WARNING: Setting this property mutates the CircBox and any changes are propagated to any Circuit that the CircBox has been added to (via Circuit.add_circbox).
         """
     @circuit_name.setter
@@ -160,7 +160,7 @@ class CircBox(Op):
 class Circuit:
     """
     Encapsulates a quantum circuit using a DAG representation.
-    
+
     >>> from pytket import Circuit
     >>> c = Circuit(4,2) # Create a circuit with 4 qubits and 2 classical bits
     >>> c.H(0) # Apply a gate to qubit 0
@@ -179,378 +179,378 @@ class Circuit:
     def AAMS(self, angle0: sympy.Expr | float, angle1: sympy.Expr | float, angle2: sympy.Expr | float, qubit0: int, qubit1: int, **kwargs: Any) -> Circuit:
         """
         Appends an AAMS gate with possibly symbolic angles (specified in half-turns).
-        
+
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def AAMS(self, angle0: sympy.Expr | float, angle1: sympy.Expr | float, angle2: sympy.Expr | float, qubit0: pytket._tket.unit_id.Qubit, qubit1: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends an AAMS gate with possibly symbolic angles (specified in half-turns).
-        
+
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def CCX(self, control_0: int, control_1: int, target: int, **kwargs: Any) -> Circuit:
         """
         Appends a CCX gate on the wires for the specified control and target qubits.
-        
+
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def CCX(self, control_0: pytket._tket.unit_id.Qubit, control_1: pytket._tket.unit_id.Qubit, target: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a CCX gate on the wires for the specified control and target qubits.
-        
+
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def CH(self, control_qubit: int, target_qubit: int, **kwargs: Any) -> Circuit:
         """
         Appends a CH gate on the wires for the specified control and target qubits.
-        
+
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def CH(self, control_qubit: pytket._tket.unit_id.Qubit, target_qubit: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a CH gate on the wires for the specified control and target qubits.
-        
+
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def CRx(self, angle: sympy.Expr | float, control_qubit: int, target_qubit: int, **kwargs: Any) -> Circuit:
         """
         Appends a CRx gate with a possibly symbolic angle (specified in half-turns) on the wires for the specified control and target qubits.
-        
+
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def CRx(self, angle: sympy.Expr | float, control_qubit: pytket._tket.unit_id.Qubit, target_qubit: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a CRx gate with a symbolic angle (specified in half-turns) on the wires for the specified control and target qubits.
-        
+
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def CRy(self, angle: sympy.Expr | float, control_qubit: int, target_qubit: int, **kwargs: Any) -> Circuit:
         """
         Appends a CRy gate with a possibly symbolic angle (specified in half-turns) on the wires for the specified control and target qubits.
-        
+
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def CRy(self, angle: sympy.Expr | float, control_qubit: pytket._tket.unit_id.Qubit, target_qubit: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a CRy gate with a symbolic angle (specified in half-turns) on the wires for the specified control and target qubits.
-        
+
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def CRz(self, angle: sympy.Expr | float, control_qubit: int, target_qubit: int, **kwargs: Any) -> Circuit:
         """
         Appends a CRz gate with a possibly symbolic angle (specified in half-turns) on the wires for the specified control and target qubits.
-        
+
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def CRz(self, angle: sympy.Expr | float, control_qubit: pytket._tket.unit_id.Qubit, target_qubit: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a CRz gate with a symbolic angle (specified in half-turns) on the wires for the specified control and target qubits.
-        
+
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def CS(self, control_qubit: int, target_qubit: int, **kwargs: Any) -> Circuit:
         """
         Appends a CS gate on the wires for the specified control and target qubits.
-        
+
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def CS(self, control_qubit: pytket._tket.unit_id.Qubit, target_qubit: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a CS gate on the wires for the specified control and target qubits.
-        
+
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def CSWAP(self, control: int, target_0: int, target_1: int, **kwargs: Any) -> Circuit:
         """
         Appends a CSWAP gate on the wires for the specified control and target qubits.
-        
+
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def CSWAP(self, control: pytket._tket.unit_id.Qubit, target_0: pytket._tket.unit_id.Qubit, target_1: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a CSWAP gate on the wires for the specified control and target qubits.
-        
+
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def CSX(self, control_qubit: int, target_qubit: int, **kwargs: Any) -> Circuit:
         """
         Appends a CSX gate on the wires for the specified control and target qubits.
-        
+
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def CSX(self, control_qubit: pytket._tket.unit_id.Qubit, target_qubit: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a CSX gate on the wires for the specified control and target qubits.
-        
+
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def CSXdg(self, control_qubit: int, target_qubit: int, **kwargs: Any) -> Circuit:
         """
         Appends a CSXdg gate on the wires for the specified control and target qubits.
-        
+
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def CSXdg(self, control_qubit: pytket._tket.unit_id.Qubit, target_qubit: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a CSXdg gate on the wires for the specified control and target qubits.
-        
+
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def CSdg(self, control_qubit: int, target_qubit: int, **kwargs: Any) -> Circuit:
         """
         Appends a CSdg gate on the wires for the specified control and target qubits.
-        
+
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def CSdg(self, control_qubit: pytket._tket.unit_id.Qubit, target_qubit: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a CSdg gate on the wires for the specified control and target qubits.
-        
+
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def CU1(self, angle: sympy.Expr | float, control_qubit: int, target_qubit: int, **kwargs: Any) -> Circuit:
         """
         Appends a CU1 gate with a possibly symbolic angle (specified in half-turns) on the wires for the specified control and target qubits.
-        
+
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def CU1(self, angle: sympy.Expr | float, control_qubit: pytket._tket.unit_id.Qubit, target_qubit: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a CU1 gate with a possibly symbolic angle (specified in half-turns) on the wires for the specified control and target qubits.
-        
+
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def CU3(self, angle0: sympy.Expr | float, angle1: sympy.Expr | float, angle2: sympy.Expr | float, control_qubit: int, target_qubit: int, **kwargs: Any) -> Circuit:
         """
         Appends a CU3 gate with possibly symbolic angles (specified in half-turns) on the wires for the specified control and target qubits.
-        
+
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def CU3(self, angle0: sympy.Expr | float, angle1: sympy.Expr | float, angle2: sympy.Expr | float, control_qubit: pytket._tket.unit_id.Qubit, target_qubit: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a CU3 gate with possibly symbolic angles (specified in half-turns) on the wires for the specified control and target qubits.
-        
+
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def CV(self, control_qubit: int, target_qubit: int, **kwargs: Any) -> Circuit:
         """
         Appends a CV gate on the wires for the specified control and target qubits.
-        
+
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def CV(self, control_qubit: pytket._tket.unit_id.Qubit, target_qubit: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a CV gate on the wires for the specified control and target qubits.
-        
+
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def CVdg(self, control_qubit: int, target_qubit: int, **kwargs: Any) -> Circuit:
         """
         Appends a CVdg gate on the wires for the specified control and target qubits.
-        
+
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def CVdg(self, control_qubit: pytket._tket.unit_id.Qubit, target_qubit: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a CVdg gate on the wires for the specified control and target qubits.
-        
+
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def CX(self, control_qubit: int, target_qubit: int, **kwargs: Any) -> Circuit:
         """
         Appends a CX gate on the wires for the specified control and target qubits.
-        
+
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def CX(self, control_qubit: pytket._tket.unit_id.Qubit, target_qubit: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a CX gate on the wires for the specified control and target qubits.
-        
+
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def CY(self, control_qubit: int, target_qubit: int, **kwargs: Any) -> Circuit:
         """
         Appends a CY gate on the wires for the specified control and target qubits.
-        
+
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def CY(self, control_qubit: pytket._tket.unit_id.Qubit, target_qubit: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a CY gate on the wires for the specified control and target qubits.
-        
+
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def CZ(self, control_qubit: int, target_qubit: int, **kwargs: Any) -> Circuit:
         """
         Appends a CZ gate on the wires for the specified control and target qubits.
-        
+
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def CZ(self, control_qubit: pytket._tket.unit_id.Qubit, target_qubit: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a CZ gate on the wires for the specified control and target qubits.
-        
+
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def ECR(self, qubit_0: int, qubit_1: int, **kwargs: Any) -> Circuit:
         """
         Appends an ECR gate on the wires for the specified qubits.
-        
+
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def ECR(self, qubit_0: pytket._tket.unit_id.Qubit, qubit_1: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends an ECR gate on the wires for the specified qubits.
-        
+
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def ESWAP(self, angle: sympy.Expr | float, qubit0: int, qubit1: int, **kwargs: Any) -> Circuit:
         """
         Appends an ESWAP gate with a possibly symbolic angle (specified in half-turns) on the wires for the specified two qubits.
-        
+
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def ESWAP(self, angle: sympy.Expr | float, qubit0: pytket._tket.unit_id.Qubit, qubit1: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends an ESWAP gate with a possibly symbolic angle (specified in half-turns) on the wires for the specified two qubits.
-        
+
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def FSim(self, angle0: sympy.Expr | float, angle1: sympy.Expr | float, qubit0: int, qubit1: int, **kwargs: Any) -> Circuit:
         """
         Appends an FSim gate with possibly symbolic angles (specified in half-turns) on the wires for the specified qubits.
-        
+
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def FSim(self, angle0: sympy.Expr | float, angle1: sympy.Expr | float, qubit0: pytket._tket.unit_id.Qubit, qubit1: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends an FSim gate with possibly symbolic angles (specified in half-turns) on the wires for the specified qubits.
-        
+
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def GPI(self, angle: sympy.Expr | float, qubit: int, **kwargs: Any) -> Circuit:
         """
         Appends a GPI gate with a possibly symbolic angle (specified in half-turns).
-        
+
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def GPI(self, angle: sympy.Expr | float, qubit: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a GPI gate with a possibly symbolic angle (specified in half-turns).
-        
+
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def GPI2(self, angle: sympy.Expr | float, qubit: int, **kwargs: Any) -> Circuit:
         """
         Appends a GPI2 gate with a possibly symbolic angle (specified in half-turns).
-        
+
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def GPI2(self, angle: sympy.Expr | float, qubit: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a GPI2 gate with a possibly symbolic angle (specified in half-turns).
-        
+
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def H(self, qubit: int, **kwargs: Any) -> Circuit:
         """
         Appends a Hadamard gate.
-        
+
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def H(self, qubit: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a Hadamard gate.
-        
+
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def ISWAP(self, angle: sympy.Expr | float, qubit0: int, qubit1: int, **kwargs: Any) -> Circuit:
         """
         Appends an ISWAP gate with a possibly symbolic angle (specified in half-turns) on the wires for the specified qubits.
-        
+
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def ISWAP(self, angle: sympy.Expr | float, qubit0: pytket._tket.unit_id.Qubit, qubit1: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends an ISWAP gate with a possibly symbolic angle (specified in half-turns) on the wires for the specified qubits.
-        
+
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def ISWAPMax(self, qubit0: int, qubit1: int, **kwargs: Any) -> Circuit:
         """
         Appends an ISWAPMax gate on the wires for the specified qubits.
-        
+
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def ISWAPMax(self, qubit0: pytket._tket.unit_id.Qubit, qubit1: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends an ISWAPMax gate on the wires for the specified qubits.
-        
+
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def Measure(self, qubit: int, bit_index: int, **kwargs: Any) -> Circuit:
         """
         Appends a single-qubit measurement in the computational (Z) basis.
-        
+
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def Measure(self, qubit: pytket._tket.unit_id.Qubit, bit: pytket._tket.unit_id.Bit, **kwargs: Any) -> Circuit:
         """
         Appends a single-qubit measurement in the computational (Z) basis.
-        
+
         :return: the new :py:class:`Circuit`
         """
     def Phase(self, arg0: sympy.Expr | float, **kwargs: Any) -> Circuit:
@@ -559,294 +559,294 @@ class Circuit:
     def PhasedISWAP(self, angle0: sympy.Expr | float, angle1: sympy.Expr | float, qubit0: int, qubit1: int, **kwargs: Any) -> Circuit:
         """
         Appends a PhasedISWAP gate with possibly symbolic angles (specified in half-turns) on the wires for the specified qubits.
-        
+
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def PhasedISWAP(self, angle0: sympy.Expr | float, angle1: sympy.Expr | float, qubit0: pytket._tket.unit_id.Qubit, qubit1: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a PhasedISWAP gate with posisbly symbolic angles (specified in half-turns) on the wires for the specified qubits.
-        
+
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def PhasedX(self, angle0: sympy.Expr | float, angle1: sympy.Expr | float, qubit: int, **kwargs: Any) -> Circuit:
         """
         Appends a PhasedX gate with possibly symbolic angles (specified in half-turns) on the wires for the specified qubits.
-        
+
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def PhasedX(self, angle0: sympy.Expr | float, angle1: sympy.Expr | float, qubit: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a PhasedX gate with possibly symbolic angles (specified in half-turns) on the wires for the specified qubits.
-        
+
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def Reset(self, qubit: int, **kwargs: Any) -> Circuit:
         """
         Appends a Reset operation. Sets a qubit to the Z-basis 0 state. Non-unitary operation.
-        
+
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def Reset(self, qubit: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a Reset operation. Sets a qubit to the Z-basis 0 state. Non-unitary operation.
-        
+
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def Rx(self, angle: sympy.Expr | float, qubit: int, **kwargs: Any) -> Circuit:
         """
         Appends an Rx gate with a possibly symbolic angle (specified in half-turns).
-        
+
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def Rx(self, angle: sympy.Expr | float, qubit: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends an Rx gate with a possibly symbolic angle (specified in half-turns).
-        
+
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def Ry(self, angle: sympy.Expr | float, qubit: int, **kwargs: Any) -> Circuit:
         """
         Appends an Ry gate with a possibly symbolic angle (specified in half-turns).
-        
+
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def Ry(self, angle: sympy.Expr | float, qubit: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends an Ry gate with a possibly symbolic angle (specified in half-turns).
-        
+
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def Rz(self, angle: sympy.Expr | float, qubit: int, **kwargs: Any) -> Circuit:
         """
         Appends an Rz gate with a possibly symbolic angle (specified in half-turns).
-        
+
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def Rz(self, angle: sympy.Expr | float, qubit: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends an Rz gate with a possibly symbolic angle (specified in half-turns).
-        
+
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def S(self, qubit: int, **kwargs: Any) -> Circuit:
         """
         Appends an S gate (equivalent to U1(0.5,-)).
-        
+
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def S(self, qubit: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends an S gate (equivalent to Rz(0.5,-)).
-        
+
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def SWAP(self, qubit_0: int, qubit_1: int, **kwargs: Any) -> Circuit:
         """
         Appends a SWAP gate on the wires for the specified qubits.
-        
+
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def SWAP(self, qubit_0: pytket._tket.unit_id.Qubit, qubit_1: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a SWAP gate on the wires for the specified qubits.
-        
+
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def SX(self, qubit: int, **kwargs: Any) -> Circuit:
         """
         Appends a SX gate (equivalent to Rx(0.5,-) up to a 0.25 global phase).
-        
+
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def SX(self, qubit: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a SX gate (equivalent to Rx(0.5,-) up to a 0.25 global phase).
-        
+
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def SXdg(self, qubit: int, **kwargs: Any) -> Circuit:
         """
         Appends a SXdg gate (equivalent to Rx(-0.5,-) up to a -0.25 global phase).
-        
+
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def SXdg(self, qubit: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a SXdg gate (equivalent to Rx(-0.5,-) up to a -0.25 global phase).
-        
+
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def Sdg(self, qubit: int, **kwargs: Any) -> Circuit:
         """
         Appends an S-dagger gate (equivalent to U1(-0.5,-)).
-        
+
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def Sdg(self, qubit: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends an S-dagger gate (equivalent to Rz(-0.5,-)).
-        
+
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def Sycamore(self, qubit0: int, qubit1: int, **kwargs: Any) -> Circuit:
         """
         Appends a Sycamore gate on the wires for the specified qubits.
-        
+
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def Sycamore(self, qubit0: pytket._tket.unit_id.Qubit, qubit1: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a Sycamore gate on the wires for the specified qubits.
-        
+
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def T(self, qubit: int, **kwargs: Any) -> Circuit:
         """
         Appends a T gate (equivalent to U1(0.25,-)).
-        
+
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def T(self, qubit: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a T gate (equivalent to Rz(0.25,-)).
-        
+
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def TK1(self, angle0: sympy.Expr | float, angle1: sympy.Expr | float, angle2: sympy.Expr | float, qubit: int, **kwargs: Any) -> Circuit:
         """
         Appends a TK1 gate with possibly symbolic angles (specified in half-turns).
-        
+
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def TK1(self, angle0: sympy.Expr | float, angle1: sympy.Expr | float, angle2: sympy.Expr | float, qubit: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a TK1 gate with possibly symbolic angles (specified in half-turns).
-        
+
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def TK2(self, angle0: sympy.Expr | float, angle1: sympy.Expr | float, angle2: sympy.Expr | float, qubit0: int, qubit1: int, **kwargs: Any) -> Circuit:
         """
         Appends a TK2 gate with possibly symbolic angles (specified in half-turns).
-        
+
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def TK2(self, angle0: sympy.Expr | float, angle1: sympy.Expr | float, angle2: sympy.Expr | float, qubit0: pytket._tket.unit_id.Qubit, qubit1: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a TK2 gate with possibly symbolic angles (specified in half-turns).
-        
+
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def Tdg(self, qubit: int, **kwargs: Any) -> Circuit:
         """
         Appends a T-dagger gate (equivalent to U1(-0.25,-)).
-        
+
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def Tdg(self, qubit: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a T-dagger gate (equivalent to Rz(-0.25,-)).
-        
+
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def U1(self, angle: sympy.Expr | float, qubit: int, **kwargs: Any) -> Circuit:
         """
         Appends a U1 gate with a possibly symbolic angle (specified in half-turns).
-        
+
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def U1(self, angle: sympy.Expr | float, qubit: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a U1 gate with a possibly symbolic angle (specified in half-turns).
-        
+
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def U2(self, angle0: sympy.Expr | float, angle1: sympy.Expr | float, qubit: int, **kwargs: Any) -> Circuit:
         """
         Appends a U2 gate with possibly symbolic angles (specified in half-turns).
-        
+
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def U2(self, angle0: sympy.Expr | float, angle1: sympy.Expr | float, qubit: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a U2 gate with possibly symbolic angles (specified in half-turns).
-        
+
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def U3(self, angle0: sympy.Expr | float, angle1: sympy.Expr | float, angle2: sympy.Expr | float, qubit: int, **kwargs: Any) -> Circuit:
         """
         Appends a U3 gate with possibly symbolic angles (specified in half-turns).
-        
+
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def U3(self, angle0: sympy.Expr | float, angle1: sympy.Expr | float, angle2: sympy.Expr | float, qubit: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a U3 gate with possibly symbolic angles (specified in half-turns).
-        
+
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def V(self, qubit: int, **kwargs: Any) -> Circuit:
         """
         Appends a V gate (equivalent to Rx(0.5,-)).
-        
+
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def V(self, qubit: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a V gate (equivalent to Rx(0.5,-)).
-        
+
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def Vdg(self, qubit: int, **kwargs: Any) -> Circuit:
         """
         Appends a V-dagger gate (equivalent to Rx(-0.5,-)).
-        
+
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def Vdg(self, qubit: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a V-dagger gate (equivalent to Rx(-0.5,-)).
-        
+
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
@@ -858,35 +858,35 @@ class Circuit:
     def X(self, qubit: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends an X gate.
-        
+
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def XXPhase(self, angle: sympy.Expr | float, qubit0: int, qubit1: int, **kwargs: Any) -> Circuit:
         """
         Appends a XX gate with a possibly symbolic angle (specified in half-turns) on the wires for the specified two qubits.
-        
+
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def XXPhase(self, qubit0: sympy.Expr | float, qubit1: pytket._tket.unit_id.Qubit, angle: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a XX gate with a symbolic angle (specified in half-turns) on the wires for the specified two qubits.
-        
+
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def XXPhase3(self, angle: sympy.Expr | float, qubit0: int, qubit1: int, qubit2: int, **kwargs: Any) -> Circuit:
         """
         Appends a 3-qubit XX gate with a possibly symbolic angle (specified in half-turns) on the wires for the specified three qubits.
-        
+
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def XXPhase3(self, angle: sympy.Expr | float, qubit0: pytket._tket.unit_id.Qubit, qubit1: pytket._tket.unit_id.Qubit, qubit2: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a 3-qubit XX gate with a symbolic angle (specified in half-turns) on the wires for the specified three qubits.
-        
+
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
@@ -898,21 +898,21 @@ class Circuit:
     def Y(self, qubit: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a Y gate.
-        
+
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def YYPhase(self, angle: sympy.Expr | float, qubit0: int, qubit1: int, **kwargs: Any) -> Circuit:
         """
         Appends a YY gate with a possibly symbolic angle (specified in half-turns) on the wires for the specified two qubits.
-        
+
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def YYPhase(self, qubit0: sympy.Expr | float, qubit1: pytket._tket.unit_id.Qubit, angle: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a YY gate with a symbolic angle (specified in half-turns) on the wires for the specified two qubits.
-        
+
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
@@ -924,35 +924,35 @@ class Circuit:
     def Z(self, qubit: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a Z gate.
-        
+
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def ZZMax(self, qubit0: int, qubit1: int, **kwargs: Any) -> Circuit:
         """
         Appends a ZZMax gate on the wires for the specified two qubits.
-        
+
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def ZZMax(self, qubit0: pytket._tket.unit_id.Qubit, qubit1: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a ZZMax gate on the wires for the specified two qubits.
-        
+
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def ZZPhase(self, angle: sympy.Expr | float, qubit0: int, qubit1: int, **kwargs: Any) -> Circuit:
         """
         Appends a ZZ gate with a possibly symbolic angle (specified in half-turns) on the wires for the specified two qubits.
-        
+
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def ZZPhase(self, angle: sympy.Expr | float, qubit0: pytket._tket.unit_id.Qubit, qubit1: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a ZZ gate with a symbolic angle (specified in half-turns) on the wires for the specified two qubits.
-        
+
         :return: the new :py:class:`Circuit`
         """
     def __eq__(self, arg0: typing.Any) -> bool:
@@ -972,21 +972,21 @@ class Circuit:
     def __init__(self, name: str) -> None:
         """
         Constructs a named circuit with a completely empty DAG.
-        
+
         :param name: name for the circuit
         """
     @typing.overload
     def __init__(self, n_qubits: int, name: str | None = None) -> None:
         """
         Constructs a circuit with a given number of qubits/blank wires.
-        
+
         >>> c = Circuit()
         >>> c.add_blank_wires(3)
-        
+
         is equivalent to
-        
+
         >>> c = Circuit(3)
-        
+
         :param n_qubits: The number of qubits in the circuit
         :param name: Optional name for the circuit.
         """
@@ -994,7 +994,7 @@ class Circuit:
     def __init__(self, n_qubits: int, n_bits: int, name: str | None = None) -> None:
         """
         Constructs a circuit with a given number of quantum and classical bits
-        
+
         :param n_qubits: The number of qubits in the circuit
         :param n_bits: The number of classical bits in the circuit
         :param name: Optional name for the circuit.
@@ -1019,15 +1019,15 @@ class Circuit:
         ...
     def _add_w_register(self, size: int) -> None:
         """
-        Creates given number of wasm bits in the circuit. If there are already wasm bits in circuit only the additional wasm bits will be added. 
-        
+        Creates given number of wasm bits in the circuit. If there are already wasm bits in circuit only the additional wasm bits will be added.
+
         :param size: Number of wasm bits that should be added to the circuit
         """
     @typing.overload
     def _add_wasm(self, funcname: str, wasm_uid: str, width_i_parameter: typing.Sequence[int], width_o_parameter: typing.Sequence[int], args: typing.Sequence[int], wasm_wire_args: typing.Sequence[int], **kwargs: Any) -> Circuit:
         """
-        Add a classical function call from a wasm file to the circuit. 
-        
+        Add a classical function call from a wasm file to the circuit.
+
         :param funcname: name of the function that is called
         :param wasm_uid: unit id to identify the wasm file
         :param width_i_parameter: list of the number of bits in the input variables
@@ -1040,8 +1040,8 @@ class Circuit:
     @typing.overload
     def _add_wasm(self, funcname: str, wasm_uid: str, width_i_parameter: typing.Sequence[int], width_o_parameter: typing.Sequence[int], args: typing.Sequence[pytket._tket.unit_id.Bit], wasm_wire_args: typing.Sequence[int], **kwargs: Any) -> Circuit:
         """
-        Add a classical function call from a wasm file to the circuit. 
-        
+        Add a classical function call from a wasm file to the circuit.
+
         :param funcname: name of the function that is called
         :param wasm_uid: unit id to identify the wasm file
         :param width_i_parameter: list of the number of bits in the input variables
@@ -1053,8 +1053,8 @@ class Circuit:
     @typing.overload
     def _add_wasm(self, funcname: str, wasm_uid: str, list_reg_in: typing.Sequence[pytket._tket.unit_id.BitRegister], list_reg_out: typing.Sequence[pytket._tket.unit_id.BitRegister], wasm_wire_args: typing.Sequence[int], **kwargs: Any) -> Circuit:
         """
-        Add a classical function call from a wasm file to the circuit. 
-        
+        Add a classical function call from a wasm file to the circuit.
+
         :param funcname: name of the function that is called
         :param wasm_uid: unit id to identify the wasm file
         :param list_reg_in: list of the classical registers in the circuit used as inputs
@@ -1076,7 +1076,7 @@ class Circuit:
     def add_assertion(self, box: ProjectorAssertionBox, qubits: typing.Sequence[int], ancilla: int | None = None, name: str | None = None) -> Circuit:
         """
         Append a :py:class:`ProjectorAssertionBox` to the circuit.
-        
+
         :param box: ProjectorAssertionBox to append
         :param qubits: indices of target qubits
         :param ancilla: index of ancilla qubit
@@ -1087,7 +1087,7 @@ class Circuit:
     def add_assertion(self, box: ProjectorAssertionBox, qubits: typing.Sequence[pytket._tket.unit_id.Qubit], ancilla: pytket._tket.unit_id.Qubit | None = None, name: str | None = None) -> Circuit:
         """
         Append a :py:class:`ProjectorAssertionBox` to the circuit.
-        
+
         :param box: ProjectorAssertionBox to append
         :param qubits: target qubits
         :param ancilla: ancilla qubit
@@ -1098,7 +1098,7 @@ class Circuit:
     def add_assertion(self, box: StabiliserAssertionBox, qubits: typing.Sequence[int], ancilla: int, name: str | None = None) -> Circuit:
         """
         Append a :py:class:`StabiliserAssertionBox` to the circuit.
-        
+
         :param box: StabiliserAssertionBox to append
         :param qubits: indices of target qubits
         :param ancilla: index of ancilla qubit
@@ -1109,7 +1109,7 @@ class Circuit:
     def add_assertion(self, box: StabiliserAssertionBox, qubits: typing.Sequence[pytket._tket.unit_id.Qubit], ancilla: pytket._tket.unit_id.Qubit, name: str | None = None) -> Circuit:
         """
         Append a :py:class:`StabiliserAssertionBox` to the circuit.
-        
+
         :param box: StabiliserAssertionBox to append
         :param qubits: target qubits
         :param ancilla: ancilla qubit
@@ -1120,7 +1120,7 @@ class Circuit:
     def add_barrier(self, qubits: typing.Sequence[int], bits: typing.Sequence[int] = [], data: str = '') -> Circuit:
         """
         Append a Barrier on the given units
-        
+
         :param data: additional data stored in the barrier
         :return: the new :py:class:`Circuit`
         """
@@ -1128,28 +1128,28 @@ class Circuit:
     def add_barrier(self, units: typing.Sequence[pytket._tket.unit_id.UnitID], data: str = '') -> Circuit:
         """
         Append a Barrier on the given units
-        
+
         :param data: additional data stored in the barrier
         :return: the new :py:class:`Circuit`
         """
     def add_bit(self, id: pytket._tket.unit_id.Bit, reject_dups: bool = True) -> None:
         """
         Constructs a single bit with the given id.
-        
+
         :param id: Unique id for the bit
         :param reject_dups: Fail if there is already a bit in this circuit with the id. Default to True
         """
     def add_blank_wires(self, number: int) -> None:
         """
         Adds a number of new qubits to the circuit. These will be added to the default register ('q') if possible, filling out the unused indices from 0.
-        
+
         :param number: Number of qubits to add
         """
     @typing.overload
     def add_c_and(self, arg0_in: int, arg1_in: int, arg_out: int, **kwargs: Any) -> Circuit:
         """
         Appends a binary AND operation to the end of the circuit.
-        
+
         :param arg0_in: first input bit
         :param arg1_in: second input bit
         :param arg_out: output bit
@@ -1164,9 +1164,9 @@ class Circuit:
     def add_c_and_to_registers(self, reg0_in: pytket._tket.unit_id.BitRegister, reg1_in: pytket._tket.unit_id.BitRegister, reg_out: pytket._tket.unit_id.BitRegister, **kwargs: Any) -> Circuit:
         """
         Applies bitwise AND to linear registers.
-        
+
         The operation is applied to the bits with indices 0, 1, 2, ... in each register, up to the size of the smallest register.
-        
+
         :param reg0_in: first input register
         :param reg1_in: second input register
         :param reg_out: output register
@@ -1177,7 +1177,7 @@ class Circuit:
     def add_c_copybits(self, args_in: typing.Sequence[int], args_out: typing.Sequence[int], **kwargs: Any) -> Circuit:
         """
         Appends a classical copy operation
-        
+
         :param args_in: source bits
         :param args_out: destination bits
         :param kwargs: additional arguments passed to `add_gate_method` . Allowed parameters are `opgroup`,  `condition` , `condition_bits`, `condition_value`
@@ -1208,7 +1208,7 @@ class Circuit:
     def add_c_not(self, arg_in: int, arg_out: int, **kwargs: Any) -> Circuit:
         """
         Appends a NOT operation to the end of the circuit.
-        
+
         :param arg_in: input bit
         :param arg_out: output bit
         :param kwargs: additional arguments passed to `add_gate_method` . Allowed parameters are `opgroup`,  `condition` , `condition_bits`, `condition_value`
@@ -1222,9 +1222,9 @@ class Circuit:
     def add_c_not_to_registers(self, reg_in: pytket._tket.unit_id.BitRegister, reg_out: pytket._tket.unit_id.BitRegister, **kwargs: Any) -> Circuit:
         """
         Applies bitwise NOT to linear registers.
-        
+
         The operation is applied to the bits with indices 0, 1, 2, ... in each register, up to the size of the smallest register.
-        
+
         :param reg_in: input register
         :param reg_out: name of output register
         :param kwargs: additional arguments passed to `add_gate_method` . Allowed parameters are `opgroup`,  `condition` , `condition_bits`, `condition_value`
@@ -1234,7 +1234,7 @@ class Circuit:
     def add_c_or(self, arg0_in: int, arg1_in: int, arg_out: int, **kwargs: Any) -> Circuit:
         """
         Appends a binary OR operation to the end of the circuit.
-        
+
         :param arg0_in: first input bit
         :param arg1_in: second input bit
         :param arg_out: output bit
@@ -1249,9 +1249,9 @@ class Circuit:
     def add_c_or_to_registers(self, reg0_in: pytket._tket.unit_id.BitRegister, reg1_in: pytket._tket.unit_id.BitRegister, reg_out: pytket._tket.unit_id.BitRegister, **kwargs: Any) -> Circuit:
         """
         Applies bitwise OR to linear registers.
-        
+
         The operation is applied to the bits with indices 0, 1, 2, ... in each register, up to the size of the smallest register.
-        
+
         :param reg0_in: first input register
         :param reg1_in: second input register
         :param reg_out: output register
@@ -1274,7 +1274,7 @@ class Circuit:
     def add_c_range_predicate(self, minval: int, maxval: int, args_in: typing.Sequence[int], arg_out: int, **kwargs: Any) -> Circuit:
         """
         Appends a range-predicate operation to the end of the circuit.
-        
+
         :param minval: lower bound of input in little-endian encoding
         :param maxval: upper bound of input in little-endian encoding
         :param args_in: input bits
@@ -1286,7 +1286,7 @@ class Circuit:
     def add_c_range_predicate(self, minval: int, maxval: int, args_in: typing.Sequence[pytket._tket.unit_id.Bit], arg_out: pytket._tket.unit_id.Bit, **kwargs: Any) -> Circuit:
         """
         Appends a range-predicate operation to the end of the circuit.
-        
+
         :param minval: lower bound of input in little-endian encoding
         :param maxval: upper bound of input in little-endian encoding
         :param args_in: input bits
@@ -1298,7 +1298,7 @@ class Circuit:
     def add_c_register(self, name: str, size: int) -> pytket._tket.unit_id.BitRegister:
         """
         Constructs a new classical register with a given name and number of bits.
-        
+
         :param name: Unique readable name for the register
         :param size: Number of bits required
         :return: a map from index to the corresponding UnitIDs
@@ -1307,14 +1307,14 @@ class Circuit:
     def add_c_register(self, register: pytket._tket.unit_id.BitRegister) -> pytket._tket.unit_id.BitRegister:
         """
         Adds BitRegister to Circuit
-        
-        :param register: BitRegister 
+
+        :param register: BitRegister
         """
     @typing.overload
     def add_c_setbits(self, values: typing.Sequence[bool], args: typing.Sequence[int], **kwargs: Any) -> Circuit:
         """
         Appends an operation to set some bit values.
-        
+
         :param values: values to set
         :param args: bits to set
         :param kwargs: additional arguments passed to `add_gate_method` . Allowed parameters are `opgroup`,  `condition` , `condition_bits`, `condition_value`
@@ -1333,7 +1333,7 @@ class Circuit:
     def add_c_transform(self, values: typing.Sequence[int], args: typing.Sequence[int], name: str = 'ClassicalTransform', **kwargs: Any) -> Circuit:
         """
         Appends a purely classical transformation, defined by a table of values, to the end of the circuit.
-        
+
         :param values: table of values: bit :math:`j` (in little-endian order) of the term indexed by :math:`sum_i a_i 2^i` is output :math:`j` of the transform applied to inputs :math:`(a_i)`.
         :param args: bits to which the transform is applied
         :param name: operation name
@@ -1349,7 +1349,7 @@ class Circuit:
     def add_c_xor(self, arg0_in: int, arg1_in: int, arg_out: int, **kwargs: Any) -> Circuit:
         """
         Appends a binary XOR operation to the end of the circuit.
-        
+
         :param arg0_in: first input bit
         :param arg1_in: second input bit
         :param arg_out: output bit
@@ -1364,9 +1364,9 @@ class Circuit:
     def add_c_xor_to_registers(self, reg0_in: pytket._tket.unit_id.BitRegister, reg1_in: pytket._tket.unit_id.BitRegister, reg_out: pytket._tket.unit_id.BitRegister, **kwargs: Any) -> Circuit:
         """
         Applies bitwise XOR to linear registers.
-        
+
         The operation is applied to the bits with indices 0, 1, 2, ... in each register, up to the size of the smallest register.
-        
+
         :param reg0_in: first input register
         :param reg1_in: second input register
         :param reg_out: output register
@@ -1377,9 +1377,9 @@ class Circuit:
     def add_circbox(self, circbox: CircBox, args: typing.Sequence[int], **kwargs: Any) -> Circuit:
         """
         Append a :py:class:`CircBox` to the circuit.
-        
+
         The qubits and bits of the :py:class:`CircBox` are wired into the circuit in lexicographic order. Bits follow qubits in the order of arguments.
-        
+
         :param circbox: The box to append
         :param args: Indices of the (default-register) qubits/bits to append the box to
         :return: the new :py:class:`Circuit`
@@ -1388,9 +1388,9 @@ class Circuit:
     def add_circbox(self, circbox: CircBox, args: typing.Sequence[pytket._tket.unit_id.UnitID], **kwargs: Any) -> Circuit:
         """
         Append a :py:class:`CircBox` to the circuit.
-        
+
         The qubits and bits of the :py:class:`CircBox` are wired into the circuit in lexicographic order. Bits follow qubits in the order of arguments.
-        
+
         :param circbox: The box to append
         :param args: The qubits/bits to append the box to
         :return: the new :py:class:`Circuit`
@@ -1398,7 +1398,7 @@ class Circuit:
     def add_circbox_regwise(self, circbox: CircBox, qregs: typing.Sequence[pytket._tket.unit_id.QubitRegister], cregs: typing.Sequence[pytket._tket.unit_id.BitRegister], **kwargs: Any) -> Circuit:
         """
         Append a :py:class:`CircBox` to the circuit, wiring whole registers together.
-        
+
         :param circbox: The box to append
         :param qregs: Sequence of :py:class:`QubitRegister` from the outer :py:class:`Circuit`, the order corresponding to the lexicographic order of corresponding registers in the :py:class:`CircBox`
         :param cregs: Sequence of :py:class:`BitRegister` from the outer :py:class:`Circuit`, the order corresponding to the lexicographic order of corresponding registers in the :py:class:`CircBox`
@@ -1407,9 +1407,9 @@ class Circuit:
     def add_circbox_with_regmap(self, circbox: CircBox, qregmap: dict[str, str], cregmap: dict[str, str], **kwargs: Any) -> Circuit:
         """
         Append a :py:class:`CircBox` to the circuit, wiring whole registers together.
-        
+
         This method expects two maps (one for qubit registers and one for bit registers), which must have keys corresponding to all register names in the box. The box may not contain any qubits or bits that do not belong to a register, i.e. all must be single-indexed contiguously from zero.
-        
+
         :param circbox: The box to append
         :param qregmap: Map specifying which qubit register in the :py:class:`CircBox` (the map's keys) matches which register in the outer circuit (the map's values)
         :param cregmap: Map specifying which bit register in the :py:class:`CircBox` (the map's keys) matches which register in the outer circuit (the map's values)
@@ -1419,7 +1419,7 @@ class Circuit:
     def add_circuit(self, circuit: Circuit, qubits: typing.Sequence[pytket._tket.unit_id.Qubit], bits: typing.Sequence[pytket._tket.unit_id.Bit] = []) -> Circuit:
         """
         In-place sequential composition of circuits, appending a copy of the argument onto the end of the circuit. Connects qubits and bits with the same behaviour as :py:meth:`add_gate`.
-        
+
         :param circuit: The circuit to be appended to the end of `self`
         :param qubits: List mapping the (default register) qubits of `circuit` to the qubits of `self`
         :param bits: List mapping the (default register) bits of `circuit` to the bits of `self`
@@ -1429,7 +1429,7 @@ class Circuit:
     def add_circuit(self, circuit: Circuit, qubits: typing.Sequence[int], bits: typing.Sequence[int] = []) -> Circuit:
         """
         In-place sequential composition of circuits, appending a copy of the argument onto the end of the circuit. Connects qubits and bits with the same behaviour as :py:meth:`add_gate`.
-        
+
         :param circuit: The circuit to be appended to the end of `self`
         :param qubits: List mapping the (default register) qubits of `circuit` to the (default register) qubits of `self`
         :param bits: List mapping the (default register) bits of `circuit` to the (default register) bits of `self`
@@ -1438,7 +1438,7 @@ class Circuit:
     def add_classicalexpbox_bit(self, expression: pytket.circuit.logic_exp.BitLogicExp, target: typing.Sequence[pytket._tket.unit_id.Bit], **kwargs: Any) -> Circuit:
         """
         Append a :py:class:`ClassicalExpBox` over Bit to the circuit.
-        
+
         :param classicalexpbox: The box to append
         :param args: Indices of the qubits to append the box to
         :return: the new :py:class:`Circuit`
@@ -1446,7 +1446,7 @@ class Circuit:
     def add_classicalexpbox_register(self, expression: pytket.circuit.logic_exp.RegLogicExp, target: typing.Sequence[pytket._tket.unit_id.Bit], **kwargs: Any) -> Circuit:
         """
         Append a :py:class:`ClassicalExpBox` over BitRegister to the circuit.
-        
+
         :param classicalexpbox: The box to append
         :param args: Indices of the qubits to append the box to
         :return: the new :py:class:`Circuit`
@@ -1455,7 +1455,7 @@ class Circuit:
     def add_conditional_barrier(self, barrier_qubits: typing.Sequence[int], barrier_bits: typing.Sequence[int], condition_bits: typing.Sequence[int], value: int, data: str = '') -> Circuit:
         """
         Append a Conditional Barrier on the given barrier qubits and barrier bits, conditioned on the given condition bits.
-        
+
         :param barrier_qubits: Qubit in Barrier operation.
         :param barrier_bits: Bit in Barrier operation.
         :param condition_bits: Bit covering classical control condition of barrier operation.
@@ -1467,7 +1467,7 @@ class Circuit:
     def add_conditional_barrier(self, barrier_args: typing.Sequence[pytket._tket.unit_id.UnitID], condition_bits: typing.Sequence[pytket._tket.unit_id.Bit], value: int, data: str = '') -> Circuit:
         """
         Append a Conditional Barrier on the given barrier qubits and barrier bits, conditioned on the given condition bits.
-        
+
         :param barrier_args: Qubit and Bit in Barrier operation.
         :param condition_bits: Bit covering classical control  condition of barrier operation.
         :param value: Value that classical condition must have to hold (little-endian).
@@ -1478,7 +1478,7 @@ class Circuit:
     def add_conjugation_box(self, box: ConjugationBox, args: typing.Sequence[pytket._tket.unit_id.UnitID], **kwargs: Any) -> Circuit:
         """
         Append a :py:class:`ConjugationBox` to the circuit.
-        
+
         :param box: The box to append
         :param args: The qubits to append the box to
         :return: the new :py:class:`Circuit`
@@ -1487,7 +1487,7 @@ class Circuit:
     def add_conjugation_box(self, box: ConjugationBox, args: typing.Sequence[int], **kwargs: Any) -> Circuit:
         """
         Append a :py:class:`ConjugationBox` to the circuit.
-        
+
         :param box: The box to append
         :param args: Indices of the qubits to append the box to
         :return: the new :py:class:`Circuit`
@@ -1496,7 +1496,7 @@ class Circuit:
     def add_custom_gate(self, definition: CustomGateDef, params: typing.Sequence[sympy.Expr | float], qubits: typing.Sequence[int], **kwargs: Any) -> Circuit:
         """
         Append an instance of a :py:class:`CustomGateDef` to the circuit.
-        
+
         :param def: The custom gate definition
         :param params: List of parameters to instantiate the gate with, in halfturns
         :param qubits: Indices of the qubits to append the box to
@@ -1506,7 +1506,7 @@ class Circuit:
     def add_custom_gate(self, definition: CustomGateDef, params: typing.Sequence[sympy.Expr | float], qubits: typing.Sequence[pytket._tket.unit_id.Qubit], **kwargs: Any) -> Circuit:
         """
         Append an instance of a :py:class:`CustomGateDef` to the circuit.
-        
+
         :param def: The custom gate definition
         :param params: List of parameters to instantiate the gate with, in halfturns
         :param qubits: The qubits to append the box to
@@ -1516,7 +1516,7 @@ class Circuit:
     def add_diagonal_box(self, box: DiagonalBox, args: typing.Sequence[pytket._tket.unit_id.UnitID], **kwargs: Any) -> Circuit:
         """
         Append a :py:class:`DiagonalBox` to the circuit.
-        
+
         :param box: The box to append
         :param args: The qubits to append the box to
         :return: the new :py:class:`Circuit`
@@ -1525,7 +1525,7 @@ class Circuit:
     def add_diagonal_box(self, box: DiagonalBox, args: typing.Sequence[int], **kwargs: Any) -> Circuit:
         """
         Append a :py:class:`DiagonalBox` to the circuit.
-        
+
         :param box: The box to append
         :param args: Indices of the qubits to append the box to
         :return: the new :py:class:`Circuit`
@@ -1534,7 +1534,7 @@ class Circuit:
     def add_dummybox(self, dummybox: DummyBox, qubits: typing.Sequence[int], bits: typing.Sequence[int], **kwargs: Any) -> Circuit:
         """
         Append a :py:class:`DummyBox` to the circuit.
-        
+
         :param dummybox: The box to append
         :param qubits: Indices (in the default register) of the qubits to append the box to
         :param bits: Indices of the bits (in the default register) to append the box to
@@ -1544,7 +1544,7 @@ class Circuit:
     def add_dummybox(self, dummybox: DummyBox, qubits: typing.Sequence[pytket._tket.unit_id.Qubit], bits: typing.Sequence[pytket._tket.unit_id.Bit], **kwargs: Any) -> Circuit:
         """
         Append a :py:class:`DummyBox` to the circuit.
-        
+
         :param dummybox: The box to append
         :param qubits: Qubits to append the box to
         :param bits: Bits to append the box to
@@ -1554,9 +1554,9 @@ class Circuit:
     def add_expbox(self, expbox: ExpBox, qubit_0: int, qubit_1: int, **kwargs: Any) -> Circuit:
         """
         Append an :py:class:`ExpBox` to the circuit.
-        
+
         The matrix representation is ILO-BE.
-        
+
         :param expbox: The box to append
         :param qubit_0: Index of the first target qubit
         :param qubit_1: Index of the second target qubit
@@ -1566,9 +1566,9 @@ class Circuit:
     def add_expbox(self, expbox: ExpBox, qubit_0: pytket._tket.unit_id.Qubit, qubit_1: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Append an :py:class:`ExpBox` to the circuit.
-        
+
         The matrix representation is ILO-BE.
-        
+
         :param expbox: The box to append
         :param qubit_0: The first target qubit
         :param qubit_1: The second target qubit
@@ -1588,10 +1588,10 @@ class Circuit:
     def add_gate(self, type: OpType, args: typing.Sequence[int], **kwargs: Any) -> Circuit:
         """
         Appends a single (non-parameterised) gate to the end of the circuit on some particular qubits from the default register ('q'). The number of qubits specified must match the arity of the gate. For `OpType.Measure` operations the bit from the default register should follow the qubit.
-        
+
         >>> c.add_gate(OpType.H, [0]) # equivalent to c.H(0)
         >>> c.add_gate(OpType.CX, [0,1]) # equivalent to c.CX(0,1)
-        
+
         :param type: The type of operation to add
         :param args: The list of indices for the qubits/bits to which the operation is applied
         :param kwargs: Additional properties for classical conditions
@@ -1601,10 +1601,10 @@ class Circuit:
     def add_gate(self, type: OpType, args: typing.Sequence[pytket._tket.unit_id.UnitID], **kwargs: Any) -> Circuit:
         """
         Appends a single (non-parameterised) gate to the end of the circuit on some particular qubits from the default register ('q'). The number of qubits specified must match the arity of the gate. For `OpType.Measure` operations the bit from the default register should follow the qubit.
-        
+
         >>> c.add_gate(OpType.H, [0]) # equivalent to c.H(0)
         >>> c.add_gate(OpType.CX, [0,1]) # equivalent to c.CX(0,1)
-        
+
         :param type: The type of operation to add
         :param args: The qubits/bits to apply the gate to
         :param kwargs: Additional properties for classical conditions
@@ -1614,7 +1614,7 @@ class Circuit:
     def add_gate(self, type: OpType, angle: sympy.Expr | float, args: typing.Sequence[int], **kwargs: Any) -> Circuit:
         """
         Appends a single gate, parameterised by an expression, to the end of circuit on some particular qubits from the default register ('q').
-        
+
         :param type: The type of gate to add
         :param angle: The parameter for the gate in halfturns
         :param args: The list of indices for the qubits to which the operation is applied
@@ -1625,7 +1625,7 @@ class Circuit:
     def add_gate(self, type: OpType, angle: sympy.Expr | float, args: typing.Sequence[pytket._tket.unit_id.UnitID], **kwargs: Any) -> Circuit:
         """
         Appends a single gate, parameterised by an expression, to the end of circuit on some particular qubits from the default register ('q').
-        
+
         :param type: The type of gate to add
         :param angle: The parameter for the gate in halfturns
         :param args: The qubits/bits to apply the gate to
@@ -1636,7 +1636,7 @@ class Circuit:
     def add_gate(self, type: OpType, angles: typing.Sequence[sympy.Expr | float], args: typing.Sequence[int], **kwargs: Any) -> Circuit:
         """
         Appends a single gate, parameterised with a vector of expressions corresponding to halfturns, to the end of circuit on some particular qubits from the default register ('q').
-        
+
         :param type: The type of gate to add
         :param angles: The parameters for the gate in halfturns
         :param args: The list of indices for the qubits to which the operation is applied
@@ -1647,7 +1647,7 @@ class Circuit:
     def add_gate(self, type: OpType, angles: typing.Sequence[sympy.Expr | float], args: typing.Sequence[pytket._tket.unit_id.UnitID], **kwargs: Any) -> Circuit:
         """
         Appends a single gate to the end of the circuit
-        
+
         :param type: The type of gate to add
         :param params: The parameters for the gate in halfturns
         :param args: The qubits/bits to apply the gate to
@@ -1658,7 +1658,7 @@ class Circuit:
     def add_multiplexed_tensored_u2(self, box: MultiplexedTensoredU2Box, args: typing.Sequence[pytket._tket.unit_id.UnitID], **kwargs: Any) -> Circuit:
         """
         Append a :py:class:`MultiplexedTensoredU2Box` to the circuit.
-        
+
         :param box: The box to append
         :param args: The qubits to append the box to
         :return: the new :py:class:`Circuit`
@@ -1667,7 +1667,7 @@ class Circuit:
     def add_multiplexed_tensored_u2(self, box: MultiplexedTensoredU2Box, args: typing.Sequence[int], **kwargs: Any) -> Circuit:
         """
         Append a :py:class:`MultiplexedTensoredU2Box` to the circuit.
-        
+
         :param box: The box to append
         :param args: Indices of the qubits to append the box to
         :return: the new :py:class:`Circuit`
@@ -1676,7 +1676,7 @@ class Circuit:
     def add_multiplexedrotation(self, box: MultiplexedRotationBox, args: typing.Sequence[pytket._tket.unit_id.UnitID], **kwargs: Any) -> Circuit:
         """
         Append a :py:class:`MultiplexedRotationBox` to the circuit.
-        
+
         :param box: The box to append
         :param args: The qubits to append the box to
         :return: the new :py:class:`Circuit`
@@ -1685,7 +1685,7 @@ class Circuit:
     def add_multiplexedrotation(self, box: MultiplexedRotationBox, args: typing.Sequence[int], **kwargs: Any) -> Circuit:
         """
         Append a :py:class:`MultiplexedRotationBox` to the circuit.
-        
+
         :param box: The box to append
         :param args: Indices of the qubits to append the box to
         :return: the new :py:class:`Circuit`
@@ -1694,7 +1694,7 @@ class Circuit:
     def add_multiplexedu2(self, box: MultiplexedU2Box, args: typing.Sequence[pytket._tket.unit_id.UnitID], **kwargs: Any) -> Circuit:
         """
         Append a :py:class:`MultiplexedU2Box` to the circuit.
-        
+
         :param box: The box to append
         :param args: The qubits to append the box to
         :return: the new :py:class:`Circuit`
@@ -1703,7 +1703,7 @@ class Circuit:
     def add_multiplexedu2(self, box: MultiplexedU2Box, args: typing.Sequence[int], **kwargs: Any) -> Circuit:
         """
         Append a :py:class:`MultiplexedU2Box` to the circuit.
-        
+
         :param box: The box to append
         :param args: Indices of the qubits to append the box to
         :return: the new :py:class:`Circuit`
@@ -1712,7 +1712,7 @@ class Circuit:
     def add_multiplexor(self, box: MultiplexorBox, args: typing.Sequence[pytket._tket.unit_id.UnitID], **kwargs: Any) -> Circuit:
         """
         Append a :py:class:`MultiplexorBox` to the circuit.
-        
+
         :param box: The box to append
         :param args: The qubits to append the box to
         :return: the new :py:class:`Circuit`
@@ -1721,7 +1721,7 @@ class Circuit:
     def add_multiplexor(self, box: MultiplexorBox, args: typing.Sequence[int], **kwargs: Any) -> Circuit:
         """
         Append a :py:class:`MultiplexorBox` to the circuit.
-        
+
         :param box: The box to append
         :param args: Indices of the qubits to append the box to
         :return: the new :py:class:`Circuit`
@@ -1730,7 +1730,7 @@ class Circuit:
     def add_pauliexpbox(self, pauliexpbox: PauliExpBox, qubits: typing.Sequence[int], **kwargs: Any) -> Circuit:
         """
         Append a :py:class:`PauliExpBox` to the circuit.
-        
+
         :param pauliexpbox: The box to append
         :param qubits: Indices of the qubits to append the box to
         :return: the new :py:class:`Circuit`
@@ -1739,7 +1739,7 @@ class Circuit:
     def add_pauliexpbox(self, pauliexpbox: PauliExpBox, qubits: typing.Sequence[pytket._tket.unit_id.Qubit], **kwargs: Any) -> Circuit:
         """
         Append a :py:class:`PauliExpBox` to the circuit.
-        
+
         :param pauliexpbox: The box to append
         :param qubits: The qubits to append the box to
         :return: the new :py:class:`Circuit`
@@ -1748,7 +1748,7 @@ class Circuit:
     def add_pauliexpcommutingsetbox(self, pauliexpcommutingsetbox: PauliExpCommutingSetBox, qubits: typing.Sequence[int], **kwargs: Any) -> Circuit:
         """
         Append a :py:class:`PauliExpCommutingSetBox` to the circuit.
-        
+
         :param pauliexpcommutingsetbox: The box to append
         :param qubits: Indices of the qubits to append the box to
         :return: the new :py:class:`Circuit`
@@ -1757,7 +1757,7 @@ class Circuit:
     def add_pauliexpcommutingsetbox(self, pauliexpcommutingsetbox: PauliExpCommutingSetBox, qubits: typing.Sequence[pytket._tket.unit_id.Qubit], **kwargs: Any) -> Circuit:
         """
         Append a :py:class:`PauliExpCommutingSetBox` to the circuit.
-        
+
         :param pauliexpcommutingsetbox: The box to append
         :param qubits: The qubits to append the box to
         :return: the new :py:class:`Circuit`
@@ -1766,7 +1766,7 @@ class Circuit:
     def add_pauliexppairbox(self, pauliexppairbox: PauliExpPairBox, qubits: typing.Sequence[int], **kwargs: Any) -> Circuit:
         """
         Append a :py:class:`PauliExpPairBox` to the circuit.
-        
+
         :param pauliexppairbox: The box to append
         :param qubits: Indices of the qubits to append the box to
         :return: the new :py:class:`Circuit`
@@ -1775,7 +1775,7 @@ class Circuit:
     def add_pauliexppairbox(self, pauliexppairbox: PauliExpPairBox, qubits: typing.Sequence[pytket._tket.unit_id.Qubit], **kwargs: Any) -> Circuit:
         """
         Append a :py:class:`PauliExpPairBox` to the circuit.
-        
+
         :param pauliexppairbox: The box to append
         :param qubits: The qubits to append the box to
         :return: the new :py:class:`Circuit`
@@ -1783,16 +1783,16 @@ class Circuit:
     def add_phase(self, a: sympy.Expr | float) -> Circuit:
         """
         Add a global phase to the circuit.
-        
+
         :param a: Phase to add, in halfturns
-        
+
         :return: circuit with added phase
         """
     @typing.overload
     def add_phasepolybox(self, phasepolybox: PhasePolyBox, qubits: typing.Sequence[int], **kwargs: Any) -> Circuit:
         """
         Append a :py:class:`PhasePolyBox` to the circuit.
-        
+
         :param phasepolybox: The box to append
         :param qubits: Indices of the qubits to append the box to
         :return: the new :py:class:`Circuit`
@@ -1801,7 +1801,7 @@ class Circuit:
     def add_phasepolybox(self, phasepolybox: PhasePolyBox, qubits: typing.Sequence[pytket._tket.unit_id.Qubit], **kwargs: Any) -> Circuit:
         """
         Append a :py:class:`PhasePolyBox` to the circuit.
-        
+
         :param phasepolybox: The box to append
         :param qubits: The qubits to append the box to
         :return: the new :py:class:`Circuit`
@@ -1810,7 +1810,7 @@ class Circuit:
     def add_q_register(self, name: str, size: int) -> pytket._tket.unit_id.QubitRegister:
         """
         Constructs a new quantum register with a given name and number of qubits.
-        
+
         :param name: Unique readable name for the register
         :param size: Number of qubits required
         :return: a map from index to the corresponding UnitIDs
@@ -1819,14 +1819,14 @@ class Circuit:
     def add_q_register(self, register: pytket._tket.unit_id.QubitRegister) -> pytket._tket.unit_id.QubitRegister:
         """
         Adds QubitRegister to Circuit
-        
-        :param register: QubitRegister 
+
+        :param register: QubitRegister
         """
     @typing.overload
     def add_qcontrolbox(self, qcontrolbox: QControlBox, args: typing.Sequence[int], **kwargs: Any) -> Circuit:
         """
         Append a :py:class:`QControlBox` to the circuit.
-        
+
         :param qcontrolbox: The box to append
         :param args: Indices of the qubits to append the box to
         :return: the new :py:class:`Circuit`
@@ -1835,7 +1835,7 @@ class Circuit:
     def add_qcontrolbox(self, qcontrolbox: QControlBox, args: typing.Sequence[pytket._tket.unit_id.UnitID], **kwargs: Any) -> Circuit:
         """
         Append a :py:class:`QControlBox` to the circuit.
-        
+
         :param qcontrolbox: The box to append
         :param args: The qubits to append the box to
         :return: the new :py:class:`Circuit`
@@ -1843,7 +1843,7 @@ class Circuit:
     def add_qubit(self, id: pytket._tket.unit_id.Qubit, reject_dups: bool = True) -> None:
         """
         Constructs a single qubit with the given id.
-        
+
         :param id: Unique id for the qubit
         :param reject_dups: Fail if there is already a qubit in this circuit with the id. Default to True
         """
@@ -1851,7 +1851,7 @@ class Circuit:
     def add_state_preparation_box(self, box: StatePreparationBox, args: typing.Sequence[pytket._tket.unit_id.UnitID], **kwargs: Any) -> Circuit:
         """
         Append a :py:class:`StatePreparationBox` to the circuit.
-        
+
         :param box: The box to append
         :param args: The qubits to append the box to
         :return: the new :py:class:`Circuit`
@@ -1860,7 +1860,7 @@ class Circuit:
     def add_state_preparation_box(self, box: StatePreparationBox, args: typing.Sequence[int], **kwargs: Any) -> Circuit:
         """
         Append a :py:class:`StatePreparationBox` to the circuit.
-        
+
         :param box: The box to append
         :param args: Indices of the qubits to append the box to
         :return: the new :py:class:`Circuit`
@@ -1869,7 +1869,7 @@ class Circuit:
     def add_termsequencebox(self, termsequencebox: TermSequenceBox, qubits: typing.Sequence[int], **kwargs: Any) -> Circuit:
         """
         Append a :py:class:`TermSequenceBox` to the circuit.
-        
+
         :param termsequencebox: The box to append
         :param qubits: Indices of the qubits to append the box to
         :return: the new :py:class:`Circuit`
@@ -1878,7 +1878,7 @@ class Circuit:
     def add_termsequencebox(self, termsequencebox: TermSequenceBox, qubits: typing.Sequence[pytket._tket.unit_id.Qubit], **kwargs: Any) -> Circuit:
         """
         Append a :py:class:`TermSequenceBox` to the circuit.
-        
+
         :param termsequencebox: The box to append
         :param qubits: The qubits to append the box to
         :return: the new :py:class:`Circuit`
@@ -1887,7 +1887,7 @@ class Circuit:
     def add_toffolibox(self, toffolibox: ToffoliBox, qubits: typing.Sequence[int], **kwargs: Any) -> Circuit:
         """
         Append a :py:class:`ToffoliBox` to the circuit.
-        
+
         :param toffolibox: The box to append
         :param qubits: Indices of the qubits to append the box to
         :return: the new :py:class:`Circuit`
@@ -1896,7 +1896,7 @@ class Circuit:
     def add_toffolibox(self, toffolibox: ToffoliBox, qubits: typing.Sequence[pytket._tket.unit_id.Qubit], **kwargs: Any) -> Circuit:
         """
         Append a :py:class:`ToffoliBox` to the circuit.
-        
+
         :param toffolibox: The box to append
         :param qubits: Indices of the qubits to append the box to
         :return: the new :py:class:`Circuit`
@@ -1905,7 +1905,7 @@ class Circuit:
     def add_unitary1qbox(self, unitarybox: Unitary1qBox, qubit_0: int, **kwargs: Any) -> Circuit:
         """
         Append a :py:class:`Unitary1qBox` to the circuit.
-        
+
         :param unitarybox: The box to append
         :param qubit_0: Index of the qubit to append the box to
         :return: the new :py:class:`Circuit`
@@ -1914,7 +1914,7 @@ class Circuit:
     def add_unitary1qbox(self, unitarybox: Unitary1qBox, qubit_0: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Append a :py:class:`Unitary1qBox` to the circuit.
-        
+
         :param unitarybox: The box to append
         :param qubit_0: The qubit to append the box to
         :return: the new :py:class:`Circuit`
@@ -1923,9 +1923,9 @@ class Circuit:
     def add_unitary2qbox(self, unitarybox: Unitary2qBox, qubit_0: int, qubit_1: int, **kwargs: Any) -> Circuit:
         """
         Append a :py:class:`Unitary2qBox` to the circuit.
-        
+
         The matrix representation is ILO-BE.
-        
+
         :param unitarybox: The box to append
         :param qubit_0: Index of the first target qubit
         :param qubit_1: Index of the second target qubit
@@ -1935,9 +1935,9 @@ class Circuit:
     def add_unitary2qbox(self, unitarybox: Unitary2qBox, qubit_0: pytket._tket.unit_id.Qubit, qubit_1: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Append a :py:class:`Unitary2qBox` to the circuit.
-        
+
         The matrix representation is ILO-BE.
-        
+
         :param unitarybox: The box to append
         :param qubit_0: The first target qubit
         :param qubit_1: The second target qubit
@@ -1947,7 +1947,7 @@ class Circuit:
     def add_unitary3qbox(self, unitarybox: Unitary3qBox, qubit_0: int, qubit_1: int, qubit_2: int, **kwargs: Any) -> Circuit:
         """
         Append a :py:class:`Unitary3qBox` to the circuit.
-        
+
         :param unitarybox: box to append
         :param qubit_0: index of target qubit 0
         :param qubit_1: index of target qubit 1
@@ -1958,73 +1958,73 @@ class Circuit:
     def add_unitary3qbox(self, unitarybox: Unitary3qBox, qubit_0: pytket._tket.unit_id.Qubit, qubit_1: pytket._tket.unit_id.Qubit, qubit_2: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Append a :py:class:`Unitary3qBox` to the circuit.
-        
+
         :param unitarybox: box to append
         :param qubit_0: index of target qubit 0
         :param qubit_1: index of target qubit 1
         :param qubit_2: index of target qubit 2
         :return: the new :py:class:`Circuit`
         """
-    def add_wasm(self, funcname: str, filehandler: pytket.wasm.wasm.WasmFileHandler, list_i: typing.Sequence[int], list_o: typing.Sequence[int], args: typing.Union[typing.Sequence[int], typing.Sequence[pytket._tket.unit_id.Bit]], args_wasm: typing.Optional[typing.Sequence[int]] = None, **kwargs: typing.Any) -> Circuit:
+    def add_wasm(self, funcname: str, filehandler: pytket.wasm.wasm.WasmModuleHandler, list_i: typing.Sequence[int], list_o: typing.Sequence[int], args: typing.Union[typing.Sequence[int], typing.Sequence[pytket._tket.unit_id.Bit]], args_wasm: typing.Optional[typing.Sequence[int]] = None, **kwargs: typing.Any) -> Circuit:
         """
         Add a classical function call from a wasm file to the circuit.
-            
-        
+
+
         :param funcname: name of the function that is called
-            
-        :param filehandler: wasm file handler to identify the wasm file
-            
+
+        :param filehandler: wasm file or module handler to identify the wasm module
+
         :param list_i: list of the number of bits in the input variables
-            
+
         :param list_o: list of the number of bits in the output variables
-            
+
         :param args: vector of circuit bits the wasm op should be added to
-            
+
         :param args_wasm: vector of wasmstates the wasm op should be added to
-            
+
         :param kwargs: additional arguments passed to `add_gate_method` .
              Allowed parameters are `opgroup`,  `condition` , `condition_bits`,
              `condition_value`
-            
+
         :return: the new :py:class:`Circuit`
         """
-    def add_wasm_to_reg(self, funcname: str, filehandler: pytket.wasm.wasm.WasmFileHandler, list_i: typing.Sequence[pytket._tket.unit_id.BitRegister], list_o: typing.Sequence[pytket._tket.unit_id.BitRegister], args_wasm: typing.Optional[typing.Sequence[int]] = None, **kwargs: typing.Any) -> Circuit:
+    def add_wasm_to_reg(self, funcname: str, filehandler: pytket.wasm.wasm.WasmModuleHandler, list_i: typing.Sequence[pytket._tket.unit_id.BitRegister], list_o: typing.Sequence[pytket._tket.unit_id.BitRegister], args_wasm: typing.Optional[typing.Sequence[int]] = None, **kwargs: typing.Any) -> Circuit:
         """
         Add a classical function call from a wasm file to the circuit.
-            
-        
+
+
         :param funcname: name of the function that is called
-            
-        :param filehandler: wasm file handler to identify the wasm file
-            
+
+        :param filehandler: wasm file or module handler to identify the wasm module
+
         :param list_i: list of the classical registers assigned to
              the input variables of the function call
-            
+
         :param list_o: list of the classical registers assigned to
              the output variables of the function call
-            
+
         :param args_wasm: vector of wasmstates the wasm op should be added to
-            
+
         :param kwargs: additional arguments passed to `add_gate_method` .
              Allowed parameters are `opgroup`,  `condition` , `condition_bits`,
              `condition_value`
-            
+
         :return: the new :py:class:`Circuit`
         """
     def append(self, circuit: Circuit) -> None:
         """
         In-place sequential composition of circuits, appending a copy of the argument onto the end of the circuit. Inputs and Outputs are unified if they share the same id, defaulting to parallel composition if there is no match.
-        
+
         :param circuit: The circuit to be appended to the end of `self`
         """
     def commands_of_type(self, optype: OpType) -> list[Command]:
         """
         Get all commands in a circuit of a given type.
-        
+
         The order is consistent with the causal order of the operations in the circuit.
-        
+
         :param optype: operation type
-        
+
         :return: list of :py:class:`Command`
         """
     def copy(self) -> Circuit:
@@ -2034,13 +2034,13 @@ class Circuit:
     def dagger(self) -> Circuit:
         """
         Given a pure circuit (i.e. without any measurements or conditional gates), produces a new circuit for the inverse/adjoint operation.
-        
+
         :return: a new :py:class:`Circuit` corresponding to the inverse operation
         """
     def depth(self) -> int:
         """
         Returns the number of interior vertices on the longest path through the DAG, excluding vertices representing barrier operations.
-        
+
         >>> c = Circuit(3)
         >>> c.depth()
         0
@@ -2049,13 +2049,13 @@ class Circuit:
         >>> c.CX(2,0)
         >>> c.depth()
         3
-        
+
         :return: the circuit depth
         """
     def depth_2q(self) -> int:
         """
         Returns the number of vertices in the longest path through the sub-DAG consisting of vertices with 2 quantum wires,excluding vertices representing barrier operations.
-        
+
         >>> c = Circuit(3)
         >>> c.CZ(0,1)
         >>> c.Z(0)
@@ -2070,14 +2070,14 @@ class Circuit:
     def depth_by_type(self, type: OpType) -> int:
         """
         Returns the number of vertices in the longest path through the sub-DAG consisting of vertices representing operations of the given type.
-        
+
         >>> c = Circuit(3)
         >>> c.CX(0,1)
         >>> c.Z(1)
         >>> c.CX(1,2)
         >>> c.depth_by_type(OpType.CX)
         2
-        
+
         :param type: the operation type of interest
         :return: the circuit depth with respect to operations matching `type`
         """
@@ -2085,14 +2085,14 @@ class Circuit:
     def depth_by_type(self, types: set[OpType]) -> int:
         """
         Returns the number of vertices in the longest path through the sub-DAG consisting of vertices representing operations of the given types.
-        
+
         >>> c = Circuit(3)
         >>> c.CZ(0,1)
         >>> c.Z(1)
         >>> c.CX(1,2)
         >>> c.depth_by_type({OpType.CZ, OpType.CX})
         2
-        
+
         :param types: the set of operation types of interest
         :return: the circuit depth with respect to operations matching an element of `types`
         """
@@ -2107,7 +2107,7 @@ class Circuit:
     def get_c_register(self, name: str) -> pytket._tket.unit_id.BitRegister:
         """
         Get the classical register with the given name.
-        
+
         :param name: name for the register
         :return: the retrieved :py:class:`BitRegister`
         """
@@ -2118,18 +2118,18 @@ class Circuit:
     def get_q_register(self, name: str) -> pytket._tket.unit_id.QubitRegister:
         """
         Get the quantum register with the given name.
-        
+
         :param name: name for the register
         :return: the retrieved :py:class:`QubitRegister`
         """
     def get_resources(self) -> ResourceData:
         """
         Calculate the overall resources of the circuit.
-        
+
         This takes account of the data stored in each py:class:`DummyBox` within the circuit, as well as other gates, to compute upper and lower bounds.
-        
+
         :return: bounds on resources of the circuit
-        
+
         >>> resource_data0 = ResourceData(
         ...     op_type_count={
         ...         OpType.T: ResourceBounds(1, 2),
@@ -2183,7 +2183,7 @@ class Circuit:
     def get_statevector(self) -> NDArray[numpy.complex128]:
         """
         Calculate the unitary matrix of the circuit, using ILO-BE convention, applied to the column vector (1,0,0...), which is thus another column vector. Due to pybind11 and numpy peculiarities, to treat the result as a genuine column vector and perform further matrix multiplication, you need to call .reshape(rows,1) to get a 2D matrix with the correct dimensions.
-        
+
         :return: The calculated vector.
         """
     def get_unitary(self) -> NDArray[numpy.complex128]:
@@ -2193,7 +2193,7 @@ class Circuit:
     def get_unitary_times_other(self, matr: NDArray[numpy.complex128]) -> NDArray[numpy.complex128]:
         """
         Calculate UM, where U is the numerical unitary matrix of the circuit, with ILO-BE convention, and M is another matrix. This is more efficient than calculating U separately, if M has fewer columns than U.
-        
+
         :param matr: The matrix to be multiplied.
         :return: The product of the circuit unitary and the given matrix.
         """
@@ -2208,13 +2208,13 @@ class Circuit:
     def measure_all(self) -> Circuit:
         """
         Appends a measure gate to all qubits, storing the results in the default classical register. Bits are added to the circuit if they do not already exist.
-        
+
         :return: the new :py:class:`Circuit`
         """
     def measure_register(self, arg0: pytket._tket.unit_id.QubitRegister, arg1: str) -> Circuit:
         """
         Appends a measure gate to all qubits in the given register, storing the results in the given classical register with matching indices.The classical register will be created if it doesn't exist.
-        
+
         :param qreg: the QubitRegister to be measured
         :param creg_name: the name of the BitRegister to store the results
         :return: the new :py:class:`Circuit`
@@ -2230,13 +2230,13 @@ class Circuit:
     def n_gates_of_type(self, type: OpType) -> int:
         """
         Returns the number of vertices in the dag of a given operation type.
-        
+
         >>> c.CX(0,1)
         >>> c.H(0)
         >>> c.CX(0,1)
         >>> c.n_gates_of_type(OpType.CX)
         2
-        
+
         :param type: The operation type to search for
         :return: the number of operations matching `type`
         """
@@ -2247,11 +2247,11 @@ class Circuit:
     def ops_of_type(self, optype: OpType) -> list[Op]:
         """
         Get all operations in the circuit of a given type.
-        
+
         The order is not guaranteed.
-        
+
         :param optype: operation type
-        
+
         :return: list of :py:class:`Op`
         """
     def qubit_create(self, arg0: pytket._tket.unit_id.Qubit) -> None:
@@ -2280,14 +2280,14 @@ class Circuit:
         """
     def remove_blank_wires(self, keep_blank_classical_wires: bool = False) -> None:
         """
-        Removes any Input-Output pairs in the DAG with no intervening operations, i.e. removes untouched qubits/bits from the circuit. This may occur when optimisations recognise that the operations on a qubit reduce to the identity, or when routing adds wires to "fill out" the architecture. This operation will only remove empty classical wires if there are no used bits with a higher index in the same register. 
-        
+        Removes any Input-Output pairs in the DAG with no intervening operations, i.e. removes untouched qubits/bits from the circuit. This may occur when optimisations recognise that the operations on a qubit reduce to the identity, or when routing adds wires to "fill out" the architecture. This operation will only remove empty classical wires if there are no used bits with a higher index in the same register.
+
         :param keep_blank_classical_wires: select if empty classical wires should not be removed
         """
     def rename_units(self, map: dict[pytket._tket.unit_id.UnitID | pytket._tket.unit_id.Qubit | pytket._tket.unit_id.Bit, pytket._tket.unit_id.UnitID | pytket._tket.unit_id.Qubit | pytket._tket.unit_id.Bit]) -> bool:
         """
         Rename qubits and bits simultaneously according to the map of ids provided
-        
+
         :param map: Dictionary from current ids to new ids
         """
     def replace_SWAPs(self) -> None:
@@ -2302,7 +2302,7 @@ class Circuit:
     def substitute_named(self, op: Op, opgroup: str) -> bool:
         """
         Substitute all ops with the given name for the given op.The replacement operations retain the same name.
-        
+
         :param op: the replacement operation
         :param opgroup: the name of the operations group to replace
         :return: whether any replacements were made
@@ -2311,7 +2311,7 @@ class Circuit:
     def substitute_named(self, repl: Circuit, opgroup: str) -> bool:
         """
         Substitute all ops with the given name for the given circuit.Named operations in the replacement circuit must not match any named operations in the circuit being modified.
-        
+
         :param repl: the replacement circuit
         :param opgroup: the name of the operations group to replace
         :return: whether any replacements were made
@@ -2320,7 +2320,7 @@ class Circuit:
     def substitute_named(self, box: CircBox, opgroup: str) -> bool:
         """
         Substitute all ops with the given name for the given box.The replacement boxes retain the same name.
-        
+
         :param box: the replacement CircBox
         :param opgroup: the name of the operations group to replace
         :return: whether any replacements were made
@@ -2329,7 +2329,7 @@ class Circuit:
     def substitute_named(self, box: Unitary1qBox, opgroup: str) -> bool:
         """
         Substitute all ops with the given name for the given box.The replacement boxes retain the same name.
-        
+
         :param box: the replacement Unitary1qBox
         :param opgroup: the name of the operations group to replace
         :return: whether any replacements were made
@@ -2338,7 +2338,7 @@ class Circuit:
     def substitute_named(self, box: Unitary2qBox, opgroup: str) -> bool:
         """
         Substitute all ops with the given name for the given box.The replacement boxes retain the same name.
-        
+
         :param box: the replacement Unitary2qBox
         :param opgroup: the name of the operations group to replace
         :return: whether any replacements were made
@@ -2347,7 +2347,7 @@ class Circuit:
     def substitute_named(self, box: Unitary3qBox, opgroup: str) -> bool:
         """
         Substitute all ops with the given name for the given box.The replacement boxes retain the same name.
-        
+
         :param box: the replacement Unitary3qBox
         :param opgroup: the name of the operations group to replace
         :return: whether any replacements were made
@@ -2356,7 +2356,7 @@ class Circuit:
     def substitute_named(self, box: ExpBox, opgroup: str) -> bool:
         """
         Substitute all ops with the given name for the given box.The replacement boxes retain the same name.
-        
+
         :param box: the replacement ExpBox
         :param opgroup: the name of the operations group to replace
         :return: whether any replacements were made
@@ -2365,7 +2365,7 @@ class Circuit:
     def substitute_named(self, box: PauliExpBox, opgroup: str) -> bool:
         """
         Substitute all ops with the given name for the given box.The replacement boxes retain the same name.
-        
+
         :param box: the replacement PauliExpBox
         :param opgroup: the name of the operations group to replace
         :return: whether any replacements were made
@@ -2374,7 +2374,7 @@ class Circuit:
     def substitute_named(self, box: ToffoliBox, opgroup: str) -> bool:
         """
         Substitute all ops with the given name for the given box.The replacement boxes retain the same name.
-        
+
         :param box: the replacement ToffoliBox
         :param opgroup: the name of the operations group to replace
         :return: whether any replacements were made
@@ -2383,7 +2383,7 @@ class Circuit:
     def substitute_named(self, box: DummyBox, opgroup: str) -> bool:
         """
         Substitute all ops with the given name for the given box.The replacement boxes retain the same name.
-        
+
         :param box: the replacement DummyBox
         :param opgroup: the name of the operations group to replace
         :return: whether any replacements were made
@@ -2392,7 +2392,7 @@ class Circuit:
     def substitute_named(self, box: QControlBox, opgroup: str) -> bool:
         """
         Substitute all ops with the given name for the given box.The replacement boxes retain the same name.
-        
+
         :param box: the replacement QControlBox
         :param opgroup: the name of the operations group to replace
         :return: whether any replacements were made
@@ -2401,7 +2401,7 @@ class Circuit:
     def substitute_named(self, box: CustomGate, opgroup: str) -> bool:
         """
         Substitute all ops with the given name for the given box.The replacement boxes retain the same name.
-        
+
         :param box: the replacement CustomGate
         :param opgroup: the name of the operations group to replace
         :return: whether any replacements were made
@@ -2409,15 +2409,15 @@ class Circuit:
     @typing.overload
     def symbol_substitution(self, symbol_map: dict[sympy.Symbol, sympy.Expr | float]) -> None:
         """
-        In-place substitution for symbolic expressions; iterates through each parameterised gate/box and performs the substitution. 
-        
+        In-place substitution for symbolic expressions; iterates through each parameterised gate/box and performs the substitution.
+
         :param symbol_map: A map from SymPy symbols to SymPy expressions
         """
     @typing.overload
     def symbol_substitution(self, symbol_map: dict[sympy.Symbol, float]) -> None:
         """
-        In-place substitution for symbolic expressions; iterates through each gate/box and performs the substitution. 
-        
+        In-place substitution for symbolic expressions; iterates through each gate/box and performs the substitution.
+
         :param symbol_map: A map from SymPy symbols to floating-point values
         """
     def to_dict(self) -> dict:
@@ -2427,23 +2427,23 @@ class Circuit:
     def to_latex_file(self, filename: str) -> None:
         """
         Produces a latex file with a visualisation of the circuit using the Quantikz package.
-        
+
         :param filename: Name of file to write output to (must end in ".tex")
         """
     def transpose(self) -> Circuit:
         """
         Given a pure circuit (i.e. without any measurements or conditional gates), produces a new circuit for the transpose operation.
-        
+
         :return: a new :py:class:`Circuit` corresponding to the transpose operation
         """
     def valid_connectivity(self, arch: pytket._tket.architecture.Architecture, directed: bool, allow_bridge: bool = False) -> bool:
         """
         Confirms whether all two qubit gates in given circuit are along some edge of the architecture.
-        
+
         :param arch: The architecture capturing the desired connectivity
         :param directed: If true, also checks that CX or ECR gates are in the same direction as the edges of the architecture
         :param allow_bridge: Accept BRIDGEs as valid, assuming the middle qubit neighbours the others
-        
+
         :return: True or False
         """
     @property
@@ -2465,9 +2465,9 @@ class Circuit:
     def c_registers(self) -> list[pytket._tket.unit_id.BitRegister]:
         """
         Get all classical registers.
-        
+
         The list only includes registers that are singly-indexed contiguously from zero.
-        
+
         :return: List of :py:class:`BitRegister`
         """
     @property
@@ -2520,9 +2520,9 @@ class Circuit:
     def q_registers(self) -> list[pytket._tket.unit_id.QubitRegister]:
         """
         Get all quantum registers.
-        
+
         The list only includes registers that are singly-indexed contiguously from zero.
-        
+
         :return: List of :py:class:`QubitRegister`
         """
     @property
@@ -2684,7 +2684,7 @@ class ConjugationBox(Op):
     def __init__(self, compute: Op, action: Op, uncompute: Op | None = None) -> None:
         """
         Construct from operations that perform compute, action, and uncompute. All three operations need to be quantum and have the same size.
-        
+
         :param compute: the compute operation
         :param action: the action operation
         :param uncompute: optional uncompute operation, default to compute.dagger(). If provided, the user needs to make sure that uncompute.dagger() and compute have the same unitary.
@@ -2753,7 +2753,7 @@ class CustomGateDef:
     def define(name: str, circ: Circuit, args: typing.Sequence[sympy.Symbol]) -> CustomGateDef:
         """
         Define a new custom gate as a composite of other gates
-        
+
         :param name: Readable name for the new gate
         :param circ: The definition of the gate as a Circuit
         :param args: Symbols to be encapsulated as arguments of the custom gate
@@ -2799,7 +2799,7 @@ class DiagonalBox(Op):
     def __init__(self, diagonal: NDArray[numpy.complex128], upper_triangle: bool = True) -> None:
         """
         Construct from the diagonal entries of the unitary operator. The size of the vector must be 2^n where n is a positive integer.
-        
+
         :param diagonal: diagonal entries
         :param upper_triangle: indicates whether the multiplexed-Rz gates take the shape of an upper triangle or a lower triangle. Default to true.
         """
@@ -2841,15 +2841,15 @@ class DummyBox(Op):
 class EdgeType:
     """
     Type of a wire in a circuit or input to an op
-    
+
     Members:
-    
+
       Boolean
-    
+
       Classical
-    
+
       Quantum
-    
+
       WASM
     """
     Boolean: typing.ClassVar[EdgeType]  # value = <EdgeType.Boolean: 2>
@@ -2896,7 +2896,7 @@ class ExpBox(Op):
     def __init__(self, A: NDArray[numpy.complex128], t: float, basis: BasisOrder = BasisOrder.ilo) -> None:
         """
         Construct :math:`e^{itA}` from a hermitian matrix :math:`A` and a parameter :math:`t`.
-        
+
         :param A: A hermitian matrix
         :param t: Exponentiation parameter
         :param basis: Whether the provided matrix is in the ILO-BE (increasing lexicographic order of qubit ids, big-endian indexing) format, or DLO-BE (decreasing lexicographic order of ids)
@@ -2915,7 +2915,7 @@ class MetaOp(Op):
     def __init__(self, type: OpType, signature: typing.Sequence[EdgeType], data: str) -> None:
         """
         Construct MetaOp with optype, signature and additional data string
-        
+
         :param type: type for the meta op
         :param signature: signature for the op
         :param data: additional string stored in the op
@@ -2952,23 +2952,23 @@ class MultiplexedRotationBox(Op):
     def __init__(self, bistring_to_op_list: typing.Sequence[tuple[typing.Sequence[bool], Op]]) -> None:
         """
         Construct from a list of bitstring-:py:class:`Op` spairs
-        
+
         All :py:class:`Op` s  must share the same single-qubit rotation type: Rx, Ry, or Rz.
-        
+
         :param bitstring_to_op_list: List of bitstring-:py:class:`Op` spairs
         """
     @typing.overload
     def __init__(self, op_map: dict[tuple[bool, ...], Op]) -> None:
         """
         Construct from a map from bitstrings to :py:class:`Op` s.All :py:class:`Op` s  must share the same single-qubit rotation type: Rx, Ry, or Rz.
-        
+
         :param op_map: Map from bitstrings to :py:class:`Op` s
         """
     @typing.overload
     def __init__(self, angles: typing.Sequence[float], axis: OpType) -> None:
         """
         Construct from a list of angles and the rotation axis.
-        
+
         :param angles: List of rotation angles in half-turns. angles[i] is the angle activated by the binary representation of i
         :param axis: ``OpType.Rx``, ``OpType.Ry`` or ``OpType.Rz``
         """
@@ -2995,16 +2995,16 @@ class MultiplexedTensoredU2Box(Op):
     def __init__(self, bistring_to_op_list: typing.Sequence[tuple[typing.Sequence[bool], typing.Sequence[Op]]]) -> None:
         """
         Construct from a list of bitstring-:py:class:`Op` spairs
-        
+
         Only supports single qubit unitary gate types and :py:class:`Unitary1qBox`.
-        
+
         :param bitstring_to_op_list: List of bitstring-List of :py:class:`Op` s pairs
         """
     @typing.overload
     def __init__(self, op_map: dict[tuple[bool, ...], typing.Sequence[Op]]) -> None:
         """
         Construct from a map from bitstrings to equal-sized lists of :py:class:`Op` s. Only supports single qubit unitary gate types and :py:class:`Unitary1qBox`.
-        
+
         :param op_map: Map from bitstrings to lists of :py:class:`Op` s
         """
     def get_bitstring_op_pair_list(self) -> list[tuple[list[bool], list[Op]]]:
@@ -3030,9 +3030,9 @@ class MultiplexedU2Box(Op):
     def __init__(self, bistring_to_op_list: typing.Sequence[tuple[typing.Sequence[bool], Op]], impl_diag: bool = True) -> None:
         """
         Construct from a list of bitstring-:py:class:`Op` spairs
-        
+
         Only supports single qubit unitary gate types and :py:class:`Unitary1qBox`.
-        
+
         :param op_map: List of bitstring-:py:class:`Op` spairs
         :param impl_diag: Whether to implement the final diagonal gate, default to True.
         """
@@ -3040,7 +3040,7 @@ class MultiplexedU2Box(Op):
     def __init__(self, op_map: dict[tuple[bool, ...], Op], impl_diag: bool = True) -> None:
         """
         Construct from a map from bitstrings to :py:class:`Op` s.Only supports single qubit unitary gate types and :py:class:`Unitary1qBox`.
-        
+
         :param op_map: Map from bitstrings to :py:class:`Op` s
         :param impl_diag: Whether to implement the final diagonal gate, default to True.
         """
@@ -3071,14 +3071,14 @@ class MultiplexorBox(Op):
     def __init__(self, bistring_to_op_list: typing.Sequence[tuple[typing.Sequence[bool], Op]]) -> None:
         """
         Construct from a list of bitstring-:py:class:`Op` spairs
-        
+
         :param bitstring_to_op_list: List of bitstring-:py:class:`Op` spairs
         """
     @typing.overload
     def __init__(self, op_map: dict[tuple[bool, ...], Op]) -> None:
         """
         Construct from a map from bitstrings to :py:class:`Op` s
-        
+
         :param op_map: Map from bitstrings to :py:class:`Op` s
         """
     def get_bitstring_op_pair_list(self) -> list[tuple[list[bool], Op]]:
@@ -3172,211 +3172,211 @@ class Op:
 class OpType:
     """
     Enum for available operations compatible with tket :py:class:`Circuit` s.
-    
+
     Members:
-    
+
       Phase : Global phase: :math:`(\\alpha) \\mapsto \\left[ \\begin{array}{c} e^{i\\pi\\alpha} \\end{array} \\right]`
-    
+
       Z : Pauli Z: :math:`\\left[ \\begin{array}{cc} 1 & 0 \\\\ 0 & -1 \\end{array} \\right]`
-    
+
       X : Pauli X: :math:`\\left[ \\begin{array}{cc} 0 & 1 \\\\ 1 & 0 \\end{array} \\right]`
-    
+
       Y : Pauli Y: :math:`\\left[ \\begin{array}{cc} 0 & -i \\\\ i & 0 \\end{array} \\right]`
-    
+
       S : :math:`\\left[ \\begin{array}{cc} 1 & 0 \\\\ 0 & i \\end{array} \\right] = \\mathrm{U1}(\\frac12)`
-    
+
       Sdg : :math:`\\mathrm{S}^{\\dagger} = \\left[ \\begin{array}{cc} 1 & 0 \\\\ 0 & -i \\end{array} \\right] = \\mathrm{U1}(-\\frac12)`
-    
+
       T : :math:`\\left[ \\begin{array}{cc} 1 & 0 \\\\ 0 & e^{i\\pi/4} \\end{array} \\right] = \\mathrm{U1}(\\frac14)`
-    
+
       Tdg : :math:`\\mathrm{T}^{\\dagger} = \\left[ \\begin{array}{cc} 1 & 0 \\\\ 0 & e^{-i\\pi/4} \\end{array} \\right] = \\mathrm{U1}(-\\frac14)`
-    
+
       V : :math:`\\frac{1}{\\sqrt 2} \\left[ \\begin{array}{cc} 1 & -i \\\\ -i & 1 \\end{array} \\right] = \\mathrm{Rx}(\\frac12)`
-    
+
       Vdg : :math:`\\mathrm{V}^{\\dagger} = \\frac{1}{\\sqrt 2} \\left[ \\begin{array}{cc} 1 & i \\\\ i & 1 \\end{array} \\right] = \\mathrm{Rx}(-\\frac12)`
-    
+
       SX : :math:`\\frac{1}{2} \\left[ \\begin{array}{cc} 1 + i & 1 - i \\\\ 1 - i & 1 + i \\end{array} \\right] = e^{\\frac{i\\pi}{4}}\\mathrm{Rx}(\\frac12)`
-    
+
       SXdg : :math:`\\mathrm{SX}^{\\dagger} = \\frac{1}{2} \\left[ \\begin{array}{cc} 1 - i & 1 + i \\\\ 1 + i & 1 - i \\end{array} \\right] = e^{\\frac{-i\\pi}{4}}\\mathrm{Rx}(-\\frac12)`
-    
+
       H : Hadamard gate: :math:`\\frac{1}{\\sqrt 2} \\left[ \\begin{array}{cc} 1 & 1 \\\\ 1 & -1 \\end{array} \\right]`
-    
+
       Rx : :math:`(\\alpha) \\mapsto e^{-\\frac12 i \\pi \\alpha \\mathrm{X}} = \\left[ \\begin{array}{cc} \\cos\\frac{\\pi\\alpha}{2} & -i\\sin\\frac{\\pi\\alpha}{2} \\\\ -i\\sin\\frac{\\pi\\alpha}{2} & \\cos\\frac{\\pi\\alpha}{2} \\end{array} \\right]`
-    
+
       Ry : :math:`(\\alpha) \\mapsto e^{-\\frac12 i \\pi \\alpha \\mathrm{Y}} = \\left[ \\begin{array}{cc} \\cos\\frac{\\pi\\alpha}{2} & -\\sin\\frac{\\pi\\alpha}{2} \\\\ \\sin\\frac{\\pi\\alpha}{2} & \\cos\\frac{\\pi\\alpha}{2} \\end{array} \\right]`
-    
+
       Rz : :math:`(\\alpha) \\mapsto e^{-\\frac12 i \\pi \\alpha \\mathrm{Z}} = \\left[ \\begin{array}{cc} e^{-\\frac12 i \\pi\\alpha} & 0 \\\\ 0 & e^{\\frac12 i \\pi\\alpha} \\end{array} \\right]`
-    
+
       U1 : :math:`(\\lambda) \\mapsto \\mathrm{U3}(0, 0, \\lambda) = e^{\\frac12 i\\pi\\lambda} \\mathrm{Rz}(\\lambda)`. U-gates are used by IBM. See https://qiskit.org/documentation/tutorials/circuits/3_summary_of_quantum_operations.html for more information on U-gates.
-    
+
       U2 : :math:`(\\phi, \\lambda) \\mapsto \\mathrm{U3}(\\frac12, \\phi, \\lambda) = e^{\\frac12 i\\pi(\\lambda+\\phi)} \\mathrm{Rz}(\\phi) \\mathrm{Ry}(\\frac12) \\mathrm{Rz}(\\lambda)`, defined by matrix multiplication
-    
+
       U3 : :math:`(\\theta, \\phi, \\lambda) \\mapsto  \\left[ \\begin{array}{cc} \\cos\\frac{\\pi\\theta}{2} & -e^{i\\pi\\lambda} \\sin\\frac{\\pi\\theta}{2} \\\\ e^{i\\pi\\phi} \\sin\\frac{\\pi\\theta}{2} & e^{i\\pi(\\lambda+\\phi)} \\cos\\frac{\\pi\\theta}{2} \\end{array} \\right] = e^{\\frac12 i\\pi(\\lambda+\\phi)} \\mathrm{Rz}(\\phi) \\mathrm{Ry}(\\theta) \\mathrm{Rz}(\\lambda)`
-    
+
       GPI : :math:`(\\phi) \\mapsto \\left[ \\begin{array}{cc} 0 & e^{-i\\pi\\phi} \\\\ e^{i\\pi\\phi} & 0 \\end{array} \\right]`
-    
+
       GPI2 : :math:`(\\phi) \\mapsto \\frac{1}{\\sqrt 2} \\left[ \\begin{array}{cc} 1 & -ie^{-i\\pi\\phi} \\\\ -ie^{i\\pi\\phi} & 1 \\end{array} \\right]`
-    
+
       AAMS : :math:`(\\theta, \\phi_0, \\phi_1) \\mapsto \\left[ \\begin{array}{cccc} \\cos\\frac{\\pi\\theta}{2} & 0 & 0 & -ie^{-i\\pi(\\phi_0+\\phi_1)}\\sin\\frac{\\pi\\theta}{2} \\\\ 0 & \\cos\\frac{\\pi\\theta}{2} & -ie^{i\\pi(\\phi_1-\\phi_0)}\\sin\\frac{\\pi\\theta}{2} & 0 \\\\ 0 & -ie^{i\\pi(\\phi_0-\\phi_1)}\\sin\\frac{\\pi\\theta}{2} & \\cos\\frac{\\pi\\theta}{2} & 0 \\\\ -ie^{i\\pi(\\phi_0+\\phi_1)}\\sin\\frac{\\pi\\theta}{2} & 0 & 0 & \\cos\\frac{\\pi\\theta}{2} \\end{array} \\right]`
-    
+
       TK1 : :math:`(\\alpha, \\beta, \\gamma) \\mapsto \\mathrm{Rz}(\\alpha) \\mathrm{Rx}(\\beta) \\mathrm{Rz}(\\gamma)`
-    
+
       TK2 : :math:`(\\alpha, \\beta, \\gamma) \\mapsto \\mathrm{XXPhase}(\\alpha) \\mathrm{YYPhase}(\\beta) \\mathrm{ZZPhase}(\\gamma)`
-    
+
       CX : Controlled :math:`\\mathrm{X}` gate
-    
+
       CY : Controlled :math:`\\mathrm{Y}` gate
-    
+
       CZ : Controlled :math:`\\mathrm{Z}` gate
-    
+
       CH : Controlled :math:`\\mathrm{H}` gate
-    
+
       CV : Controlled :math:`\\mathrm{V}` gate
-    
+
       CVdg : Controlled :math:`\\mathrm{V}^{\\dagger}` gate
-    
+
       CSX : Controlled :math:`\\mathrm{SX}` gate
-    
+
       CSXdg : Controlled :math:`\\mathrm{SX}^{\\dagger}` gate
-    
+
       CS : Controlled :math:`\\mathrm{S}` gate
-    
+
       CSdg : Controlled :math:`\\mathrm{S}^{\\dagger}` gate
-    
+
       CRz : :math:`(\\alpha) \\mapsto` Controlled :math:`\\mathrm{Rz}(\\alpha)` gate
-    
+
       CRx : :math:`(\\alpha) \\mapsto` Controlled :math:`\\mathrm{Rx}(\\alpha)` gate
-    
+
       CRy : :math:`(\\alpha) \\mapsto` Controlled :math:`\\mathrm{Ry}(\\alpha)` gate
-    
+
       CU1 : :math:`(\\lambda) \\mapsto` Controlled :math:`\\mathrm{U1}(\\lambda)` gate. Note that this is not equivalent to a :math:`\\mathrm{CRz}(\\lambda)` up to global phase, differing by an extra :math:`\\mathrm{Rz}(\\frac{\\lambda}{2})` on the control qubit.
-    
+
       CU3 : :math:`(\\theta, \\phi, \\lambda) \\mapsto` Controlled :math:`\\mathrm{U3}(\\theta, \\phi, \\lambda)` gate. Similar rules apply.
-    
+
       CCX : Toffoli gate
-    
+
       ECR : :math:`\\frac{1}{\\sqrt 2} \\left[ \\begin{array}{cccc} 0 & 0 & 1 & i \\\\0 & 0 & i & 1 \\\\1 & -i & 0 & 0 \\\\-i & 1 & 0 & 0 \\end{array} \\right]`
-    
+
       SWAP : Swap gate
-    
+
       CSWAP : Controlled swap gate
-    
+
       noop : Identity gate. These gates are not permanent and are automatically stripped by the compiler
-    
+
       Barrier : Meta-operation preventing compilation through it. Not automatically stripped by the compiler
-    
+
       Label : Label for control flow jumps. Does not appear within a circuit
-    
+
       Branch : A control flow jump to a label dependent on the value of a given Bit. Does not appear within a circuit
-    
+
       Goto : An unconditional control flow jump to a Label. Does not appear within a circuit.
-    
+
       Stop : Halts execution immediately. Used to terminate a program. Does not appear within a circuit.
-    
+
       BRIDGE : A CX Bridge over 3 qubits. Used to apply a logical CX between the first and third qubits when they are not adjacent on the device, but both neighbour the second qubit. Acts as the identity on the second qubit
-    
+
       Measure : Z-basis projective measurement, storing the measurement outcome in a specified bit
-    
+
       Reset : Resets the qubit to :math:`\\left|0\\right>`
-    
+
       CircBox : Represents an arbitrary subcircuit
-    
+
       PhasePolyBox : An operation representing arbitrary circuits made up of CX and Rz gates, represented as a phase polynomial together with a boolean matrix representing an additional linear transformation.
-    
+
       Unitary1qBox : Represents an arbitrary one-qubit unitary operation by its matrix
-    
+
       Unitary2qBox : Represents an arbitrary two-qubit unitary operation by its matrix
-    
+
       Unitary3qBox : Represents an arbitrary three-qubit unitary operation by its matrix
-    
+
       ExpBox : A two-qubit operation corresponding to a unitary matrix defined as the exponential :math:`e^{itA}` of an arbitrary 4x4 hermitian matrix :math:`A`.
-    
+
       PauliExpBox : An operation defined as the exponential :math:`e^{-\\frac{i\\pi\\alpha}{2} P}` of a tensor :math:`P` of Pauli operations.
-    
+
       PauliExpPairBox : A pair of (not necessarily commuting) Pauli exponentials :math:`e^{-\\frac{i\\pi\\alpha}{2} P}` performed in sequence.
-    
+
       PauliExpCommutingSetBox : An operation defined as a setof commuting exponentials of the form :math:`e^{-\\frac{i\\pi\\alpha}{2} P}` of a tensor :math:`P` of Pauli operations.
-    
+
       TermSequenceBox : An unordered collection of Pauli exponentials that can be synthesised in any order, causing a change in the unitary operation. Synthesis order depends on the synthesis strategy chosen only.
-    
+
       QControlBox : An arbitrary n-controlled operation
-    
+
       ToffoliBox : A permutation of classical basis states
-    
+
       ConjugationBox : An operation composed of 'action', 'compute' and 'uncompute' circuits
-    
+
       DummyBox : A placeholder operation that holds resource data
-    
+
       CustomGate : :math:`(\\alpha, \\beta, \\ldots) \\mapsto` A user-defined operation, based on a :py:class:`Circuit` :math:`C` with parameters :math:`\\alpha, \\beta, \\ldots` substituted in place of bound symbolic variables in :math:`C`, as defined by the :py:class:`CustomGateDef`.
-    
+
       Conditional : An operation to be applied conditionally on the value of some classical register
-    
+
       ISWAP : :math:`(\\alpha) \\mapsto e^{\\frac14 i \\pi\\alpha (\\mathrm{X} \\otimes \\mathrm{X} + \\mathrm{Y} \\otimes \\mathrm{Y})} = \\left[ \\begin{array}{cccc} 1 & 0 & 0 & 0 \\\\ 0 & \\cos\\frac{\\pi\\alpha}{2} & i\\sin\\frac{\\pi\\alpha}{2} & 0 \\\\ 0 & i\\sin\\frac{\\pi\\alpha}{2} & \\cos\\frac{\\pi\\alpha}{2} & 0 \\\\ 0 & 0 & 0 & 1 \\end{array} \\right]`
-    
+
       PhasedISWAP : :math:`(p, t) \\mapsto \\left[ \\begin{array}{cccc} 1 & 0 & 0 & 0 \\\\ 0 & \\cos\\frac{\\pi t}{2} & i\\sin\\frac{\\pi t}{2}e^{2i\\pi p} & 0 \\\\ 0 & i\\sin\\frac{\\pi t}{2}e^{-2i\\pi p} & \\cos\\frac{\\pi t}{2} & 0 \\\\ 0 & 0 & 0 & 1 \\end{array} \\right]` (equivalent to: Rz(p)[0]; Rz(-p)[1]; ISWAP(t); Rz(-p)[0]; Rz(p)[1])
-    
+
       XXPhase : :math:`(\\alpha) \\mapsto e^{-\\frac12 i \\pi\\alpha (\\mathrm{X} \\otimes \\mathrm{X})} = \\left[ \\begin{array}{cccc} \\cos\\frac{\\pi\\alpha}{2} & 0 & 0 & -i\\sin\\frac{\\pi\\alpha}{2} \\\\ 0 & \\cos\\frac{\\pi\\alpha}{2} & -i\\sin\\frac{\\pi\\alpha}{2} & 0 \\\\ 0 & -i\\sin\\frac{\\pi\\alpha}{2} & \\cos\\frac{\\pi\\alpha}{2} & 0 \\\\ -i\\sin\\frac{\\pi\\alpha}{2} & 0 & 0 & \\cos\\frac{\\pi\\alpha}{2} \\end{array} \\right]`
-    
+
       YYPhase : :math:`(\\alpha) \\mapsto e^{-\\frac12 i \\pi\\alpha (\\mathrm{Y} \\otimes \\mathrm{Y})} = \\left[ \\begin{array}{cccc} \\cos\\frac{\\pi\\alpha}{2} & 0 & 0 & i\\sin\\frac{\\pi\\alpha}{2} \\\\ 0 & \\cos\\frac{\\pi\\alpha}{2} & -i\\sin\\frac{\\pi\\alpha}{2} & 0 \\\\ 0 & -i\\sin\\frac{\\pi\\alpha}{2} & \\cos\\frac{\\pi\\alpha}{2} & 0 \\\\ i\\sin\\frac{\\pi\\alpha}{2} & 0 & 0 & \\cos\\frac{\\pi\\alpha}{2} \\end{array} \\right]`
-    
+
       ZZPhase : :math:`(\\alpha) \\mapsto e^{-\\frac12 i \\pi\\alpha (\\mathrm{Z} \\otimes \\mathrm{Z})} = \\left[ \\begin{array}{cccc} e^{-\\frac12 i \\pi\\alpha} & 0 & 0 & 0 \\\\ 0 & e^{\\frac12 i \\pi\\alpha} & 0 & 0 \\\\ 0 & 0 & e^{\\frac12 i \\pi\\alpha} & 0 \\\\ 0 & 0 & 0 & e^{-\\frac12 i \\pi\\alpha} \\end{array} \\right]`
-    
+
       XXPhase3 : A 3-qubit gate XXPhase3(α) consists of pairwise 2-qubit XXPhase(α) interactions. Equivalent to XXPhase(α) XXPhase(α) XXPhase(α).
-    
+
       PhasedX : :math:`(\\alpha,\\beta) \\mapsto \\mathrm{Rz}(\\beta)\\mathrm{Rx}(\\alpha)\\mathrm{Rz}(-\\beta)` (matrix-multiplication order)
-    
+
       NPhasedX : :math:`(\\alpha, \\beta) \\mapsto \\mathrm{PhasedX}(\\alpha, \\beta)^{\\otimes n}` (n-qubit gate composed of identical PhasedX in parallel.
-    
+
       CnRx : :math:`(\\alpha)` := n-controlled :math:`\\mathrm{Rx}(\\alpha)` gate.
-    
+
       CnRy : :math:`(\\alpha)` := n-controlled :math:`\\mathrm{Ry}(\\alpha)` gate.
-    
+
       CnRz : :math:`(\\alpha)` := n-controlled :math:`\\mathrm{Rz}(\\alpha)` gate.
-    
+
       CnX : n-controlled X gate.
-    
+
       CnY : n-controlled Y gate.
-    
+
       CnZ : n-controlled Z gate.
-    
+
       ZZMax : :math:`e^{-\\frac{i\\pi}{4}(\\mathrm{Z} \\otimes \\mathrm{Z})}`, a maximally entangling ZZPhase
-    
+
       ESWAP : :math:`\\alpha \\mapsto e^{-\\frac12 i\\pi\\alpha \\cdot \\mathrm{SWAP}} = \\left[ \\begin{array}{cccc} e^{-\\frac12 i \\pi\\alpha} & 0 & 0 & 0 \\\\ 0 & \\cos\\frac{\\pi\\alpha}{2} & -i\\sin\\frac{\\pi\\alpha}{2} & 0 \\\\ 0 & -i\\sin\\frac{\\pi\\alpha}{2} & \\cos\\frac{\\pi\\alpha}{2} & 0 \\\\ 0 & 0 & 0 & e^{-\\frac12 i \\pi\\alpha} \\end{array} \\right]`
-    
+
       FSim : :math:`(\\alpha, \\beta) \\mapsto \\left[ \\begin{array}{cccc} 1 & 0 & 0 & 0 \\\\ 0 & \\cos \\pi\\alpha & -i\\sin \\pi\\alpha & 0 \\\\ 0 & -i\\sin \\pi\\alpha & \\cos \\pi\\alpha & 0 \\\\ 0 & 0 & 0 & e^{-i\\pi\\beta} \\end{array} \\right]`
-    
+
       Sycamore : :math:`\\mathrm{FSim}(\\frac12, \\frac16)`
-    
+
       ISWAPMax : :math:`\\mathrm{ISWAP}(1) = \\left[ \\begin{array}{cccc} 1 & 0 & 0 & 0 \\\\ 0 & 0 & i & 0 \\\\ 0 & i & 0 & 0 \\\\ 0 & 0 & 0 & 1 \\end{array} \\right]`
-    
+
       ClassicalTransform : A general classical operation where all inputs are also outputs
-    
+
       WASM : Op containing a classical wasm function call
-    
+
       SetBits : An operation to set some bits to specified values
-    
+
       CopyBits : An operation to copy some bit values
-    
+
       RangePredicate : A classical predicate defined by a range of values in binary encoding
-    
+
       ExplicitPredicate : A classical predicate defined by a truth table
-    
+
       ExplicitModifier : An operation defined by a truth table that modifies one bit
-    
+
       MultiBit : A classical operation applied to multiple bits simultaneously
-    
+
       ClassicalExpBox : A box for holding compound classical operations on Bits.
-    
+
       MultiplexorBox : A multiplexor (i.e. uniformly controlled operations)
-    
+
       MultiplexedRotationBox : A multiplexed rotation gate (i.e. uniformly controlled single-axis rotations)
-    
+
       MultiplexedU2Box : A multiplexed U2 gate (i.e. uniformly controlled U2 gate)
-    
+
       MultiplexedTensoredU2Box : A multiplexed tensored-U2 gate
-    
+
       StatePreparationBox : A box for preparing quantum states using multiplexed-Ry and multiplexed-Rz gates
-    
+
       DiagonalBox : A box for synthesising a diagonal unitary matrix into a sequence of multiplexed-Rz gates
     """
     AAMS: typing.ClassVar[OpType]  # value = <OpType.AAMS: 42>
@@ -3619,7 +3619,7 @@ class PhasePolyBox(Op):
     def __init__(self, n_qubits: int, qubit_indices: dict[pytket._tket.unit_id.Qubit, int], phase_polynomial: typing.Sequence[tuple[typing.Sequence[bool], sympy.Expr | float]], linear_transformation: NDArray[numpy.bool_]) -> None:
         """
         Construct from the number of qubits, the mapping from Qubit to index, the phase polynomial (list of bitstring phase pairs) and the linear transformation (boolean matrix)
-        
+
         If any bitstring is repeated in the phase polynomial list, the last given value for that bistring will be used
         """
     @typing.overload
@@ -3666,7 +3666,7 @@ class ProjectorAssertionBox(Op):
     def __init__(self, m: NDArray[numpy.complex128], basis: BasisOrder = BasisOrder.ilo) -> None:
         """
         Construct from a projector matrix.
-        
+
         :param m: The projector matrix
         :param basis: Whether the provided unitary is in the ILO-BE (increasing lexicographic order of qubit ids, big-endian indexing) format, or DLO-BE (decreasing lexicographic order of ids)
         """
@@ -3689,7 +3689,7 @@ class QControlBox(Op):
     def __init__(self, op: Op, n_controls: int = 1, control_state: typing.Sequence[bool] = []) -> None:
         """
         Construct from an :py:class:`Op`, a number of quantum controls, and the control state expressed as a bit vector. The controls occupy the low-index ports of the resulting operation.
-        
+
         :param op: the underlying operator
         :param n_controls: the number of control qubits. Default to 1
         :param control_state: the control state expressed as a bit vector. Default to all 1s
@@ -3698,7 +3698,7 @@ class QControlBox(Op):
     def __init__(self, op: Op, n_controls: int, control_state: int) -> None:
         """
         Construct from an :py:class:`Op`, a number of quantum controls, and the control state expressed as an integer. The controls occupy the low-index ports of the resulting operation.
-        
+
         :param op: the underlying operator
         :param n_controls: the number of control qubits
         :param control_state: the control state expressed as an integer. Big-endian
@@ -3759,7 +3759,7 @@ class ResourceBounds:
     def __init__(self, min: int, max: int) -> None:
         """
         Constructs a ResourceBounds object.
-        
+
         :param min: minimum value
         :param max: maximum value
         """
@@ -3774,9 +3774,9 @@ class ResourceBounds:
 class ResourceData:
     """
     An object holding resource data for use in a :py:class:`DummyBox`.
-    
+
     The object holds several fields representing minimum and maximum values for certain resources. The absence of an :py:class:`OpType` in one of these fields is interpreted as the absence of gates of that type in the (imagined) circuit.
-    
+
     See :py:meth:`Circuit.get_resources` for how to use this data.
     """
     @staticmethod
@@ -3785,7 +3785,7 @@ class ResourceData:
     def __init__(self, op_type_count: dict[OpType, ResourceBounds], gate_depth: ResourceBounds, op_type_depth: dict[OpType, ResourceBounds], two_qubit_gate_depth: ResourceBounds) -> None:
         """
         Constructs a ResourceData object.
-        
+
         :param op_type_count: dictionary of counts of selected :py:class:`OpType`
         :param gate_depth: overall gate depth
         :param op_type_depth: dictionary of depths of selected :py:class:`OpType`
@@ -3836,14 +3836,14 @@ class StabiliserAssertionBox(Op):
     def __init__(self, stabilisers: typing.Sequence[pytket._tket.pauli.PauliStabiliser]) -> None:
         """
         Construct from a list of Pauli stabilisers.
-        
+
         :param stabilisers: The list of Pauli stabilisers
         """
     @typing.overload
     def __init__(self, stabilisers: typing.Sequence[str]) -> None:
         """
         Construct from a list of Pauli stabilisers.
-        
+
         :param m: The list of Pauli stabilisers expressed as Python strings
         """
     def get_circuit(self) -> Circuit:
@@ -3864,7 +3864,7 @@ class StatePreparationBox(Op):
     def __init__(self, statevector: NDArray[numpy.complex128], is_inverse: bool = False, with_initial_reset: bool = False) -> None:
         """
         Construct from a statevector
-        
+
         :param statevector: normalised statevector
         :param is_inverse: whether to implement the dagger of the state preparation circuit, default to false
         :param with_initial_reset: whether to explicitly set the state to zero initially (by default the initial zero state is assumed and no explicit reset is applied)
@@ -3936,7 +3936,7 @@ class ToffoliBox(Op):
     def __init__(self, permutation: typing.Sequence[tuple[typing.Sequence[bool], typing.Sequence[bool]]], strat: ToffoliBoxSynthStrat, rotation_axis: OpType = OpType.Ry) -> None:
         """
         Construct from a permutation of basis states
-        
+
         :param permutation: a list of bitstring pairs
         :param strat: synthesis strategy
         :param rotation_axis: the rotation axis of the multiplexors used in the decomposition. Can be either Rx or Ry. Only applicable to the Matching strategy. Default to Ry.
@@ -3945,7 +3945,7 @@ class ToffoliBox(Op):
     def __init__(self, permutation: typing.Sequence[tuple[typing.Sequence[bool], typing.Sequence[bool]]], rotation_axis: OpType = OpType.Ry) -> None:
         """
         Construct from a permutation of basis states and perform synthesis using the Matching strategy
-        
+
         :param permutation: a list of bitstring pairs
         :param rotation_axis: the rotation axis of the multiplexors used in the decomposition. Can be either Rx or Ry, default to Ry.
         """
@@ -3958,7 +3958,7 @@ class ToffoliBox(Op):
     def __init__(self, permutation: dict[tuple[bool, ...], typing.Sequence[bool]], strat: ToffoliBoxSynthStrat, rotation_axis: OpType = OpType.Ry) -> None:
         """
         Construct from a permutation of basis states
-        
+
         :param permutation: a map between bitstrings
         :param strat: synthesis strategy
         :param rotation_axis: the rotation axis of the multiplexors used in the decomposition. Can be either Rx or Ry. Only applicable to the Matching strategy. Default to Ry.
@@ -3967,7 +3967,7 @@ class ToffoliBox(Op):
     def __init__(self, permutation: dict[tuple[bool, ...], typing.Sequence[bool]], rotation_axis: OpType = OpType.Ry) -> None:
         """
         Construct from a permutation of basis states and perform synthesis using the Matching strategy
-        
+
         :param permutation: a map between bitstrings
         :param rotation_axis: the rotation axis of the multiplexors used in the decomposition. Can be either Rx or Ry, default to Ry.
         """
@@ -3995,11 +3995,11 @@ class ToffoliBox(Op):
 class ToffoliBoxSynthStrat:
     """
     Enum strategies for synthesising ToffoliBoxes
-    
+
     Members:
-    
+
       Matching : Use multiplexors to perform parallel swaps on hypercubes
-    
+
       Cycle : Use CnX gates to perform transpositions
     """
     Cycle: typing.ClassVar[ToffoliBoxSynthStrat]  # value = <ToffoliBoxSynthStrat.Cycle: 1>
@@ -4063,7 +4063,7 @@ class Unitary2qBox(Op):
     def __init__(self, m: NDArray[numpy.complex128], basis: BasisOrder = BasisOrder.ilo) -> None:
         """
         Construct from a unitary matrix.
-        
+
         :param m: The unitary matrix
         :param basis: Whether the provided unitary is in the ILO-BE (increasing lexicographic order of qubit ids, big-endian indexing) format, or DLO-BE (decreasing lexicographic order of ids)
         """
@@ -4085,7 +4085,7 @@ class Unitary3qBox(Op):
     def __init__(self, m: NDArray[numpy.complex128], basis: BasisOrder = BasisOrder.ilo) -> None:
         """
         Construct from a unitary matrix.
-        
+
         :param m: The unitary matrix
         :param basis: Whether the provided unitary is in the ILO-BE (increasing lexicographic order of qubit ids, big-endian indexing) format, or DLO-BE (decreasing lexicographic order of ids)
         """
@@ -4146,8 +4146,8 @@ class WASMOp(ClassicalOp):
 def fresh_symbol(preferred: str = 'a') -> sympy.Symbol:
     """
     Given some preferred symbol, this finds an appropriate suffix that will guarantee it has not yet been used in the current python session.
-    
+
     :param preferred: The preferred readable symbol name as a string (default is 'a')
-    
+
     :return: A new sympy symbol object
     """

--- a/pytket/pytket/_tket/circuit.pyi
+++ b/pytket/pytket/_tket/circuit.pyi
@@ -37,11 +37,11 @@ class BasisOrder:
     For statevector and unitaries, the string abc is interpreted as an index in a big-endian (BE) fashion. e.g. the statevector :math:`(a_{00}, a_{01}, a_{10}, a_{11})`
     Some backends (Qiskit, ProjectQ, etc.) use a DLO-BE (decreasing lexicographic order, big-endian) convention. This is the same as ILO-LE (little-endian) for statevectors and unitaries, but gives shot tables/readouts in a counter-intuitive manner.
     Every backend and matrix-based box has a BasisOrder option which can toggle between ILO-BE (ilo) and DLO-BE (dlo).
-
+    
     Members:
-
+    
       ilo : Increasing Lexicographic Order of UnitID, big-endian
-
+    
       dlo : Decreasing Lexicographic Order of UnitID, big-endian
     """
     __members__: typing.ClassVar[dict[str, BasisOrder]]  # value = {'ilo': <BasisOrder.ilo: 0>, 'dlo': <BasisOrder.dlo: 1>}
@@ -79,15 +79,15 @@ class BasisOrder:
 class CXConfigType:
     """
     Enum for available configurations for CXs upon decompose phase gadgets
-
+    
     Members:
-
+    
       Snake : linear nearest neighbour CX sequence. Linear depth.
-
+    
       Star : Every CX has same target, linear depth, good for gate cancellation.
-
+    
       Tree : Balanced tree: logarithmic depth, harder to route.
-
+    
       MultiQGate : Support for multi-qubit architectures, decomposing to 3-qubit XXPhase3 gates instead of CXs where possible.
     """
     MultiQGate: typing.ClassVar[CXConfigType]  # value = <CXConfigType.MultiQGate: 3>
@@ -141,17 +141,17 @@ class CircBox(Op):
         """
     def symbol_substitution(self, symbol_map: dict[sympy.Symbol, sympy.Expr | float]) -> None:
         """
-        In-place substitution of symbolic expressions within underlying circuit; iterates through each parameterised gate/box within the circuit and performs the substitution.
-
-         WARNING: This method potentially mutates the CircBox and any changes are propagated to any Circuit that the CircBox has been added to (via Circuit.add_circbox).
-
+        In-place substitution of symbolic expressions within underlying circuit; iterates through each parameterised gate/box within the circuit and performs the substitution. 
+        
+         WARNING: This method potentially mutates the CircBox and any changes are propagated to any Circuit that the CircBox has been added to (via Circuit.add_circbox). 
+        
         :param symbol_map: A map from SymPy symbols to SymPy expressions
         """
     @property
     def circuit_name(self) -> str | None:
         """
-        :return: the name of the contained circuit.
-
+        :return: the name of the contained circuit. 
+        
          WARNING: Setting this property mutates the CircBox and any changes are propagated to any Circuit that the CircBox has been added to (via Circuit.add_circbox).
         """
     @circuit_name.setter
@@ -160,7 +160,7 @@ class CircBox(Op):
 class Circuit:
     """
     Encapsulates a quantum circuit using a DAG representation.
-
+    
     >>> from pytket import Circuit
     >>> c = Circuit(4,2) # Create a circuit with 4 qubits and 2 classical bits
     >>> c.H(0) # Apply a gate to qubit 0
@@ -179,378 +179,378 @@ class Circuit:
     def AAMS(self, angle0: sympy.Expr | float, angle1: sympy.Expr | float, angle2: sympy.Expr | float, qubit0: int, qubit1: int, **kwargs: Any) -> Circuit:
         """
         Appends an AAMS gate with possibly symbolic angles (specified in half-turns).
-
+        
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def AAMS(self, angle0: sympy.Expr | float, angle1: sympy.Expr | float, angle2: sympy.Expr | float, qubit0: pytket._tket.unit_id.Qubit, qubit1: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends an AAMS gate with possibly symbolic angles (specified in half-turns).
-
+        
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def CCX(self, control_0: int, control_1: int, target: int, **kwargs: Any) -> Circuit:
         """
         Appends a CCX gate on the wires for the specified control and target qubits.
-
+        
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def CCX(self, control_0: pytket._tket.unit_id.Qubit, control_1: pytket._tket.unit_id.Qubit, target: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a CCX gate on the wires for the specified control and target qubits.
-
+        
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def CH(self, control_qubit: int, target_qubit: int, **kwargs: Any) -> Circuit:
         """
         Appends a CH gate on the wires for the specified control and target qubits.
-
+        
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def CH(self, control_qubit: pytket._tket.unit_id.Qubit, target_qubit: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a CH gate on the wires for the specified control and target qubits.
-
+        
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def CRx(self, angle: sympy.Expr | float, control_qubit: int, target_qubit: int, **kwargs: Any) -> Circuit:
         """
         Appends a CRx gate with a possibly symbolic angle (specified in half-turns) on the wires for the specified control and target qubits.
-
+        
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def CRx(self, angle: sympy.Expr | float, control_qubit: pytket._tket.unit_id.Qubit, target_qubit: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a CRx gate with a symbolic angle (specified in half-turns) on the wires for the specified control and target qubits.
-
+        
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def CRy(self, angle: sympy.Expr | float, control_qubit: int, target_qubit: int, **kwargs: Any) -> Circuit:
         """
         Appends a CRy gate with a possibly symbolic angle (specified in half-turns) on the wires for the specified control and target qubits.
-
+        
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def CRy(self, angle: sympy.Expr | float, control_qubit: pytket._tket.unit_id.Qubit, target_qubit: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a CRy gate with a symbolic angle (specified in half-turns) on the wires for the specified control and target qubits.
-
+        
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def CRz(self, angle: sympy.Expr | float, control_qubit: int, target_qubit: int, **kwargs: Any) -> Circuit:
         """
         Appends a CRz gate with a possibly symbolic angle (specified in half-turns) on the wires for the specified control and target qubits.
-
+        
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def CRz(self, angle: sympy.Expr | float, control_qubit: pytket._tket.unit_id.Qubit, target_qubit: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a CRz gate with a symbolic angle (specified in half-turns) on the wires for the specified control and target qubits.
-
+        
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def CS(self, control_qubit: int, target_qubit: int, **kwargs: Any) -> Circuit:
         """
         Appends a CS gate on the wires for the specified control and target qubits.
-
+        
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def CS(self, control_qubit: pytket._tket.unit_id.Qubit, target_qubit: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a CS gate on the wires for the specified control and target qubits.
-
+        
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def CSWAP(self, control: int, target_0: int, target_1: int, **kwargs: Any) -> Circuit:
         """
         Appends a CSWAP gate on the wires for the specified control and target qubits.
-
+        
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def CSWAP(self, control: pytket._tket.unit_id.Qubit, target_0: pytket._tket.unit_id.Qubit, target_1: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a CSWAP gate on the wires for the specified control and target qubits.
-
+        
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def CSX(self, control_qubit: int, target_qubit: int, **kwargs: Any) -> Circuit:
         """
         Appends a CSX gate on the wires for the specified control and target qubits.
-
+        
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def CSX(self, control_qubit: pytket._tket.unit_id.Qubit, target_qubit: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a CSX gate on the wires for the specified control and target qubits.
-
+        
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def CSXdg(self, control_qubit: int, target_qubit: int, **kwargs: Any) -> Circuit:
         """
         Appends a CSXdg gate on the wires for the specified control and target qubits.
-
+        
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def CSXdg(self, control_qubit: pytket._tket.unit_id.Qubit, target_qubit: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a CSXdg gate on the wires for the specified control and target qubits.
-
+        
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def CSdg(self, control_qubit: int, target_qubit: int, **kwargs: Any) -> Circuit:
         """
         Appends a CSdg gate on the wires for the specified control and target qubits.
-
+        
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def CSdg(self, control_qubit: pytket._tket.unit_id.Qubit, target_qubit: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a CSdg gate on the wires for the specified control and target qubits.
-
+        
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def CU1(self, angle: sympy.Expr | float, control_qubit: int, target_qubit: int, **kwargs: Any) -> Circuit:
         """
         Appends a CU1 gate with a possibly symbolic angle (specified in half-turns) on the wires for the specified control and target qubits.
-
+        
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def CU1(self, angle: sympy.Expr | float, control_qubit: pytket._tket.unit_id.Qubit, target_qubit: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a CU1 gate with a possibly symbolic angle (specified in half-turns) on the wires for the specified control and target qubits.
-
+        
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def CU3(self, angle0: sympy.Expr | float, angle1: sympy.Expr | float, angle2: sympy.Expr | float, control_qubit: int, target_qubit: int, **kwargs: Any) -> Circuit:
         """
         Appends a CU3 gate with possibly symbolic angles (specified in half-turns) on the wires for the specified control and target qubits.
-
+        
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def CU3(self, angle0: sympy.Expr | float, angle1: sympy.Expr | float, angle2: sympy.Expr | float, control_qubit: pytket._tket.unit_id.Qubit, target_qubit: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a CU3 gate with possibly symbolic angles (specified in half-turns) on the wires for the specified control and target qubits.
-
+        
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def CV(self, control_qubit: int, target_qubit: int, **kwargs: Any) -> Circuit:
         """
         Appends a CV gate on the wires for the specified control and target qubits.
-
+        
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def CV(self, control_qubit: pytket._tket.unit_id.Qubit, target_qubit: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a CV gate on the wires for the specified control and target qubits.
-
+        
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def CVdg(self, control_qubit: int, target_qubit: int, **kwargs: Any) -> Circuit:
         """
         Appends a CVdg gate on the wires for the specified control and target qubits.
-
+        
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def CVdg(self, control_qubit: pytket._tket.unit_id.Qubit, target_qubit: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a CVdg gate on the wires for the specified control and target qubits.
-
+        
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def CX(self, control_qubit: int, target_qubit: int, **kwargs: Any) -> Circuit:
         """
         Appends a CX gate on the wires for the specified control and target qubits.
-
+        
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def CX(self, control_qubit: pytket._tket.unit_id.Qubit, target_qubit: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a CX gate on the wires for the specified control and target qubits.
-
+        
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def CY(self, control_qubit: int, target_qubit: int, **kwargs: Any) -> Circuit:
         """
         Appends a CY gate on the wires for the specified control and target qubits.
-
+        
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def CY(self, control_qubit: pytket._tket.unit_id.Qubit, target_qubit: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a CY gate on the wires for the specified control and target qubits.
-
+        
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def CZ(self, control_qubit: int, target_qubit: int, **kwargs: Any) -> Circuit:
         """
         Appends a CZ gate on the wires for the specified control and target qubits.
-
+        
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def CZ(self, control_qubit: pytket._tket.unit_id.Qubit, target_qubit: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a CZ gate on the wires for the specified control and target qubits.
-
+        
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def ECR(self, qubit_0: int, qubit_1: int, **kwargs: Any) -> Circuit:
         """
         Appends an ECR gate on the wires for the specified qubits.
-
+        
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def ECR(self, qubit_0: pytket._tket.unit_id.Qubit, qubit_1: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends an ECR gate on the wires for the specified qubits.
-
+        
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def ESWAP(self, angle: sympy.Expr | float, qubit0: int, qubit1: int, **kwargs: Any) -> Circuit:
         """
         Appends an ESWAP gate with a possibly symbolic angle (specified in half-turns) on the wires for the specified two qubits.
-
+        
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def ESWAP(self, angle: sympy.Expr | float, qubit0: pytket._tket.unit_id.Qubit, qubit1: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends an ESWAP gate with a possibly symbolic angle (specified in half-turns) on the wires for the specified two qubits.
-
+        
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def FSim(self, angle0: sympy.Expr | float, angle1: sympy.Expr | float, qubit0: int, qubit1: int, **kwargs: Any) -> Circuit:
         """
         Appends an FSim gate with possibly symbolic angles (specified in half-turns) on the wires for the specified qubits.
-
+        
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def FSim(self, angle0: sympy.Expr | float, angle1: sympy.Expr | float, qubit0: pytket._tket.unit_id.Qubit, qubit1: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends an FSim gate with possibly symbolic angles (specified in half-turns) on the wires for the specified qubits.
-
+        
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def GPI(self, angle: sympy.Expr | float, qubit: int, **kwargs: Any) -> Circuit:
         """
         Appends a GPI gate with a possibly symbolic angle (specified in half-turns).
-
+        
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def GPI(self, angle: sympy.Expr | float, qubit: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a GPI gate with a possibly symbolic angle (specified in half-turns).
-
+        
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def GPI2(self, angle: sympy.Expr | float, qubit: int, **kwargs: Any) -> Circuit:
         """
         Appends a GPI2 gate with a possibly symbolic angle (specified in half-turns).
-
+        
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def GPI2(self, angle: sympy.Expr | float, qubit: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a GPI2 gate with a possibly symbolic angle (specified in half-turns).
-
+        
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def H(self, qubit: int, **kwargs: Any) -> Circuit:
         """
         Appends a Hadamard gate.
-
+        
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def H(self, qubit: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a Hadamard gate.
-
+        
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def ISWAP(self, angle: sympy.Expr | float, qubit0: int, qubit1: int, **kwargs: Any) -> Circuit:
         """
         Appends an ISWAP gate with a possibly symbolic angle (specified in half-turns) on the wires for the specified qubits.
-
+        
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def ISWAP(self, angle: sympy.Expr | float, qubit0: pytket._tket.unit_id.Qubit, qubit1: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends an ISWAP gate with a possibly symbolic angle (specified in half-turns) on the wires for the specified qubits.
-
+        
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def ISWAPMax(self, qubit0: int, qubit1: int, **kwargs: Any) -> Circuit:
         """
         Appends an ISWAPMax gate on the wires for the specified qubits.
-
+        
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def ISWAPMax(self, qubit0: pytket._tket.unit_id.Qubit, qubit1: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends an ISWAPMax gate on the wires for the specified qubits.
-
+        
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def Measure(self, qubit: int, bit_index: int, **kwargs: Any) -> Circuit:
         """
         Appends a single-qubit measurement in the computational (Z) basis.
-
+        
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def Measure(self, qubit: pytket._tket.unit_id.Qubit, bit: pytket._tket.unit_id.Bit, **kwargs: Any) -> Circuit:
         """
         Appends a single-qubit measurement in the computational (Z) basis.
-
+        
         :return: the new :py:class:`Circuit`
         """
     def Phase(self, arg0: sympy.Expr | float, **kwargs: Any) -> Circuit:
@@ -559,294 +559,294 @@ class Circuit:
     def PhasedISWAP(self, angle0: sympy.Expr | float, angle1: sympy.Expr | float, qubit0: int, qubit1: int, **kwargs: Any) -> Circuit:
         """
         Appends a PhasedISWAP gate with possibly symbolic angles (specified in half-turns) on the wires for the specified qubits.
-
+        
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def PhasedISWAP(self, angle0: sympy.Expr | float, angle1: sympy.Expr | float, qubit0: pytket._tket.unit_id.Qubit, qubit1: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a PhasedISWAP gate with posisbly symbolic angles (specified in half-turns) on the wires for the specified qubits.
-
+        
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def PhasedX(self, angle0: sympy.Expr | float, angle1: sympy.Expr | float, qubit: int, **kwargs: Any) -> Circuit:
         """
         Appends a PhasedX gate with possibly symbolic angles (specified in half-turns) on the wires for the specified qubits.
-
+        
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def PhasedX(self, angle0: sympy.Expr | float, angle1: sympy.Expr | float, qubit: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a PhasedX gate with possibly symbolic angles (specified in half-turns) on the wires for the specified qubits.
-
+        
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def Reset(self, qubit: int, **kwargs: Any) -> Circuit:
         """
         Appends a Reset operation. Sets a qubit to the Z-basis 0 state. Non-unitary operation.
-
+        
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def Reset(self, qubit: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a Reset operation. Sets a qubit to the Z-basis 0 state. Non-unitary operation.
-
+        
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def Rx(self, angle: sympy.Expr | float, qubit: int, **kwargs: Any) -> Circuit:
         """
         Appends an Rx gate with a possibly symbolic angle (specified in half-turns).
-
+        
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def Rx(self, angle: sympy.Expr | float, qubit: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends an Rx gate with a possibly symbolic angle (specified in half-turns).
-
+        
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def Ry(self, angle: sympy.Expr | float, qubit: int, **kwargs: Any) -> Circuit:
         """
         Appends an Ry gate with a possibly symbolic angle (specified in half-turns).
-
+        
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def Ry(self, angle: sympy.Expr | float, qubit: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends an Ry gate with a possibly symbolic angle (specified in half-turns).
-
+        
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def Rz(self, angle: sympy.Expr | float, qubit: int, **kwargs: Any) -> Circuit:
         """
         Appends an Rz gate with a possibly symbolic angle (specified in half-turns).
-
+        
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def Rz(self, angle: sympy.Expr | float, qubit: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends an Rz gate with a possibly symbolic angle (specified in half-turns).
-
+        
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def S(self, qubit: int, **kwargs: Any) -> Circuit:
         """
         Appends an S gate (equivalent to U1(0.5,-)).
-
+        
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def S(self, qubit: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends an S gate (equivalent to Rz(0.5,-)).
-
+        
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def SWAP(self, qubit_0: int, qubit_1: int, **kwargs: Any) -> Circuit:
         """
         Appends a SWAP gate on the wires for the specified qubits.
-
+        
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def SWAP(self, qubit_0: pytket._tket.unit_id.Qubit, qubit_1: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a SWAP gate on the wires for the specified qubits.
-
+        
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def SX(self, qubit: int, **kwargs: Any) -> Circuit:
         """
         Appends a SX gate (equivalent to Rx(0.5,-) up to a 0.25 global phase).
-
+        
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def SX(self, qubit: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a SX gate (equivalent to Rx(0.5,-) up to a 0.25 global phase).
-
+        
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def SXdg(self, qubit: int, **kwargs: Any) -> Circuit:
         """
         Appends a SXdg gate (equivalent to Rx(-0.5,-) up to a -0.25 global phase).
-
+        
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def SXdg(self, qubit: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a SXdg gate (equivalent to Rx(-0.5,-) up to a -0.25 global phase).
-
+        
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def Sdg(self, qubit: int, **kwargs: Any) -> Circuit:
         """
         Appends an S-dagger gate (equivalent to U1(-0.5,-)).
-
+        
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def Sdg(self, qubit: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends an S-dagger gate (equivalent to Rz(-0.5,-)).
-
+        
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def Sycamore(self, qubit0: int, qubit1: int, **kwargs: Any) -> Circuit:
         """
         Appends a Sycamore gate on the wires for the specified qubits.
-
+        
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def Sycamore(self, qubit0: pytket._tket.unit_id.Qubit, qubit1: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a Sycamore gate on the wires for the specified qubits.
-
+        
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def T(self, qubit: int, **kwargs: Any) -> Circuit:
         """
         Appends a T gate (equivalent to U1(0.25,-)).
-
+        
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def T(self, qubit: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a T gate (equivalent to Rz(0.25,-)).
-
+        
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def TK1(self, angle0: sympy.Expr | float, angle1: sympy.Expr | float, angle2: sympy.Expr | float, qubit: int, **kwargs: Any) -> Circuit:
         """
         Appends a TK1 gate with possibly symbolic angles (specified in half-turns).
-
+        
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def TK1(self, angle0: sympy.Expr | float, angle1: sympy.Expr | float, angle2: sympy.Expr | float, qubit: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a TK1 gate with possibly symbolic angles (specified in half-turns).
-
+        
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def TK2(self, angle0: sympy.Expr | float, angle1: sympy.Expr | float, angle2: sympy.Expr | float, qubit0: int, qubit1: int, **kwargs: Any) -> Circuit:
         """
         Appends a TK2 gate with possibly symbolic angles (specified in half-turns).
-
+        
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def TK2(self, angle0: sympy.Expr | float, angle1: sympy.Expr | float, angle2: sympy.Expr | float, qubit0: pytket._tket.unit_id.Qubit, qubit1: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a TK2 gate with possibly symbolic angles (specified in half-turns).
-
+        
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def Tdg(self, qubit: int, **kwargs: Any) -> Circuit:
         """
         Appends a T-dagger gate (equivalent to U1(-0.25,-)).
-
+        
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def Tdg(self, qubit: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a T-dagger gate (equivalent to Rz(-0.25,-)).
-
+        
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def U1(self, angle: sympy.Expr | float, qubit: int, **kwargs: Any) -> Circuit:
         """
         Appends a U1 gate with a possibly symbolic angle (specified in half-turns).
-
+        
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def U1(self, angle: sympy.Expr | float, qubit: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a U1 gate with a possibly symbolic angle (specified in half-turns).
-
+        
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def U2(self, angle0: sympy.Expr | float, angle1: sympy.Expr | float, qubit: int, **kwargs: Any) -> Circuit:
         """
         Appends a U2 gate with possibly symbolic angles (specified in half-turns).
-
+        
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def U2(self, angle0: sympy.Expr | float, angle1: sympy.Expr | float, qubit: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a U2 gate with possibly symbolic angles (specified in half-turns).
-
+        
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def U3(self, angle0: sympy.Expr | float, angle1: sympy.Expr | float, angle2: sympy.Expr | float, qubit: int, **kwargs: Any) -> Circuit:
         """
         Appends a U3 gate with possibly symbolic angles (specified in half-turns).
-
+        
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def U3(self, angle0: sympy.Expr | float, angle1: sympy.Expr | float, angle2: sympy.Expr | float, qubit: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a U3 gate with possibly symbolic angles (specified in half-turns).
-
+        
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def V(self, qubit: int, **kwargs: Any) -> Circuit:
         """
         Appends a V gate (equivalent to Rx(0.5,-)).
-
+        
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def V(self, qubit: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a V gate (equivalent to Rx(0.5,-)).
-
+        
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def Vdg(self, qubit: int, **kwargs: Any) -> Circuit:
         """
         Appends a V-dagger gate (equivalent to Rx(-0.5,-)).
-
+        
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def Vdg(self, qubit: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a V-dagger gate (equivalent to Rx(-0.5,-)).
-
+        
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
@@ -858,35 +858,35 @@ class Circuit:
     def X(self, qubit: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends an X gate.
-
+        
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def XXPhase(self, angle: sympy.Expr | float, qubit0: int, qubit1: int, **kwargs: Any) -> Circuit:
         """
         Appends a XX gate with a possibly symbolic angle (specified in half-turns) on the wires for the specified two qubits.
-
+        
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def XXPhase(self, qubit0: sympy.Expr | float, qubit1: pytket._tket.unit_id.Qubit, angle: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a XX gate with a symbolic angle (specified in half-turns) on the wires for the specified two qubits.
-
+        
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def XXPhase3(self, angle: sympy.Expr | float, qubit0: int, qubit1: int, qubit2: int, **kwargs: Any) -> Circuit:
         """
         Appends a 3-qubit XX gate with a possibly symbolic angle (specified in half-turns) on the wires for the specified three qubits.
-
+        
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def XXPhase3(self, angle: sympy.Expr | float, qubit0: pytket._tket.unit_id.Qubit, qubit1: pytket._tket.unit_id.Qubit, qubit2: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a 3-qubit XX gate with a symbolic angle (specified in half-turns) on the wires for the specified three qubits.
-
+        
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
@@ -898,21 +898,21 @@ class Circuit:
     def Y(self, qubit: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a Y gate.
-
+        
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def YYPhase(self, angle: sympy.Expr | float, qubit0: int, qubit1: int, **kwargs: Any) -> Circuit:
         """
         Appends a YY gate with a possibly symbolic angle (specified in half-turns) on the wires for the specified two qubits.
-
+        
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def YYPhase(self, qubit0: sympy.Expr | float, qubit1: pytket._tket.unit_id.Qubit, angle: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a YY gate with a symbolic angle (specified in half-turns) on the wires for the specified two qubits.
-
+        
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
@@ -924,35 +924,35 @@ class Circuit:
     def Z(self, qubit: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a Z gate.
-
+        
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def ZZMax(self, qubit0: int, qubit1: int, **kwargs: Any) -> Circuit:
         """
         Appends a ZZMax gate on the wires for the specified two qubits.
-
+        
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def ZZMax(self, qubit0: pytket._tket.unit_id.Qubit, qubit1: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a ZZMax gate on the wires for the specified two qubits.
-
+        
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def ZZPhase(self, angle: sympy.Expr | float, qubit0: int, qubit1: int, **kwargs: Any) -> Circuit:
         """
         Appends a ZZ gate with a possibly symbolic angle (specified in half-turns) on the wires for the specified two qubits.
-
+        
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
     def ZZPhase(self, angle: sympy.Expr | float, qubit0: pytket._tket.unit_id.Qubit, qubit1: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a ZZ gate with a symbolic angle (specified in half-turns) on the wires for the specified two qubits.
-
+        
         :return: the new :py:class:`Circuit`
         """
     def __eq__(self, arg0: typing.Any) -> bool:
@@ -972,21 +972,21 @@ class Circuit:
     def __init__(self, name: str) -> None:
         """
         Constructs a named circuit with a completely empty DAG.
-
+        
         :param name: name for the circuit
         """
     @typing.overload
     def __init__(self, n_qubits: int, name: str | None = None) -> None:
         """
         Constructs a circuit with a given number of qubits/blank wires.
-
+        
         >>> c = Circuit()
         >>> c.add_blank_wires(3)
-
+        
         is equivalent to
-
+        
         >>> c = Circuit(3)
-
+        
         :param n_qubits: The number of qubits in the circuit
         :param name: Optional name for the circuit.
         """
@@ -994,7 +994,7 @@ class Circuit:
     def __init__(self, n_qubits: int, n_bits: int, name: str | None = None) -> None:
         """
         Constructs a circuit with a given number of quantum and classical bits
-
+        
         :param n_qubits: The number of qubits in the circuit
         :param n_bits: The number of classical bits in the circuit
         :param name: Optional name for the circuit.
@@ -1019,15 +1019,15 @@ class Circuit:
         ...
     def _add_w_register(self, size: int) -> None:
         """
-        Creates given number of wasm bits in the circuit. If there are already wasm bits in circuit only the additional wasm bits will be added.
-
+        Creates given number of wasm bits in the circuit. If there are already wasm bits in circuit only the additional wasm bits will be added. 
+        
         :param size: Number of wasm bits that should be added to the circuit
         """
     @typing.overload
     def _add_wasm(self, funcname: str, wasm_uid: str, width_i_parameter: typing.Sequence[int], width_o_parameter: typing.Sequence[int], args: typing.Sequence[int], wasm_wire_args: typing.Sequence[int], **kwargs: Any) -> Circuit:
         """
-        Add a classical function call from a wasm file to the circuit.
-
+        Add a classical function call from a wasm file to the circuit. 
+        
         :param funcname: name of the function that is called
         :param wasm_uid: unit id to identify the wasm file
         :param width_i_parameter: list of the number of bits in the input variables
@@ -1040,8 +1040,8 @@ class Circuit:
     @typing.overload
     def _add_wasm(self, funcname: str, wasm_uid: str, width_i_parameter: typing.Sequence[int], width_o_parameter: typing.Sequence[int], args: typing.Sequence[pytket._tket.unit_id.Bit], wasm_wire_args: typing.Sequence[int], **kwargs: Any) -> Circuit:
         """
-        Add a classical function call from a wasm file to the circuit.
-
+        Add a classical function call from a wasm file to the circuit. 
+        
         :param funcname: name of the function that is called
         :param wasm_uid: unit id to identify the wasm file
         :param width_i_parameter: list of the number of bits in the input variables
@@ -1053,8 +1053,8 @@ class Circuit:
     @typing.overload
     def _add_wasm(self, funcname: str, wasm_uid: str, list_reg_in: typing.Sequence[pytket._tket.unit_id.BitRegister], list_reg_out: typing.Sequence[pytket._tket.unit_id.BitRegister], wasm_wire_args: typing.Sequence[int], **kwargs: Any) -> Circuit:
         """
-        Add a classical function call from a wasm file to the circuit.
-
+        Add a classical function call from a wasm file to the circuit. 
+        
         :param funcname: name of the function that is called
         :param wasm_uid: unit id to identify the wasm file
         :param list_reg_in: list of the classical registers in the circuit used as inputs
@@ -1076,7 +1076,7 @@ class Circuit:
     def add_assertion(self, box: ProjectorAssertionBox, qubits: typing.Sequence[int], ancilla: int | None = None, name: str | None = None) -> Circuit:
         """
         Append a :py:class:`ProjectorAssertionBox` to the circuit.
-
+        
         :param box: ProjectorAssertionBox to append
         :param qubits: indices of target qubits
         :param ancilla: index of ancilla qubit
@@ -1087,7 +1087,7 @@ class Circuit:
     def add_assertion(self, box: ProjectorAssertionBox, qubits: typing.Sequence[pytket._tket.unit_id.Qubit], ancilla: pytket._tket.unit_id.Qubit | None = None, name: str | None = None) -> Circuit:
         """
         Append a :py:class:`ProjectorAssertionBox` to the circuit.
-
+        
         :param box: ProjectorAssertionBox to append
         :param qubits: target qubits
         :param ancilla: ancilla qubit
@@ -1098,7 +1098,7 @@ class Circuit:
     def add_assertion(self, box: StabiliserAssertionBox, qubits: typing.Sequence[int], ancilla: int, name: str | None = None) -> Circuit:
         """
         Append a :py:class:`StabiliserAssertionBox` to the circuit.
-
+        
         :param box: StabiliserAssertionBox to append
         :param qubits: indices of target qubits
         :param ancilla: index of ancilla qubit
@@ -1109,7 +1109,7 @@ class Circuit:
     def add_assertion(self, box: StabiliserAssertionBox, qubits: typing.Sequence[pytket._tket.unit_id.Qubit], ancilla: pytket._tket.unit_id.Qubit, name: str | None = None) -> Circuit:
         """
         Append a :py:class:`StabiliserAssertionBox` to the circuit.
-
+        
         :param box: StabiliserAssertionBox to append
         :param qubits: target qubits
         :param ancilla: ancilla qubit
@@ -1120,7 +1120,7 @@ class Circuit:
     def add_barrier(self, qubits: typing.Sequence[int], bits: typing.Sequence[int] = [], data: str = '') -> Circuit:
         """
         Append a Barrier on the given units
-
+        
         :param data: additional data stored in the barrier
         :return: the new :py:class:`Circuit`
         """
@@ -1128,28 +1128,28 @@ class Circuit:
     def add_barrier(self, units: typing.Sequence[pytket._tket.unit_id.UnitID], data: str = '') -> Circuit:
         """
         Append a Barrier on the given units
-
+        
         :param data: additional data stored in the barrier
         :return: the new :py:class:`Circuit`
         """
     def add_bit(self, id: pytket._tket.unit_id.Bit, reject_dups: bool = True) -> None:
         """
         Constructs a single bit with the given id.
-
+        
         :param id: Unique id for the bit
         :param reject_dups: Fail if there is already a bit in this circuit with the id. Default to True
         """
     def add_blank_wires(self, number: int) -> None:
         """
         Adds a number of new qubits to the circuit. These will be added to the default register ('q') if possible, filling out the unused indices from 0.
-
+        
         :param number: Number of qubits to add
         """
     @typing.overload
     def add_c_and(self, arg0_in: int, arg1_in: int, arg_out: int, **kwargs: Any) -> Circuit:
         """
         Appends a binary AND operation to the end of the circuit.
-
+        
         :param arg0_in: first input bit
         :param arg1_in: second input bit
         :param arg_out: output bit
@@ -1164,9 +1164,9 @@ class Circuit:
     def add_c_and_to_registers(self, reg0_in: pytket._tket.unit_id.BitRegister, reg1_in: pytket._tket.unit_id.BitRegister, reg_out: pytket._tket.unit_id.BitRegister, **kwargs: Any) -> Circuit:
         """
         Applies bitwise AND to linear registers.
-
+        
         The operation is applied to the bits with indices 0, 1, 2, ... in each register, up to the size of the smallest register.
-
+        
         :param reg0_in: first input register
         :param reg1_in: second input register
         :param reg_out: output register
@@ -1177,7 +1177,7 @@ class Circuit:
     def add_c_copybits(self, args_in: typing.Sequence[int], args_out: typing.Sequence[int], **kwargs: Any) -> Circuit:
         """
         Appends a classical copy operation
-
+        
         :param args_in: source bits
         :param args_out: destination bits
         :param kwargs: additional arguments passed to `add_gate_method` . Allowed parameters are `opgroup`,  `condition` , `condition_bits`, `condition_value`
@@ -1208,7 +1208,7 @@ class Circuit:
     def add_c_not(self, arg_in: int, arg_out: int, **kwargs: Any) -> Circuit:
         """
         Appends a NOT operation to the end of the circuit.
-
+        
         :param arg_in: input bit
         :param arg_out: output bit
         :param kwargs: additional arguments passed to `add_gate_method` . Allowed parameters are `opgroup`,  `condition` , `condition_bits`, `condition_value`
@@ -1222,9 +1222,9 @@ class Circuit:
     def add_c_not_to_registers(self, reg_in: pytket._tket.unit_id.BitRegister, reg_out: pytket._tket.unit_id.BitRegister, **kwargs: Any) -> Circuit:
         """
         Applies bitwise NOT to linear registers.
-
+        
         The operation is applied to the bits with indices 0, 1, 2, ... in each register, up to the size of the smallest register.
-
+        
         :param reg_in: input register
         :param reg_out: name of output register
         :param kwargs: additional arguments passed to `add_gate_method` . Allowed parameters are `opgroup`,  `condition` , `condition_bits`, `condition_value`
@@ -1234,7 +1234,7 @@ class Circuit:
     def add_c_or(self, arg0_in: int, arg1_in: int, arg_out: int, **kwargs: Any) -> Circuit:
         """
         Appends a binary OR operation to the end of the circuit.
-
+        
         :param arg0_in: first input bit
         :param arg1_in: second input bit
         :param arg_out: output bit
@@ -1249,9 +1249,9 @@ class Circuit:
     def add_c_or_to_registers(self, reg0_in: pytket._tket.unit_id.BitRegister, reg1_in: pytket._tket.unit_id.BitRegister, reg_out: pytket._tket.unit_id.BitRegister, **kwargs: Any) -> Circuit:
         """
         Applies bitwise OR to linear registers.
-
+        
         The operation is applied to the bits with indices 0, 1, 2, ... in each register, up to the size of the smallest register.
-
+        
         :param reg0_in: first input register
         :param reg1_in: second input register
         :param reg_out: output register
@@ -1274,7 +1274,7 @@ class Circuit:
     def add_c_range_predicate(self, minval: int, maxval: int, args_in: typing.Sequence[int], arg_out: int, **kwargs: Any) -> Circuit:
         """
         Appends a range-predicate operation to the end of the circuit.
-
+        
         :param minval: lower bound of input in little-endian encoding
         :param maxval: upper bound of input in little-endian encoding
         :param args_in: input bits
@@ -1286,7 +1286,7 @@ class Circuit:
     def add_c_range_predicate(self, minval: int, maxval: int, args_in: typing.Sequence[pytket._tket.unit_id.Bit], arg_out: pytket._tket.unit_id.Bit, **kwargs: Any) -> Circuit:
         """
         Appends a range-predicate operation to the end of the circuit.
-
+        
         :param minval: lower bound of input in little-endian encoding
         :param maxval: upper bound of input in little-endian encoding
         :param args_in: input bits
@@ -1298,7 +1298,7 @@ class Circuit:
     def add_c_register(self, name: str, size: int) -> pytket._tket.unit_id.BitRegister:
         """
         Constructs a new classical register with a given name and number of bits.
-
+        
         :param name: Unique readable name for the register
         :param size: Number of bits required
         :return: a map from index to the corresponding UnitIDs
@@ -1307,14 +1307,14 @@ class Circuit:
     def add_c_register(self, register: pytket._tket.unit_id.BitRegister) -> pytket._tket.unit_id.BitRegister:
         """
         Adds BitRegister to Circuit
-
-        :param register: BitRegister
+        
+        :param register: BitRegister 
         """
     @typing.overload
     def add_c_setbits(self, values: typing.Sequence[bool], args: typing.Sequence[int], **kwargs: Any) -> Circuit:
         """
         Appends an operation to set some bit values.
-
+        
         :param values: values to set
         :param args: bits to set
         :param kwargs: additional arguments passed to `add_gate_method` . Allowed parameters are `opgroup`,  `condition` , `condition_bits`, `condition_value`
@@ -1333,7 +1333,7 @@ class Circuit:
     def add_c_transform(self, values: typing.Sequence[int], args: typing.Sequence[int], name: str = 'ClassicalTransform', **kwargs: Any) -> Circuit:
         """
         Appends a purely classical transformation, defined by a table of values, to the end of the circuit.
-
+        
         :param values: table of values: bit :math:`j` (in little-endian order) of the term indexed by :math:`sum_i a_i 2^i` is output :math:`j` of the transform applied to inputs :math:`(a_i)`.
         :param args: bits to which the transform is applied
         :param name: operation name
@@ -1349,7 +1349,7 @@ class Circuit:
     def add_c_xor(self, arg0_in: int, arg1_in: int, arg_out: int, **kwargs: Any) -> Circuit:
         """
         Appends a binary XOR operation to the end of the circuit.
-
+        
         :param arg0_in: first input bit
         :param arg1_in: second input bit
         :param arg_out: output bit
@@ -1364,9 +1364,9 @@ class Circuit:
     def add_c_xor_to_registers(self, reg0_in: pytket._tket.unit_id.BitRegister, reg1_in: pytket._tket.unit_id.BitRegister, reg_out: pytket._tket.unit_id.BitRegister, **kwargs: Any) -> Circuit:
         """
         Applies bitwise XOR to linear registers.
-
+        
         The operation is applied to the bits with indices 0, 1, 2, ... in each register, up to the size of the smallest register.
-
+        
         :param reg0_in: first input register
         :param reg1_in: second input register
         :param reg_out: output register
@@ -1377,9 +1377,9 @@ class Circuit:
     def add_circbox(self, circbox: CircBox, args: typing.Sequence[int], **kwargs: Any) -> Circuit:
         """
         Append a :py:class:`CircBox` to the circuit.
-
+        
         The qubits and bits of the :py:class:`CircBox` are wired into the circuit in lexicographic order. Bits follow qubits in the order of arguments.
-
+        
         :param circbox: The box to append
         :param args: Indices of the (default-register) qubits/bits to append the box to
         :return: the new :py:class:`Circuit`
@@ -1388,9 +1388,9 @@ class Circuit:
     def add_circbox(self, circbox: CircBox, args: typing.Sequence[pytket._tket.unit_id.UnitID], **kwargs: Any) -> Circuit:
         """
         Append a :py:class:`CircBox` to the circuit.
-
+        
         The qubits and bits of the :py:class:`CircBox` are wired into the circuit in lexicographic order. Bits follow qubits in the order of arguments.
-
+        
         :param circbox: The box to append
         :param args: The qubits/bits to append the box to
         :return: the new :py:class:`Circuit`
@@ -1398,7 +1398,7 @@ class Circuit:
     def add_circbox_regwise(self, circbox: CircBox, qregs: typing.Sequence[pytket._tket.unit_id.QubitRegister], cregs: typing.Sequence[pytket._tket.unit_id.BitRegister], **kwargs: Any) -> Circuit:
         """
         Append a :py:class:`CircBox` to the circuit, wiring whole registers together.
-
+        
         :param circbox: The box to append
         :param qregs: Sequence of :py:class:`QubitRegister` from the outer :py:class:`Circuit`, the order corresponding to the lexicographic order of corresponding registers in the :py:class:`CircBox`
         :param cregs: Sequence of :py:class:`BitRegister` from the outer :py:class:`Circuit`, the order corresponding to the lexicographic order of corresponding registers in the :py:class:`CircBox`
@@ -1407,9 +1407,9 @@ class Circuit:
     def add_circbox_with_regmap(self, circbox: CircBox, qregmap: dict[str, str], cregmap: dict[str, str], **kwargs: Any) -> Circuit:
         """
         Append a :py:class:`CircBox` to the circuit, wiring whole registers together.
-
+        
         This method expects two maps (one for qubit registers and one for bit registers), which must have keys corresponding to all register names in the box. The box may not contain any qubits or bits that do not belong to a register, i.e. all must be single-indexed contiguously from zero.
-
+        
         :param circbox: The box to append
         :param qregmap: Map specifying which qubit register in the :py:class:`CircBox` (the map's keys) matches which register in the outer circuit (the map's values)
         :param cregmap: Map specifying which bit register in the :py:class:`CircBox` (the map's keys) matches which register in the outer circuit (the map's values)
@@ -1419,7 +1419,7 @@ class Circuit:
     def add_circuit(self, circuit: Circuit, qubits: typing.Sequence[pytket._tket.unit_id.Qubit], bits: typing.Sequence[pytket._tket.unit_id.Bit] = []) -> Circuit:
         """
         In-place sequential composition of circuits, appending a copy of the argument onto the end of the circuit. Connects qubits and bits with the same behaviour as :py:meth:`add_gate`.
-
+        
         :param circuit: The circuit to be appended to the end of `self`
         :param qubits: List mapping the (default register) qubits of `circuit` to the qubits of `self`
         :param bits: List mapping the (default register) bits of `circuit` to the bits of `self`
@@ -1429,7 +1429,7 @@ class Circuit:
     def add_circuit(self, circuit: Circuit, qubits: typing.Sequence[int], bits: typing.Sequence[int] = []) -> Circuit:
         """
         In-place sequential composition of circuits, appending a copy of the argument onto the end of the circuit. Connects qubits and bits with the same behaviour as :py:meth:`add_gate`.
-
+        
         :param circuit: The circuit to be appended to the end of `self`
         :param qubits: List mapping the (default register) qubits of `circuit` to the (default register) qubits of `self`
         :param bits: List mapping the (default register) bits of `circuit` to the (default register) bits of `self`
@@ -1438,7 +1438,7 @@ class Circuit:
     def add_classicalexpbox_bit(self, expression: pytket.circuit.logic_exp.BitLogicExp, target: typing.Sequence[pytket._tket.unit_id.Bit], **kwargs: Any) -> Circuit:
         """
         Append a :py:class:`ClassicalExpBox` over Bit to the circuit.
-
+        
         :param classicalexpbox: The box to append
         :param args: Indices of the qubits to append the box to
         :return: the new :py:class:`Circuit`
@@ -1446,7 +1446,7 @@ class Circuit:
     def add_classicalexpbox_register(self, expression: pytket.circuit.logic_exp.RegLogicExp, target: typing.Sequence[pytket._tket.unit_id.Bit], **kwargs: Any) -> Circuit:
         """
         Append a :py:class:`ClassicalExpBox` over BitRegister to the circuit.
-
+        
         :param classicalexpbox: The box to append
         :param args: Indices of the qubits to append the box to
         :return: the new :py:class:`Circuit`
@@ -1455,7 +1455,7 @@ class Circuit:
     def add_conditional_barrier(self, barrier_qubits: typing.Sequence[int], barrier_bits: typing.Sequence[int], condition_bits: typing.Sequence[int], value: int, data: str = '') -> Circuit:
         """
         Append a Conditional Barrier on the given barrier qubits and barrier bits, conditioned on the given condition bits.
-
+        
         :param barrier_qubits: Qubit in Barrier operation.
         :param barrier_bits: Bit in Barrier operation.
         :param condition_bits: Bit covering classical control condition of barrier operation.
@@ -1467,7 +1467,7 @@ class Circuit:
     def add_conditional_barrier(self, barrier_args: typing.Sequence[pytket._tket.unit_id.UnitID], condition_bits: typing.Sequence[pytket._tket.unit_id.Bit], value: int, data: str = '') -> Circuit:
         """
         Append a Conditional Barrier on the given barrier qubits and barrier bits, conditioned on the given condition bits.
-
+        
         :param barrier_args: Qubit and Bit in Barrier operation.
         :param condition_bits: Bit covering classical control  condition of barrier operation.
         :param value: Value that classical condition must have to hold (little-endian).
@@ -1478,7 +1478,7 @@ class Circuit:
     def add_conjugation_box(self, box: ConjugationBox, args: typing.Sequence[pytket._tket.unit_id.UnitID], **kwargs: Any) -> Circuit:
         """
         Append a :py:class:`ConjugationBox` to the circuit.
-
+        
         :param box: The box to append
         :param args: The qubits to append the box to
         :return: the new :py:class:`Circuit`
@@ -1487,7 +1487,7 @@ class Circuit:
     def add_conjugation_box(self, box: ConjugationBox, args: typing.Sequence[int], **kwargs: Any) -> Circuit:
         """
         Append a :py:class:`ConjugationBox` to the circuit.
-
+        
         :param box: The box to append
         :param args: Indices of the qubits to append the box to
         :return: the new :py:class:`Circuit`
@@ -1496,7 +1496,7 @@ class Circuit:
     def add_custom_gate(self, definition: CustomGateDef, params: typing.Sequence[sympy.Expr | float], qubits: typing.Sequence[int], **kwargs: Any) -> Circuit:
         """
         Append an instance of a :py:class:`CustomGateDef` to the circuit.
-
+        
         :param def: The custom gate definition
         :param params: List of parameters to instantiate the gate with, in halfturns
         :param qubits: Indices of the qubits to append the box to
@@ -1506,7 +1506,7 @@ class Circuit:
     def add_custom_gate(self, definition: CustomGateDef, params: typing.Sequence[sympy.Expr | float], qubits: typing.Sequence[pytket._tket.unit_id.Qubit], **kwargs: Any) -> Circuit:
         """
         Append an instance of a :py:class:`CustomGateDef` to the circuit.
-
+        
         :param def: The custom gate definition
         :param params: List of parameters to instantiate the gate with, in halfturns
         :param qubits: The qubits to append the box to
@@ -1516,7 +1516,7 @@ class Circuit:
     def add_diagonal_box(self, box: DiagonalBox, args: typing.Sequence[pytket._tket.unit_id.UnitID], **kwargs: Any) -> Circuit:
         """
         Append a :py:class:`DiagonalBox` to the circuit.
-
+        
         :param box: The box to append
         :param args: The qubits to append the box to
         :return: the new :py:class:`Circuit`
@@ -1525,7 +1525,7 @@ class Circuit:
     def add_diagonal_box(self, box: DiagonalBox, args: typing.Sequence[int], **kwargs: Any) -> Circuit:
         """
         Append a :py:class:`DiagonalBox` to the circuit.
-
+        
         :param box: The box to append
         :param args: Indices of the qubits to append the box to
         :return: the new :py:class:`Circuit`
@@ -1534,7 +1534,7 @@ class Circuit:
     def add_dummybox(self, dummybox: DummyBox, qubits: typing.Sequence[int], bits: typing.Sequence[int], **kwargs: Any) -> Circuit:
         """
         Append a :py:class:`DummyBox` to the circuit.
-
+        
         :param dummybox: The box to append
         :param qubits: Indices (in the default register) of the qubits to append the box to
         :param bits: Indices of the bits (in the default register) to append the box to
@@ -1544,7 +1544,7 @@ class Circuit:
     def add_dummybox(self, dummybox: DummyBox, qubits: typing.Sequence[pytket._tket.unit_id.Qubit], bits: typing.Sequence[pytket._tket.unit_id.Bit], **kwargs: Any) -> Circuit:
         """
         Append a :py:class:`DummyBox` to the circuit.
-
+        
         :param dummybox: The box to append
         :param qubits: Qubits to append the box to
         :param bits: Bits to append the box to
@@ -1554,9 +1554,9 @@ class Circuit:
     def add_expbox(self, expbox: ExpBox, qubit_0: int, qubit_1: int, **kwargs: Any) -> Circuit:
         """
         Append an :py:class:`ExpBox` to the circuit.
-
+        
         The matrix representation is ILO-BE.
-
+        
         :param expbox: The box to append
         :param qubit_0: Index of the first target qubit
         :param qubit_1: Index of the second target qubit
@@ -1566,9 +1566,9 @@ class Circuit:
     def add_expbox(self, expbox: ExpBox, qubit_0: pytket._tket.unit_id.Qubit, qubit_1: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Append an :py:class:`ExpBox` to the circuit.
-
+        
         The matrix representation is ILO-BE.
-
+        
         :param expbox: The box to append
         :param qubit_0: The first target qubit
         :param qubit_1: The second target qubit
@@ -1588,10 +1588,10 @@ class Circuit:
     def add_gate(self, type: OpType, args: typing.Sequence[int], **kwargs: Any) -> Circuit:
         """
         Appends a single (non-parameterised) gate to the end of the circuit on some particular qubits from the default register ('q'). The number of qubits specified must match the arity of the gate. For `OpType.Measure` operations the bit from the default register should follow the qubit.
-
+        
         >>> c.add_gate(OpType.H, [0]) # equivalent to c.H(0)
         >>> c.add_gate(OpType.CX, [0,1]) # equivalent to c.CX(0,1)
-
+        
         :param type: The type of operation to add
         :param args: The list of indices for the qubits/bits to which the operation is applied
         :param kwargs: Additional properties for classical conditions
@@ -1601,10 +1601,10 @@ class Circuit:
     def add_gate(self, type: OpType, args: typing.Sequence[pytket._tket.unit_id.UnitID], **kwargs: Any) -> Circuit:
         """
         Appends a single (non-parameterised) gate to the end of the circuit on some particular qubits from the default register ('q'). The number of qubits specified must match the arity of the gate. For `OpType.Measure` operations the bit from the default register should follow the qubit.
-
+        
         >>> c.add_gate(OpType.H, [0]) # equivalent to c.H(0)
         >>> c.add_gate(OpType.CX, [0,1]) # equivalent to c.CX(0,1)
-
+        
         :param type: The type of operation to add
         :param args: The qubits/bits to apply the gate to
         :param kwargs: Additional properties for classical conditions
@@ -1614,7 +1614,7 @@ class Circuit:
     def add_gate(self, type: OpType, angle: sympy.Expr | float, args: typing.Sequence[int], **kwargs: Any) -> Circuit:
         """
         Appends a single gate, parameterised by an expression, to the end of circuit on some particular qubits from the default register ('q').
-
+        
         :param type: The type of gate to add
         :param angle: The parameter for the gate in halfturns
         :param args: The list of indices for the qubits to which the operation is applied
@@ -1625,7 +1625,7 @@ class Circuit:
     def add_gate(self, type: OpType, angle: sympy.Expr | float, args: typing.Sequence[pytket._tket.unit_id.UnitID], **kwargs: Any) -> Circuit:
         """
         Appends a single gate, parameterised by an expression, to the end of circuit on some particular qubits from the default register ('q').
-
+        
         :param type: The type of gate to add
         :param angle: The parameter for the gate in halfturns
         :param args: The qubits/bits to apply the gate to
@@ -1636,7 +1636,7 @@ class Circuit:
     def add_gate(self, type: OpType, angles: typing.Sequence[sympy.Expr | float], args: typing.Sequence[int], **kwargs: Any) -> Circuit:
         """
         Appends a single gate, parameterised with a vector of expressions corresponding to halfturns, to the end of circuit on some particular qubits from the default register ('q').
-
+        
         :param type: The type of gate to add
         :param angles: The parameters for the gate in halfturns
         :param args: The list of indices for the qubits to which the operation is applied
@@ -1647,7 +1647,7 @@ class Circuit:
     def add_gate(self, type: OpType, angles: typing.Sequence[sympy.Expr | float], args: typing.Sequence[pytket._tket.unit_id.UnitID], **kwargs: Any) -> Circuit:
         """
         Appends a single gate to the end of the circuit
-
+        
         :param type: The type of gate to add
         :param params: The parameters for the gate in halfturns
         :param args: The qubits/bits to apply the gate to
@@ -1658,7 +1658,7 @@ class Circuit:
     def add_multiplexed_tensored_u2(self, box: MultiplexedTensoredU2Box, args: typing.Sequence[pytket._tket.unit_id.UnitID], **kwargs: Any) -> Circuit:
         """
         Append a :py:class:`MultiplexedTensoredU2Box` to the circuit.
-
+        
         :param box: The box to append
         :param args: The qubits to append the box to
         :return: the new :py:class:`Circuit`
@@ -1667,7 +1667,7 @@ class Circuit:
     def add_multiplexed_tensored_u2(self, box: MultiplexedTensoredU2Box, args: typing.Sequence[int], **kwargs: Any) -> Circuit:
         """
         Append a :py:class:`MultiplexedTensoredU2Box` to the circuit.
-
+        
         :param box: The box to append
         :param args: Indices of the qubits to append the box to
         :return: the new :py:class:`Circuit`
@@ -1676,7 +1676,7 @@ class Circuit:
     def add_multiplexedrotation(self, box: MultiplexedRotationBox, args: typing.Sequence[pytket._tket.unit_id.UnitID], **kwargs: Any) -> Circuit:
         """
         Append a :py:class:`MultiplexedRotationBox` to the circuit.
-
+        
         :param box: The box to append
         :param args: The qubits to append the box to
         :return: the new :py:class:`Circuit`
@@ -1685,7 +1685,7 @@ class Circuit:
     def add_multiplexedrotation(self, box: MultiplexedRotationBox, args: typing.Sequence[int], **kwargs: Any) -> Circuit:
         """
         Append a :py:class:`MultiplexedRotationBox` to the circuit.
-
+        
         :param box: The box to append
         :param args: Indices of the qubits to append the box to
         :return: the new :py:class:`Circuit`
@@ -1694,7 +1694,7 @@ class Circuit:
     def add_multiplexedu2(self, box: MultiplexedU2Box, args: typing.Sequence[pytket._tket.unit_id.UnitID], **kwargs: Any) -> Circuit:
         """
         Append a :py:class:`MultiplexedU2Box` to the circuit.
-
+        
         :param box: The box to append
         :param args: The qubits to append the box to
         :return: the new :py:class:`Circuit`
@@ -1703,7 +1703,7 @@ class Circuit:
     def add_multiplexedu2(self, box: MultiplexedU2Box, args: typing.Sequence[int], **kwargs: Any) -> Circuit:
         """
         Append a :py:class:`MultiplexedU2Box` to the circuit.
-
+        
         :param box: The box to append
         :param args: Indices of the qubits to append the box to
         :return: the new :py:class:`Circuit`
@@ -1712,7 +1712,7 @@ class Circuit:
     def add_multiplexor(self, box: MultiplexorBox, args: typing.Sequence[pytket._tket.unit_id.UnitID], **kwargs: Any) -> Circuit:
         """
         Append a :py:class:`MultiplexorBox` to the circuit.
-
+        
         :param box: The box to append
         :param args: The qubits to append the box to
         :return: the new :py:class:`Circuit`
@@ -1721,7 +1721,7 @@ class Circuit:
     def add_multiplexor(self, box: MultiplexorBox, args: typing.Sequence[int], **kwargs: Any) -> Circuit:
         """
         Append a :py:class:`MultiplexorBox` to the circuit.
-
+        
         :param box: The box to append
         :param args: Indices of the qubits to append the box to
         :return: the new :py:class:`Circuit`
@@ -1730,7 +1730,7 @@ class Circuit:
     def add_pauliexpbox(self, pauliexpbox: PauliExpBox, qubits: typing.Sequence[int], **kwargs: Any) -> Circuit:
         """
         Append a :py:class:`PauliExpBox` to the circuit.
-
+        
         :param pauliexpbox: The box to append
         :param qubits: Indices of the qubits to append the box to
         :return: the new :py:class:`Circuit`
@@ -1739,7 +1739,7 @@ class Circuit:
     def add_pauliexpbox(self, pauliexpbox: PauliExpBox, qubits: typing.Sequence[pytket._tket.unit_id.Qubit], **kwargs: Any) -> Circuit:
         """
         Append a :py:class:`PauliExpBox` to the circuit.
-
+        
         :param pauliexpbox: The box to append
         :param qubits: The qubits to append the box to
         :return: the new :py:class:`Circuit`
@@ -1748,7 +1748,7 @@ class Circuit:
     def add_pauliexpcommutingsetbox(self, pauliexpcommutingsetbox: PauliExpCommutingSetBox, qubits: typing.Sequence[int], **kwargs: Any) -> Circuit:
         """
         Append a :py:class:`PauliExpCommutingSetBox` to the circuit.
-
+        
         :param pauliexpcommutingsetbox: The box to append
         :param qubits: Indices of the qubits to append the box to
         :return: the new :py:class:`Circuit`
@@ -1757,7 +1757,7 @@ class Circuit:
     def add_pauliexpcommutingsetbox(self, pauliexpcommutingsetbox: PauliExpCommutingSetBox, qubits: typing.Sequence[pytket._tket.unit_id.Qubit], **kwargs: Any) -> Circuit:
         """
         Append a :py:class:`PauliExpCommutingSetBox` to the circuit.
-
+        
         :param pauliexpcommutingsetbox: The box to append
         :param qubits: The qubits to append the box to
         :return: the new :py:class:`Circuit`
@@ -1766,7 +1766,7 @@ class Circuit:
     def add_pauliexppairbox(self, pauliexppairbox: PauliExpPairBox, qubits: typing.Sequence[int], **kwargs: Any) -> Circuit:
         """
         Append a :py:class:`PauliExpPairBox` to the circuit.
-
+        
         :param pauliexppairbox: The box to append
         :param qubits: Indices of the qubits to append the box to
         :return: the new :py:class:`Circuit`
@@ -1775,7 +1775,7 @@ class Circuit:
     def add_pauliexppairbox(self, pauliexppairbox: PauliExpPairBox, qubits: typing.Sequence[pytket._tket.unit_id.Qubit], **kwargs: Any) -> Circuit:
         """
         Append a :py:class:`PauliExpPairBox` to the circuit.
-
+        
         :param pauliexppairbox: The box to append
         :param qubits: The qubits to append the box to
         :return: the new :py:class:`Circuit`
@@ -1783,16 +1783,16 @@ class Circuit:
     def add_phase(self, a: sympy.Expr | float) -> Circuit:
         """
         Add a global phase to the circuit.
-
+        
         :param a: Phase to add, in halfturns
-
+        
         :return: circuit with added phase
         """
     @typing.overload
     def add_phasepolybox(self, phasepolybox: PhasePolyBox, qubits: typing.Sequence[int], **kwargs: Any) -> Circuit:
         """
         Append a :py:class:`PhasePolyBox` to the circuit.
-
+        
         :param phasepolybox: The box to append
         :param qubits: Indices of the qubits to append the box to
         :return: the new :py:class:`Circuit`
@@ -1801,7 +1801,7 @@ class Circuit:
     def add_phasepolybox(self, phasepolybox: PhasePolyBox, qubits: typing.Sequence[pytket._tket.unit_id.Qubit], **kwargs: Any) -> Circuit:
         """
         Append a :py:class:`PhasePolyBox` to the circuit.
-
+        
         :param phasepolybox: The box to append
         :param qubits: The qubits to append the box to
         :return: the new :py:class:`Circuit`
@@ -1810,7 +1810,7 @@ class Circuit:
     def add_q_register(self, name: str, size: int) -> pytket._tket.unit_id.QubitRegister:
         """
         Constructs a new quantum register with a given name and number of qubits.
-
+        
         :param name: Unique readable name for the register
         :param size: Number of qubits required
         :return: a map from index to the corresponding UnitIDs
@@ -1819,14 +1819,14 @@ class Circuit:
     def add_q_register(self, register: pytket._tket.unit_id.QubitRegister) -> pytket._tket.unit_id.QubitRegister:
         """
         Adds QubitRegister to Circuit
-
-        :param register: QubitRegister
+        
+        :param register: QubitRegister 
         """
     @typing.overload
     def add_qcontrolbox(self, qcontrolbox: QControlBox, args: typing.Sequence[int], **kwargs: Any) -> Circuit:
         """
         Append a :py:class:`QControlBox` to the circuit.
-
+        
         :param qcontrolbox: The box to append
         :param args: Indices of the qubits to append the box to
         :return: the new :py:class:`Circuit`
@@ -1835,7 +1835,7 @@ class Circuit:
     def add_qcontrolbox(self, qcontrolbox: QControlBox, args: typing.Sequence[pytket._tket.unit_id.UnitID], **kwargs: Any) -> Circuit:
         """
         Append a :py:class:`QControlBox` to the circuit.
-
+        
         :param qcontrolbox: The box to append
         :param args: The qubits to append the box to
         :return: the new :py:class:`Circuit`
@@ -1843,7 +1843,7 @@ class Circuit:
     def add_qubit(self, id: pytket._tket.unit_id.Qubit, reject_dups: bool = True) -> None:
         """
         Constructs a single qubit with the given id.
-
+        
         :param id: Unique id for the qubit
         :param reject_dups: Fail if there is already a qubit in this circuit with the id. Default to True
         """
@@ -1851,7 +1851,7 @@ class Circuit:
     def add_state_preparation_box(self, box: StatePreparationBox, args: typing.Sequence[pytket._tket.unit_id.UnitID], **kwargs: Any) -> Circuit:
         """
         Append a :py:class:`StatePreparationBox` to the circuit.
-
+        
         :param box: The box to append
         :param args: The qubits to append the box to
         :return: the new :py:class:`Circuit`
@@ -1860,7 +1860,7 @@ class Circuit:
     def add_state_preparation_box(self, box: StatePreparationBox, args: typing.Sequence[int], **kwargs: Any) -> Circuit:
         """
         Append a :py:class:`StatePreparationBox` to the circuit.
-
+        
         :param box: The box to append
         :param args: Indices of the qubits to append the box to
         :return: the new :py:class:`Circuit`
@@ -1869,7 +1869,7 @@ class Circuit:
     def add_termsequencebox(self, termsequencebox: TermSequenceBox, qubits: typing.Sequence[int], **kwargs: Any) -> Circuit:
         """
         Append a :py:class:`TermSequenceBox` to the circuit.
-
+        
         :param termsequencebox: The box to append
         :param qubits: Indices of the qubits to append the box to
         :return: the new :py:class:`Circuit`
@@ -1878,7 +1878,7 @@ class Circuit:
     def add_termsequencebox(self, termsequencebox: TermSequenceBox, qubits: typing.Sequence[pytket._tket.unit_id.Qubit], **kwargs: Any) -> Circuit:
         """
         Append a :py:class:`TermSequenceBox` to the circuit.
-
+        
         :param termsequencebox: The box to append
         :param qubits: The qubits to append the box to
         :return: the new :py:class:`Circuit`
@@ -1887,7 +1887,7 @@ class Circuit:
     def add_toffolibox(self, toffolibox: ToffoliBox, qubits: typing.Sequence[int], **kwargs: Any) -> Circuit:
         """
         Append a :py:class:`ToffoliBox` to the circuit.
-
+        
         :param toffolibox: The box to append
         :param qubits: Indices of the qubits to append the box to
         :return: the new :py:class:`Circuit`
@@ -1896,7 +1896,7 @@ class Circuit:
     def add_toffolibox(self, toffolibox: ToffoliBox, qubits: typing.Sequence[pytket._tket.unit_id.Qubit], **kwargs: Any) -> Circuit:
         """
         Append a :py:class:`ToffoliBox` to the circuit.
-
+        
         :param toffolibox: The box to append
         :param qubits: Indices of the qubits to append the box to
         :return: the new :py:class:`Circuit`
@@ -1905,7 +1905,7 @@ class Circuit:
     def add_unitary1qbox(self, unitarybox: Unitary1qBox, qubit_0: int, **kwargs: Any) -> Circuit:
         """
         Append a :py:class:`Unitary1qBox` to the circuit.
-
+        
         :param unitarybox: The box to append
         :param qubit_0: Index of the qubit to append the box to
         :return: the new :py:class:`Circuit`
@@ -1914,7 +1914,7 @@ class Circuit:
     def add_unitary1qbox(self, unitarybox: Unitary1qBox, qubit_0: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Append a :py:class:`Unitary1qBox` to the circuit.
-
+        
         :param unitarybox: The box to append
         :param qubit_0: The qubit to append the box to
         :return: the new :py:class:`Circuit`
@@ -1923,9 +1923,9 @@ class Circuit:
     def add_unitary2qbox(self, unitarybox: Unitary2qBox, qubit_0: int, qubit_1: int, **kwargs: Any) -> Circuit:
         """
         Append a :py:class:`Unitary2qBox` to the circuit.
-
+        
         The matrix representation is ILO-BE.
-
+        
         :param unitarybox: The box to append
         :param qubit_0: Index of the first target qubit
         :param qubit_1: Index of the second target qubit
@@ -1935,9 +1935,9 @@ class Circuit:
     def add_unitary2qbox(self, unitarybox: Unitary2qBox, qubit_0: pytket._tket.unit_id.Qubit, qubit_1: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Append a :py:class:`Unitary2qBox` to the circuit.
-
+        
         The matrix representation is ILO-BE.
-
+        
         :param unitarybox: The box to append
         :param qubit_0: The first target qubit
         :param qubit_1: The second target qubit
@@ -1947,7 +1947,7 @@ class Circuit:
     def add_unitary3qbox(self, unitarybox: Unitary3qBox, qubit_0: int, qubit_1: int, qubit_2: int, **kwargs: Any) -> Circuit:
         """
         Append a :py:class:`Unitary3qBox` to the circuit.
-
+        
         :param unitarybox: box to append
         :param qubit_0: index of target qubit 0
         :param qubit_1: index of target qubit 1
@@ -1958,7 +1958,7 @@ class Circuit:
     def add_unitary3qbox(self, unitarybox: Unitary3qBox, qubit_0: pytket._tket.unit_id.Qubit, qubit_1: pytket._tket.unit_id.Qubit, qubit_2: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Append a :py:class:`Unitary3qBox` to the circuit.
-
+        
         :param unitarybox: box to append
         :param qubit_0: index of target qubit 0
         :param qubit_1: index of target qubit 1
@@ -1968,63 +1968,63 @@ class Circuit:
     def add_wasm(self, funcname: str, filehandler: pytket.wasm.wasm.WasmModuleHandler, list_i: typing.Sequence[int], list_o: typing.Sequence[int], args: typing.Union[typing.Sequence[int], typing.Sequence[pytket._tket.unit_id.Bit]], args_wasm: typing.Optional[typing.Sequence[int]] = None, **kwargs: typing.Any) -> Circuit:
         """
         Add a classical function call from a wasm file to the circuit.
-
-
+            
+        
         :param funcname: name of the function that is called
-
+            
         :param filehandler: wasm file or module handler to identify the wasm module
-
+            
         :param list_i: list of the number of bits in the input variables
-
+            
         :param list_o: list of the number of bits in the output variables
-
+            
         :param args: vector of circuit bits the wasm op should be added to
-
+            
         :param args_wasm: vector of wasmstates the wasm op should be added to
-
+            
         :param kwargs: additional arguments passed to `add_gate_method` .
              Allowed parameters are `opgroup`,  `condition` , `condition_bits`,
              `condition_value`
-
+            
         :return: the new :py:class:`Circuit`
         """
     def add_wasm_to_reg(self, funcname: str, filehandler: pytket.wasm.wasm.WasmModuleHandler, list_i: typing.Sequence[pytket._tket.unit_id.BitRegister], list_o: typing.Sequence[pytket._tket.unit_id.BitRegister], args_wasm: typing.Optional[typing.Sequence[int]] = None, **kwargs: typing.Any) -> Circuit:
         """
         Add a classical function call from a wasm file to the circuit.
-
-
+            
+        
         :param funcname: name of the function that is called
-
+            
         :param filehandler: wasm file or module handler to identify the wasm module
-
+            
         :param list_i: list of the classical registers assigned to
              the input variables of the function call
-
+            
         :param list_o: list of the classical registers assigned to
              the output variables of the function call
-
+            
         :param args_wasm: vector of wasmstates the wasm op should be added to
-
+            
         :param kwargs: additional arguments passed to `add_gate_method` .
              Allowed parameters are `opgroup`,  `condition` , `condition_bits`,
              `condition_value`
-
+            
         :return: the new :py:class:`Circuit`
         """
     def append(self, circuit: Circuit) -> None:
         """
         In-place sequential composition of circuits, appending a copy of the argument onto the end of the circuit. Inputs and Outputs are unified if they share the same id, defaulting to parallel composition if there is no match.
-
+        
         :param circuit: The circuit to be appended to the end of `self`
         """
     def commands_of_type(self, optype: OpType) -> list[Command]:
         """
         Get all commands in a circuit of a given type.
-
+        
         The order is consistent with the causal order of the operations in the circuit.
-
+        
         :param optype: operation type
-
+        
         :return: list of :py:class:`Command`
         """
     def copy(self) -> Circuit:
@@ -2034,13 +2034,13 @@ class Circuit:
     def dagger(self) -> Circuit:
         """
         Given a pure circuit (i.e. without any measurements or conditional gates), produces a new circuit for the inverse/adjoint operation.
-
+        
         :return: a new :py:class:`Circuit` corresponding to the inverse operation
         """
     def depth(self) -> int:
         """
         Returns the number of interior vertices on the longest path through the DAG, excluding vertices representing barrier operations.
-
+        
         >>> c = Circuit(3)
         >>> c.depth()
         0
@@ -2049,13 +2049,13 @@ class Circuit:
         >>> c.CX(2,0)
         >>> c.depth()
         3
-
+        
         :return: the circuit depth
         """
     def depth_2q(self) -> int:
         """
         Returns the number of vertices in the longest path through the sub-DAG consisting of vertices with 2 quantum wires,excluding vertices representing barrier operations.
-
+        
         >>> c = Circuit(3)
         >>> c.CZ(0,1)
         >>> c.Z(0)
@@ -2070,14 +2070,14 @@ class Circuit:
     def depth_by_type(self, type: OpType) -> int:
         """
         Returns the number of vertices in the longest path through the sub-DAG consisting of vertices representing operations of the given type.
-
+        
         >>> c = Circuit(3)
         >>> c.CX(0,1)
         >>> c.Z(1)
         >>> c.CX(1,2)
         >>> c.depth_by_type(OpType.CX)
         2
-
+        
         :param type: the operation type of interest
         :return: the circuit depth with respect to operations matching `type`
         """
@@ -2085,14 +2085,14 @@ class Circuit:
     def depth_by_type(self, types: set[OpType]) -> int:
         """
         Returns the number of vertices in the longest path through the sub-DAG consisting of vertices representing operations of the given types.
-
+        
         >>> c = Circuit(3)
         >>> c.CZ(0,1)
         >>> c.Z(1)
         >>> c.CX(1,2)
         >>> c.depth_by_type({OpType.CZ, OpType.CX})
         2
-
+        
         :param types: the set of operation types of interest
         :return: the circuit depth with respect to operations matching an element of `types`
         """
@@ -2107,7 +2107,7 @@ class Circuit:
     def get_c_register(self, name: str) -> pytket._tket.unit_id.BitRegister:
         """
         Get the classical register with the given name.
-
+        
         :param name: name for the register
         :return: the retrieved :py:class:`BitRegister`
         """
@@ -2118,18 +2118,18 @@ class Circuit:
     def get_q_register(self, name: str) -> pytket._tket.unit_id.QubitRegister:
         """
         Get the quantum register with the given name.
-
+        
         :param name: name for the register
         :return: the retrieved :py:class:`QubitRegister`
         """
     def get_resources(self) -> ResourceData:
         """
         Calculate the overall resources of the circuit.
-
+        
         This takes account of the data stored in each py:class:`DummyBox` within the circuit, as well as other gates, to compute upper and lower bounds.
-
+        
         :return: bounds on resources of the circuit
-
+        
         >>> resource_data0 = ResourceData(
         ...     op_type_count={
         ...         OpType.T: ResourceBounds(1, 2),
@@ -2183,7 +2183,7 @@ class Circuit:
     def get_statevector(self) -> NDArray[numpy.complex128]:
         """
         Calculate the unitary matrix of the circuit, using ILO-BE convention, applied to the column vector (1,0,0...), which is thus another column vector. Due to pybind11 and numpy peculiarities, to treat the result as a genuine column vector and perform further matrix multiplication, you need to call .reshape(rows,1) to get a 2D matrix with the correct dimensions.
-
+        
         :return: The calculated vector.
         """
     def get_unitary(self) -> NDArray[numpy.complex128]:
@@ -2193,7 +2193,7 @@ class Circuit:
     def get_unitary_times_other(self, matr: NDArray[numpy.complex128]) -> NDArray[numpy.complex128]:
         """
         Calculate UM, where U is the numerical unitary matrix of the circuit, with ILO-BE convention, and M is another matrix. This is more efficient than calculating U separately, if M has fewer columns than U.
-
+        
         :param matr: The matrix to be multiplied.
         :return: The product of the circuit unitary and the given matrix.
         """
@@ -2208,13 +2208,13 @@ class Circuit:
     def measure_all(self) -> Circuit:
         """
         Appends a measure gate to all qubits, storing the results in the default classical register. Bits are added to the circuit if they do not already exist.
-
+        
         :return: the new :py:class:`Circuit`
         """
     def measure_register(self, arg0: pytket._tket.unit_id.QubitRegister, arg1: str) -> Circuit:
         """
         Appends a measure gate to all qubits in the given register, storing the results in the given classical register with matching indices.The classical register will be created if it doesn't exist.
-
+        
         :param qreg: the QubitRegister to be measured
         :param creg_name: the name of the BitRegister to store the results
         :return: the new :py:class:`Circuit`
@@ -2230,13 +2230,13 @@ class Circuit:
     def n_gates_of_type(self, type: OpType) -> int:
         """
         Returns the number of vertices in the dag of a given operation type.
-
+        
         >>> c.CX(0,1)
         >>> c.H(0)
         >>> c.CX(0,1)
         >>> c.n_gates_of_type(OpType.CX)
         2
-
+        
         :param type: The operation type to search for
         :return: the number of operations matching `type`
         """
@@ -2247,11 +2247,11 @@ class Circuit:
     def ops_of_type(self, optype: OpType) -> list[Op]:
         """
         Get all operations in the circuit of a given type.
-
+        
         The order is not guaranteed.
-
+        
         :param optype: operation type
-
+        
         :return: list of :py:class:`Op`
         """
     def qubit_create(self, arg0: pytket._tket.unit_id.Qubit) -> None:
@@ -2280,14 +2280,14 @@ class Circuit:
         """
     def remove_blank_wires(self, keep_blank_classical_wires: bool = False) -> None:
         """
-        Removes any Input-Output pairs in the DAG with no intervening operations, i.e. removes untouched qubits/bits from the circuit. This may occur when optimisations recognise that the operations on a qubit reduce to the identity, or when routing adds wires to "fill out" the architecture. This operation will only remove empty classical wires if there are no used bits with a higher index in the same register.
-
+        Removes any Input-Output pairs in the DAG with no intervening operations, i.e. removes untouched qubits/bits from the circuit. This may occur when optimisations recognise that the operations on a qubit reduce to the identity, or when routing adds wires to "fill out" the architecture. This operation will only remove empty classical wires if there are no used bits with a higher index in the same register. 
+        
         :param keep_blank_classical_wires: select if empty classical wires should not be removed
         """
     def rename_units(self, map: dict[pytket._tket.unit_id.UnitID | pytket._tket.unit_id.Qubit | pytket._tket.unit_id.Bit, pytket._tket.unit_id.UnitID | pytket._tket.unit_id.Qubit | pytket._tket.unit_id.Bit]) -> bool:
         """
         Rename qubits and bits simultaneously according to the map of ids provided
-
+        
         :param map: Dictionary from current ids to new ids
         """
     def replace_SWAPs(self) -> None:
@@ -2302,7 +2302,7 @@ class Circuit:
     def substitute_named(self, op: Op, opgroup: str) -> bool:
         """
         Substitute all ops with the given name for the given op.The replacement operations retain the same name.
-
+        
         :param op: the replacement operation
         :param opgroup: the name of the operations group to replace
         :return: whether any replacements were made
@@ -2311,7 +2311,7 @@ class Circuit:
     def substitute_named(self, repl: Circuit, opgroup: str) -> bool:
         """
         Substitute all ops with the given name for the given circuit.Named operations in the replacement circuit must not match any named operations in the circuit being modified.
-
+        
         :param repl: the replacement circuit
         :param opgroup: the name of the operations group to replace
         :return: whether any replacements were made
@@ -2320,7 +2320,7 @@ class Circuit:
     def substitute_named(self, box: CircBox, opgroup: str) -> bool:
         """
         Substitute all ops with the given name for the given box.The replacement boxes retain the same name.
-
+        
         :param box: the replacement CircBox
         :param opgroup: the name of the operations group to replace
         :return: whether any replacements were made
@@ -2329,7 +2329,7 @@ class Circuit:
     def substitute_named(self, box: Unitary1qBox, opgroup: str) -> bool:
         """
         Substitute all ops with the given name for the given box.The replacement boxes retain the same name.
-
+        
         :param box: the replacement Unitary1qBox
         :param opgroup: the name of the operations group to replace
         :return: whether any replacements were made
@@ -2338,7 +2338,7 @@ class Circuit:
     def substitute_named(self, box: Unitary2qBox, opgroup: str) -> bool:
         """
         Substitute all ops with the given name for the given box.The replacement boxes retain the same name.
-
+        
         :param box: the replacement Unitary2qBox
         :param opgroup: the name of the operations group to replace
         :return: whether any replacements were made
@@ -2347,7 +2347,7 @@ class Circuit:
     def substitute_named(self, box: Unitary3qBox, opgroup: str) -> bool:
         """
         Substitute all ops with the given name for the given box.The replacement boxes retain the same name.
-
+        
         :param box: the replacement Unitary3qBox
         :param opgroup: the name of the operations group to replace
         :return: whether any replacements were made
@@ -2356,7 +2356,7 @@ class Circuit:
     def substitute_named(self, box: ExpBox, opgroup: str) -> bool:
         """
         Substitute all ops with the given name for the given box.The replacement boxes retain the same name.
-
+        
         :param box: the replacement ExpBox
         :param opgroup: the name of the operations group to replace
         :return: whether any replacements were made
@@ -2365,7 +2365,7 @@ class Circuit:
     def substitute_named(self, box: PauliExpBox, opgroup: str) -> bool:
         """
         Substitute all ops with the given name for the given box.The replacement boxes retain the same name.
-
+        
         :param box: the replacement PauliExpBox
         :param opgroup: the name of the operations group to replace
         :return: whether any replacements were made
@@ -2374,7 +2374,7 @@ class Circuit:
     def substitute_named(self, box: ToffoliBox, opgroup: str) -> bool:
         """
         Substitute all ops with the given name for the given box.The replacement boxes retain the same name.
-
+        
         :param box: the replacement ToffoliBox
         :param opgroup: the name of the operations group to replace
         :return: whether any replacements were made
@@ -2383,7 +2383,7 @@ class Circuit:
     def substitute_named(self, box: DummyBox, opgroup: str) -> bool:
         """
         Substitute all ops with the given name for the given box.The replacement boxes retain the same name.
-
+        
         :param box: the replacement DummyBox
         :param opgroup: the name of the operations group to replace
         :return: whether any replacements were made
@@ -2392,7 +2392,7 @@ class Circuit:
     def substitute_named(self, box: QControlBox, opgroup: str) -> bool:
         """
         Substitute all ops with the given name for the given box.The replacement boxes retain the same name.
-
+        
         :param box: the replacement QControlBox
         :param opgroup: the name of the operations group to replace
         :return: whether any replacements were made
@@ -2401,7 +2401,7 @@ class Circuit:
     def substitute_named(self, box: CustomGate, opgroup: str) -> bool:
         """
         Substitute all ops with the given name for the given box.The replacement boxes retain the same name.
-
+        
         :param box: the replacement CustomGate
         :param opgroup: the name of the operations group to replace
         :return: whether any replacements were made
@@ -2409,15 +2409,15 @@ class Circuit:
     @typing.overload
     def symbol_substitution(self, symbol_map: dict[sympy.Symbol, sympy.Expr | float]) -> None:
         """
-        In-place substitution for symbolic expressions; iterates through each parameterised gate/box and performs the substitution.
-
+        In-place substitution for symbolic expressions; iterates through each parameterised gate/box and performs the substitution. 
+        
         :param symbol_map: A map from SymPy symbols to SymPy expressions
         """
     @typing.overload
     def symbol_substitution(self, symbol_map: dict[sympy.Symbol, float]) -> None:
         """
-        In-place substitution for symbolic expressions; iterates through each gate/box and performs the substitution.
-
+        In-place substitution for symbolic expressions; iterates through each gate/box and performs the substitution. 
+        
         :param symbol_map: A map from SymPy symbols to floating-point values
         """
     def to_dict(self) -> dict:
@@ -2427,23 +2427,23 @@ class Circuit:
     def to_latex_file(self, filename: str) -> None:
         """
         Produces a latex file with a visualisation of the circuit using the Quantikz package.
-
+        
         :param filename: Name of file to write output to (must end in ".tex")
         """
     def transpose(self) -> Circuit:
         """
         Given a pure circuit (i.e. without any measurements or conditional gates), produces a new circuit for the transpose operation.
-
+        
         :return: a new :py:class:`Circuit` corresponding to the transpose operation
         """
     def valid_connectivity(self, arch: pytket._tket.architecture.Architecture, directed: bool, allow_bridge: bool = False) -> bool:
         """
         Confirms whether all two qubit gates in given circuit are along some edge of the architecture.
-
+        
         :param arch: The architecture capturing the desired connectivity
         :param directed: If true, also checks that CX or ECR gates are in the same direction as the edges of the architecture
         :param allow_bridge: Accept BRIDGEs as valid, assuming the middle qubit neighbours the others
-
+        
         :return: True or False
         """
     @property
@@ -2465,9 +2465,9 @@ class Circuit:
     def c_registers(self) -> list[pytket._tket.unit_id.BitRegister]:
         """
         Get all classical registers.
-
+        
         The list only includes registers that are singly-indexed contiguously from zero.
-
+        
         :return: List of :py:class:`BitRegister`
         """
     @property
@@ -2520,9 +2520,9 @@ class Circuit:
     def q_registers(self) -> list[pytket._tket.unit_id.QubitRegister]:
         """
         Get all quantum registers.
-
+        
         The list only includes registers that are singly-indexed contiguously from zero.
-
+        
         :return: List of :py:class:`QubitRegister`
         """
     @property
@@ -2684,7 +2684,7 @@ class ConjugationBox(Op):
     def __init__(self, compute: Op, action: Op, uncompute: Op | None = None) -> None:
         """
         Construct from operations that perform compute, action, and uncompute. All three operations need to be quantum and have the same size.
-
+        
         :param compute: the compute operation
         :param action: the action operation
         :param uncompute: optional uncompute operation, default to compute.dagger(). If provided, the user needs to make sure that uncompute.dagger() and compute have the same unitary.
@@ -2753,7 +2753,7 @@ class CustomGateDef:
     def define(name: str, circ: Circuit, args: typing.Sequence[sympy.Symbol]) -> CustomGateDef:
         """
         Define a new custom gate as a composite of other gates
-
+        
         :param name: Readable name for the new gate
         :param circ: The definition of the gate as a Circuit
         :param args: Symbols to be encapsulated as arguments of the custom gate
@@ -2799,7 +2799,7 @@ class DiagonalBox(Op):
     def __init__(self, diagonal: NDArray[numpy.complex128], upper_triangle: bool = True) -> None:
         """
         Construct from the diagonal entries of the unitary operator. The size of the vector must be 2^n where n is a positive integer.
-
+        
         :param diagonal: diagonal entries
         :param upper_triangle: indicates whether the multiplexed-Rz gates take the shape of an upper triangle or a lower triangle. Default to true.
         """
@@ -2841,15 +2841,15 @@ class DummyBox(Op):
 class EdgeType:
     """
     Type of a wire in a circuit or input to an op
-
+    
     Members:
-
+    
       Boolean
-
+    
       Classical
-
+    
       Quantum
-
+    
       WASM
     """
     Boolean: typing.ClassVar[EdgeType]  # value = <EdgeType.Boolean: 2>
@@ -2896,7 +2896,7 @@ class ExpBox(Op):
     def __init__(self, A: NDArray[numpy.complex128], t: float, basis: BasisOrder = BasisOrder.ilo) -> None:
         """
         Construct :math:`e^{itA}` from a hermitian matrix :math:`A` and a parameter :math:`t`.
-
+        
         :param A: A hermitian matrix
         :param t: Exponentiation parameter
         :param basis: Whether the provided matrix is in the ILO-BE (increasing lexicographic order of qubit ids, big-endian indexing) format, or DLO-BE (decreasing lexicographic order of ids)
@@ -2915,7 +2915,7 @@ class MetaOp(Op):
     def __init__(self, type: OpType, signature: typing.Sequence[EdgeType], data: str) -> None:
         """
         Construct MetaOp with optype, signature and additional data string
-
+        
         :param type: type for the meta op
         :param signature: signature for the op
         :param data: additional string stored in the op
@@ -2952,23 +2952,23 @@ class MultiplexedRotationBox(Op):
     def __init__(self, bistring_to_op_list: typing.Sequence[tuple[typing.Sequence[bool], Op]]) -> None:
         """
         Construct from a list of bitstring-:py:class:`Op` spairs
-
+        
         All :py:class:`Op` s  must share the same single-qubit rotation type: Rx, Ry, or Rz.
-
+        
         :param bitstring_to_op_list: List of bitstring-:py:class:`Op` spairs
         """
     @typing.overload
     def __init__(self, op_map: dict[tuple[bool, ...], Op]) -> None:
         """
         Construct from a map from bitstrings to :py:class:`Op` s.All :py:class:`Op` s  must share the same single-qubit rotation type: Rx, Ry, or Rz.
-
+        
         :param op_map: Map from bitstrings to :py:class:`Op` s
         """
     @typing.overload
     def __init__(self, angles: typing.Sequence[float], axis: OpType) -> None:
         """
         Construct from a list of angles and the rotation axis.
-
+        
         :param angles: List of rotation angles in half-turns. angles[i] is the angle activated by the binary representation of i
         :param axis: ``OpType.Rx``, ``OpType.Ry`` or ``OpType.Rz``
         """
@@ -2995,16 +2995,16 @@ class MultiplexedTensoredU2Box(Op):
     def __init__(self, bistring_to_op_list: typing.Sequence[tuple[typing.Sequence[bool], typing.Sequence[Op]]]) -> None:
         """
         Construct from a list of bitstring-:py:class:`Op` spairs
-
+        
         Only supports single qubit unitary gate types and :py:class:`Unitary1qBox`.
-
+        
         :param bitstring_to_op_list: List of bitstring-List of :py:class:`Op` s pairs
         """
     @typing.overload
     def __init__(self, op_map: dict[tuple[bool, ...], typing.Sequence[Op]]) -> None:
         """
         Construct from a map from bitstrings to equal-sized lists of :py:class:`Op` s. Only supports single qubit unitary gate types and :py:class:`Unitary1qBox`.
-
+        
         :param op_map: Map from bitstrings to lists of :py:class:`Op` s
         """
     def get_bitstring_op_pair_list(self) -> list[tuple[list[bool], list[Op]]]:
@@ -3030,9 +3030,9 @@ class MultiplexedU2Box(Op):
     def __init__(self, bistring_to_op_list: typing.Sequence[tuple[typing.Sequence[bool], Op]], impl_diag: bool = True) -> None:
         """
         Construct from a list of bitstring-:py:class:`Op` spairs
-
+        
         Only supports single qubit unitary gate types and :py:class:`Unitary1qBox`.
-
+        
         :param op_map: List of bitstring-:py:class:`Op` spairs
         :param impl_diag: Whether to implement the final diagonal gate, default to True.
         """
@@ -3040,7 +3040,7 @@ class MultiplexedU2Box(Op):
     def __init__(self, op_map: dict[tuple[bool, ...], Op], impl_diag: bool = True) -> None:
         """
         Construct from a map from bitstrings to :py:class:`Op` s.Only supports single qubit unitary gate types and :py:class:`Unitary1qBox`.
-
+        
         :param op_map: Map from bitstrings to :py:class:`Op` s
         :param impl_diag: Whether to implement the final diagonal gate, default to True.
         """
@@ -3071,14 +3071,14 @@ class MultiplexorBox(Op):
     def __init__(self, bistring_to_op_list: typing.Sequence[tuple[typing.Sequence[bool], Op]]) -> None:
         """
         Construct from a list of bitstring-:py:class:`Op` spairs
-
+        
         :param bitstring_to_op_list: List of bitstring-:py:class:`Op` spairs
         """
     @typing.overload
     def __init__(self, op_map: dict[tuple[bool, ...], Op]) -> None:
         """
         Construct from a map from bitstrings to :py:class:`Op` s
-
+        
         :param op_map: Map from bitstrings to :py:class:`Op` s
         """
     def get_bitstring_op_pair_list(self) -> list[tuple[list[bool], Op]]:
@@ -3172,211 +3172,211 @@ class Op:
 class OpType:
     """
     Enum for available operations compatible with tket :py:class:`Circuit` s.
-
+    
     Members:
-
+    
       Phase : Global phase: :math:`(\\alpha) \\mapsto \\left[ \\begin{array}{c} e^{i\\pi\\alpha} \\end{array} \\right]`
-
+    
       Z : Pauli Z: :math:`\\left[ \\begin{array}{cc} 1 & 0 \\\\ 0 & -1 \\end{array} \\right]`
-
+    
       X : Pauli X: :math:`\\left[ \\begin{array}{cc} 0 & 1 \\\\ 1 & 0 \\end{array} \\right]`
-
+    
       Y : Pauli Y: :math:`\\left[ \\begin{array}{cc} 0 & -i \\\\ i & 0 \\end{array} \\right]`
-
+    
       S : :math:`\\left[ \\begin{array}{cc} 1 & 0 \\\\ 0 & i \\end{array} \\right] = \\mathrm{U1}(\\frac12)`
-
+    
       Sdg : :math:`\\mathrm{S}^{\\dagger} = \\left[ \\begin{array}{cc} 1 & 0 \\\\ 0 & -i \\end{array} \\right] = \\mathrm{U1}(-\\frac12)`
-
+    
       T : :math:`\\left[ \\begin{array}{cc} 1 & 0 \\\\ 0 & e^{i\\pi/4} \\end{array} \\right] = \\mathrm{U1}(\\frac14)`
-
+    
       Tdg : :math:`\\mathrm{T}^{\\dagger} = \\left[ \\begin{array}{cc} 1 & 0 \\\\ 0 & e^{-i\\pi/4} \\end{array} \\right] = \\mathrm{U1}(-\\frac14)`
-
+    
       V : :math:`\\frac{1}{\\sqrt 2} \\left[ \\begin{array}{cc} 1 & -i \\\\ -i & 1 \\end{array} \\right] = \\mathrm{Rx}(\\frac12)`
-
+    
       Vdg : :math:`\\mathrm{V}^{\\dagger} = \\frac{1}{\\sqrt 2} \\left[ \\begin{array}{cc} 1 & i \\\\ i & 1 \\end{array} \\right] = \\mathrm{Rx}(-\\frac12)`
-
+    
       SX : :math:`\\frac{1}{2} \\left[ \\begin{array}{cc} 1 + i & 1 - i \\\\ 1 - i & 1 + i \\end{array} \\right] = e^{\\frac{i\\pi}{4}}\\mathrm{Rx}(\\frac12)`
-
+    
       SXdg : :math:`\\mathrm{SX}^{\\dagger} = \\frac{1}{2} \\left[ \\begin{array}{cc} 1 - i & 1 + i \\\\ 1 + i & 1 - i \\end{array} \\right] = e^{\\frac{-i\\pi}{4}}\\mathrm{Rx}(-\\frac12)`
-
+    
       H : Hadamard gate: :math:`\\frac{1}{\\sqrt 2} \\left[ \\begin{array}{cc} 1 & 1 \\\\ 1 & -1 \\end{array} \\right]`
-
+    
       Rx : :math:`(\\alpha) \\mapsto e^{-\\frac12 i \\pi \\alpha \\mathrm{X}} = \\left[ \\begin{array}{cc} \\cos\\frac{\\pi\\alpha}{2} & -i\\sin\\frac{\\pi\\alpha}{2} \\\\ -i\\sin\\frac{\\pi\\alpha}{2} & \\cos\\frac{\\pi\\alpha}{2} \\end{array} \\right]`
-
+    
       Ry : :math:`(\\alpha) \\mapsto e^{-\\frac12 i \\pi \\alpha \\mathrm{Y}} = \\left[ \\begin{array}{cc} \\cos\\frac{\\pi\\alpha}{2} & -\\sin\\frac{\\pi\\alpha}{2} \\\\ \\sin\\frac{\\pi\\alpha}{2} & \\cos\\frac{\\pi\\alpha}{2} \\end{array} \\right]`
-
+    
       Rz : :math:`(\\alpha) \\mapsto e^{-\\frac12 i \\pi \\alpha \\mathrm{Z}} = \\left[ \\begin{array}{cc} e^{-\\frac12 i \\pi\\alpha} & 0 \\\\ 0 & e^{\\frac12 i \\pi\\alpha} \\end{array} \\right]`
-
+    
       U1 : :math:`(\\lambda) \\mapsto \\mathrm{U3}(0, 0, \\lambda) = e^{\\frac12 i\\pi\\lambda} \\mathrm{Rz}(\\lambda)`. U-gates are used by IBM. See https://qiskit.org/documentation/tutorials/circuits/3_summary_of_quantum_operations.html for more information on U-gates.
-
+    
       U2 : :math:`(\\phi, \\lambda) \\mapsto \\mathrm{U3}(\\frac12, \\phi, \\lambda) = e^{\\frac12 i\\pi(\\lambda+\\phi)} \\mathrm{Rz}(\\phi) \\mathrm{Ry}(\\frac12) \\mathrm{Rz}(\\lambda)`, defined by matrix multiplication
-
+    
       U3 : :math:`(\\theta, \\phi, \\lambda) \\mapsto  \\left[ \\begin{array}{cc} \\cos\\frac{\\pi\\theta}{2} & -e^{i\\pi\\lambda} \\sin\\frac{\\pi\\theta}{2} \\\\ e^{i\\pi\\phi} \\sin\\frac{\\pi\\theta}{2} & e^{i\\pi(\\lambda+\\phi)} \\cos\\frac{\\pi\\theta}{2} \\end{array} \\right] = e^{\\frac12 i\\pi(\\lambda+\\phi)} \\mathrm{Rz}(\\phi) \\mathrm{Ry}(\\theta) \\mathrm{Rz}(\\lambda)`
-
+    
       GPI : :math:`(\\phi) \\mapsto \\left[ \\begin{array}{cc} 0 & e^{-i\\pi\\phi} \\\\ e^{i\\pi\\phi} & 0 \\end{array} \\right]`
-
+    
       GPI2 : :math:`(\\phi) \\mapsto \\frac{1}{\\sqrt 2} \\left[ \\begin{array}{cc} 1 & -ie^{-i\\pi\\phi} \\\\ -ie^{i\\pi\\phi} & 1 \\end{array} \\right]`
-
+    
       AAMS : :math:`(\\theta, \\phi_0, \\phi_1) \\mapsto \\left[ \\begin{array}{cccc} \\cos\\frac{\\pi\\theta}{2} & 0 & 0 & -ie^{-i\\pi(\\phi_0+\\phi_1)}\\sin\\frac{\\pi\\theta}{2} \\\\ 0 & \\cos\\frac{\\pi\\theta}{2} & -ie^{i\\pi(\\phi_1-\\phi_0)}\\sin\\frac{\\pi\\theta}{2} & 0 \\\\ 0 & -ie^{i\\pi(\\phi_0-\\phi_1)}\\sin\\frac{\\pi\\theta}{2} & \\cos\\frac{\\pi\\theta}{2} & 0 \\\\ -ie^{i\\pi(\\phi_0+\\phi_1)}\\sin\\frac{\\pi\\theta}{2} & 0 & 0 & \\cos\\frac{\\pi\\theta}{2} \\end{array} \\right]`
-
+    
       TK1 : :math:`(\\alpha, \\beta, \\gamma) \\mapsto \\mathrm{Rz}(\\alpha) \\mathrm{Rx}(\\beta) \\mathrm{Rz}(\\gamma)`
-
+    
       TK2 : :math:`(\\alpha, \\beta, \\gamma) \\mapsto \\mathrm{XXPhase}(\\alpha) \\mathrm{YYPhase}(\\beta) \\mathrm{ZZPhase}(\\gamma)`
-
+    
       CX : Controlled :math:`\\mathrm{X}` gate
-
+    
       CY : Controlled :math:`\\mathrm{Y}` gate
-
+    
       CZ : Controlled :math:`\\mathrm{Z}` gate
-
+    
       CH : Controlled :math:`\\mathrm{H}` gate
-
+    
       CV : Controlled :math:`\\mathrm{V}` gate
-
+    
       CVdg : Controlled :math:`\\mathrm{V}^{\\dagger}` gate
-
+    
       CSX : Controlled :math:`\\mathrm{SX}` gate
-
+    
       CSXdg : Controlled :math:`\\mathrm{SX}^{\\dagger}` gate
-
+    
       CS : Controlled :math:`\\mathrm{S}` gate
-
+    
       CSdg : Controlled :math:`\\mathrm{S}^{\\dagger}` gate
-
+    
       CRz : :math:`(\\alpha) \\mapsto` Controlled :math:`\\mathrm{Rz}(\\alpha)` gate
-
+    
       CRx : :math:`(\\alpha) \\mapsto` Controlled :math:`\\mathrm{Rx}(\\alpha)` gate
-
+    
       CRy : :math:`(\\alpha) \\mapsto` Controlled :math:`\\mathrm{Ry}(\\alpha)` gate
-
+    
       CU1 : :math:`(\\lambda) \\mapsto` Controlled :math:`\\mathrm{U1}(\\lambda)` gate. Note that this is not equivalent to a :math:`\\mathrm{CRz}(\\lambda)` up to global phase, differing by an extra :math:`\\mathrm{Rz}(\\frac{\\lambda}{2})` on the control qubit.
-
+    
       CU3 : :math:`(\\theta, \\phi, \\lambda) \\mapsto` Controlled :math:`\\mathrm{U3}(\\theta, \\phi, \\lambda)` gate. Similar rules apply.
-
+    
       CCX : Toffoli gate
-
+    
       ECR : :math:`\\frac{1}{\\sqrt 2} \\left[ \\begin{array}{cccc} 0 & 0 & 1 & i \\\\0 & 0 & i & 1 \\\\1 & -i & 0 & 0 \\\\-i & 1 & 0 & 0 \\end{array} \\right]`
-
+    
       SWAP : Swap gate
-
+    
       CSWAP : Controlled swap gate
-
+    
       noop : Identity gate. These gates are not permanent and are automatically stripped by the compiler
-
+    
       Barrier : Meta-operation preventing compilation through it. Not automatically stripped by the compiler
-
+    
       Label : Label for control flow jumps. Does not appear within a circuit
-
+    
       Branch : A control flow jump to a label dependent on the value of a given Bit. Does not appear within a circuit
-
+    
       Goto : An unconditional control flow jump to a Label. Does not appear within a circuit.
-
+    
       Stop : Halts execution immediately. Used to terminate a program. Does not appear within a circuit.
-
+    
       BRIDGE : A CX Bridge over 3 qubits. Used to apply a logical CX between the first and third qubits when they are not adjacent on the device, but both neighbour the second qubit. Acts as the identity on the second qubit
-
+    
       Measure : Z-basis projective measurement, storing the measurement outcome in a specified bit
-
+    
       Reset : Resets the qubit to :math:`\\left|0\\right>`
-
+    
       CircBox : Represents an arbitrary subcircuit
-
+    
       PhasePolyBox : An operation representing arbitrary circuits made up of CX and Rz gates, represented as a phase polynomial together with a boolean matrix representing an additional linear transformation.
-
+    
       Unitary1qBox : Represents an arbitrary one-qubit unitary operation by its matrix
-
+    
       Unitary2qBox : Represents an arbitrary two-qubit unitary operation by its matrix
-
+    
       Unitary3qBox : Represents an arbitrary three-qubit unitary operation by its matrix
-
+    
       ExpBox : A two-qubit operation corresponding to a unitary matrix defined as the exponential :math:`e^{itA}` of an arbitrary 4x4 hermitian matrix :math:`A`.
-
+    
       PauliExpBox : An operation defined as the exponential :math:`e^{-\\frac{i\\pi\\alpha}{2} P}` of a tensor :math:`P` of Pauli operations.
-
+    
       PauliExpPairBox : A pair of (not necessarily commuting) Pauli exponentials :math:`e^{-\\frac{i\\pi\\alpha}{2} P}` performed in sequence.
-
+    
       PauliExpCommutingSetBox : An operation defined as a setof commuting exponentials of the form :math:`e^{-\\frac{i\\pi\\alpha}{2} P}` of a tensor :math:`P` of Pauli operations.
-
+    
       TermSequenceBox : An unordered collection of Pauli exponentials that can be synthesised in any order, causing a change in the unitary operation. Synthesis order depends on the synthesis strategy chosen only.
-
+    
       QControlBox : An arbitrary n-controlled operation
-
+    
       ToffoliBox : A permutation of classical basis states
-
+    
       ConjugationBox : An operation composed of 'action', 'compute' and 'uncompute' circuits
-
+    
       DummyBox : A placeholder operation that holds resource data
-
+    
       CustomGate : :math:`(\\alpha, \\beta, \\ldots) \\mapsto` A user-defined operation, based on a :py:class:`Circuit` :math:`C` with parameters :math:`\\alpha, \\beta, \\ldots` substituted in place of bound symbolic variables in :math:`C`, as defined by the :py:class:`CustomGateDef`.
-
+    
       Conditional : An operation to be applied conditionally on the value of some classical register
-
+    
       ISWAP : :math:`(\\alpha) \\mapsto e^{\\frac14 i \\pi\\alpha (\\mathrm{X} \\otimes \\mathrm{X} + \\mathrm{Y} \\otimes \\mathrm{Y})} = \\left[ \\begin{array}{cccc} 1 & 0 & 0 & 0 \\\\ 0 & \\cos\\frac{\\pi\\alpha}{2} & i\\sin\\frac{\\pi\\alpha}{2} & 0 \\\\ 0 & i\\sin\\frac{\\pi\\alpha}{2} & \\cos\\frac{\\pi\\alpha}{2} & 0 \\\\ 0 & 0 & 0 & 1 \\end{array} \\right]`
-
+    
       PhasedISWAP : :math:`(p, t) \\mapsto \\left[ \\begin{array}{cccc} 1 & 0 & 0 & 0 \\\\ 0 & \\cos\\frac{\\pi t}{2} & i\\sin\\frac{\\pi t}{2}e^{2i\\pi p} & 0 \\\\ 0 & i\\sin\\frac{\\pi t}{2}e^{-2i\\pi p} & \\cos\\frac{\\pi t}{2} & 0 \\\\ 0 & 0 & 0 & 1 \\end{array} \\right]` (equivalent to: Rz(p)[0]; Rz(-p)[1]; ISWAP(t); Rz(-p)[0]; Rz(p)[1])
-
+    
       XXPhase : :math:`(\\alpha) \\mapsto e^{-\\frac12 i \\pi\\alpha (\\mathrm{X} \\otimes \\mathrm{X})} = \\left[ \\begin{array}{cccc} \\cos\\frac{\\pi\\alpha}{2} & 0 & 0 & -i\\sin\\frac{\\pi\\alpha}{2} \\\\ 0 & \\cos\\frac{\\pi\\alpha}{2} & -i\\sin\\frac{\\pi\\alpha}{2} & 0 \\\\ 0 & -i\\sin\\frac{\\pi\\alpha}{2} & \\cos\\frac{\\pi\\alpha}{2} & 0 \\\\ -i\\sin\\frac{\\pi\\alpha}{2} & 0 & 0 & \\cos\\frac{\\pi\\alpha}{2} \\end{array} \\right]`
-
+    
       YYPhase : :math:`(\\alpha) \\mapsto e^{-\\frac12 i \\pi\\alpha (\\mathrm{Y} \\otimes \\mathrm{Y})} = \\left[ \\begin{array}{cccc} \\cos\\frac{\\pi\\alpha}{2} & 0 & 0 & i\\sin\\frac{\\pi\\alpha}{2} \\\\ 0 & \\cos\\frac{\\pi\\alpha}{2} & -i\\sin\\frac{\\pi\\alpha}{2} & 0 \\\\ 0 & -i\\sin\\frac{\\pi\\alpha}{2} & \\cos\\frac{\\pi\\alpha}{2} & 0 \\\\ i\\sin\\frac{\\pi\\alpha}{2} & 0 & 0 & \\cos\\frac{\\pi\\alpha}{2} \\end{array} \\right]`
-
+    
       ZZPhase : :math:`(\\alpha) \\mapsto e^{-\\frac12 i \\pi\\alpha (\\mathrm{Z} \\otimes \\mathrm{Z})} = \\left[ \\begin{array}{cccc} e^{-\\frac12 i \\pi\\alpha} & 0 & 0 & 0 \\\\ 0 & e^{\\frac12 i \\pi\\alpha} & 0 & 0 \\\\ 0 & 0 & e^{\\frac12 i \\pi\\alpha} & 0 \\\\ 0 & 0 & 0 & e^{-\\frac12 i \\pi\\alpha} \\end{array} \\right]`
-
+    
       XXPhase3 : A 3-qubit gate XXPhase3(α) consists of pairwise 2-qubit XXPhase(α) interactions. Equivalent to XXPhase(α) XXPhase(α) XXPhase(α).
-
+    
       PhasedX : :math:`(\\alpha,\\beta) \\mapsto \\mathrm{Rz}(\\beta)\\mathrm{Rx}(\\alpha)\\mathrm{Rz}(-\\beta)` (matrix-multiplication order)
-
+    
       NPhasedX : :math:`(\\alpha, \\beta) \\mapsto \\mathrm{PhasedX}(\\alpha, \\beta)^{\\otimes n}` (n-qubit gate composed of identical PhasedX in parallel.
-
+    
       CnRx : :math:`(\\alpha)` := n-controlled :math:`\\mathrm{Rx}(\\alpha)` gate.
-
+    
       CnRy : :math:`(\\alpha)` := n-controlled :math:`\\mathrm{Ry}(\\alpha)` gate.
-
+    
       CnRz : :math:`(\\alpha)` := n-controlled :math:`\\mathrm{Rz}(\\alpha)` gate.
-
+    
       CnX : n-controlled X gate.
-
+    
       CnY : n-controlled Y gate.
-
+    
       CnZ : n-controlled Z gate.
-
+    
       ZZMax : :math:`e^{-\\frac{i\\pi}{4}(\\mathrm{Z} \\otimes \\mathrm{Z})}`, a maximally entangling ZZPhase
-
+    
       ESWAP : :math:`\\alpha \\mapsto e^{-\\frac12 i\\pi\\alpha \\cdot \\mathrm{SWAP}} = \\left[ \\begin{array}{cccc} e^{-\\frac12 i \\pi\\alpha} & 0 & 0 & 0 \\\\ 0 & \\cos\\frac{\\pi\\alpha}{2} & -i\\sin\\frac{\\pi\\alpha}{2} & 0 \\\\ 0 & -i\\sin\\frac{\\pi\\alpha}{2} & \\cos\\frac{\\pi\\alpha}{2} & 0 \\\\ 0 & 0 & 0 & e^{-\\frac12 i \\pi\\alpha} \\end{array} \\right]`
-
+    
       FSim : :math:`(\\alpha, \\beta) \\mapsto \\left[ \\begin{array}{cccc} 1 & 0 & 0 & 0 \\\\ 0 & \\cos \\pi\\alpha & -i\\sin \\pi\\alpha & 0 \\\\ 0 & -i\\sin \\pi\\alpha & \\cos \\pi\\alpha & 0 \\\\ 0 & 0 & 0 & e^{-i\\pi\\beta} \\end{array} \\right]`
-
+    
       Sycamore : :math:`\\mathrm{FSim}(\\frac12, \\frac16)`
-
+    
       ISWAPMax : :math:`\\mathrm{ISWAP}(1) = \\left[ \\begin{array}{cccc} 1 & 0 & 0 & 0 \\\\ 0 & 0 & i & 0 \\\\ 0 & i & 0 & 0 \\\\ 0 & 0 & 0 & 1 \\end{array} \\right]`
-
+    
       ClassicalTransform : A general classical operation where all inputs are also outputs
-
+    
       WASM : Op containing a classical wasm function call
-
+    
       SetBits : An operation to set some bits to specified values
-
+    
       CopyBits : An operation to copy some bit values
-
+    
       RangePredicate : A classical predicate defined by a range of values in binary encoding
-
+    
       ExplicitPredicate : A classical predicate defined by a truth table
-
+    
       ExplicitModifier : An operation defined by a truth table that modifies one bit
-
+    
       MultiBit : A classical operation applied to multiple bits simultaneously
-
+    
       ClassicalExpBox : A box for holding compound classical operations on Bits.
-
+    
       MultiplexorBox : A multiplexor (i.e. uniformly controlled operations)
-
+    
       MultiplexedRotationBox : A multiplexed rotation gate (i.e. uniformly controlled single-axis rotations)
-
+    
       MultiplexedU2Box : A multiplexed U2 gate (i.e. uniformly controlled U2 gate)
-
+    
       MultiplexedTensoredU2Box : A multiplexed tensored-U2 gate
-
+    
       StatePreparationBox : A box for preparing quantum states using multiplexed-Ry and multiplexed-Rz gates
-
+    
       DiagonalBox : A box for synthesising a diagonal unitary matrix into a sequence of multiplexed-Rz gates
     """
     AAMS: typing.ClassVar[OpType]  # value = <OpType.AAMS: 42>
@@ -3619,7 +3619,7 @@ class PhasePolyBox(Op):
     def __init__(self, n_qubits: int, qubit_indices: dict[pytket._tket.unit_id.Qubit, int], phase_polynomial: typing.Sequence[tuple[typing.Sequence[bool], sympy.Expr | float]], linear_transformation: NDArray[numpy.bool_]) -> None:
         """
         Construct from the number of qubits, the mapping from Qubit to index, the phase polynomial (list of bitstring phase pairs) and the linear transformation (boolean matrix)
-
+        
         If any bitstring is repeated in the phase polynomial list, the last given value for that bistring will be used
         """
     @typing.overload
@@ -3666,7 +3666,7 @@ class ProjectorAssertionBox(Op):
     def __init__(self, m: NDArray[numpy.complex128], basis: BasisOrder = BasisOrder.ilo) -> None:
         """
         Construct from a projector matrix.
-
+        
         :param m: The projector matrix
         :param basis: Whether the provided unitary is in the ILO-BE (increasing lexicographic order of qubit ids, big-endian indexing) format, or DLO-BE (decreasing lexicographic order of ids)
         """
@@ -3689,7 +3689,7 @@ class QControlBox(Op):
     def __init__(self, op: Op, n_controls: int = 1, control_state: typing.Sequence[bool] = []) -> None:
         """
         Construct from an :py:class:`Op`, a number of quantum controls, and the control state expressed as a bit vector. The controls occupy the low-index ports of the resulting operation.
-
+        
         :param op: the underlying operator
         :param n_controls: the number of control qubits. Default to 1
         :param control_state: the control state expressed as a bit vector. Default to all 1s
@@ -3698,7 +3698,7 @@ class QControlBox(Op):
     def __init__(self, op: Op, n_controls: int, control_state: int) -> None:
         """
         Construct from an :py:class:`Op`, a number of quantum controls, and the control state expressed as an integer. The controls occupy the low-index ports of the resulting operation.
-
+        
         :param op: the underlying operator
         :param n_controls: the number of control qubits
         :param control_state: the control state expressed as an integer. Big-endian
@@ -3759,7 +3759,7 @@ class ResourceBounds:
     def __init__(self, min: int, max: int) -> None:
         """
         Constructs a ResourceBounds object.
-
+        
         :param min: minimum value
         :param max: maximum value
         """
@@ -3774,9 +3774,9 @@ class ResourceBounds:
 class ResourceData:
     """
     An object holding resource data for use in a :py:class:`DummyBox`.
-
+    
     The object holds several fields representing minimum and maximum values for certain resources. The absence of an :py:class:`OpType` in one of these fields is interpreted as the absence of gates of that type in the (imagined) circuit.
-
+    
     See :py:meth:`Circuit.get_resources` for how to use this data.
     """
     @staticmethod
@@ -3785,7 +3785,7 @@ class ResourceData:
     def __init__(self, op_type_count: dict[OpType, ResourceBounds], gate_depth: ResourceBounds, op_type_depth: dict[OpType, ResourceBounds], two_qubit_gate_depth: ResourceBounds) -> None:
         """
         Constructs a ResourceData object.
-
+        
         :param op_type_count: dictionary of counts of selected :py:class:`OpType`
         :param gate_depth: overall gate depth
         :param op_type_depth: dictionary of depths of selected :py:class:`OpType`
@@ -3836,14 +3836,14 @@ class StabiliserAssertionBox(Op):
     def __init__(self, stabilisers: typing.Sequence[pytket._tket.pauli.PauliStabiliser]) -> None:
         """
         Construct from a list of Pauli stabilisers.
-
+        
         :param stabilisers: The list of Pauli stabilisers
         """
     @typing.overload
     def __init__(self, stabilisers: typing.Sequence[str]) -> None:
         """
         Construct from a list of Pauli stabilisers.
-
+        
         :param m: The list of Pauli stabilisers expressed as Python strings
         """
     def get_circuit(self) -> Circuit:
@@ -3864,7 +3864,7 @@ class StatePreparationBox(Op):
     def __init__(self, statevector: NDArray[numpy.complex128], is_inverse: bool = False, with_initial_reset: bool = False) -> None:
         """
         Construct from a statevector
-
+        
         :param statevector: normalised statevector
         :param is_inverse: whether to implement the dagger of the state preparation circuit, default to false
         :param with_initial_reset: whether to explicitly set the state to zero initially (by default the initial zero state is assumed and no explicit reset is applied)
@@ -3936,7 +3936,7 @@ class ToffoliBox(Op):
     def __init__(self, permutation: typing.Sequence[tuple[typing.Sequence[bool], typing.Sequence[bool]]], strat: ToffoliBoxSynthStrat, rotation_axis: OpType = OpType.Ry) -> None:
         """
         Construct from a permutation of basis states
-
+        
         :param permutation: a list of bitstring pairs
         :param strat: synthesis strategy
         :param rotation_axis: the rotation axis of the multiplexors used in the decomposition. Can be either Rx or Ry. Only applicable to the Matching strategy. Default to Ry.
@@ -3945,7 +3945,7 @@ class ToffoliBox(Op):
     def __init__(self, permutation: typing.Sequence[tuple[typing.Sequence[bool], typing.Sequence[bool]]], rotation_axis: OpType = OpType.Ry) -> None:
         """
         Construct from a permutation of basis states and perform synthesis using the Matching strategy
-
+        
         :param permutation: a list of bitstring pairs
         :param rotation_axis: the rotation axis of the multiplexors used in the decomposition. Can be either Rx or Ry, default to Ry.
         """
@@ -3958,7 +3958,7 @@ class ToffoliBox(Op):
     def __init__(self, permutation: dict[tuple[bool, ...], typing.Sequence[bool]], strat: ToffoliBoxSynthStrat, rotation_axis: OpType = OpType.Ry) -> None:
         """
         Construct from a permutation of basis states
-
+        
         :param permutation: a map between bitstrings
         :param strat: synthesis strategy
         :param rotation_axis: the rotation axis of the multiplexors used in the decomposition. Can be either Rx or Ry. Only applicable to the Matching strategy. Default to Ry.
@@ -3967,7 +3967,7 @@ class ToffoliBox(Op):
     def __init__(self, permutation: dict[tuple[bool, ...], typing.Sequence[bool]], rotation_axis: OpType = OpType.Ry) -> None:
         """
         Construct from a permutation of basis states and perform synthesis using the Matching strategy
-
+        
         :param permutation: a map between bitstrings
         :param rotation_axis: the rotation axis of the multiplexors used in the decomposition. Can be either Rx or Ry, default to Ry.
         """
@@ -3995,11 +3995,11 @@ class ToffoliBox(Op):
 class ToffoliBoxSynthStrat:
     """
     Enum strategies for synthesising ToffoliBoxes
-
+    
     Members:
-
+    
       Matching : Use multiplexors to perform parallel swaps on hypercubes
-
+    
       Cycle : Use CnX gates to perform transpositions
     """
     Cycle: typing.ClassVar[ToffoliBoxSynthStrat]  # value = <ToffoliBoxSynthStrat.Cycle: 1>
@@ -4063,7 +4063,7 @@ class Unitary2qBox(Op):
     def __init__(self, m: NDArray[numpy.complex128], basis: BasisOrder = BasisOrder.ilo) -> None:
         """
         Construct from a unitary matrix.
-
+        
         :param m: The unitary matrix
         :param basis: Whether the provided unitary is in the ILO-BE (increasing lexicographic order of qubit ids, big-endian indexing) format, or DLO-BE (decreasing lexicographic order of ids)
         """
@@ -4085,7 +4085,7 @@ class Unitary3qBox(Op):
     def __init__(self, m: NDArray[numpy.complex128], basis: BasisOrder = BasisOrder.ilo) -> None:
         """
         Construct from a unitary matrix.
-
+        
         :param m: The unitary matrix
         :param basis: Whether the provided unitary is in the ILO-BE (increasing lexicographic order of qubit ids, big-endian indexing) format, or DLO-BE (decreasing lexicographic order of ids)
         """
@@ -4146,8 +4146,8 @@ class WASMOp(ClassicalOp):
 def fresh_symbol(preferred: str = 'a') -> sympy.Symbol:
     """
     Given some preferred symbol, this finds an appropriate suffix that will guarantee it has not yet been used in the current python session.
-
+    
     :param preferred: The preferred readable symbol name as a string (default is 'a')
-
+    
     :return: A new sympy symbol object
     """

--- a/pytket/pytket/circuit/__init__.py
+++ b/pytket/pytket/circuit/__init__.py
@@ -63,7 +63,7 @@ from .logic_exp import (
 def overload_add_wasm(
     self: Circuit,
     funcname: str,
-    filehandler: wasm.WasmFileHandler,
+    filehandler: wasm.WasmModuleHandler,
     list_i: Sequence[int],
     list_o: Sequence[int],
     args: Union[Sequence[int], Sequence[Bit]],
@@ -72,7 +72,7 @@ def overload_add_wasm(
 ) -> Circuit:
     """Add a classical function call from a wasm file to the circuit.
     \n\n:param funcname: name of the function that is called
-    \n:param filehandler: wasm file handler to identify the wasm file
+    \n:param filehandler: wasm file or module handler to identify the wasm module
     \n:param list_i: list of the number of bits in the input variables
     \n:param list_o: list of the number of bits in the output variables
     \n:param args: vector of circuit bits the wasm op should be added to
@@ -113,7 +113,7 @@ setattr(Circuit, "add_wasm", overload_add_wasm)
 def overload_add_wasm_to_reg(
     self: Circuit,
     funcname: str,
-    filehandler: wasm.WasmFileHandler,
+    filehandler: wasm.WasmModuleHandler,
     list_i: Sequence[BitRegister],
     list_o: Sequence[BitRegister],
     args_wasm: Optional[Sequence[int]] = None,
@@ -121,7 +121,7 @@ def overload_add_wasm_to_reg(
 ) -> Circuit:
     """Add a classical function call from a wasm file to the circuit.
     \n\n:param funcname: name of the function that is called
-    \n:param filehandler: wasm file handler to identify the wasm file
+    \n:param filehandler: wasm file or module handler to identify the wasm module
     \n:param list_i: list of the classical registers assigned to
      the input variables of the function call
     \n:param list_o: list of the classical registers assigned to

--- a/pytket/pytket/wasm/__init__.py
+++ b/pytket/pytket/wasm/__init__.py
@@ -17,4 +17,5 @@ __path__ = __import__("pkgutil").extend_path(__path__, __name__)
 
 from .wasm import (
     WasmFileHandler,
+    WasmModuleHandler,
 )

--- a/pytket/tests/classical_test.py
+++ b/pytket/tests/classical_test.py
@@ -192,6 +192,18 @@ def test_wasm_3() -> None:
     assert c.depth() == 1
 
 
+def test_wasm_3_bytes() -> None:
+    with open("testfile.wasm", "rb") as f:
+        bytecode = f.read()
+    c = Circuit(0, 6)
+
+    w = wasm.WasmModuleHandler(bytecode)
+
+    c.add_wasm("add_one", w, [1], [1], [Bit(0), Bit(1)])
+
+    assert c.depth() == 1
+
+
 def test_wasm_4() -> None:
     w = wasm.WasmFileHandler("testfile.wasm")
 
@@ -404,6 +416,19 @@ def test_wasm_function_check_5() -> None:
 
 def test_wasm_function_check_6() -> None:
     w = wasm.WasmFileHandler("testfile.wasm")
+    c = Circuit(20, 20)
+    c0 = c.add_c_register("c0", 32)
+    c1 = c.add_c_register("c1", 4)
+
+    c.add_wasm_to_reg("add_one", w, [c0], [c1])
+    assert c.depth() == 1
+
+
+def test_wasm_function_check_6_bytes() -> None:
+    with open("testfile.wasm", "rb") as f:
+        bytecode = f.read()
+
+    w = wasm.WasmModuleHandler(bytecode)
     c = Circuit(20, 20)
     c0 = c.add_c_register("c0", 32)
     c1 = c.add_c_register("c1", 4)


### PR DESCRIPTION
# Description

The `add_wasm` and `add_wasm_to_reg` functions should now accept `WasmModuleHandler` which is a super class of `WasmFileHandler`.

# Related issues

Follow up to #1503

# Checklist

- [x] I have performed a self-review of my code.
- [ ] I have commented hard-to-understand parts of my code.
- [ ] I have made corresponding changes to the public API documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the changelog with any user-facing changes.
