### PR TITLE
Reimplement `Circuit::get_commands_of_type()`

### DIFF
--- a/pytket/conanfile.py
+++ b/pytket/conanfile.py
@@ -38,7 +38,7 @@ class pytketRecipe(ConanFile):
         self.requires("pybind11_json/0.2.15")
         self.requires("symengine/0.13.0")
         self.requires("tkassert/0.3.4@tket/stable")
-        self.requires("tket/1.3.57@tket/stable")
+        self.requires("tket/1.3.58@tket/stable")
         self.requires("tklog/0.3.3@tket/stable")
         self.requires("tkrng/0.3.3@tket/stable")
         self.requires("tktokenswap/0.3.9@tket/stable")

--- a/pytket/docs/changelog.rst
+++ b/pytket/docs/changelog.rst
@@ -8,6 +8,10 @@ Features:
 
 * Squash sequences of conditional gates in `SquashRzPhasedX` pass.
 
+Fixes:
+
+* Fix issue with `Circuit.commands_of_type(OpType.Conditional)`.
+
 1.37.0 (December 2024)
 ----------------------
 

--- a/tket/conanfile.py
+++ b/tket/conanfile.py
@@ -23,7 +23,7 @@ from conan.errors import ConanInvalidConfiguration
 
 class TketConan(ConanFile):
     name = "tket"
-    version = "1.3.57"
+    version = "1.3.58"
     package_type = "library"
     license = "Apache 2"
     homepage = "https://github.com/CQCL/tket"

--- a/tket/src/Circuit/macro_circ_info.cpp
+++ b/tket/src/Circuit/macro_circ_info.cpp
@@ -82,20 +82,9 @@ VertexSet Circuit::get_gates_of_type(const OpType& op_type) const {
 
 std::list<Command> Circuit::get_commands_of_type(OpType op_type) const {
   std::list<Command> coms;
-  std::function<bool(Op_ptr)> skip_func = [=](Op_ptr op) {
-    return (op->get_type() != op_type);
-  };
-  SliceIterator slice_iter(*this, skip_func);
-  for (const Vertex& v : *slice_iter) {
-    coms.push_back(command_from_vertex(
-        v, slice_iter.get_u_frontier(), slice_iter.get_prev_b_frontier()));
-  }
-  while (!slice_iter.finished()) {
-    slice_iter.cut_ = next_cut(
-        slice_iter.cut_.u_frontier, slice_iter.cut_.b_frontier, skip_func);
-    for (const Vertex& v : *slice_iter) {
-      coms.push_back(command_from_vertex(
-          v, slice_iter.get_u_frontier(), slice_iter.get_prev_b_frontier()));
+  for (const Command& cmd : *this) {
+    if (cmd.get_op_ptr()->get_type() == op_type) {
+      coms.push_back(cmd);
     }
   }
   return coms;

--- a/tket/test/src/Circuit/test_Circ.cpp
+++ b/tket/test/src/Circuit/test_Circ.cpp
@@ -3548,5 +3548,16 @@ SCENARIO("Finding subcircuits") {
   }
 }
 
+SCENARIO("Filter conditional commands") {
+  // https://github.com/CQCL/tket/issues/1726
+  GIVEN("Circuit with a conditional after a measure") {
+    Circuit c(1, 1);
+    c.add_measure(0, 0);
+    c.add_conditional_gate<unsigned>(OpType::X, {}, {0}, {0}, 1);
+    std::list<Command> cmds = c.get_commands_of_type(OpType::Conditional);
+    REQUIRE(cmds.size() == 1);
+  }
+}
+
 }  // namespace test_Circ
 }  // namespace tket


### PR DESCRIPTION
Fixes #1726 .

This function was implemented using a method where the slice iterator skipped certain vertices, leading to problems when some of those vertices were sources of Boolean wires targeting the unskipped vertices. The new implementation is simpler and avoids this problem.