### PR TITLE
perf: Avoid rehashing in index_map

### DIFF
--- a/tket/src/Circuit/Circuit.cpp
+++ b/tket/src/Circuit/Circuit.cpp
@@ -132,6 +132,9 @@ VertexVec Circuit::vertices_in_order() /*const*/ {
 
 IndexMap Circuit::index_map() const {
   IndexMap im;
+  // Reserve space for every edge to avoid rehashing.
+  im.reserve(boost::concepts::EdgeListGraph<DAG>::num_edges(dag));
+
   std::size_t i = 0;
   BGL_FORALL_VERTICES(v, dag, DAG) { im[v] = i++; }
   return im;


### PR DESCRIPTION
# Description
The IndexMap data structure is an unordered_map which means that if the hash table is too small it can result in having to rehash all members of the table as seen in https://github.com/CQCL/tket/issues/1696 .

This commit attempts to reserve an exact size of hash table up front such that rehashing is unlikely as an additional optimization for large circuits.

# Related issues

https://github.com/CQCL/tket/issues/1696 <- original issue
https://github.com/CQCL/tket/pull/1697 <- reduces the number of calls to index_map

# Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have commented hard-to-understand parts of my code.
- [ ] I have made corresponding changes to the public API documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the changelog with any user-facing changes.
