### PR TITLE
Timeout on `GPGraph` construction in `GreedyPauliSimp`

### DIFF
--- a/pytket/conanfile.py
+++ b/pytket/conanfile.py
@@ -38,7 +38,7 @@ class pytketRecipe(ConanFile):
         self.requires("pybind11_json/0.2.14")
         self.requires("symengine/0.13.0")
         self.requires("tkassert/0.3.4@tket/stable")
-        self.requires("tket/1.3.53@tket/stable")
+        self.requires("tket/1.3.54@tket/stable")
         self.requires("tklog/0.3.3@tket/stable")
         self.requires("tkrng/0.3.3@tket/stable")
         self.requires("tktokenswap/0.3.9@tket/stable")

--- a/pytket/conanfile.py
+++ b/pytket/conanfile.py
@@ -38,7 +38,7 @@ class pytketRecipe(ConanFile):
         self.requires("pybind11_json/0.2.14")
         self.requires("symengine/0.13.0")
         self.requires("tkassert/0.3.4@tket/stable")
-        self.requires("tket/1.3.51@tket/stable")
+        self.requires("tket/1.3.52@tket/stable")
         self.requires("tklog/0.3.3@tket/stable")
         self.requires("tkrng/0.3.3@tket/stable")
         self.requires("tktokenswap/0.3.9@tket/stable")

--- a/pytket/conanfile.py
+++ b/pytket/conanfile.py
@@ -38,7 +38,7 @@ class pytketRecipe(ConanFile):
         self.requires("pybind11_json/0.2.14")
         self.requires("symengine/0.13.0")
         self.requires("tkassert/0.3.4@tket/stable")
-        self.requires("tket/1.3.52@tket/stable")
+        self.requires("tket/1.3.53@tket/stable")
         self.requires("tklog/0.3.3@tket/stable")
         self.requires("tkrng/0.3.3@tket/stable")
         self.requires("tktokenswap/0.3.9@tket/stable")

--- a/pytket/docs/changelog.rst
+++ b/pytket/docs/changelog.rst
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+
+Unreleased
+----------
+
+Performance:
+* Update `GreedyPauliSimp` `thread_timeout` to hit timeout when constructing Pauli Graph.
+
 1.36.0 (November 2024)
 ----------------------
 

--- a/pytket/docs/changelog.rst
+++ b/pytket/docs/changelog.rst
@@ -1,12 +1,12 @@
 Changelog
 =========
 
-Unreleased
-----------
+1.36.0 (November 2024)
+----------------------
 
 Features:
 
-* Add `BasePass.get_preconditions()` and `BasePass.getpost_conditions()`.
+* Add `BasePass.get_preconditions()` and `BasePass.get_postconditions()`.
 
 API changes:
 
@@ -15,6 +15,11 @@ API changes:
 Features:
 
 * Add `Circuit.wasm_uid` property to get the wasm UID from the circuit
+
+Performance:
+
+* Optimization in Clifford simplification, reducing compilation times for
+  `FullPeeopholeOptimise` by an order of magnitude on x86_64.
 
 Fixes:
 

--- a/tket/conanfile.py
+++ b/tket/conanfile.py
@@ -23,7 +23,7 @@ from conan.errors import ConanInvalidConfiguration
 
 class TketConan(ConanFile):
     name = "tket"
-    version = "1.3.52"
+    version = "1.3.53"
     package_type = "library"
     license = "Apache 2"
     homepage = "https://github.com/CQCL/tket"

--- a/tket/conanfile.py
+++ b/tket/conanfile.py
@@ -23,7 +23,7 @@ from conan.errors import ConanInvalidConfiguration
 
 class TketConan(ConanFile):
     name = "tket"
-    version = "1.3.53"
+    version = "1.3.54"
     package_type = "library"
     license = "Apache 2"
     homepage = "https://github.com/CQCL/tket"

--- a/tket/conanfile.py
+++ b/tket/conanfile.py
@@ -23,7 +23,7 @@ from conan.errors import ConanInvalidConfiguration
 
 class TketConan(ConanFile):
     name = "tket"
-    version = "1.3.51"
+    version = "1.3.52"
     package_type = "library"
     license = "Apache 2"
     homepage = "https://github.com/CQCL/tket"

--- a/tket/include/tket/Transformations/CliffordReductionPass.hpp
+++ b/tket/include/tket/Transformations/CliffordReductionPass.hpp
@@ -112,7 +112,7 @@ class CliffordReductionPass {
   /** The circuit under transformation */
   Circuit &circ;
 
-  /** Topological-order-respecting map from circuit vertices to integers */
+  /** Map from circuit vertices to their indices in the DAG */
   IndexMap im;
 
   /** Table of potential transports of 2qb interactions through the circuit */

--- a/tket/include/tket/Transformations/GreedyPauliOptimisation.hpp
+++ b/tket/include/tket/Transformations/GreedyPauliOptimisation.hpp
@@ -525,9 +525,6 @@ typedef boost::adj_list_vertex_property_map<
  */
 class GPGraph {
  public:
-  /** Construct an GPGraph from a circuit */
-  GPGraph(const Circuit& circ);
-
   /** Construct an GPGraph from the circuit size */
   GPGraph(qubit_vector_t qubits, bit_vector_t bits);
 

--- a/tket/include/tket/Transformations/GreedyPauliOptimisation.hpp
+++ b/tket/include/tket/Transformations/GreedyPauliOptimisation.hpp
@@ -528,6 +528,12 @@ class GPGraph {
   /** Construct an GPGraph from a circuit */
   GPGraph(const Circuit& circ);
 
+  /** Construct an GPGraph from the circuit size */
+  GPGraph(qubit_vector_t qubits, bit_vector_t bits);
+
+  GPGraph get_graph(
+      const Circuit& circ, std::shared_ptr<std::atomic<bool>> stop_flag);
+
   GPVertSet get_successors(const GPVert& vert) const;
 
   GPVertSet get_predecessors(const GPVert& vert) const;
@@ -544,9 +550,8 @@ class GPGraph {
   std::tuple<
       std::vector<std::vector<PauliNode_ptr>>, std::vector<PauliNode_ptr>,
       boost::bimap<unsigned, unsigned>>
-  get_sequence();
+  get_sequence(std::shared_ptr<std::atomic<bool>> stop_flag);
 
- private:
   /**
    * Applies the given gate to the end of the graph.
    * Clifford gates transform the tableau.
@@ -558,6 +563,7 @@ class GPGraph {
       const Command& cmd, bool conditional = false,
       std::vector<unsigned> cond_bits = {}, unsigned cond_value = 0);
 
+ private:
   /**
    * Add a Pauli rotation to the graph
    * If the angle is non-Clifford or if conditional is true then add to the DAG

--- a/tket/include/tket/Transformations/GreedyPauliOptimisation.hpp
+++ b/tket/include/tket/Transformations/GreedyPauliOptimisation.hpp
@@ -528,9 +528,6 @@ class GPGraph {
   /** Construct an GPGraph from the circuit size */
   GPGraph(qubit_vector_t qubits, bit_vector_t bits);
 
-  GPGraph get_graph(
-      const Circuit& circ, std::shared_ptr<std::atomic<bool>> stop_flag);
-
   GPVertSet get_successors(const GPVert& vert) const;
 
   GPVertSet get_predecessors(const GPVert& vert) const;

--- a/tket/src/Transformations/GreedyPauliConverters.cpp
+++ b/tket/src/Transformations/GreedyPauliConverters.cpp
@@ -127,6 +127,19 @@ GPGraph::GPGraph(const Circuit& circ)
   for (const Command& cmd : circ.get_commands()) {
     apply_gate_at_end(cmd);
   }
+  valid_construction = true;
+}
+GPGraph::GPGraph(qubit_vector_t qubits, bit_vector_t bits)
+    : n_qubits_(qubits.size()), n_bits_(bits.size()) {
+  for (const Qubit& q : qubits) {
+    TKET_ASSERT(q.reg_name() == q_default_reg());
+    TKET_ASSERT(q.index().at(0) < qubits.size());
+  }
+  for (const Bit& b : bits) {
+    TKET_ASSERT(b.reg_name() == c_default_reg());
+    TKET_ASSERT(b.index().at(0) < bits.size());
+  }
+  cliff_ = UnitaryRevTableau(n_qubits_);
 }
 
 GPVertSet GPGraph::get_successors(const GPVert& vert) const {
@@ -487,11 +500,14 @@ std::vector<GPVert> GPGraph::vertices_in_order() const {
 std::tuple<
     std::vector<std::vector<PauliNode_ptr>>, std::vector<PauliNode_ptr>,
     boost::bimap<unsigned, unsigned>>
-GPGraph::get_sequence() {
+GPGraph::get_sequence(std::shared_ptr<std::atomic<bool>> stop_flag) {
   std::vector<GPVert> vertices = vertices_in_order();
   auto it = vertices.begin();
   std::vector<std::vector<PauliNode_ptr>> interior_nodes;
   while (it != vertices.end()) {
+    if (stop_flag.get()->load()) {
+      return {};
+    }
     const PauliNode_ptr& node = graph_[*it];
     std::vector<PauliNode_ptr> commuting_set;
     commuting_set.push_back(node);

--- a/tket/src/Transformations/GreedyPauliConverters.cpp
+++ b/tket/src/Transformations/GreedyPauliConverters.cpp
@@ -111,24 +111,6 @@ static bool nodes_commute(const PauliNode_ptr& n1, const PauliNode_ptr& n2) {
   return true;
 }
 
-GPGraph::GPGraph(const Circuit& circ)
-    : n_qubits_(circ.n_qubits()), n_bits_(circ.n_bits()) {
-  qubit_vector_t qubits = circ.all_qubits();
-  bit_vector_t bits = circ.all_bits();
-  for (const Qubit& q : qubits) {
-    TKET_ASSERT(q.reg_name() == q_default_reg());
-    TKET_ASSERT(q.index().at(0) < qubits.size());
-  }
-  for (const Bit& b : bits) {
-    TKET_ASSERT(b.reg_name() == c_default_reg());
-    TKET_ASSERT(b.index().at(0) < bits.size());
-  }
-  cliff_ = UnitaryRevTableau(n_qubits_);
-  for (const Command& cmd : circ.get_commands()) {
-    apply_gate_at_end(cmd);
-  }
-}
-
 GPGraph::GPGraph(qubit_vector_t qubits, bit_vector_t bits)
     : n_qubits_(qubits.size()), n_bits_(bits.size()) {
   for (const Qubit& q : qubits) {

--- a/tket/src/Transformations/GreedyPauliConverters.cpp
+++ b/tket/src/Transformations/GreedyPauliConverters.cpp
@@ -127,8 +127,8 @@ GPGraph::GPGraph(const Circuit& circ)
   for (const Command& cmd : circ.get_commands()) {
     apply_gate_at_end(cmd);
   }
-  valid_construction = true;
 }
+
 GPGraph::GPGraph(qubit_vector_t qubits, bit_vector_t bits)
     : n_qubits_(qubits.size()), n_bits_(bits.size()) {
   for (const Qubit& q : qubits) {

--- a/tket/src/Transformations/GreedyPauliOptimisation.cpp
+++ b/tket/src/Transformations/GreedyPauliOptimisation.cpp
@@ -772,14 +772,21 @@ Circuit greedy_pauli_graph_synthesis_flag(
   for (const auto& pair : unit_map) {
     rev_unit_map.insert({pair.second, pair.first});
   }
-  GPGraph gpg(circ_flat);
+
+  GPGraph gpg(circ_flat.all_qubits(), circ_flat.all_bits());
+  for (const Command& cmd : circ_flat.get_commands()) {
+    if (stop_flag.get()->load()) {
+      return Circuit();
+    }
+    gpg.apply_gate_at_end(cmd);
+  }
 
   // We regularly check whether the timeout has ocurred
   if (stop_flag.get()->load()) {
     return Circuit();
   }
 
-  auto [rotation_sets, rows, measures] = gpg.get_sequence();
+  auto [rotation_sets, rows, measures] = gpg.get_sequence(stop_flag);
 
   if (stop_flag.get()->load()) {
     return Circuit();

--- a/tket/test/src/test_GreedyPauli.cpp
+++ b/tket/test/src/test_GreedyPauli.cpp
@@ -764,7 +764,7 @@ SCENARIO("Test GreedyPauliSimp pass construction") {
 SCENARIO("Test GreedyPauliSimp with multiple trials and threads") {
   GIVEN("Large circuit with ZZPhase") {
     Circuit circ(6);
-    for (unsigned i = 0; i < 5000; i++) {
+    for (unsigned i = 0; i < 1000; i++) {
       circ.add_box(
           PauliExpBox(SymPauliTensor({Pauli::X, Pauli::X}, 0.3)), {0, 1});
       circ.add_box(
@@ -825,7 +825,7 @@ SCENARIO("Test GreedyPauliSimp with multiple trials and threads") {
                  0.7, 0.3, 500, 500, 0, true, 1, 10)
                  .apply(d));
     REQUIRE(Transforms::greedy_pauli_optimisation(
-                0.7, 0.3, 500, 500, 0, true, 10000, 10)
+                0.7, 0.3, 500, 500, 0, true, 100, 10)
                 .apply(d));
     REQUIRE(test_unitary_comparison(circ, d, true));
   }

--- a/tket/test/src/test_GreedyPauli.cpp
+++ b/tket/test/src/test_GreedyPauli.cpp
@@ -764,7 +764,7 @@ SCENARIO("Test GreedyPauliSimp pass construction") {
 SCENARIO("Test GreedyPauliSimp with multiple trials and threads") {
   GIVEN("Large circuit with ZZPhase") {
     Circuit circ(6);
-    for (unsigned i = 0; i < 3; i++) {
+    for (unsigned i = 0; i < 10000; i++) {
       circ.add_box(
           PauliExpBox(SymPauliTensor({Pauli::X, Pauli::X}, 0.3)), {0, 1});
       circ.add_box(
@@ -836,7 +836,7 @@ SCENARIO(
     "construction") {
   GIVEN("Large circuit") {
     Circuit circ(6);
-    for (unsigned i = 0; i < 100; i++) {
+    for (unsigned i = 0; i < 1000; i++) {
       circ.add_box(
           PauliExpBox(SymPauliTensor({Pauli::X, Pauli::X}, 0.3)), {0, 1});
       circ.add_box(

--- a/tket/test/src/test_GreedyPauli.cpp
+++ b/tket/test/src/test_GreedyPauli.cpp
@@ -836,7 +836,7 @@ SCENARIO(
     "construction") {
   GIVEN("Large circuit") {
     Circuit circ(6);
-    for (unsigned i = 0; i < 10; i++) {
+    for (unsigned i = 0; i < 100; i++) {
       circ.add_box(
           PauliExpBox(SymPauliTensor({Pauli::X, Pauli::X}, 0.3)), {0, 1});
       circ.add_box(

--- a/tket/test/src/test_GreedyPauli.cpp
+++ b/tket/test/src/test_GreedyPauli.cpp
@@ -825,7 +825,7 @@ SCENARIO("Test GreedyPauliSimp with multiple trials and threads") {
                  0.7, 0.3, 500, 500, 0, true, 1, 10)
                  .apply(d));
     REQUIRE(Transforms::greedy_pauli_optimisation(
-                0.7, 0.3, 500, 500, 0, true, 100, 10)
+                0.7, 0.3, 500, 500, 0, true, 10000, 10)
                 .apply(d));
     REQUIRE(test_unitary_comparison(circ, d, true));
   }

--- a/tket/test/src/test_GreedyPauli.cpp
+++ b/tket/test/src/test_GreedyPauli.cpp
@@ -825,82 +825,11 @@ SCENARIO("Test GreedyPauliSimp with multiple trials and threads") {
                  0.7, 0.3, 500, 500, 0, true, 1, 10)
                  .apply(d));
     REQUIRE(Transforms::greedy_pauli_optimisation(
-                0.7, 0.3, 500, 500, 0, true, 10, 10)
+                0.7, 0.3, 500, 500, 0, true, 100, 10)
                 .apply(d));
     REQUIRE(test_unitary_comparison(circ, d, true));
   }
 }
 
-SCENARIO(
-    "Test GreedyPauliSimp with large enough timeout to hit PauliGraph "
-    "construction") {
-  GIVEN("Large circuit") {
-    Circuit circ(6);
-    for (unsigned i = 0; i < 1000; i++) {
-      circ.add_box(
-          PauliExpBox(SymPauliTensor({Pauli::X, Pauli::X}, 0.3)), {0, 1});
-      circ.add_box(
-          PauliExpBox(SymPauliTensor({Pauli::Z, Pauli::Y, Pauli::X}, 0.2)),
-          {0, 1, 2});
-      circ.add_box(
-          PauliExpCommutingSetBox({
-              {{Pauli::I, Pauli::Y, Pauli::I, Pauli::Z}, 1.2},
-              {{Pauli::X, Pauli::Y, Pauli::Z, Pauli::I}, 0.8},
-              {{Pauli::I, Pauli::I, Pauli::I, Pauli::Z}, 1.25},
-          }),
-          {1, 2, 3, 4});
-      circ.add_box(
-          PauliExpBox(SymPauliTensor({Pauli::Y, Pauli::X}, 0.1)), {2, 3});
-      circ.add_box(
-          PauliExpBox(SymPauliTensor({Pauli::Z, Pauli::Y, Pauli::X}, 0.11)),
-          {1, 3, 4});
-      circ.add_box(
-          PauliExpBox(SymPauliTensor({Pauli::Y, Pauli::Y}, 0.2)), {4, 5});
-      circ.add_box(
-          PauliExpBox(SymPauliTensor({Pauli::Z, Pauli::Z, Pauli::X}, 0.15)),
-          {2, 4, 5});
-      circ.add_box(
-          PauliExpBox(
-              SymPauliTensor({Pauli::X, Pauli::X, Pauli::X, Pauli::X}, 0.25)),
-          {2, 4, 5, 0});
-      circ.add_box(
-          PauliExpBox(
-              SymPauliTensor({Pauli::Y, Pauli::Z, Pauli::Z, Pauli::X}, 0.125)),
-          {1, 3, 5, 0});
-
-      circ.add_box(
-          PauliExpBox(SymPauliTensor(
-              {Pauli::X, Pauli::Z, Pauli::Y, Pauli::Y, Pauli::Z, Pauli::X},
-              0.125)),
-          {1, 3, 5, 0, 2, 4});
-
-      circ.add_box(
-          PauliExpBox(SymPauliTensor(
-              {Pauli::Z, Pauli::Y, Pauli::Y, Pauli::Z, Pauli::Z, Pauli::X},
-              0.125)),
-          {0, 1, 2, 3, 4, 5});
-
-      circ.add_box(
-          PauliExpBox(SymPauliTensor(
-              {Pauli::X, Pauli::Z, Pauli::Y, Pauli::Z, Pauli::Z, Pauli::X},
-              0.125)),
-          {5, 2, 4, 1, 3, 0});
-
-      circ.add_box(
-          PauliExpBox(SymPauliTensor(
-              {Pauli::X, Pauli::Z, Pauli::Y, Pauli::Y, Pauli::Z, Pauli::X},
-              0.125)),
-          {0, 5, 1, 4, 3, 2});
-    }
-    Circuit d(circ);
-    REQUIRE(!Transforms::greedy_pauli_optimisation(
-                 0.7, 0.3, 500, 500, 0, true, 1, 1)
-                 .apply(d));
-    REQUIRE(Transforms::greedy_pauli_optimisation(
-                0.7, 0.3, 500, 500, 0, true, 100, 1)
-                .apply(d));
-    REQUIRE(test_unitary_comparison(circ, d, true));
-  }
-}
 }  // namespace test_GreedyPauliSimp
 }  // namespace tket

--- a/tket/test/src/test_GreedyPauli.cpp
+++ b/tket/test/src/test_GreedyPauli.cpp
@@ -764,67 +764,140 @@ SCENARIO("Test GreedyPauliSimp pass construction") {
 SCENARIO("Test GreedyPauliSimp with multiple trials and threads") {
   GIVEN("Large circuit with ZZPhase") {
     Circuit circ(6);
-    circ.add_box(
-        PauliExpBox(SymPauliTensor({Pauli::X, Pauli::X}, 0.3)), {0, 1});
-    circ.add_box(
-        PauliExpBox(SymPauliTensor({Pauli::Z, Pauli::Y, Pauli::X}, 0.2)),
-        {0, 1, 2});
-    circ.add_box(
-        PauliExpCommutingSetBox({
-            {{Pauli::I, Pauli::Y, Pauli::I, Pauli::Z}, 1.2},
-            {{Pauli::X, Pauli::Y, Pauli::Z, Pauli::I}, 0.8},
-            {{Pauli::I, Pauli::I, Pauli::I, Pauli::Z}, 1.25},
-        }),
-        {1, 2, 3, 4});
-    circ.add_box(
-        PauliExpBox(SymPauliTensor({Pauli::Y, Pauli::X}, 0.1)), {2, 3});
-    circ.add_box(
-        PauliExpBox(SymPauliTensor({Pauli::Z, Pauli::Y, Pauli::X}, 0.11)),
-        {1, 3, 4});
-    circ.add_box(
-        PauliExpBox(SymPauliTensor({Pauli::Y, Pauli::Y}, 0.2)), {4, 5});
-    circ.add_box(
-        PauliExpBox(SymPauliTensor({Pauli::Z, Pauli::Z, Pauli::X}, 0.15)),
-        {2, 4, 5});
-    circ.add_box(
-        PauliExpBox(
-            SymPauliTensor({Pauli::X, Pauli::X, Pauli::X, Pauli::X}, 0.25)),
-        {2, 4, 5, 0});
-    circ.add_box(
-        PauliExpBox(
-            SymPauliTensor({Pauli::Y, Pauli::Z, Pauli::Z, Pauli::X}, 0.125)),
-        {1, 3, 5, 0});
+    for (unsigned i = 0; i < 3; i++) {
+      circ.add_box(
+          PauliExpBox(SymPauliTensor({Pauli::X, Pauli::X}, 0.3)), {0, 1});
+      circ.add_box(
+          PauliExpBox(SymPauliTensor({Pauli::Z, Pauli::Y, Pauli::X}, 0.2)),
+          {0, 1, 2});
+      circ.add_box(
+          PauliExpCommutingSetBox({
+              {{Pauli::I, Pauli::Y, Pauli::I, Pauli::Z}, 1.2},
+              {{Pauli::X, Pauli::Y, Pauli::Z, Pauli::I}, 0.8},
+              {{Pauli::I, Pauli::I, Pauli::I, Pauli::Z}, 1.25},
+          }),
+          {1, 2, 3, 4});
+      circ.add_box(
+          PauliExpBox(SymPauliTensor({Pauli::Y, Pauli::X}, 0.1)), {2, 3});
+      circ.add_box(
+          PauliExpBox(SymPauliTensor({Pauli::Z, Pauli::Y, Pauli::X}, 0.11)),
+          {1, 3, 4});
+      circ.add_box(
+          PauliExpBox(SymPauliTensor({Pauli::Y, Pauli::Y}, 0.2)), {4, 5});
+      circ.add_box(
+          PauliExpBox(SymPauliTensor({Pauli::Z, Pauli::Z, Pauli::X}, 0.15)),
+          {2, 4, 5});
+      circ.add_box(
+          PauliExpBox(
+              SymPauliTensor({Pauli::X, Pauli::X, Pauli::X, Pauli::X}, 0.25)),
+          {2, 4, 5, 0});
+      circ.add_box(
+          PauliExpBox(
+              SymPauliTensor({Pauli::Y, Pauli::Z, Pauli::Z, Pauli::X}, 0.125)),
+          {1, 3, 5, 0});
 
-    circ.add_box(
-        PauliExpBox(SymPauliTensor(
-            {Pauli::X, Pauli::Z, Pauli::Y, Pauli::Y, Pauli::Z, Pauli::X},
-            0.125)),
-        {1, 3, 5, 0, 2, 4});
+      circ.add_box(
+          PauliExpBox(SymPauliTensor(
+              {Pauli::X, Pauli::Z, Pauli::Y, Pauli::Y, Pauli::Z, Pauli::X},
+              0.125)),
+          {1, 3, 5, 0, 2, 4});
 
-    circ.add_box(
-        PauliExpBox(SymPauliTensor(
-            {Pauli::Z, Pauli::Y, Pauli::Y, Pauli::Z, Pauli::Z, Pauli::X},
-            0.125)),
-        {0, 1, 2, 3, 4, 5});
+      circ.add_box(
+          PauliExpBox(SymPauliTensor(
+              {Pauli::Z, Pauli::Y, Pauli::Y, Pauli::Z, Pauli::Z, Pauli::X},
+              0.125)),
+          {0, 1, 2, 3, 4, 5});
 
-    circ.add_box(
-        PauliExpBox(SymPauliTensor(
-            {Pauli::X, Pauli::Z, Pauli::Y, Pauli::Z, Pauli::Z, Pauli::X},
-            0.125)),
-        {5, 2, 4, 1, 3, 0});
+      circ.add_box(
+          PauliExpBox(SymPauliTensor(
+              {Pauli::X, Pauli::Z, Pauli::Y, Pauli::Z, Pauli::Z, Pauli::X},
+              0.125)),
+          {5, 2, 4, 1, 3, 0});
 
-    circ.add_box(
-        PauliExpBox(SymPauliTensor(
-            {Pauli::X, Pauli::Z, Pauli::Y, Pauli::Y, Pauli::Z, Pauli::X},
-            0.125)),
-        {0, 5, 1, 4, 3, 2});
-
+      circ.add_box(
+          PauliExpBox(SymPauliTensor(
+              {Pauli::X, Pauli::Z, Pauli::Y, Pauli::Y, Pauli::Z, Pauli::X},
+              0.125)),
+          {0, 5, 1, 4, 3, 2});
+    }
     Circuit d(circ);
     REQUIRE(!Transforms::greedy_pauli_optimisation(
-                 0.7, 0.3, 500, 500, 0, true, 0, 10)
+                 0.7, 0.3, 500, 500, 0, true, 1, 10)
                  .apply(d));
     REQUIRE(Transforms::greedy_pauli_optimisation(
                 0.7, 0.3, 500, 500, 0, true, 10, 10)
+                .apply(d));
+    REQUIRE(test_unitary_comparison(circ, d, true));
+  }
+}
+
+SCENARIO(
+    "Test GreedyPauliSimp with large enough timeout to hit PauliGraph "
+    "construction") {
+  GIVEN("Large circuit") {
+    Circuit circ(6);
+    for (unsigned i = 0; i < 10; i++) {
+      circ.add_box(
+          PauliExpBox(SymPauliTensor({Pauli::X, Pauli::X}, 0.3)), {0, 1});
+      circ.add_box(
+          PauliExpBox(SymPauliTensor({Pauli::Z, Pauli::Y, Pauli::X}, 0.2)),
+          {0, 1, 2});
+      circ.add_box(
+          PauliExpCommutingSetBox({
+              {{Pauli::I, Pauli::Y, Pauli::I, Pauli::Z}, 1.2},
+              {{Pauli::X, Pauli::Y, Pauli::Z, Pauli::I}, 0.8},
+              {{Pauli::I, Pauli::I, Pauli::I, Pauli::Z}, 1.25},
+          }),
+          {1, 2, 3, 4});
+      circ.add_box(
+          PauliExpBox(SymPauliTensor({Pauli::Y, Pauli::X}, 0.1)), {2, 3});
+      circ.add_box(
+          PauliExpBox(SymPauliTensor({Pauli::Z, Pauli::Y, Pauli::X}, 0.11)),
+          {1, 3, 4});
+      circ.add_box(
+          PauliExpBox(SymPauliTensor({Pauli::Y, Pauli::Y}, 0.2)), {4, 5});
+      circ.add_box(
+          PauliExpBox(SymPauliTensor({Pauli::Z, Pauli::Z, Pauli::X}, 0.15)),
+          {2, 4, 5});
+      circ.add_box(
+          PauliExpBox(
+              SymPauliTensor({Pauli::X, Pauli::X, Pauli::X, Pauli::X}, 0.25)),
+          {2, 4, 5, 0});
+      circ.add_box(
+          PauliExpBox(
+              SymPauliTensor({Pauli::Y, Pauli::Z, Pauli::Z, Pauli::X}, 0.125)),
+          {1, 3, 5, 0});
+
+      circ.add_box(
+          PauliExpBox(SymPauliTensor(
+              {Pauli::X, Pauli::Z, Pauli::Y, Pauli::Y, Pauli::Z, Pauli::X},
+              0.125)),
+          {1, 3, 5, 0, 2, 4});
+
+      circ.add_box(
+          PauliExpBox(SymPauliTensor(
+              {Pauli::Z, Pauli::Y, Pauli::Y, Pauli::Z, Pauli::Z, Pauli::X},
+              0.125)),
+          {0, 1, 2, 3, 4, 5});
+
+      circ.add_box(
+          PauliExpBox(SymPauliTensor(
+              {Pauli::X, Pauli::Z, Pauli::Y, Pauli::Z, Pauli::Z, Pauli::X},
+              0.125)),
+          {5, 2, 4, 1, 3, 0});
+
+      circ.add_box(
+          PauliExpBox(SymPauliTensor(
+              {Pauli::X, Pauli::Z, Pauli::Y, Pauli::Y, Pauli::Z, Pauli::X},
+              0.125)),
+          {0, 5, 1, 4, 3, 2});
+    }
+    Circuit d(circ);
+    REQUIRE(!Transforms::greedy_pauli_optimisation(
+                 0.7, 0.3, 500, 500, 0, true, 1, 1)
+                 .apply(d));
+    REQUIRE(Transforms::greedy_pauli_optimisation(
+                0.7, 0.3, 500, 500, 0, true, 100, 1)
                 .apply(d));
     REQUIRE(test_unitary_comparison(circ, d, true));
   }

--- a/tket/test/src/test_GreedyPauli.cpp
+++ b/tket/test/src/test_GreedyPauli.cpp
@@ -764,7 +764,7 @@ SCENARIO("Test GreedyPauliSimp pass construction") {
 SCENARIO("Test GreedyPauliSimp with multiple trials and threads") {
   GIVEN("Large circuit with ZZPhase") {
     Circuit circ(6);
-    for (unsigned i = 0; i < 10000; i++) {
+    for (unsigned i = 0; i < 5000; i++) {
       circ.add_box(
           PauliExpBox(SymPauliTensor({Pauli::X, Pauli::X}, 0.3)), {0, 1});
       circ.add_box(


### PR DESCRIPTION
`GPGraph` construction and `GPGraph::get_sequence` can run significantly longer than the given timeout. This PR updates `greedy_pauli_graph_synthesis_flag` to check timeout during the execution of these methods and to finish early if the timeout is met.

# Related issues

Please mention any github issues addressed by this PR.

# Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have commented hard-to-understand parts of my code.
- [ ] I have made corresponding changes to the public API documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the changelog with any user-facing changes.
