### PR TITLE
Remove hardware inefficient rz-sx decomposition for TK1

### DIFF
--- a/pytket/conanfile.py
+++ b/pytket/conanfile.py
@@ -38,7 +38,7 @@ class pytketRecipe(ConanFile):
         self.requires("pybind11_json/0.2.14")
         self.requires("symengine/0.12.0")
         self.requires("tkassert/0.3.4@tket/stable")
-        self.requires("tket/1.3.36@tket/stable")
+        self.requires("tket/1.3.37@tket/stable")
         self.requires("tklog/0.3.3@tket/stable")
         self.requires("tkrng/0.3.3@tket/stable")
         self.requires("tktokenswap/0.3.9@tket/stable")

--- a/pytket/docs/changelog.rst
+++ b/pytket/docs/changelog.rst
@@ -7,6 +7,7 @@ Unreleased
 Fixes:
 
 * Fix `symbol_substitution` not preserving opgroups.
+* Remove hardware inefficient circuit construction in `_tk1_to_rzsx`
 
 1.34.0 (October 2024)
 ---------------------

--- a/pytket/tests/predicates_test.py
+++ b/pytket/tests/predicates_test.py
@@ -846,6 +846,14 @@ def test_conditional_phase() -> None:
     assert any(any_check_list)
 
 
+def test_rz_sx_decomp() -> None:
+    c = Circuit(1).TK1(0, 1.5, 0, 0)
+    AutoRebase({OpType.CX, OpType.SX, OpType.Rz}).apply(c)
+    comp = Circuit(1).Rz(1, 0).SX(0).Rz(1, 0)
+    comp.add_phase(1.75)
+    assert c == comp
+
+
 def test_flatten_relabel_pass() -> None:
     c = Circuit(3)
     c.H(1).H(2)
@@ -1112,3 +1120,4 @@ if __name__ == "__main__":
     test_rebase_custom_tk2()
     test_selectively_decompose_boxes()
     test_clifford_push_through_measures()
+    test_rz_sx_decomp()

--- a/tket/conanfile.py
+++ b/tket/conanfile.py
@@ -23,7 +23,7 @@ from conan.errors import ConanInvalidConfiguration
 
 class TketConan(ConanFile):
     name = "tket"
-    version = "1.3.36"
+    version = "1.3.37"
     package_type = "library"
     license = "Apache 2"
     homepage = "https://github.com/CQCL/tket"

--- a/tket/src/Circuit/CircPool.cpp
+++ b/tket/src/Circuit/CircPool.cpp
@@ -1306,18 +1306,6 @@ static Circuit _tk1_to_rzsx(
     c.add_op<unsigned>(OpType::SX, {0});
     c.add_op<unsigned>(OpType::Rz, alpha, {0});
     correction_phase = int_half(beta - 0.5) - 0.25;
-  } else if (equiv_0(beta + 0.5) && equiv_0(alpha) && equiv_0(gamma)) {
-    // a = 2k, b = 2m-0.5, c = 2n
-    // Rz(2k)Rx(2m - 0.5)Rz(2n) = (-1)^{k+m+n}e^{i \pi /4} X.SX
-    if (allow_x) {
-      c.add_op<unsigned>(OpType::X, {0});
-    } else {
-      c.add_op<unsigned>(OpType::SX, {0});
-      c.add_op<unsigned>(OpType::SX, {0});
-    }
-    c.add_op<unsigned>(OpType::SX, {0});
-    correction_phase =
-        int_half(beta + 0.5) + int_half(alpha) + int_half(gamma) + 0.25;
   } else if (equiv_0(beta + 0.5)) {
     // SX.Rz(2m+0.5).SX = (-1)^{m}e^{i \pi /4} Rz(0.5).SX.Rz(0.5)
     c.add_op<unsigned>(OpType::Rz, gamma + 1, {0});


### PR DESCRIPTION
# Description

A 3 SX gate alternative construction in `_tk1_to_rzsx` is actually expected to be less efficient on hardware than the default case with two Rz gates and one SX gate. This PR removes the alternative construction. See https://github.com/CQCL/tket/issues/1631#issuecomment-2439276370

# Related issues

Please mention any github issues addressed by this PR.

# Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented hard-to-understand parts of my code.
- [x] I have made corresponding changes to the public API documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have updated the changelog with any user-facing changes.
