### PR TITLE
Add utility method to check register alignment in `ClExprOp`

### DIFF
--- a/pytket/docs/changelog.rst
+++ b/pytket/docs/changelog.rst
@@ -4,6 +4,11 @@ Changelog
 Unreleased
 ----------
 
+Features:
+
+* Add `clexpr.check_register_alignments()` method to check register alignments
+  in `ClExprOp`.
+
 Fixes:
 
 * Fix `symbol_substitution` not preserving opgroups.

--- a/pytket/pytket/circuit/clexpr.py
+++ b/pytket/pytket/circuit/clexpr.py
@@ -175,7 +175,9 @@ def check_register_alignments(circ: Circuit) -> bool:
     :param circ: circuit to check
     :return: True iff all `ClExprOp` operations are register-aligned
     """
-    cregs: set(tuple[Bit]) = set(tuple(creg.to_list()) for creg in circ.c_registers)
+    cregs: set[tuple[Bit, ...]] = set(
+        tuple(creg.to_list()) for creg in circ.c_registers
+    )
     for cmd in circ:
         op = cmd.op
         if op.type == OpType.ClExpr:

--- a/pytket/pytket/qasm/qasm.py
+++ b/pytket/pytket/qasm/qasm.py
@@ -1133,13 +1133,11 @@ def check_can_convert_circuit(circ: Circuit, header: str, maxwidth: int) -> None
             f"Circuit contains a classical register larger than {maxwidth}: try "
             "setting the `maxwidth` parameter to a higher value."
         )
+    # Empty CustomGates should have been removed by DecomposeBoxes().
     for cmd in circ:
-        if is_empty_customgate(cmd.op) or (
-            isinstance(cmd.op, Conditional) and is_empty_customgate(cmd.op.op)
-        ):
-            raise QASMUnsupportedError(
-                f"Empty CustomGates and opaque gates are not supported."
-            )
+        assert not is_empty_customgate(cmd.op)
+        if isinstance(cmd.op, Conditional):
+            assert not is_empty_customgate(cmd.op.op)
     if not check_register_alignments(circ):
         raise QASMUnsupportedError(
             "Circuit contains classical expressions on registers whose arguments or "

--- a/pytket/pytket/qasm/qasm.py
+++ b/pytket/pytket/qasm/qasm.py
@@ -69,7 +69,11 @@ from pytket.circuit import (
     QubitRegister,
     UnitID,
 )
-from pytket.circuit.clexpr import has_reg_output, wired_clexpr_from_logic_exp
+from pytket.circuit.clexpr import (
+    check_register_alignments,
+    has_reg_output,
+    wired_clexpr_from_logic_exp,
+)
 from pytket.circuit.decompose_classical import int_to_bools
 from pytket.circuit.logic_exp import (
     BitLogicExp,
@@ -1136,6 +1140,11 @@ def check_can_convert_circuit(circ: Circuit, header: str, maxwidth: int) -> None
             raise QASMUnsupportedError(
                 f"Empty CustomGates and opaque gates are not supported."
             )
+    if not check_register_alignments(circ):
+        raise QASMUnsupportedError(
+            "Circuit contains classical expressions on registers whose arguments or "
+            "outputs are not register-aligned."
+        )
 
 
 def circuit_to_qasm_str(

--- a/pytket/pytket/qasm/qasm.py
+++ b/pytket/pytket/qasm/qasm.py
@@ -1158,12 +1158,12 @@ def circuit_to_qasm_str(
     :return: qasm string
     """
 
-    check_can_convert_circuit(circ, header, maxwidth)
     qasm_writer = QasmWriter(
         circ.qubits, circ.bits, header, include_gate_defs, maxwidth
     )
     circ1 = circ.copy()
     DecomposeBoxes().apply(circ1)
+    check_can_convert_circuit(circ1, header, maxwidth)
     for command in circ1:
         assert isinstance(command, Command)
         qasm_writer.add_op(command.op, command.args)

--- a/pytket/pytket/qasm/qasm.py
+++ b/pytket/pytket/qasm/qasm.py
@@ -1792,9 +1792,9 @@ class QasmWriter:
                     input_regs[i] = creg
                     break
             else:
-                raise QASMUnsupportedError(
-                    f"ClExprOp ({wexpr}) contains a register variable (r{i}) "
-                    "that is not wired to any BitRegister in the circuit."
+                assert (
+                    not f"ClExprOp ({wexpr}) contains a register variable (r{i}) that "
+                    "is not wired to any BitRegister in the circuit."
                 )
         # 2. Write the left-hand side of the assignment.
         output_repr: Optional[str] = None
@@ -1812,6 +1812,8 @@ class QasmWriter:
             for creg in all_cregs:
                 if creg.to_list() == output_args:
                     output_repr = creg.name
+                    break
+            assert output_repr is not None
         self.strings.add_string(f"{output_repr} = ")
         # 3. Write the right-hand side of the assignment.
         self.strings.add_string(

--- a/pytket/tests/qasm_test.py
+++ b/pytket/tests/qasm_test.py
@@ -451,9 +451,9 @@ def test_opaque() -> None:
     c = circuit_from_qasm_str(
         'OPENQASM 2.0;\ninclude "qelib1.inc";\nqreg q[4];\nopaque myopaq() q1, q2;\n myopaq() q[0], q[1];'
     )
-    with pytest.raises(QASMUnsupportedError) as e:
-        circuit_to_qasm_str(c)
-    assert "Empty CustomGates and opaque gates are not supported" in str(e.value)
+    assert (
+        circuit_to_qasm_str(c) == 'OPENQASM 2.0;\ninclude "qelib1.inc";\n\nqreg q[4];\n'
+    )
 
 
 def test_alternate_encoding() -> None:


### PR DESCRIPTION
Closes #1644 .

Includes a fix to check the suitability of a pytket circuit for conversion to QASM _after_ calling `DecomposeBoxes()`.