### PR TITLE
Use built-in `int` type for `get_counts()`

### DIFF
--- a/pytket/docs/changelog.rst
+++ b/pytket/docs/changelog.rst
@@ -7,6 +7,7 @@ Changelog
 Fixes:
 
 * Fix circuit iteration giving invalid slices in some cases.
+* Use built-in int type for get_counts() instead of numpy int types.
 
 Performance:
 

--- a/pytket/pytket/utils/outcomearray.py
+++ b/pytket/pytket/utils/outcomearray.py
@@ -203,4 +203,4 @@ def readout_counts(
     ctr: Counter[OutcomeArray],
 ) -> Counter[tuple[int, ...]]:
     """Convert counts from :py:class:`OutcomeArray` types to tuples of ints."""
-    return Counter({tuple(oa.to_readout()): n for oa, n in ctr.items()})
+    return Counter({tuple(map(int, oa.to_readout())): int(n) for oa, n in ctr.items()})

--- a/pytket/tests/backend_test.py
+++ b/pytket/tests/backend_test.py
@@ -589,6 +589,19 @@ def test_empty_backenresult() -> None:
     assert r.get_counts() == Counter()
 
 
+def test_int_type() -> None:
+    # https://github.com/CQCL/tket/issues/1677
+    b = TketSimShotBackend(ignore_measures=True)
+    c = Circuit(2).H(0).H(1).measure_all()
+    c1 = b.get_compiled_circuit(c)
+    h = b.process_circuit(c1, n_shots=10)
+    r = b.get_result(h)
+    counts = r.get_counts()
+    for k, v in counts.items():
+        assert all(isinstance(i, int) for i in k)
+        assert isinstance(v, int)
+
+
 if __name__ == "__main__":
     # test_resulthandle()
     # test_bell()


### PR DESCRIPTION
Fixes #1677 .