### PR TITLE
Add Python 3.13 support to the ZX module

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -290,11 +290,7 @@ jobs:
     - name: Build pytket
       run: |
         cd pytket
-        if python --version | grep -q '3.13' ; then
-          pip install -e . -v
-        else
-          pip install -e .[ZX] -v
-        fi
+        pip install -e .[ZX] -v
     - name: Run doctests
       run: |
         cd pytket
@@ -404,11 +400,7 @@ jobs:
     - name: Build pytket
       run: |
         cd pytket
-        if python --version | grep -q '3.13' ; then
-          pip install -e . -v
-        else
-          pip install -e .[ZX] -v
-        fi
+        pip install -e .[ZX] -v
     - name: Run doctests
       run: |
         cd pytket
@@ -534,11 +526,7 @@ jobs:
       shell: bash
       run: |
         cd pytket
-        if python --version | grep -q '3.13' ; then
-          pip install -e . -v
-        else
-          pip install -e .[ZX] -v
-        fi
+        pip install -e .[ZX] -v
     - name: Run doctests
       run: |
         cd pytket

--- a/pytket/docs/changelog.rst
+++ b/pytket/docs/changelog.rst
@@ -4,6 +4,10 @@ Changelog
 Unreleased
 ----------
 
+Features:
+
+* Add Python 3.13 support to the ZX module.
+
 Fixes:
 
 * Make `CliffordCircuitPredicate` accept circuits containing measurements.

--- a/pytket/setup.py
+++ b/pytket/setup.py
@@ -204,7 +204,7 @@ setup(
     ],
     extras_require={
         "ZX": [
-            "numba >= 0.60.0",
+            "numba >= 0.61.0",
             "quimb >= 1.8.2",
             "autoray >= 0.6.12",
         ],


### PR DESCRIPTION
Requires numba >= 0.61.0.