### PR TITLE
Remove use of thread for `greedy_pauli_optimisation`

### DIFF
--- a/pytket/binders/passes.cpp
+++ b/pytket/binders/passes.cpp
@@ -970,7 +970,7 @@ PYBIND11_MODULE(passes, m) {
       "\n:param allow_zzphase: If set to True, allows the algorithm to "
       "implement 2-qubit rotations using ZZPhase gates when deemed "
       "optimal. Defaults to False."
-      "\n:param thread_timeout: Sets maximum out of time spent finding a "
+      "\n:param timeout: Sets maximum out of time spent finding a "
       "single solution in one thread."
       "\n:param only_reduce: Only returns modified circuit if it has "
       "fewer two-qubit gates."
@@ -981,7 +981,7 @@ PYBIND11_MODULE(passes, m) {
       py::arg("discount_rate") = 0.7, py::arg("depth_weight") = 0.3,
       py::arg("max_lookahead") = 500, py::arg("max_tqe_candidates") = 500,
       py::arg("seed") = 0, py::arg("allow_zzphase") = false,
-      py::arg("thread_timeout") = 100, py::arg("only_reduce") = false,
+      py::arg("timeout") = 100, py::arg("only_reduce") = false,
       py::arg("trials") = 1);
   m.def(
       "PauliSquash", &PauliSquash,

--- a/pytket/binders/transform.cpp
+++ b/pytket/binders/transform.cpp
@@ -451,7 +451,7 @@ PYBIND11_MODULE(transform, m) {
           "\n:param allow_zzphase: If set to True, allows the algorithm to "
           "implement 2-qubit rotations using ZZPhase gates when deemed "
           "optimal. Defaults to False."
-          "\n:param thread_timeout: Sets maximum out of time spent finding a "
+          "\n:param timeout: Sets maximum out of time spent finding a "
           "single solution in one thread."
           "\n:param trials: Sets maximum number of found solutions. The "
           "smallest circuit is returned, prioritising the number of 2qb-gates, "
@@ -460,7 +460,7 @@ PYBIND11_MODULE(transform, m) {
           py::arg("discount_rate") = 0.7, py::arg("depth_weight") = 0.3,
           py::arg("max_tqe_candidates") = 500, py::arg("max_lookahead") = 500,
           py::arg("seed") = 0, py::arg("allow_zzphase") = false,
-          py::arg("thread_timeout") = 100, py::arg("trials") = 1)
+          py::arg("timeout") = 100, py::arg("trials") = 1)
       .def_static(
           "ZZPhaseToRz", &Transforms::ZZPhase_to_Rz,
           "Fixes all ZZPhase gate angles to [-1, 1) half turns.")

--- a/pytket/conanfile.py
+++ b/pytket/conanfile.py
@@ -38,7 +38,7 @@ class pytketRecipe(ConanFile):
         self.requires("pybind11_json/0.2.14")
         self.requires("symengine/0.13.0")
         self.requires("tkassert/0.3.4@tket/stable")
-        self.requires("tket/1.3.49@tket/stable")
+        self.requires("tket/1.3.50@tket/stable")
         self.requires("tklog/0.3.3@tket/stable")
         self.requires("tkrng/0.3.3@tket/stable")
         self.requires("tktokenswap/0.3.9@tket/stable")

--- a/pytket/docs/changelog.rst
+++ b/pytket/docs/changelog.rst
@@ -12,7 +12,7 @@ Features:
   conditions.
 * Add `custom_deserialisation` argument to `BasePass` and `SequencePass` 
   `from_dict` method to support construction of `CustomPass` from json.
-* Add `thread_timeout`, `only_reduce`, and `trials` arguments 
+* Add `timeout`, `only_reduce`, and `trials` arguments 
   to `GreedyPauliSimp`.
 * Add option to not relabel `ClassicalExpBox` when calling `rename_units`
   and `flatten_registers`

--- a/pytket/pytket/_tket/passes.pyi
+++ b/pytket/pytket/_tket/passes.pyi
@@ -447,7 +447,7 @@ def GlobalisePhasedX(squash: bool = True) -> BasePass:
     
     It is not recommended to use this pass with symbolic expressions, as in certain cases a blow-up in symbolic expression sizes may occur.
     """
-def GreedyPauliSimp(discount_rate: float = 0.7, depth_weight: float = 0.3, max_lookahead: int = 500, max_tqe_candidates: int = 500, seed: int = 0, allow_zzphase: bool = False, thread_timeout: int = 100, only_reduce: bool = False, trials: int = 1) -> BasePass:
+def GreedyPauliSimp(discount_rate: float = 0.7, depth_weight: float = 0.3, max_lookahead: int = 500, max_tqe_candidates: int = 500, seed: int = 0, allow_zzphase: bool = False, timeout: int = 100, only_reduce: bool = False, trials: int = 1) -> BasePass:
     """
     Construct a pass that converts a circuit into a graph of Pauli gadgets to account for commutation and phase folding, and resynthesises them using a greedy algorithm adapted from arxiv.org/abs/2103.08602. The method for synthesising the final Clifford operator is adapted from arxiv.org/abs/2305.10966.
     
@@ -457,7 +457,7 @@ def GreedyPauliSimp(discount_rate: float = 0.7, depth_weight: float = 0.3, max_l
     :param max_lookahead:  Maximum lookahead when evaluating each Clifford gate candidate. Default to 500.
     :param seed:  Unsigned integer seed used for sampling candidates and tie breaking. Default to 0.
     :param allow_zzphase: If set to True, allows the algorithm to implement 2-qubit rotations using ZZPhase gates when deemed optimal. Defaults to False.
-    :param thread_timeout: Sets maximum out of time spent finding a single solution in one thread.
+    :param timeout: Sets maximum out of time spent finding a single solution in one thread.
     :param only_reduce: Only returns modified circuit if it has fewer two-qubit gates.
     :param trials: Sets maximum number of found solutions. The smallest circuit is returned, prioritising the number of 2qb-gates, then the number of gates, then the depth.
     :return: a pass to perform the simplification

--- a/pytket/pytket/_tket/transform.pyi
+++ b/pytket/pytket/_tket/transform.pyi
@@ -167,7 +167,7 @@ class Transform:
         It is not recommended to use this transformation with symbolic expressions, as in certain cases a blow-up in symbolic expression sizes may occur.
         """
     @staticmethod
-    def GreedyPauliSimp(discount_rate: float = 0.7, depth_weight: float = 0.3, max_tqe_candidates: int = 500, max_lookahead: int = 500, seed: int = 0, allow_zzphase: bool = False, thread_timeout: int = 100, trials: int = 1) -> Transform:
+    def GreedyPauliSimp(discount_rate: float = 0.7, depth_weight: float = 0.3, max_tqe_candidates: int = 500, max_lookahead: int = 500, seed: int = 0, allow_zzphase: bool = False, timeout: int = 100, trials: int = 1) -> Transform:
         """
         Convert a circuit into a graph of Pauli gadgets to account for commutation and phase folding, and resynthesises them using a greedy algorithm adapted from arxiv.org/abs/2103.08602. The method for synthesising the final Clifford operator is adapted from arxiv.org/abs/2305.10966.
         
@@ -177,7 +177,7 @@ class Transform:
         :param max_lookahead:  Maximum lookahead when evaluating each Clifford gate candidate. Default to 500.
         :param seed:  Unsigned integer seed used for sampling candidates and tie breaking. Default to 0.
         :param allow_zzphase: If set to True, allows the algorithm to implement 2-qubit rotations using ZZPhase gates when deemed optimal. Defaults to False.
-        :param thread_timeout: Sets maximum out of time spent finding a single solution in one thread.
+        :param timeout: Sets maximum out of time spent finding a single solution in one thread.
         :param trials: Sets maximum number of found solutions. The smallest circuit is returned, prioritising the number of 2qb-gates, then the number of gates, then the depth.
         :return: a pass to perform the simplification
         """

--- a/pytket/tests/passes_serialisation_test.py
+++ b/pytket/tests/passes_serialisation_test.py
@@ -296,7 +296,7 @@ TWO_WAY_PARAM_PASSES = {
             "max_tqe_candidates": 100,
             "seed": 2,
             "allow_zzphase": True,
-            "thread_timeout": 5000,
+            "timeout": 5000,
             "only_reduce": False,
             "trials": 1,
         }

--- a/pytket/tests/predicates_test.py
+++ b/pytket/tests/predicates_test.py
@@ -1035,7 +1035,7 @@ def test_greedy_pauli_synth() -> None:
         rega[0], regb[0]
     ).SWAP(regb[1], rega[0])
     d = circ.copy()
-    assert GreedyPauliSimp(0.5, 0.5, thread_timeout=10, trials=5).apply(d)
+    assert GreedyPauliSimp(0.5, 0.5, timeout=10, trials=5).apply(d)
 
     assert np.allclose(circ.get_unitary(), d.get_unitary())
     assert d.name == "test"
@@ -1082,7 +1082,7 @@ def test_greedy_pauli_synth() -> None:
         GreedyPauliSimp().apply(circ)
     err_msg = "Predicate requirements are not satisfied"
     assert err_msg in str(e.value)
-    # large circuit that doesn't complete within thread_timeout argument
+    # large circuit that doesn't complete within timeout argument
     c = Circuit(13)
     for _ in range(20):
         for i in range(13):
@@ -1090,7 +1090,7 @@ def test_greedy_pauli_synth() -> None:
                 c.CX(i, j)
                 c.Rz(0.23, j)
             c.H(i)
-    assert not GreedyPauliSimp(thread_timeout=1).apply(c)
+    assert not GreedyPauliSimp(timeout=1).apply(c)
     assert GreedyPauliSimp().apply(c)
 
 

--- a/schemas/compiler_pass_v1.json
+++ b/schemas/compiler_pass_v1.json
@@ -374,7 +374,7 @@
           "type": "boolean",
           "definition": "parameter controlling the use of ZZPhase gates in \"GreedyPauliSimp\""
         },
-        "thread_timeout": {
+        "timeout": {
           "type": "number",
           "definition": "parameter controlling the maximum runtime of a single thread in \"GreedyPauliSimp\""
         },
@@ -917,7 +917,7 @@
               "max_tqe_candidates",
               "seed",
               "allow_zzphase",
-              "thread_timeout",
+              "timeout",
               "only_reduce",
               "trials"
             ],

--- a/tket/conanfile.py
+++ b/tket/conanfile.py
@@ -23,7 +23,7 @@ from conan.errors import ConanInvalidConfiguration
 
 class TketConan(ConanFile):
     name = "tket"
-    version = "1.3.49"
+    version = "1.3.50"
     package_type = "library"
     license = "Apache 2"
     homepage = "https://github.com/CQCL/tket"

--- a/tket/include/tket/Predicates/PassGenerators.hpp
+++ b/tket/include/tket/Predicates/PassGenerators.hpp
@@ -355,7 +355,7 @@ PassPtr gen_special_UCC_synthesis(
  * @param max_tqe_candidates
  * @param seed
  * @param allow_zzphase
- * @param thread_timeout
+ * @param timeout
  * @param only_reduce
  * @param trials
  * @return PassPtr
@@ -363,9 +363,8 @@ PassPtr gen_special_UCC_synthesis(
 PassPtr gen_greedy_pauli_simp(
     double discount_rate = 0.7, double depth_weight = 0.3,
     unsigned max_lookahead = 500, unsigned max_tqe_candidates = 500,
-    unsigned seed = 0, bool allow_zzphase = false,
-    unsigned thread_timeout = 100, bool only_reduce = false,
-    unsigned trials = 1);
+    unsigned seed = 0, bool allow_zzphase = false, unsigned timeout = 100,
+    bool only_reduce = false, unsigned trials = 1);
 
 /**
  * Generate a pass to simplify the circuit where it acts on known basis states.

--- a/tket/include/tket/Transformations/GreedyPauliOptimisation.hpp
+++ b/tket/include/tket/Transformations/GreedyPauliOptimisation.hpp
@@ -610,40 +610,20 @@ gpg_from_unordered_set(const std::vector<SymPauliTensor>& unordered_set);
  * from a thread via a stop_flag.
  *
  * @param circ
- * @param stop_flag
  * @param discount_rate
  * @param depth_weight
  * @param max_lookahead
  * @param max_tqe_candidates
  * @param seed
  * @param allow_zzphase
+ * @param timeout
  * @return Circuit
  */
-Circuit greedy_pauli_graph_synthesis_flag(
+Circuit greedy_pauli_graph_synthesis(
     Circuit circ, std::atomic<bool>& stop_flag, double discount_rate = 0.7,
     double depth_weight = 0.3, unsigned max_lookahead = 500,
     unsigned max_tqe_candidates = 500, unsigned seed = 0,
     bool allow_zzphase = false);
-
-/**
- * @brief Converts the given circuit into a GPGraph and conjugates each node
- * by greedily applying 2-qubit Clifford gates until the node can be realised
- * as a single-qubit gate, a measurement, or a reset. The final Clifford
- * operator is synthesized in a similar fashion.
- *
- * @param circ
- * @param discount_rate
- * @param depth_weight
- * @param max_lookahead
- * @param max_tqe_candidates
- * @param seed
- * @param allow_zzphase
- * @return Circuit
- */
-Circuit greedy_pauli_graph_synthesis(
-    const Circuit& circ, double discount_rate = 0.7, double depth_weight = 0.3,
-    unsigned max_lookahead = 500, unsigned max_tqe_candidates = 500,
-    unsigned seed = 0, bool allow_zzphase = false);
 
 /**
  * @brief Synthesise a set of unordered Pauli exponentials by applying Clifford
@@ -668,8 +648,8 @@ Circuit greedy_pauli_set_synthesis(
 Transform greedy_pauli_optimisation(
     double discount_rate = 0.7, double depth_weight = 0.3,
     unsigned max_lookahead = 500, unsigned max_tqe_candidates = 500,
-    unsigned seed = 0, bool allow_zzphase = false,
-    unsigned thread_timeout = 100, unsigned trials = 1);
+    unsigned seed = 0, bool allow_zzphase = false, unsigned timeout = 100,
+    unsigned trials = 1);
 
 }  // namespace Transforms
 

--- a/tket/src/Predicates/CompilerPass.cpp
+++ b/tket/src/Predicates/CompilerPass.cpp
@@ -522,7 +522,7 @@ PassPtr deserialise(
       unsigned max_lookahead = content.at("max_lookahead").get<unsigned>();
       unsigned seed = content.at("seed").get<unsigned>();
       bool allow_zzphase = content.at("allow_zzphase").get<bool>();
-      unsigned timeout = content.at("thread_timeout").get<unsigned>();
+      unsigned timeout = content.at("timeout").get<unsigned>();
       bool only_reduce = content.at("only_reduce").get<bool>();
       unsigned trials = content.at("trials").get<unsigned>();
       pp = gen_greedy_pauli_simp(

--- a/tket/src/Predicates/PassGenerators.cpp
+++ b/tket/src/Predicates/PassGenerators.cpp
@@ -1017,13 +1017,13 @@ PassPtr gen_synthesise_pauli_graph(
 PassPtr gen_greedy_pauli_simp(
     double discount_rate, double depth_weight, unsigned max_lookahead,
     unsigned max_tqe_candidates, unsigned seed, bool allow_zzphase,
-    unsigned thread_timeout, bool only_reduce, unsigned trials) {
+    unsigned timeout, bool only_reduce, unsigned trials) {
   Transform t = Transform([discount_rate, depth_weight, max_lookahead,
-                           max_tqe_candidates, seed, allow_zzphase,
-                           thread_timeout, only_reduce, trials](Circuit& circ) {
+                           max_tqe_candidates, seed, allow_zzphase, timeout,
+                           only_reduce, trials](Circuit& circ) {
     Transform gpo = Transforms::greedy_pauli_optimisation(
         discount_rate, depth_weight, max_lookahead, max_tqe_candidates, seed,
-        allow_zzphase, thread_timeout, trials);
+        allow_zzphase, timeout, trials);
     if (only_reduce) {
       Circuit gpo_circ = circ;
       // comparison will be inaccurate if circuit has PauliExpBox
@@ -1092,7 +1092,7 @@ PassPtr gen_greedy_pauli_simp(
   j["max_tqe_candidates"] = max_tqe_candidates;
   j["seed"] = seed;
   j["allow_zzphase"] = allow_zzphase;
-  j["thread_timeout"] = thread_timeout;
+  j["timeout"] = timeout;
   j["only_reduce"] = only_reduce;
   j["trials"] = trials;
 


### PR DESCRIPTION
Threading seems to be causing incorrect circuits to be produced that testing missed. Given we aren't multithreading, we can get the same performance by just doing manual checking on the timeout, which this PR adds.


# Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have commented hard-to-understand parts of my code.
- [ ] I have made corresponding changes to the public API documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the changelog with any user-facing changes.
