### PR TITLE
Update macos CI runners

### DIFF
--- a/.github/workflows/build-with-nix.yml
+++ b/.github/workflows/build-with-nix.yml
@@ -16,7 +16,7 @@ jobs:
   build_and_test:
     strategy:
       matrix:
-        os: ['ubuntu-24.04', 'macos-14']
+        os: ['ubuntu-24.04', 'macos-15']
     runs-on: ${{matrix.os}}
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -82,7 +82,7 @@ jobs:
     name: Check C++ code formatting
     needs: check_changes
     if: needs.check_changes.outputs.tket_or_workflow_changed == 'true'
-    runs-on: 'macos-14'
+    runs-on: 'macos-15'
     steps:
       - uses: actions/checkout@v4
       - name: Check C++ code formatting
@@ -98,7 +98,7 @@ jobs:
     if: needs.check_changes.outputs.tket_or_workflow_changed == 'true'
     strategy:
       matrix:
-        os: ['ubuntu-24.04', 'macos-12', 'macos-14']
+        os: ['ubuntu-24.04', 'macos-13', 'macos-15']
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4
@@ -342,7 +342,7 @@ jobs:
     if: needs.check_changes.outputs.tket_or_workflow_changed == 'true' || needs.check_changes.outputs.pytket_or_workflow_changed == 'true'
     strategy:
       matrix:
-        os: ['macos-12', 'macos-14']
+        os: ['macos-13', 'macos-15']
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4
@@ -363,7 +363,7 @@ jobs:
     - name: ccache
       uses: hendrikmuhs/ccache-action@v1.2
       with:
-        key: tket-dynamic-macos-12
+        key: tket-dynamic-macos
     - name: further ccache config
       run: |
         ccache --set-config base_dir=${HOME}
@@ -416,7 +416,7 @@ jobs:
         python -m pip install -r requirements.txt
         python -m pytest --ignore=simulator/
     - name: Check type stubs are up-to-date and run mypy
-      if: matrix.os == 'macos-14' && (github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch')
+      if: matrix.os == 'macos-15' && (github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch')
       run: |
         python -m pip install -U mypy pybind11-stubgen
         cd pytket

--- a/.github/workflows/build_libs.yml
+++ b/.github/workflows/build_libs.yml
@@ -46,7 +46,7 @@ jobs:
     if: ${{ needs.changes.outputs.libs != '[]' && needs.changes.outputs.libs != '' }}
     strategy:
       matrix:
-        os: ['ubuntu-24.04', 'macos-12', 'windows-2022', 'macos-14']
+        os: ['ubuntu-24.04', 'macos-13', 'macos-15', 'windows-2022']
         lib: ${{ fromJson(needs.changes.outputs.libs) }}
         build_type: ['Release', 'Debug']
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -17,7 +17,7 @@ jobs:
     name: Build
     strategy:
       matrix:
-        os: ['ubuntu-24.04', 'macos-12', 'windows-2022', 'macos-14']
+        os: ['ubuntu-24.04', 'macos-13', 'macos-14', 'macos-15', 'windows-2022']
     runs-on: ${{ matrix.os }}
     steps:
 

--- a/.github/workflows/pytket_benchmarking.yml
+++ b/.github/workflows/pytket_benchmarking.yml
@@ -30,7 +30,7 @@ jobs:
       run: |
         conan profile detect
         DEFAULT_PROFILE_PATH=`conan profile path default`
-        PROFILE_PATH=./conan-profiles/macos-14
+        PROFILE_PATH=./conan-profiles/macos-15
         diff ${DEFAULT_PROFILE_PATH} ${PROFILE_PATH} || true
         cp ${PROFILE_PATH} ${DEFAULT_PROFILE_PATH}
         conan remote add tket-libs https://quantinuumsw.jfrog.io/artifactory/api/conan/tket1-libs --index 0
@@ -57,7 +57,7 @@ jobs:
 
   compile-and-compare:
     name: Compile and compare
-    runs-on: macos-14
+    runs-on: macos-15
     needs: build_wheels
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,7 @@ jobs:
 
   build_macos_x86_wheels:
     name: Build macos x86 wheels
-    runs-on: macos-12
+    runs-on: macos-13
     strategy:
       matrix:
         python-version: ['3.10', '3.11', '3.12']
@@ -83,7 +83,7 @@ jobs:
       run: |
         conan profile detect
         DEFAULT_PROFILE_PATH=`conan profile path default`
-        PROFILE_PATH=./conan-profiles/macos-12
+        PROFILE_PATH=./conan-profiles/macos-13
         diff ${DEFAULT_PROFILE_PATH} ${PROFILE_PATH} || true
         cp ${PROFILE_PATH} ${DEFAULT_PROFILE_PATH}
         conan remote add tket-libs https://quantinuumsw.jfrog.io/artifactory/api/conan/tket1-libs --index 0
@@ -106,7 +106,7 @@ jobs:
 
   build_macos_arm64_wheels:
     name: Build macos arm64 wheels
-    runs-on: macos-14
+    runs-on: macos-15
     env:
         MACOSX_DEPLOYMENT_TARGET: '12.0'
     strategy:
@@ -127,7 +127,7 @@ jobs:
       run: |
         conan profile detect
         DEFAULT_PROFILE_PATH=`conan profile path default`
-        PROFILE_PATH=./conan-profiles/macos-14
+        PROFILE_PATH=./conan-profiles/macos-15
         diff ${DEFAULT_PROFILE_PATH} ${PROFILE_PATH} || true
         cp ${PROFILE_PATH} ${DEFAULT_PROFILE_PATH}
         conan remote add tket-libs https://quantinuumsw.jfrog.io/artifactory/api/conan/tket1-libs --index 0
@@ -259,7 +259,7 @@ jobs:
     needs: build_macos_x86_wheels
     strategy:
       matrix:
-        os: ['macos-12', 'macos-13']
+        os: ['macos-13']
         python-version: ['3.10', '3.11', '3.12']
     runs-on: ${{ matrix.os }}
     steps:
@@ -289,7 +289,7 @@ jobs:
     needs: build_macos_arm64_wheels
     strategy:
       matrix:
-        os: ['macos-13-xlarge', 'macos-14']
+        os: ['macos-14', 'macos-15']
         python-version: ['3.10', '3.11', '3.12']
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/test_libs.yml
+++ b/.github/workflows/test_libs.yml
@@ -63,7 +63,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ['ubuntu-24.04', 'macos-12', 'windows-2022', 'macos-14']
+        os: ['ubuntu-24.04', 'macos-13', 'macos-15', 'windows-2022']
         lib: ${{ fromJson(needs.set_libs_matrix.outputs.libs) }}
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/test_libs_all.yml
+++ b/.github/workflows/test_libs_all.yml
@@ -10,7 +10,7 @@ jobs:
     name: test library
     strategy:
       matrix:
-        os: ['ubuntu-24.04', 'macos-12', 'windows-2022', 'macos-14']
+        os: ['ubuntu-24.04', 'macos-13', 'macos-15', 'windows-2022']
         lib: ['tklog', 'tkassert', 'tkrng', 'tktokenswap', 'tkwsm']
     runs-on: ${{ matrix.os }}
     steps:

--- a/conan-profiles/macos-13
+++ b/conan-profiles/macos-13
@@ -1,0 +1,8 @@
+[settings]
+arch=x86_64
+build_type=Release
+compiler=apple-clang
+compiler.cppstd=gnu17
+compiler.libcxx=libc++
+compiler.version=15
+os=Macos

--- a/conan-profiles/macos-15
+++ b/conan-profiles/macos-15
@@ -1,0 +1,8 @@
+[settings]
+arch=armv8
+build_type=Release
+compiler=apple-clang
+compiler.cppstd=gnu17
+compiler.libcxx=libc++
+compiler.version=16
+os=Macos

--- a/pytket/conanfile.py
+++ b/pytket/conanfile.py
@@ -38,7 +38,7 @@ class pytketRecipe(ConanFile):
         self.requires("pybind11_json/0.2.14")
         self.requires("symengine/0.12.0")
         self.requires("tkassert/0.3.4@tket/stable")
-        self.requires("tket/1.3.32@tket/stable")
+        self.requires("tket/1.3.33@tket/stable")
         self.requires("tklog/0.3.3@tket/stable")
         self.requires("tkrng/0.3.3@tket/stable")
         self.requires("tktokenswap/0.3.9@tket/stable")

--- a/tket/conanfile.py
+++ b/tket/conanfile.py
@@ -23,7 +23,7 @@ from conan.errors import ConanInvalidConfiguration
 
 class TketConan(ConanFile):
     name = "tket"
-    version = "1.3.32"
+    version = "1.3.33"
     package_type = "library"
     license = "Apache 2"
     homepage = "https://github.com/CQCL/tket"


### PR DESCRIPTION
Closes #1608 .

Use `macos-13` and `macos-15` for the x86 and arm64 builds, respectively.

Release build tested [here](https://github.com/CQCL/tket/actions/runs/11293468007).