### PR TITLE
Remove `OpType::Collapse` from `gen_auto_rebase_pass` `GateSetPredicate`

### DIFF
--- a/pytket/binders/passes.cpp
+++ b/pytket/binders/passes.cpp
@@ -540,7 +540,7 @@ PYBIND11_MODULE(passes, m) {
   m.def(
       "RebaseTket", &RebaseTket,
       "Converts all gates to CX, TK1 and Phase. "
-      "(Any Measure, Reset and Collapse operations are left untouched; "
+      "(Any Measure and Reset operations are left untouched; "
       "Conditional gates are also allowed.)");
   m.def(
       "RemoveRedundancies", &RemoveRedundancies,
@@ -650,7 +650,7 @@ PYBIND11_MODULE(passes, m) {
       ":math:`(a,b,c)` to generate replacement circuits."
       "\n\n"
       ":param gateset: the allowed operations in the rebased circuit "
-      "(in addition, Measure, Reset and Collapse operations are always allowed "
+      "(in addition, Measure and Reset operations are always allowed "
       "and are left alone; conditional operations may be present; and Phase "
       "gates may also be introduced by the rebase)"
       "\n:param cx_replacement: the equivalent circuit to replace a CX gate "
@@ -660,8 +660,7 @@ PYBIND11_MODULE(passes, m) {
       "Rz(a)Rx(b)Rz(c) triple, returns an equivalent circuit in the desired "
       "basis"
       "\n:return: a pass that rebases to the given gate set (possibly "
-      "including conditional and phase operations, and Measure, Reset and "
-      "Collapse)",
+      "including conditional and phase operations, and Measure and Reset",
       py::arg("gateset"), py::arg("cx_replacement"),
       py::arg("tk1_replacement"));
 
@@ -679,7 +678,7 @@ PYBIND11_MODULE(passes, m) {
       "to each TK1(a,b,c)."
       "\n\n"
       ":param gateset: the allowed operations in the rebased circuit "
-      "(in addition, Measure, Reset and Collapse operations are always allowed "
+      "(in addition, Measure and Reset always allowed "
       "and are left alone; conditional operations may be present; and Phase "
       "gates may also be introduced by the rebase)\n"
       ":param tk2_replacement: a function which, given the parameters (a,b,c) "
@@ -689,7 +688,7 @@ PYBIND11_MODULE(passes, m) {
       "of an Rz(a)Rx(b)Rz(c) triple, returns an equivalent circuit in the "
       "desired basis\n"
       ":return: a pass that rebases to the given gate set (possibly including "
-      "conditional and phase operations, and Measure, Reset and Collapse)",
+      "conditional and phase operations, and Measure and Reset)",
       py::arg("gateset"), py::arg("tk2_replacement"),
       py::arg("tk1_replacement"));
   m.def(
@@ -701,7 +700,7 @@ PYBIND11_MODULE(passes, m) {
       "Raises an error if no known decompositions can be found, in which case "
       "try using :py:class:`RebaseCustom` with your own decompositions.\n\n"
       ":param gateset: Set of supported OpTypes, target gate set. "
-      "(in addition, Measure, Reset and Collapse operations are always allowed "
+      "(in addition, Measure and Reset operations are always allowed "
       "and are left alone; conditional operations may be present; and Phase "
       "gates may also be introduced by the rebase)\n"
       ":param allow_swaps: Whether to allow implicit wire swaps. Default to "

--- a/pytket/conanfile.py
+++ b/pytket/conanfile.py
@@ -38,7 +38,7 @@ class pytketRecipe(ConanFile):
         self.requires("pybind11_json/0.2.14")
         self.requires("symengine/0.13.0")
         self.requires("tkassert/0.3.4@tket/stable")
-        self.requires("tket/1.3.46@tket/stable")
+        self.requires("tket/1.3.47@tket/stable")
         self.requires("tklog/0.3.3@tket/stable")
         self.requires("tkrng/0.3.3@tket/stable")
         self.requires("tktokenswap/0.3.9@tket/stable")

--- a/pytket/docs/changelog.rst
+++ b/pytket/docs/changelog.rst
@@ -21,6 +21,7 @@ Features:
 * Extend `DecomposeClassicalExp` to handle `ClExprOp` as well as
   `ClassicalExpBox`.
 * Add convenience method `Circuit.add_clecpr_from_logicexp()`.
+* Remove `OpType::Collapse` from the `GateSetPredicate` of `gen_auto_rebase_pass`.
 
 Deprecations:
 

--- a/pytket/pytket/_tket/passes.pyi
+++ b/pytket/pytket/_tket/passes.pyi
@@ -249,7 +249,7 @@ def AutoRebase(gateset: set[pytket._tket.circuit.OpType], allow_swaps: bool = Fa
     Attempt to generate a rebase pass automatically for the given target gateset. Checks if there are known existing decompositions to target gateset and TK1 to target gateset and uses those to construct a custom rebase.
     Raises an error if no known decompositions can be found, in which case try using :py:class:`RebaseCustom` with your own decompositions.
     
-    :param gateset: Set of supported OpTypes, target gate set. (in addition, Measure, Reset and Collapse operations are always allowed and are left alone; conditional operations may be present; and Phase gates may also be introduced by the rebase)
+    :param gateset: Set of supported OpTypes, target gate set. (in addition, Measure and Reset operations are always allowed and are left alone; conditional operations may be present; and Phase gates may also be introduced by the rebase)
     :param allow_swaps: Whether to allow implicit wire swaps. Default to False.
     """
 def AutoSquash(singleqs: set[pytket._tket.circuit.OpType]) -> BasePass:
@@ -564,10 +564,10 @@ def RebaseCustom(gateset: set[pytket._tket.circuit.OpType], cx_replacement: pytk
     3. converts any single-qubit gates not in the gate type set to the form :math:`\\mathrm{Rz}(a)\\mathrm{Rx}(b)\\mathrm{Rz}(c)` (in matrix-multiplication order, i.e. reverse order in the circuit);
     4. applies the `tk1_replacement` function to each of these triples :math:`(a,b,c)` to generate replacement circuits.
     
-    :param gateset: the allowed operations in the rebased circuit (in addition, Measure, Reset and Collapse operations are always allowed and are left alone; conditional operations may be present; and Phase gates may also be introduced by the rebase)
+    :param gateset: the allowed operations in the rebased circuit (in addition, Measure and Reset operations are always allowed and are left alone; conditional operations may be present; and Phase gates may also be introduced by the rebase)
     :param cx_replacement: the equivalent circuit to replace a CX gate using two qubit gates from the desired basis (can use any single qubit OpTypes)
     :param tk1_replacement: a function which, given the parameters of an Rz(a)Rx(b)Rz(c) triple, returns an equivalent circuit in the desired basis
-    :return: a pass that rebases to the given gate set (possibly including conditional and phase operations, and Measure, Reset and Collapse)
+    :return: a pass that rebases to the given gate set (possibly including conditional and phase operations, and Measure and Reset
     """
 @typing.overload
 def RebaseCustom(gateset: set[pytket._tket.circuit.OpType], tk2_replacement: typing.Callable[[sympy.Expr | float, sympy.Expr | float, sympy.Expr | float], pytket._tket.circuit.Circuit], tk1_replacement: typing.Callable[[sympy.Expr | float, sympy.Expr | float, sympy.Expr | float], pytket._tket.circuit.Circuit]) -> BasePass:
@@ -579,14 +579,14 @@ def RebaseCustom(gateset: set[pytket._tket.circuit.OpType], tk2_replacement: typ
     3. converts any single-qubit gates not in the gate type set to TK1;
     4. if TK2 is not in `gateset`. applies the `tk1_replacement` function to each TK1(a,b,c).
     
-    :param gateset: the allowed operations in the rebased circuit (in addition, Measure, Reset and Collapse operations are always allowed and are left alone; conditional operations may be present; and Phase gates may also be introduced by the rebase)
+    :param gateset: the allowed operations in the rebased circuit (in addition, Measure and Reset always allowed and are left alone; conditional operations may be present; and Phase gates may also be introduced by the rebase)
     :param tk2_replacement: a function which, given the parameters (a,b,c) of an XXPhase(a)YYPhase(b)ZZPhase(c) triple, returns an equivalent circuit in the desired basis
     :param tk1_replacement: a function which, given the parameters (a,b,c) of an Rz(a)Rx(b)Rz(c) triple, returns an equivalent circuit in the desired basis
-    :return: a pass that rebases to the given gate set (possibly including conditional and phase operations, and Measure, Reset and Collapse)
+    :return: a pass that rebases to the given gate set (possibly including conditional and phase operations, and Measure and Reset)
     """
 def RebaseTket() -> BasePass:
     """
-    Converts all gates to CX, TK1 and Phase. (Any Measure, Reset and Collapse operations are left untouched; Conditional gates are also allowed.)
+    Converts all gates to CX, TK1 and Phase. (Any Measure and Reset operations are left untouched; Conditional gates are also allowed.)
     """
 def RemoveBarriers() -> BasePass:
     """

--- a/pytket/pytket/passes/auto_rebase.py
+++ b/pytket/pytket/passes/auto_rebase.py
@@ -44,8 +44,8 @@ def auto_rebase_pass(gateset: set[OpType], allow_swaps: bool = False) -> BasePas
     Raises an error if no known decompositions can be found, in which case try
     using RebaseCustom with your own decompositions.
 
-    In addition to the gate types in ``gateset``, any ``Measure``, ``Reset`` and
-    ``Collapse`` operations in the original circuit are retained. Conditional
+    In addition to the gate types in ``gateset``, any ``Measure`` and ``Reset``
+    operations in the original circuit are retained. Conditional
     operations are also allowed. ``Phase`` gates may also be introduced.
 
     :param gateset: Set of supported OpTypes, target gate set.

--- a/tket/conanfile.py
+++ b/tket/conanfile.py
@@ -23,7 +23,7 @@ from conan.errors import ConanInvalidConfiguration
 
 class TketConan(ConanFile):
     name = "tket"
-    version = "1.3.46"
+    version = "1.3.47"
     package_type = "library"
     license = "Apache 2"
     homepage = "https://github.com/CQCL/tket"

--- a/tket/src/Predicates/PassGenerators.cpp
+++ b/tket/src/Predicates/PassGenerators.cpp
@@ -244,7 +244,6 @@ PassPtr gen_auto_rebase_pass(const OpTypeSet& allowed_gates, bool allow_swaps) {
   PredicatePtrMap precons;
   OpTypeSet all_types(allowed_gates);
   all_types.insert(OpType::Measure);
-  all_types.insert(OpType::Collapse);
   all_types.insert(OpType::Reset);
   PredicatePtr postcon1 = std::make_shared<GateSetPredicate>(all_types);
   PredicatePtr postcon2 = std::make_shared<MaxTwoQubitGatesPredicate>();


### PR DESCRIPTION
`OpType::Collapse` isn't available at the python layer - there is no `OpType.Collapse` - and is not a supported operation in any `Backends` we have. Currently, I don't think it's even possible to construct a pytket `Circuit` with `Collapse` operations, having briefly looked through where it is used.

However, it's proving a blocker on `SequencePass` construction in some places. As an example, `GreedyPauliSimp` supports all the `OpType` required to compile to qiskit & quantinuum hardware, but if added to a `SequencePass` after an `AutoRebasePass`, the `SequencePass` construction fails due to `OpType::Collapse` always being included in the `GateSetPredicate`.


# Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have commented hard-to-understand parts of my code.
- [ ] I have made corresponding changes to the public API documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have updated the changelog with any user-facing changes.
