### PR TITLE
Use "trusted publishing" for uploading wheels to pypi

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -344,7 +344,7 @@ jobs:
     if: github.event_name == 'release'
     needs: [test_linux_wheels, test_linux_aarch64_wheels, test_macos_x86_wheels, test_macos_arm64_wheels, test_Windows_wheels]
     runs-on: ubuntu-latest
-    environmemt:
+    environment:
       name: release
       url: https://pypi.org/p/pytket
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -343,7 +343,12 @@ jobs:
     name: Publish to pypi
     if: github.event_name == 'release'
     needs: [test_linux_wheels, test_linux_aarch64_wheels, test_macos_x86_wheels, test_macos_arm64_wheels, test_Windows_wheels]
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
+    environmemt:
+      name: release
+      url: https://pypi.org/p/pytket
+    permissions:
+      id-token: write
     steps:
     - name: Download all wheels
       uses: actions/download-artifact@v4
@@ -355,7 +360,3 @@ jobs:
         for w in `find wheelhouse/ -type f -name "*.whl"` ; do cp $w dist/ ; done
     - name: Publish wheels
       uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        user: __token__
-        password: ${{ secrets.PYPI_PYTKET_API_TOKEN }}
-        verbose: true


### PR DESCRIPTION
Tested [here](https://github.com/CQCL/tket/actions/runs/12712092140).

I've set things up on pypi and github so that this works. This seems to be the recommended way.