### PR TITLE
Add check for graph validity before commuting conditional gates in squashing passes

### DIFF
--- a/pytket/conanfile.py
+++ b/pytket/conanfile.py
@@ -38,7 +38,7 @@ class pytketRecipe(ConanFile):
         self.requires("pybind11_json/0.2.14")
         self.requires("symengine/0.13.0")
         self.requires("tkassert/0.3.4@tket/stable")
-        self.requires("tket/1.3.54@tket/stable")
+        self.requires("tket/1.3.55@tket/stable")
         self.requires("tklog/0.3.3@tket/stable")
         self.requires("tkrng/0.3.3@tket/stable")
         self.requires("tktokenswap/0.3.9@tket/stable")

--- a/pytket/docs/changelog.rst
+++ b/pytket/docs/changelog.rst
@@ -8,6 +8,8 @@ Fixes:
 
 * Fix circuit iteration giving invalid slices in some cases.
 * Use built-in int type for get_counts() instead of numpy int types.
+* Add check for validity of resultant graph before pushing conditional gates
+  through other vertices in squashing passes.
 
 Performance:
 

--- a/tket/conanfile.py
+++ b/tket/conanfile.py
@@ -23,7 +23,7 @@ from conan.errors import ConanInvalidConfiguration
 
 class TketConan(ConanFile):
     name = "tket"
-    version = "1.3.54"
+    version = "1.3.55"
     package_type = "library"
     license = "Apache 2"
     homepage = "https://github.com/CQCL/tket"

--- a/tket/include/tket/Transformations/SingleQubitSquash.hpp
+++ b/tket/include/tket/Transformations/SingleQubitSquash.hpp
@@ -145,6 +145,14 @@ class SingleQubitSquash {
       const Circuit &sub, const VertexVec &single_chain, Edge &e,
       const Condition &condition);
 
+  // whether there is a path in the DAG to v from any vertex in vs (if
+  // reversed_ is true then paths are considered in the reverse direction)
+  bool path_exists(const Vertex &v, const VertexSet &vs) const;
+
+  // whether we are allowed to commute a given conditional single-qubit gate
+  // through the target of e without invalidating the DAG structure
+  bool commute_ok(const Edge &e, const Condition &condition) const;
+
   // insert a gate at the given edge, respecting condition
   void insert_left_over_gate(
       Op_ptr left_over, const Edge &e, const Condition &condition);


### PR DESCRIPTION
Fixes #1324 .
Fixes #1357 .

I was a bit concerned about the performance impact of this but it increases the running time of the tket tests by only about 1% so I think it's OK. (If it does turn out to be a problem, an alternative would be never to commute these gates, but that would give poorer results -- or somehow to find a cheaper way to do the check.)