### PR TITLE
docs: cherrypick #1658 onto `docmain`

### DIFF
--- a/pytket/binders/circuit/clexpr.cpp
+++ b/pytket/binders/circuit/clexpr.cpp
@@ -423,7 +423,9 @@ void init_clexpr(py::module &m) {
   py::class_<ClBitVar, std::shared_ptr<ClBitVar>>(
       m, "ClBitVar", "A bit variable within an expression")
       .def(
-          py::init<unsigned>(), "Construct from an integer identifier",
+          py::init<unsigned>(),
+          "Construct from an integer identifier.\n\n"
+          ":param i: integer identifier for the variable",
           py::arg("i"))
       .def("__eq__", &py_equals<ClBitVar>)
       .def(
@@ -443,12 +445,14 @@ void init_clexpr(py::module &m) {
       .def("__hash__", [](const ClBitVar &var) { return var.index; })
       .def_property_readonly(
           "index", [](const ClBitVar &var) { return var.index; },
-          ":return: integer identifier for the variable");
+          "integer identifier for the variable");
 
   py::class_<ClRegVar, std::shared_ptr<ClRegVar>>(
       m, "ClRegVar", "A register variable within an expression")
       .def(
-          py::init<unsigned>(), "Construct from an integer identifier",
+          py::init<unsigned>(),
+          "Construct from an integer identifier.\n\n"
+          ":param i: integer identifier for the variable",
           py::arg("i"))
       .def("__eq__", &py_equals<ClRegVar>)
       .def(
@@ -468,14 +472,18 @@ void init_clexpr(py::module &m) {
       .def("__hash__", [](const ClRegVar &var) { return var.index; })
       .def_property_readonly(
           "index", [](const ClRegVar &var) { return var.index; },
-          ":return: integer identifier for the variable");
+          "integer identifier for the variable");
 
   py::class_<ClExpr, std::shared_ptr<ClExpr>>(
       m, "ClExpr", "A classical expression")
       .def(
           py::init<ClOp, std::vector<ClExprArg>>(),
-          "Construct from an operation and a list of arguments", py::arg("op"),
-          py::arg("args"))
+          "Construct from an operation type and a list of arguments.\n\n"
+          ":param op: the operation type\n"
+          ":param args: list of arguments to the expression (which may be "
+          "integers, :py:class:`ClBitVar` variables, :py:class:`ClRegVar` "
+          "variables, or other :py:class:`ClExpr`)",
+          py::arg("op"), py::arg("args"))
       .def("__eq__", &py_equals<ClExpr>)
       .def(
           "__str__",
@@ -485,8 +493,8 @@ void init_clexpr(py::module &m) {
             return ss.str();
           })
       .def("__hash__", &deletedHash<ClExpr>, deletedHashDocstring)
-      .def_property_readonly("op", &ClExpr::get_op, ":return: main operation")
-      .def_property_readonly("args", &ClExpr::get_args, ":return: arguments")
+      .def_property_readonly("op", &ClExpr::get_op, "main operation")
+      .def_property_readonly("args", &ClExpr::get_args, "arguments")
       .def(
           "as_qasm",
           [](const ClExpr &expr, const std::map<int, Bit> input_bits,
@@ -499,13 +507,24 @@ void init_clexpr(py::module &m) {
 
   py::class_<WiredClExpr, std::shared_ptr<WiredClExpr>>(
       m, "WiredClExpr",
-      "A classical expression defined over a sequence of bits")
+      "An operation defined by a classical expression over a sequence of bits")
       .def(
           py::init<
               ClExpr, std::map<unsigned, unsigned>,
               std::map<unsigned, std::vector<unsigned>>,
               std::vector<unsigned>>(),
-          "Construct from an expression with bit and register positions",
+          "Construct from an expression with bit and register positions.\n\n"
+          ":param expr: an abstract classical expression\n"
+          ":param bit_posn: a map whose keys are the indices of the "
+          ":py:class:`ClBitVar` occurring in the expression, and whose values "
+          "are the positions of the corresponding bits in the arguments of the "
+          "operation\n"
+          ":param reg_posn: a map whose keys are the indices of the "
+          ":py:class:`ClRegVar` occurring in the expression, and whose values "
+          "are the sequences of positions of the corresponding bits in the "
+          "arguments of the operation\n"
+          ":param output_posn: a list giving the positions of the output bits "
+          "in the arguments of the operation",
           py::arg("expr"), py::arg("bit_posn") = std::map<unsigned, unsigned>(),
           py::arg("reg_posn") = std::map<unsigned, std::vector<unsigned>>(),
           py::arg("output_posn") = std::vector<unsigned>())
@@ -518,15 +537,13 @@ void init_clexpr(py::module &m) {
             return ss.str();
           })
       .def("__hash__", &deletedHash<WiredClExpr>, deletedHashDocstring)
+      .def_property_readonly("expr", &WiredClExpr::get_expr, "expression")
       .def_property_readonly(
-          "expr", &WiredClExpr::get_expr, ":return: expression")
+          "bit_posn", &WiredClExpr::get_bit_posn, "bit positions")
       .def_property_readonly(
-          "bit_posn", &WiredClExpr::get_bit_posn, ":return: bit positions")
+          "reg_posn", &WiredClExpr::get_reg_posn, "register positions")
       .def_property_readonly(
-          "reg_posn", &WiredClExpr::get_reg_posn, ":return: register positions")
-      .def_property_readonly(
-          "output_posn", &WiredClExpr::get_output_posn,
-          ":return: output positions")
+          "output_posn", &WiredClExpr::get_output_posn, "output positions")
       .def(
           "to_dict",
           [](const WiredClExpr &wexpr) {
@@ -545,10 +562,9 @@ void init_clexpr(py::module &m) {
       .def(
           py::init<WiredClExpr>(),
           "Construct from a wired classical expression")
+      .def_property_readonly("type", &ClExprOp::get_type, "operation type")
       .def_property_readonly(
-          "type", &ClExprOp::get_type, ":return: operation type")
-      .def_property_readonly(
-          "expr", &ClExprOp::get_wired_expr, ":return: wired expression");
+          "expr", &ClExprOp::get_wired_expr, "wired expression");
 }
 
 }  // namespace tket

--- a/pytket/docs/circuit.rst
+++ b/pytket/docs/circuit.rst
@@ -65,6 +65,23 @@ pytket.circuit
     :members:
 .. autoclass:: pytket.circuit.ClassicalExpBox
     :members:
+.. autoclass:: pytket.circuit.ClExprOp
+    :special-members:
+    :members:
+.. autoclass:: pytket.circuit.WiredClExpr
+    :special-members: __init__
+    :members:
+.. autoclass:: pytket.circuit.ClExpr
+    :special-members: __init__
+    :members:
+.. autoclass:: pytket.circuit.ClOp
+    :members:
+.. autoclass:: pytket.circuit.ClBitVar
+    :special-members: __init__
+    :members:
+.. autoclass:: pytket.circuit.ClRegVar
+    :special-members: __init__
+    :members:
 .. autoclass:: pytket.circuit.PhasePolyBox
     :special-members:
     :members:

--- a/pytket/docs/circuit_class.rst
+++ b/pytket/docs/circuit_class.rst
@@ -182,6 +182,8 @@ condition on a specified set of bit values.)
 
    .. automethod:: add_classicalexpbox_register
 
+   .. automethod:: add_clexpr
+
    .. automethod:: qubit_create
 
    .. automethod:: qubit_create_all

--- a/pytket/pytket/_tket/circuit.pyi
+++ b/pytket/pytket/_tket/circuit.pyi
@@ -2561,7 +2561,9 @@ class ClBitVar:
         ...
     def __init__(self, i: int) -> None:
         """
-        Construct from an integer identifier
+        Construct from an integer identifier.
+        
+        :param i: integer identifier for the variable
         """
     def __repr__(self) -> str:
         ...
@@ -2570,7 +2572,7 @@ class ClBitVar:
     @property
     def index(self) -> int:
         """
-        :return: integer identifier for the variable
+        integer identifier for the variable
         """
 class ClExpr:
     """
@@ -2587,7 +2589,10 @@ class ClExpr:
         """
     def __init__(self, op: ClOp, args: list[int | ClBitVar | ClRegVar | ClExpr]) -> None:
         """
-        Construct from an operation and a list of arguments
+        Construct from an operation type and a list of arguments.
+        
+        :param op: the operation type
+        :param args: list of arguments to the expression (which may be integers, :py:class:`ClBitVar` variables, :py:class:`ClRegVar` variables, or other :py:class:`ClExpr`)
         """
     def __str__(self) -> str:
         ...
@@ -2598,12 +2603,12 @@ class ClExpr:
     @property
     def args(self) -> list[int | ClBitVar | ClRegVar | ClExpr]:
         """
-        :return: arguments
+        arguments
         """
     @property
     def op(self) -> ClOp:
         """
-        :return: main operation
+        main operation
         """
 class ClExprOp(Op):
     """
@@ -2619,12 +2624,12 @@ class ClExprOp(Op):
     @property
     def expr(self) -> WiredClExpr:
         """
-        :return: wired expression
+        wired expression
         """
     @property
     def type(self) -> OpType:
         """
-        :return: operation type
+        operation type
         """
 class ClOp:
     """
@@ -2770,7 +2775,9 @@ class ClRegVar:
         ...
     def __init__(self, i: int) -> None:
         """
-        Construct from an integer identifier
+        Construct from an integer identifier.
+        
+        :param i: integer identifier for the variable
         """
     def __repr__(self) -> str:
         ...
@@ -2779,7 +2786,7 @@ class ClRegVar:
     @property
     def index(self) -> int:
         """
-        :return: integer identifier for the variable
+        integer identifier for the variable
         """
 class ClassicalEvalOp(ClassicalOp):
     """
@@ -4389,7 +4396,7 @@ class WASMOp(ClassicalOp):
         """
 class WiredClExpr:
     """
-    A classical expression defined over a sequence of bits
+    An operation defined by a classical expression over a sequence of bits
     """
     @staticmethod
     def _pybind11_conduit_v1_(*args, **kwargs):  # type: ignore
@@ -4407,7 +4414,12 @@ class WiredClExpr:
         """
     def __init__(self, expr: ClExpr, bit_posn: dict[int, int] = {}, reg_posn: dict[int, list[int]] = {}, output_posn: list[int] = []) -> None:
         """
-        Construct from an expression with bit and register positions
+        Construct from an expression with bit and register positions.
+        
+        :param expr: an abstract classical expression
+        :param bit_posn: a map whose keys are the indices of the :py:class:`ClBitVar` occurring in the expression, and whose values are the positions of the corresponding bits in the arguments of the operation
+        :param reg_posn: a map whose keys are the indices of the :py:class:`ClRegVar` occurring in the expression, and whose values are the sequences of positions of the corresponding bits in the arguments of the operation
+        :param output_posn: a list giving the positions of the output bits in the arguments of the operation
         """
     def __str__(self) -> str:
         ...
@@ -4418,22 +4430,22 @@ class WiredClExpr:
     @property
     def bit_posn(self) -> dict[int, int]:
         """
-        :return: bit positions
+        bit positions
         """
     @property
     def expr(self) -> ClExpr:
         """
-        :return: expression
+        expression
         """
     @property
     def output_posn(self) -> list[int]:
         """
-        :return: output positions
+        output positions
         """
     @property
     def reg_posn(self) -> dict[int, list[int]]:
         """
-        :return: register positions
+        register positions
         """
 def fresh_symbol(preferred: str = 'a') -> sympy.Symbol:
     """


### PR DESCRIPTION
# Description

Cherrypicking the change from #1658 so we can have the documentation of `ClExpr` in the docs prior to the next release. Is there another commit I need as well?
