### PR TITLE
docs: link to pytket-quest extensions docs

### DIFF
--- a/pytket/docs/extensions.md
+++ b/pytket/docs/extensions.md
@@ -69,6 +69,8 @@ A full list of available pytket backends is shown below.
 [ProjectQBackend](inv:#*.ProjectQBackend)
 \- Backend for running statevector simulations on the ProjectQ simulator.
 
+[QuESTBackend](https://docs.quantinuum.com/tket/extensions/pytket-quest/api.html#pytket.extensions.quest.QuESTBackend) Interface to the [QUEST simulator](https://quest.qtechtheory.org/docs/).
+
 ## Unitary Simulators
 
 [AerUnitaryBackend](inv:#*.AerUnitaryBackend) - Backend for running simulations on the Qiskit Aer unitary simulator.

--- a/pytket/docs/extensions.md
+++ b/pytket/docs/extensions.md
@@ -127,7 +127,7 @@ pytket-pyzx <https://docs.quantinuum.com/tket/extensions/pytket-pyzx>
 pytket-qir <https://docs.quantinuum.com/tket/extensions/pytket-qir>
 pytket-qiskit <https://docs.quantinuum.com/tket/extensions/pytket-qiskit>
 pytket-quantinuum <https://docs.quantinuum.com/tket/extensions/pytket-quantinuum>
-pytket-quest <https://docs.quantinuum.com/tket/extensions/pytket-quest>_
+pytket-quest <https://docs.quantinuum.com/tket/extensions/pytket-quest>
 pytket-cutensornet <https://docs.quantinuum.com/tket/extensions/pytket-cutensornet>
 pytket-qulacs <https://docs.quantinuum.com/tket/extensions/pytket-qulacs>
 pytket-qujax <https://docs.quantinuum.com/tket/extensions/pytket-qujax>

--- a/pytket/docs/extensions.md
+++ b/pytket/docs/extensions.md
@@ -123,6 +123,7 @@ pytket-pyzx <https://docs.quantinuum.com/tket/extensions/pytket-pyzx>
 pytket-qir <https://docs.quantinuum.com/tket/extensions/pytket-qir>
 pytket-qiskit <https://docs.quantinuum.com/tket/extensions/pytket-qiskit>
 pytket-quantinuum <https://docs.quantinuum.com/tket/extensions/pytket-quantinuum>
+pytket-quest <https://docs.quantinuum.com/tket/extensions/pytket-quest>_
 pytket-cutensornet <https://docs.quantinuum.com/tket/extensions/pytket-cutensornet>
 pytket-qulacs <https://docs.quantinuum.com/tket/extensions/pytket-qulacs>
 pytket-qujax <https://docs.quantinuum.com/tket/extensions/pytket-qujax>

--- a/pytket/docs/extensions.md
+++ b/pytket/docs/extensions.md
@@ -75,6 +75,8 @@ A full list of available pytket backends is shown below.
 
 ## Density Matrix Simulators
 
+[AerDensityMatrixBackend](inv:#*qiskit.AerDensityMatrixBackend) - Backend for density matrix simulation using qiskit Aer. Can take a `NoiseModel` as an optional argument.
+
 [CirqDensityMatrixSampleBackend](inv:#*.CirqDensityMatrixSampleBackend)
 \- Backend for Cirq density matrix simulator sampling.
 


### PR DESCRIPTION
# Description

Adding a crosslink to the extensions index to mention pytket-quest. Should I also mention quest explicitly as a density matrix simulator?

Driveby: mention `AerDensityMatrixBackend` from pytket-qiskit which was left out until now.