### PR TITLE
Remove all references to dead vertices in ZX extraction

### DIFF
--- a/pytket/conanfile.py
+++ b/pytket/conanfile.py
@@ -38,7 +38,7 @@ class pytketRecipe(ConanFile):
         self.requires("pybind11_json/0.2.14")
         self.requires("symengine/0.13.0")
         self.requires("tkassert/0.3.4@tket/stable")
-        self.requires("tket/1.3.48@tket/stable")
+        self.requires("tket/1.3.49@tket/stable")
         self.requires("tklog/0.3.3@tket/stable")
         self.requires("tkrng/0.3.3@tket/stable")
         self.requires("tktokenswap/0.3.9@tket/stable")

--- a/tket/conanfile.py
+++ b/tket/conanfile.py
@@ -23,7 +23,7 @@ from conan.errors import ConanInvalidConfiguration
 
 class TketConan(ConanFile):
     name = "tket"
-    version = "1.3.48"
+    version = "1.3.49"
     package_type = "library"
     license = "Apache 2"
     homepage = "https://github.com/CQCL/tket"

--- a/tket/test/src/ZX/test_ZXSimp.cpp
+++ b/tket/test/src/ZX/test_ZXSimp.cpp
@@ -191,47 +191,40 @@ SCENARIO("Testing for vertex reuse bug") {
    * new vertices would be added which may (depending on how boost was feeling
    * with memory) reuse the same memory locations, so the old pointers now
    * worked, meaning lookups in sets/functions would give false positives.
-   *
-   * Running these multiple times to give a low chance of a false positive when
-   * running this on CI.
    */
   GIVEN("Offender 1") {
-    for (unsigned i = 0; i < 50; ++i) {
-      Circuit circ(3);
-      circ.add_op<unsigned>(OpType::H, {1});
-      circ.add_op<unsigned>(OpType::H, {2});
-      circ.add_op<unsigned>(OpType::CX, {2, 1});
-      circ.add_op<unsigned>(OpType::Rz, 1.1, {1});
-      circ.add_op<unsigned>(OpType::H, {0});
-      circ.add_op<unsigned>(OpType::CX, {2, 1});
-      circ.add_op<unsigned>(OpType::H, {1});
-      circ.add_op<unsigned>(OpType::H, {2});
-      circ.add_op<unsigned>(OpType::Rz, 0.970644, {1});
-      circ.add_op<unsigned>(OpType::Rz, 0.9, {2});
-      circ.add_op<unsigned>(OpType::H, {1});
-      circ.add_op<unsigned>(OpType::H, {2});
+    Circuit circ(3);
+    circ.add_op<unsigned>(OpType::H, {1});
+    circ.add_op<unsigned>(OpType::H, {2});
+    circ.add_op<unsigned>(OpType::CX, {2, 1});
+    circ.add_op<unsigned>(OpType::Rz, 1.1, {1});
+    circ.add_op<unsigned>(OpType::H, {0});
+    circ.add_op<unsigned>(OpType::CX, {2, 1});
+    circ.add_op<unsigned>(OpType::H, {1});
+    circ.add_op<unsigned>(OpType::H, {2});
+    circ.add_op<unsigned>(OpType::Rz, 0.970644, {1});
+    circ.add_op<unsigned>(OpType::Rz, 0.9, {2});
+    circ.add_op<unsigned>(OpType::H, {1});
+    circ.add_op<unsigned>(OpType::H, {2});
 
-      CompilationUnit cu(circ);
-      ZXGraphlikeOptimisation()->apply(cu);
-    }
+    CompilationUnit cu(circ);
+    ZXGraphlikeOptimisation()->apply(cu);
   }
   GIVEN("Offender 2") {
-    for (unsigned i = 0; i < 50; ++i) {
-      Circuit circ(6);
-      circ.add_op<unsigned>(OpType::Rx, -0.78, {3});
-      circ.add_op<unsigned>(OpType::Rx, 1.069, {5});
-      circ.add_op<unsigned>(OpType::CX, {0, 3});
-      circ.add_op<unsigned>(OpType::CX, {3, 5});
-      circ.add_op<unsigned>(OpType::CX, {0, 5});
-      circ.add_op<unsigned>(OpType::Rx, 1.069, {3});
-      circ.add_op<unsigned>(OpType::Rx, -5.958, {4});
-      circ.add_op<unsigned>(OpType::CX, {3, 4});
-      circ.add_op<unsigned>(OpType::CX, {3, 5});
-      circ.add_op<unsigned>(OpType::CX, {0, 3});
+    Circuit circ(6);
+    circ.add_op<unsigned>(OpType::Rx, -0.78, {3});
+    circ.add_op<unsigned>(OpType::Rx, 1.069, {5});
+    circ.add_op<unsigned>(OpType::CX, {0, 3});
+    circ.add_op<unsigned>(OpType::CX, {3, 5});
+    circ.add_op<unsigned>(OpType::CX, {0, 5});
+    circ.add_op<unsigned>(OpType::Rx, 1.069, {3});
+    circ.add_op<unsigned>(OpType::Rx, -5.958, {4});
+    circ.add_op<unsigned>(OpType::CX, {3, 4});
+    circ.add_op<unsigned>(OpType::CX, {3, 5});
+    circ.add_op<unsigned>(OpType::CX, {0, 3});
 
-      CompilationUnit cu(circ);
-      ZXGraphlikeOptimisation()->apply(cu);
-    }
+    CompilationUnit cu(circ);
+    ZXGraphlikeOptimisation()->apply(cu);
   }
 }
 

--- a/tket/test/src/ZX/test_ZXSimp.cpp
+++ b/tket/test/src/ZX/test_ZXSimp.cpp
@@ -15,6 +15,7 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include "tket/Converters/Converters.hpp"
+#include "tket/Predicates/PassLibrary.hpp"
 #include "tket/Transformations/Rebase.hpp"
 #include "tket/ZX/Rewrite.hpp"
 
@@ -176,6 +177,60 @@ SCENARIO("Testing cases for internalising gadgets in MBQC") {
           (axis_basis == ZXType::XY &&
            (gadget_basis == ZXType::XY || gadget_basis == ZXType::XZ)) ^
           changed);
+    }
+  }
+}
+
+SCENARIO("Testing for vertex reuse bug") {
+  /**
+   * The following circuits were shown to hit errors non-deterministically, with
+   * the error likelihood varying with the device.
+   *
+   * At some point during extraction, a vertex would be removed from the graph,
+   * but some pointers to it lingered. Later, if an input extension occurred,
+   * new vertices would be added which may (depending on how boost was feeling
+   * with memory) reuse the same memory locations, so the old pointers now
+   * worked, meaning lookups in sets/functions would give false positives.
+   *
+   * Running these multiple times to give a low chance of a false positive when
+   * running this on CI.
+   */
+  GIVEN("Offender 1") {
+    for (unsigned i = 0; i < 50; ++i) {
+      Circuit circ(3);
+      circ.add_op<unsigned>(OpType::H, {1});
+      circ.add_op<unsigned>(OpType::H, {2});
+      circ.add_op<unsigned>(OpType::CX, {2, 1});
+      circ.add_op<unsigned>(OpType::Rz, 1.1, {1});
+      circ.add_op<unsigned>(OpType::H, {0});
+      circ.add_op<unsigned>(OpType::CX, {2, 1});
+      circ.add_op<unsigned>(OpType::H, {1});
+      circ.add_op<unsigned>(OpType::H, {2});
+      circ.add_op<unsigned>(OpType::Rz, 0.970644, {1});
+      circ.add_op<unsigned>(OpType::Rz, 0.9, {2});
+      circ.add_op<unsigned>(OpType::H, {1});
+      circ.add_op<unsigned>(OpType::H, {2});
+
+      CompilationUnit cu(circ);
+      ZXGraphlikeOptimisation()->apply(cu);
+    }
+  }
+  GIVEN("Offender 2") {
+    for (unsigned i = 0; i < 50; ++i) {
+      Circuit circ(6);
+      circ.add_op<unsigned>(OpType::Rx, -0.78, {3});
+      circ.add_op<unsigned>(OpType::Rx, 1.069, {5});
+      circ.add_op<unsigned>(OpType::CX, {0, 3});
+      circ.add_op<unsigned>(OpType::CX, {3, 5});
+      circ.add_op<unsigned>(OpType::CX, {0, 5});
+      circ.add_op<unsigned>(OpType::Rx, 1.069, {3});
+      circ.add_op<unsigned>(OpType::Rx, -5.958, {4});
+      circ.add_op<unsigned>(OpType::CX, {3, 4});
+      circ.add_op<unsigned>(OpType::CX, {3, 5});
+      circ.add_op<unsigned>(OpType::CX, {0, 3});
+
+      CompilationUnit cu(circ);
+      ZXGraphlikeOptimisation()->apply(cu);
     }
   }
 }


### PR DESCRIPTION
# Description

During extraction, vertices are gradually removed from a ZX graph as we extract gates. Some additional tracking info is maintained via sets and maps of vertices. When vertices are removed, this shouldn't cause issues with looking up remaining vertices in these sets and maps.

HOWEVER, if needed it will perform an input extension which adds new vertices to the graph. Depending on how boost is feeling with memory management, it may reuse the memory locations of removed vertices for these new ones. Because the vertex descriptors are void* pointers under the hood, this clash of memory locations means we can get false positives when looking up vertices in the sets/maps.

#1566 and a related circuit found internally were shown to hit errors during extraction which at first seemed device-dependent, but was found to just be non-deterministic on any device. These were due to one of these false positive lookups which cause some vertices to be ignored when looking for a flow (hence the error message `Error during extraction from ZX diagram: diagram does not have gflow`).

Given the bug only occurs with some probability (that may be device-dependent), the tests for this fix run the circuits a bunch of times to reduce the likelihood of a false positive for CI.

# Related issues

Closes #1566 

# Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented hard-to-understand parts of my code.
- [ ] I have made corresponding changes to the public API documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the changelog with any user-facing changes.
