### PR TITLE
Melf/update copyright

### DIFF
--- a/.github/workflows/build-docs
+++ b/.github/workflows/build-docs
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.github/workflows/compare-coverage
+++ b/.github/workflows/compare-coverage
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.github/workflows/compare-pytket-coverage
+++ b/.github/workflows/compare-pytket-coverage
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.github/workflows/linuxbuildlib
+++ b/.github/workflows/linuxbuildlib
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.github/workflows/linuxbuildpackages
+++ b/.github/workflows/linuxbuildpackages
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.github/workflows/linuxbuildwheel
+++ b/.github/workflows/linuxbuildwheel
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.github/workflows/linuxtestwheel
+++ b/.github/workflows/linuxtestwheel
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/do-clang-format
+++ b/do-clang-format
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/libs/tkassert/CMakeLists.txt
+++ b/libs/tkassert/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/libs/tkassert/conanfile.py
+++ b/libs/tkassert/conanfile.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/libs/tkassert/include/tkassert/Assert.hpp
+++ b/libs/tkassert/include/tkassert/Assert.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkassert/include/tkassert/AssertMessage.hpp
+++ b/libs/tkassert/include/tkassert/AssertMessage.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkassert/src/AssertMessage.cpp
+++ b/libs/tkassert/src/AssertMessage.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkassert/test/CMakeLists.txt
+++ b/libs/tkassert/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/libs/tkassert/test/conanfile.py
+++ b/libs/tkassert/test/conanfile.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/libs/tkassert/test/src/test_assert.cpp
+++ b/libs/tkassert/test/src/test_assert.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkassert/test_package/CMakeLists.txt
+++ b/libs/tkassert/test_package/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/libs/tkassert/test_package/conanfile.py
+++ b/libs/tkassert/test_package/conanfile.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/libs/tkassert/test_package/src/example.cpp
+++ b/libs/tkassert/test_package/src/example.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tklog/CMakeLists.txt
+++ b/libs/tklog/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/libs/tklog/conanfile.py
+++ b/libs/tklog/conanfile.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/libs/tklog/include/tklog/TketLog.hpp
+++ b/libs/tklog/include/tklog/TketLog.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tklog/src/TketLog.cpp
+++ b/libs/tklog/src/TketLog.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tklog/test/CMakeLists.txt
+++ b/libs/tklog/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/libs/tklog/test/conanfile.py
+++ b/libs/tklog/test/conanfile.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/libs/tklog/test/src/test_Logging.cpp
+++ b/libs/tklog/test/src/test_Logging.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tklog/test_package/CMakeLists.txt
+++ b/libs/tklog/test_package/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/libs/tklog/test_package/conanfile.py
+++ b/libs/tklog/test_package/conanfile.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/libs/tklog/test_package/src/example.cpp
+++ b/libs/tklog/test_package/src/example.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkrng/CMakeLists.txt
+++ b/libs/tkrng/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/libs/tkrng/conanfile.py
+++ b/libs/tkrng/conanfile.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/libs/tkrng/include/tkrng/RNG.hpp
+++ b/libs/tkrng/include/tkrng/RNG.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkrng/src/RNG.cpp
+++ b/libs/tkrng/src/RNG.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkrng/test/CMakeLists.txt
+++ b/libs/tkrng/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/libs/tkrng/test/conanfile.py
+++ b/libs/tkrng/test/conanfile.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/libs/tkrng/test/src/test_RNG.cpp
+++ b/libs/tkrng/test/src/test_RNG.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkrng/test_package/CMakeLists.txt
+++ b/libs/tkrng/test_package/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/libs/tkrng/test_package/conanfile.py
+++ b/libs/tkrng/test_package/conanfile.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/libs/tkrng/test_package/src/example.cpp
+++ b/libs/tkrng/test_package/src/example.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tktokenswap/CMakeLists.txt
+++ b/libs/tktokenswap/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/libs/tktokenswap/conanfile.py
+++ b/libs/tktokenswap/conanfile.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/libs/tktokenswap/include/tktokenswap/BestFullTsa.hpp
+++ b/libs/tktokenswap/include/tktokenswap/BestFullTsa.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tktokenswap/include/tktokenswap/CanonicalRelabelling.hpp
+++ b/libs/tktokenswap/include/tktokenswap/CanonicalRelabelling.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tktokenswap/include/tktokenswap/CyclesCandidateManager.hpp
+++ b/libs/tktokenswap/include/tktokenswap/CyclesCandidateManager.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tktokenswap/include/tktokenswap/CyclesGrowthManager.hpp
+++ b/libs/tktokenswap/include/tktokenswap/CyclesGrowthManager.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tktokenswap/include/tktokenswap/CyclesPartialTsa.hpp
+++ b/libs/tktokenswap/include/tktokenswap/CyclesPartialTsa.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tktokenswap/include/tktokenswap/DistanceFunctions.hpp
+++ b/libs/tktokenswap/include/tktokenswap/DistanceFunctions.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tktokenswap/include/tktokenswap/DistancesInterface.hpp
+++ b/libs/tktokenswap/include/tktokenswap/DistancesInterface.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tktokenswap/include/tktokenswap/DynamicTokenTracker.hpp
+++ b/libs/tktokenswap/include/tktokenswap/DynamicTokenTracker.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tktokenswap/include/tktokenswap/ExactMappingLookup.hpp
+++ b/libs/tktokenswap/include/tktokenswap/ExactMappingLookup.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tktokenswap/include/tktokenswap/FilteredSwapSequences.hpp
+++ b/libs/tktokenswap/include/tktokenswap/FilteredSwapSequences.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tktokenswap/include/tktokenswap/GeneralFunctions.hpp
+++ b/libs/tktokenswap/include/tktokenswap/GeneralFunctions.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tktokenswap/include/tktokenswap/HybridTsa.hpp
+++ b/libs/tktokenswap/include/tktokenswap/HybridTsa.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tktokenswap/include/tktokenswap/NeighboursInterface.hpp
+++ b/libs/tktokenswap/include/tktokenswap/NeighboursInterface.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tktokenswap/include/tktokenswap/PartialMappingLookup.hpp
+++ b/libs/tktokenswap/include/tktokenswap/PartialMappingLookup.hpp
@@ -1,5 +1,5 @@
 
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tktokenswap/include/tktokenswap/PartialTsaInterface.hpp
+++ b/libs/tktokenswap/include/tktokenswap/PartialTsaInterface.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tktokenswap/include/tktokenswap/RiverFlowPathFinder.hpp
+++ b/libs/tktokenswap/include/tktokenswap/RiverFlowPathFinder.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tktokenswap/include/tktokenswap/SwapConversion.hpp
+++ b/libs/tktokenswap/include/tktokenswap/SwapConversion.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tktokenswap/include/tktokenswap/SwapFunctions.hpp
+++ b/libs/tktokenswap/include/tktokenswap/SwapFunctions.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tktokenswap/include/tktokenswap/SwapListOptimiser.hpp
+++ b/libs/tktokenswap/include/tktokenswap/SwapListOptimiser.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tktokenswap/include/tktokenswap/SwapListSegmentOptimiser.hpp
+++ b/libs/tktokenswap/include/tktokenswap/SwapListSegmentOptimiser.hpp
@@ -1,5 +1,5 @@
 
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tktokenswap/include/tktokenswap/SwapListTableOptimiser.hpp
+++ b/libs/tktokenswap/include/tktokenswap/SwapListTableOptimiser.hpp
@@ -1,5 +1,5 @@
 
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tktokenswap/include/tktokenswap/SwapSequenceTable.hpp
+++ b/libs/tktokenswap/include/tktokenswap/SwapSequenceTable.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tktokenswap/include/tktokenswap/TrivialTSA.hpp
+++ b/libs/tktokenswap/include/tktokenswap/TrivialTSA.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tktokenswap/include/tktokenswap/VectorListHybrid.hpp
+++ b/libs/tktokenswap/include/tktokenswap/VectorListHybrid.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tktokenswap/include/tktokenswap/VectorListHybridSkeleton.hpp
+++ b/libs/tktokenswap/include/tktokenswap/VectorListHybridSkeleton.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tktokenswap/include/tktokenswap/VertexMapResizing.hpp
+++ b/libs/tktokenswap/include/tktokenswap/VertexMapResizing.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tktokenswap/include/tktokenswap/VertexMappingFunctions.hpp
+++ b/libs/tktokenswap/include/tktokenswap/VertexMappingFunctions.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tktokenswap/include/tktokenswap/VertexSwapResult.hpp
+++ b/libs/tktokenswap/include/tktokenswap/VertexSwapResult.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tktokenswap/src/BestFullTsa.cpp
+++ b/libs/tktokenswap/src/BestFullTsa.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tktokenswap/src/CyclesCandidateManager.cpp
+++ b/libs/tktokenswap/src/CyclesCandidateManager.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tktokenswap/src/CyclesGrowthManager.cpp
+++ b/libs/tktokenswap/src/CyclesGrowthManager.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tktokenswap/src/CyclesPartialTsa.cpp
+++ b/libs/tktokenswap/src/CyclesPartialTsa.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tktokenswap/src/CyclicShiftCostEstimate.cpp
+++ b/libs/tktokenswap/src/CyclicShiftCostEstimate.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tktokenswap/src/CyclicShiftCostEstimate.hpp
+++ b/libs/tktokenswap/src/CyclicShiftCostEstimate.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tktokenswap/src/DistancesInterface.cpp
+++ b/libs/tktokenswap/src/DistancesInterface.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tktokenswap/src/DynamicTokenTracker.cpp
+++ b/libs/tktokenswap/src/DynamicTokenTracker.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tktokenswap/src/HybridTsa.cpp
+++ b/libs/tktokenswap/src/HybridTsa.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tktokenswap/src/NeighboursInterface.cpp
+++ b/libs/tktokenswap/src/NeighboursInterface.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tktokenswap/src/PartialTsaInterface.cpp
+++ b/libs/tktokenswap/src/PartialTsaInterface.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tktokenswap/src/README.txt
+++ b/libs/tktokenswap/src/README.txt
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tktokenswap/src/RiverFlowPathFinder.cpp
+++ b/libs/tktokenswap/src/RiverFlowPathFinder.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tktokenswap/src/SwapListOptimiser.cpp
+++ b/libs/tktokenswap/src/SwapListOptimiser.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tktokenswap/src/TSAUtils/DistanceFunctions.cpp
+++ b/libs/tktokenswap/src/TSAUtils/DistanceFunctions.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tktokenswap/src/TSAUtils/SwapFunctions.cpp
+++ b/libs/tktokenswap/src/TSAUtils/SwapFunctions.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tktokenswap/src/TSAUtils/VertexMappingFunctions.cpp
+++ b/libs/tktokenswap/src/TSAUtils/VertexMappingFunctions.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tktokenswap/src/TSAUtils/VertexSwapResult.cpp
+++ b/libs/tktokenswap/src/TSAUtils/VertexSwapResult.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tktokenswap/src/TableLookup/CanonicalRelabelling.cpp
+++ b/libs/tktokenswap/src/TableLookup/CanonicalRelabelling.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tktokenswap/src/TableLookup/ExactMappingLookup.cpp
+++ b/libs/tktokenswap/src/TableLookup/ExactMappingLookup.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tktokenswap/src/TableLookup/FilteredSwapSequences.cpp
+++ b/libs/tktokenswap/src/TableLookup/FilteredSwapSequences.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tktokenswap/src/TableLookup/PartialMappingLookup.cpp
+++ b/libs/tktokenswap/src/TableLookup/PartialMappingLookup.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tktokenswap/src/TableLookup/SwapConversion.cpp
+++ b/libs/tktokenswap/src/TableLookup/SwapConversion.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tktokenswap/src/TableLookup/SwapListSegmentOptimiser.cpp
+++ b/libs/tktokenswap/src/TableLookup/SwapListSegmentOptimiser.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tktokenswap/src/TableLookup/SwapListTableOptimiser.cpp
+++ b/libs/tktokenswap/src/TableLookup/SwapListTableOptimiser.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tktokenswap/src/TableLookup/SwapSequenceTable.cpp
+++ b/libs/tktokenswap/src/TableLookup/SwapSequenceTable.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tktokenswap/src/TableLookup/VertexMapResizing.cpp
+++ b/libs/tktokenswap/src/TableLookup/VertexMapResizing.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tktokenswap/src/TableLookup/VertexMapResizing.hpp
+++ b/libs/tktokenswap/src/TableLookup/VertexMapResizing.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tktokenswap/src/TrivialTSA.cpp
+++ b/libs/tktokenswap/src/TrivialTSA.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tktokenswap/src/VectorListHybridSkeleton.cpp
+++ b/libs/tktokenswap/src/VectorListHybridSkeleton.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tktokenswap/test/CMakeLists.txt
+++ b/libs/tktokenswap/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/libs/tktokenswap/test/conanfile.py
+++ b/libs/tktokenswap/test/conanfile.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/libs/tktokenswap/test/src/Data/FixedCompleteSolutions.cpp
+++ b/libs/tktokenswap/test/src/Data/FixedCompleteSolutions.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tktokenswap/test/src/Data/FixedCompleteSolutions.hpp
+++ b/libs/tktokenswap/test/src/Data/FixedCompleteSolutions.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tktokenswap/test/src/Data/FixedSwapSequences.cpp
+++ b/libs/tktokenswap/test/src/Data/FixedSwapSequences.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tktokenswap/test/src/Data/FixedSwapSequences.hpp
+++ b/libs/tktokenswap/test/src/Data/FixedSwapSequences.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tktokenswap/test/src/TSAUtils/test_SwapFunctions.cpp
+++ b/libs/tktokenswap/test/src/TSAUtils/test_SwapFunctions.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tktokenswap/test/src/TableLookup/NeighboursFromEdges.cpp
+++ b/libs/tktokenswap/test/src/TableLookup/NeighboursFromEdges.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tktokenswap/test/src/TableLookup/NeighboursFromEdges.hpp
+++ b/libs/tktokenswap/test/src/TableLookup/NeighboursFromEdges.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tktokenswap/test/src/TableLookup/PermutationTestUtils.cpp
+++ b/libs/tktokenswap/test/src/TableLookup/PermutationTestUtils.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tktokenswap/test/src/TableLookup/PermutationTestUtils.hpp
+++ b/libs/tktokenswap/test/src/TableLookup/PermutationTestUtils.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tktokenswap/test/src/TableLookup/SwapSequenceReductionTester.cpp
+++ b/libs/tktokenswap/test/src/TableLookup/SwapSequenceReductionTester.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tktokenswap/test/src/TableLookup/SwapSequenceReductionTester.hpp
+++ b/libs/tktokenswap/test/src/TableLookup/SwapSequenceReductionTester.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tktokenswap/test/src/TableLookup/test_CanonicalRelabelling.cpp
+++ b/libs/tktokenswap/test/src/TableLookup/test_CanonicalRelabelling.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tktokenswap/test/src/TableLookup/test_ExactMappingLookup.cpp
+++ b/libs/tktokenswap/test/src/TableLookup/test_ExactMappingLookup.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tktokenswap/test/src/TableLookup/test_FilteredSwapSequences.cpp
+++ b/libs/tktokenswap/test/src/TableLookup/test_FilteredSwapSequences.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tktokenswap/test/src/TableLookup/test_SwapSequenceReductions.cpp
+++ b/libs/tktokenswap/test/src/TableLookup/test_SwapSequenceReductions.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tktokenswap/test/src/TableLookup/test_SwapSequenceTable.cpp
+++ b/libs/tktokenswap/test/src/TableLookup/test_SwapSequenceTable.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tktokenswap/test/src/TestUtils/ArchitectureEdgesReimplementation.cpp
+++ b/libs/tktokenswap/test/src/TestUtils/ArchitectureEdgesReimplementation.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tktokenswap/test/src/TestUtils/ArchitectureEdgesReimplementation.hpp
+++ b/libs/tktokenswap/test/src/TestUtils/ArchitectureEdgesReimplementation.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tktokenswap/test/src/TestUtils/DebugFunctions.cpp
+++ b/libs/tktokenswap/test/src/TestUtils/DebugFunctions.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tktokenswap/test/src/TestUtils/DebugFunctions.hpp
+++ b/libs/tktokenswap/test/src/TestUtils/DebugFunctions.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tktokenswap/test/src/TestUtils/DecodedProblemData.cpp
+++ b/libs/tktokenswap/test/src/TestUtils/DecodedProblemData.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tktokenswap/test/src/TestUtils/DecodedProblemData.hpp
+++ b/libs/tktokenswap/test/src/TestUtils/DecodedProblemData.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tktokenswap/test/src/TestUtils/GetRandomSet.cpp
+++ b/libs/tktokenswap/test/src/TestUtils/GetRandomSet.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tktokenswap/test/src/TestUtils/GetRandomSet.hpp
+++ b/libs/tktokenswap/test/src/TestUtils/GetRandomSet.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tktokenswap/test/src/TestUtils/ProblemGeneration.cpp
+++ b/libs/tktokenswap/test/src/TestUtils/ProblemGeneration.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tktokenswap/test/src/TestUtils/ProblemGeneration.hpp
+++ b/libs/tktokenswap/test/src/TestUtils/ProblemGeneration.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tktokenswap/test/src/TestUtils/TestStatsStructs.cpp
+++ b/libs/tktokenswap/test/src/TestUtils/TestStatsStructs.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tktokenswap/test/src/TestUtils/TestStatsStructs.hpp
+++ b/libs/tktokenswap/test/src/TestUtils/TestStatsStructs.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tktokenswap/test/src/TestUtils/test_DebugFunctions.cpp
+++ b/libs/tktokenswap/test/src/TestUtils/test_DebugFunctions.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tktokenswap/test/src/test_SwapList.cpp
+++ b/libs/tktokenswap/test/src/test_SwapList.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tktokenswap/test/src/test_SwapListOptimiser.cpp
+++ b/libs/tktokenswap/test/src/test_SwapListOptimiser.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tktokenswap/test/src/test_VectorListHybrid.cpp
+++ b/libs/tktokenswap/test/src/test_VectorListHybrid.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tktokenswap/test/src/test_VectorListHybridSkeleton.cpp
+++ b/libs/tktokenswap/test/src/test_VectorListHybridSkeleton.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tktokenswap/test_package/CMakeLists.txt
+++ b/libs/tktokenswap/test_package/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/libs/tktokenswap/test_package/conanfile.py
+++ b/libs/tktokenswap/test_package/conanfile.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/libs/tktokenswap/test_package/src/example.cpp
+++ b/libs/tktokenswap/test_package/src/example.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/CMakeLists.txt
+++ b/libs/tkwsm/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/libs/tkwsm/conanfile.py
+++ b/libs/tkwsm/conanfile.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/libs/tkwsm/include/tkwsm/Common/BitFunctions.hpp
+++ b/libs/tkwsm/include/tkwsm/Common/BitFunctions.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/include/tkwsm/Common/DyadicFraction.hpp
+++ b/libs/tkwsm/include/tkwsm/Common/DyadicFraction.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/include/tkwsm/Common/GeneralUtils.hpp
+++ b/libs/tkwsm/include/tkwsm/Common/GeneralUtils.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/include/tkwsm/Common/LogicalStack.hpp
+++ b/libs/tkwsm/include/tkwsm/Common/LogicalStack.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/include/tkwsm/Common/ReusableStorage.hpp
+++ b/libs/tkwsm/include/tkwsm/Common/ReusableStorage.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/include/tkwsm/Common/SpecialExceptions.hpp
+++ b/libs/tkwsm/include/tkwsm/Common/SpecialExceptions.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/include/tkwsm/Common/TemporaryRefactorCode.hpp
+++ b/libs/tkwsm/include/tkwsm/Common/TemporaryRefactorCode.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/include/tkwsm/EndToEndWrappers/MainSolver.hpp
+++ b/libs/tkwsm/include/tkwsm/EndToEndWrappers/MainSolver.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/include/tkwsm/EndToEndWrappers/MainSolverParameters.hpp
+++ b/libs/tkwsm/include/tkwsm/EndToEndWrappers/MainSolverParameters.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/include/tkwsm/EndToEndWrappers/PreSearchComponents.hpp
+++ b/libs/tkwsm/include/tkwsm/EndToEndWrappers/PreSearchComponents.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/include/tkwsm/EndToEndWrappers/SearchComponents.hpp
+++ b/libs/tkwsm/include/tkwsm/EndToEndWrappers/SearchComponents.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/include/tkwsm/EndToEndWrappers/SolutionData.hpp
+++ b/libs/tkwsm/include/tkwsm/EndToEndWrappers/SolutionData.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/include/tkwsm/EndToEndWrappers/SolutionWSM.hpp
+++ b/libs/tkwsm/include/tkwsm/EndToEndWrappers/SolutionWSM.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/include/tkwsm/GraphTheoretic/DerivedGraphStructs.hpp
+++ b/libs/tkwsm/include/tkwsm/GraphTheoretic/DerivedGraphStructs.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/include/tkwsm/GraphTheoretic/DerivedGraphs.hpp
+++ b/libs/tkwsm/include/tkwsm/GraphTheoretic/DerivedGraphs.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/include/tkwsm/GraphTheoretic/DerivedGraphsCalculator.hpp
+++ b/libs/tkwsm/include/tkwsm/GraphTheoretic/DerivedGraphsCalculator.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/include/tkwsm/GraphTheoretic/DomainInitialiser.hpp
+++ b/libs/tkwsm/include/tkwsm/GraphTheoretic/DomainInitialiser.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/include/tkwsm/GraphTheoretic/FilterUtils.hpp
+++ b/libs/tkwsm/include/tkwsm/GraphTheoretic/FilterUtils.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/include/tkwsm/GraphTheoretic/GeneralStructs.hpp
+++ b/libs/tkwsm/include/tkwsm/GraphTheoretic/GeneralStructs.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/include/tkwsm/GraphTheoretic/NearNeighboursData.hpp
+++ b/libs/tkwsm/include/tkwsm/GraphTheoretic/NearNeighboursData.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/include/tkwsm/GraphTheoretic/NeighboursData.hpp
+++ b/libs/tkwsm/include/tkwsm/GraphTheoretic/NeighboursData.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/include/tkwsm/GraphTheoretic/VertexRelabelling.hpp
+++ b/libs/tkwsm/include/tkwsm/GraphTheoretic/VertexRelabelling.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/include/tkwsm/InitPlacement/EndToEndIQP.hpp
+++ b/libs/tkwsm/include/tkwsm/InitPlacement/EndToEndIQP.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/include/tkwsm/InitPlacement/FastRandomBits.hpp
+++ b/libs/tkwsm/include/tkwsm/InitPlacement/FastRandomBits.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/include/tkwsm/InitPlacement/InputStructs.hpp
+++ b/libs/tkwsm/include/tkwsm/InitPlacement/InputStructs.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/include/tkwsm/InitPlacement/MonteCarloCompleteTargetSolution.hpp
+++ b/libs/tkwsm/include/tkwsm/InitPlacement/MonteCarloCompleteTargetSolution.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/include/tkwsm/InitPlacement/MonteCarloManager.hpp
+++ b/libs/tkwsm/include/tkwsm/InitPlacement/MonteCarloManager.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/include/tkwsm/InitPlacement/PrunedTargetEdges.hpp
+++ b/libs/tkwsm/include/tkwsm/InitPlacement/PrunedTargetEdges.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/include/tkwsm/InitPlacement/SolutionJumper.hpp
+++ b/libs/tkwsm/include/tkwsm/InitPlacement/SolutionJumper.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/include/tkwsm/InitPlacement/UtilsIQP.hpp
+++ b/libs/tkwsm/include/tkwsm/InitPlacement/UtilsIQP.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/include/tkwsm/Reducing/DerivedGraphsReducer.hpp
+++ b/libs/tkwsm/include/tkwsm/Reducing/DerivedGraphsReducer.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/include/tkwsm/Reducing/DistancesReducer.hpp
+++ b/libs/tkwsm/include/tkwsm/Reducing/DistancesReducer.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/include/tkwsm/Reducing/HallSetReduction.hpp
+++ b/libs/tkwsm/include/tkwsm/Reducing/HallSetReduction.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/include/tkwsm/Reducing/ReducerWrapper.hpp
+++ b/libs/tkwsm/include/tkwsm/Reducing/ReducerWrapper.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/include/tkwsm/Searching/DomainsAccessor.hpp
+++ b/libs/tkwsm/include/tkwsm/Searching/DomainsAccessor.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/include/tkwsm/Searching/NodeListTraversal.hpp
+++ b/libs/tkwsm/include/tkwsm/Searching/NodeListTraversal.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/include/tkwsm/Searching/NodesRawData.hpp
+++ b/libs/tkwsm/include/tkwsm/Searching/NodesRawData.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/include/tkwsm/Searching/SearchBranch.hpp
+++ b/libs/tkwsm/include/tkwsm/Searching/SearchBranch.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/include/tkwsm/Searching/ValueOrdering.hpp
+++ b/libs/tkwsm/include/tkwsm/Searching/ValueOrdering.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/include/tkwsm/Searching/VariableOrdering.hpp
+++ b/libs/tkwsm/include/tkwsm/Searching/VariableOrdering.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/include/tkwsm/Searching/WeightCalculator.hpp
+++ b/libs/tkwsm/include/tkwsm/Searching/WeightCalculator.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/include/tkwsm/WeightPruning/WeightChecker.hpp
+++ b/libs/tkwsm/include/tkwsm/WeightPruning/WeightChecker.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/include/tkwsm/WeightPruning/WeightNogoodDetector.hpp
+++ b/libs/tkwsm/include/tkwsm/WeightPruning/WeightNogoodDetector.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/include/tkwsm/WeightPruning/WeightNogoodDetectorManager.hpp
+++ b/libs/tkwsm/include/tkwsm/WeightPruning/WeightNogoodDetectorManager.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/src/Common/BitFunctions.cpp
+++ b/libs/tkwsm/src/Common/BitFunctions.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/src/Common/DyadicFraction.cpp
+++ b/libs/tkwsm/src/Common/DyadicFraction.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/src/EndToEndWrappers/MainSolver.cpp
+++ b/libs/tkwsm/src/EndToEndWrappers/MainSolver.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/src/EndToEndWrappers/MainSolverParameters.cpp
+++ b/libs/tkwsm/src/EndToEndWrappers/MainSolverParameters.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/src/EndToEndWrappers/PreSearchComponents.cpp
+++ b/libs/tkwsm/src/EndToEndWrappers/PreSearchComponents.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/src/EndToEndWrappers/SolutionWSM.cpp
+++ b/libs/tkwsm/src/EndToEndWrappers/SolutionWSM.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/src/GraphTheoretic/DerivedGraphs.cpp
+++ b/libs/tkwsm/src/GraphTheoretic/DerivedGraphs.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/src/GraphTheoretic/DerivedGraphsCalculator.cpp
+++ b/libs/tkwsm/src/GraphTheoretic/DerivedGraphsCalculator.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/src/GraphTheoretic/DomainInitialiser.cpp
+++ b/libs/tkwsm/src/GraphTheoretic/DomainInitialiser.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/src/GraphTheoretic/FilterUtils.cpp
+++ b/libs/tkwsm/src/GraphTheoretic/FilterUtils.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/src/GraphTheoretic/GeneralStructs.cpp
+++ b/libs/tkwsm/src/GraphTheoretic/GeneralStructs.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/src/GraphTheoretic/NearNeighboursData.cpp
+++ b/libs/tkwsm/src/GraphTheoretic/NearNeighboursData.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/src/GraphTheoretic/NeighboursData.cpp
+++ b/libs/tkwsm/src/GraphTheoretic/NeighboursData.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/src/GraphTheoretic/VertexRelabelling.cpp
+++ b/libs/tkwsm/src/GraphTheoretic/VertexRelabelling.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/src/InitPlacement/EndToEndIQP.cpp
+++ b/libs/tkwsm/src/InitPlacement/EndToEndIQP.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/src/InitPlacement/FastRandomBits.cpp
+++ b/libs/tkwsm/src/InitPlacement/FastRandomBits.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/src/InitPlacement/InputStructs.cpp
+++ b/libs/tkwsm/src/InitPlacement/InputStructs.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/src/InitPlacement/MonteCarloCompleteTargetSolution.cpp
+++ b/libs/tkwsm/src/InitPlacement/MonteCarloCompleteTargetSolution.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/src/InitPlacement/MonteCarloManager.cpp
+++ b/libs/tkwsm/src/InitPlacement/MonteCarloManager.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/src/InitPlacement/PrunedTargetEdges.cpp
+++ b/libs/tkwsm/src/InitPlacement/PrunedTargetEdges.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/src/InitPlacement/SolutionJumper.cpp
+++ b/libs/tkwsm/src/InitPlacement/SolutionJumper.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/src/InitPlacement/UtilsIQP.cpp
+++ b/libs/tkwsm/src/InitPlacement/UtilsIQP.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/src/README.txt
+++ b/libs/tkwsm/src/README.txt
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/src/Reducing/DerivedGraphsReducer.cpp
+++ b/libs/tkwsm/src/Reducing/DerivedGraphsReducer.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/src/Reducing/DistancesReducer.cpp
+++ b/libs/tkwsm/src/Reducing/DistancesReducer.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/src/Reducing/HallSetReduction.cpp
+++ b/libs/tkwsm/src/Reducing/HallSetReduction.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/src/Reducing/ReducerWrapper.cpp
+++ b/libs/tkwsm/src/Reducing/ReducerWrapper.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/src/Searching/DomainsAccessor.cpp
+++ b/libs/tkwsm/src/Searching/DomainsAccessor.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/src/Searching/NodeListTraversal.cpp
+++ b/libs/tkwsm/src/Searching/NodeListTraversal.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/src/Searching/NodesRawData.cpp
+++ b/libs/tkwsm/src/Searching/NodesRawData.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/src/Searching/SearchBranch.cpp
+++ b/libs/tkwsm/src/Searching/SearchBranch.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/src/Searching/ValueOrdering.cpp
+++ b/libs/tkwsm/src/Searching/ValueOrdering.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/src/Searching/VariableOrdering.cpp
+++ b/libs/tkwsm/src/Searching/VariableOrdering.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/src/Searching/WeightCalculator.cpp
+++ b/libs/tkwsm/src/Searching/WeightCalculator.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/src/WeightPruning/WeightChecker.cpp
+++ b/libs/tkwsm/src/WeightPruning/WeightChecker.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/src/WeightPruning/WeightNogoodDetector.cpp
+++ b/libs/tkwsm/src/WeightPruning/WeightNogoodDetector.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/src/WeightPruning/WeightNogoodDetectorManager.cpp
+++ b/libs/tkwsm/src/WeightPruning/WeightNogoodDetectorManager.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/test/CMakeLists.txt
+++ b/libs/tkwsm/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/libs/tkwsm/test/conanfile.py
+++ b/libs/tkwsm/test/conanfile.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/libs/tkwsm/test/src/Common/test_BitFunctions.cpp
+++ b/libs/tkwsm/test/src/Common/test_BitFunctions.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/test/src/Common/test_DyadicFraction.cpp
+++ b/libs/tkwsm/test/src/Common/test_DyadicFraction.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/test/src/Common/test_GeneralUtils.cpp
+++ b/libs/tkwsm/test/src/Common/test_GeneralUtils.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/test/src/Common/test_LogicalStack.cpp
+++ b/libs/tkwsm/test/src/Common/test_LogicalStack.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/test/src/EndToEndWrappers/test_SolutionWSM.cpp
+++ b/libs/tkwsm/test/src/EndToEndWrappers/test_SolutionWSM.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/test/src/GraphTheoretic/test_FilterUtils.cpp
+++ b/libs/tkwsm/test/src/GraphTheoretic/test_FilterUtils.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/test/src/GraphTheoretic/test_GeneralStructs.cpp
+++ b/libs/tkwsm/test/src/GraphTheoretic/test_GeneralStructs.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/test/src/GraphTheoretic/test_NeighboursData.cpp
+++ b/libs/tkwsm/test/src/GraphTheoretic/test_NeighboursData.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/test/src/InitPlacement/PlacementCostModelInterface.cpp
+++ b/libs/tkwsm/test/src/InitPlacement/PlacementCostModelInterface.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/test/src/InitPlacement/PlacementCostModelInterface.hpp
+++ b/libs/tkwsm/test/src/InitPlacement/PlacementCostModelInterface.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/test/src/InitPlacement/TestUtilsIQP.cpp
+++ b/libs/tkwsm/test/src/InitPlacement/TestUtilsIQP.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/test/src/InitPlacement/TestUtilsIQP.hpp
+++ b/libs/tkwsm/test/src/InitPlacement/TestUtilsIQP.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/test/src/InitPlacement/TestWeightedGraphData.cpp
+++ b/libs/tkwsm/test/src/InitPlacement/TestWeightedGraphData.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/test/src/InitPlacement/TestWeightedGraphData.hpp
+++ b/libs/tkwsm/test/src/InitPlacement/TestWeightedGraphData.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/test/src/InitPlacement/WeightedBinaryTree.cpp
+++ b/libs/tkwsm/test/src/InitPlacement/WeightedBinaryTree.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/test/src/InitPlacement/WeightedBinaryTree.hpp
+++ b/libs/tkwsm/test/src/InitPlacement/WeightedBinaryTree.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/test/src/InitPlacement/WeightedSquareGrid.cpp
+++ b/libs/tkwsm/test/src/InitPlacement/WeightedSquareGrid.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/test/src/InitPlacement/WeightedSquareGrid.hpp
+++ b/libs/tkwsm/test/src/InitPlacement/WeightedSquareGrid.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/test/src/InitPlacement/test_InitialPlacementProblems.cpp
+++ b/libs/tkwsm/test/src/InitPlacement/test_InitialPlacementProblems.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/test/src/InitPlacement/test_MonteCarloCompleteTargetSolution.cpp
+++ b/libs/tkwsm/test/src/InitPlacement/test_MonteCarloCompleteTargetSolution.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/test/src/InitPlacement/test_PrunedTargetEdges.cpp
+++ b/libs/tkwsm/test/src/InitPlacement/test_PrunedTargetEdges.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/test/src/InitPlacement/test_WeightedBinaryTree.cpp
+++ b/libs/tkwsm/test/src/InitPlacement/test_WeightedBinaryTree.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/test/src/InitPlacement/test_WeightedSquareGrid.cpp
+++ b/libs/tkwsm/test/src/InitPlacement/test_WeightedSquareGrid.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/test/src/Searching/test_NodesRawData.cpp
+++ b/libs/tkwsm/test/src/Searching/test_NodesRawData.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/test/src/Searching/test_NodesRawDataTraversals.cpp
+++ b/libs/tkwsm/test/src/Searching/test_NodesRawDataTraversals.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/test/src/SolvingProblems/test_CubicLattice.cpp
+++ b/libs/tkwsm/test/src/SolvingProblems/test_CubicLattice.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/test/src/SolvingProblems/test_FixedSmallGraphs.cpp
+++ b/libs/tkwsm/test/src/SolvingProblems/test_FixedSmallGraphs.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/test/src/SolvingProblems/test_RandomGraphs.cpp
+++ b/libs/tkwsm/test/src/SolvingProblems/test_RandomGraphs.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/test/src/SolvingProblems/test_SnakeIntoSquareGrid.cpp
+++ b/libs/tkwsm/test/src/SolvingProblems/test_SnakeIntoSquareGrid.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/test/src/SolvingProblems/test_SpecialProblems.cpp
+++ b/libs/tkwsm/test/src/SolvingProblems/test_SpecialProblems.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/test/src/SolvingProblems/test_SquareGrids.cpp
+++ b/libs/tkwsm/test/src/SolvingProblems/test_SquareGrids.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/test/src/SolvingProblems/test_UnweightedProblems.cpp
+++ b/libs/tkwsm/test/src/SolvingProblems/test_UnweightedProblems.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/test/src/SolvingProblems/test_UnweightedSelfEmbeddings.cpp
+++ b/libs/tkwsm/test/src/SolvingProblems/test_UnweightedSelfEmbeddings.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/test/src/TestUtils/CheckedSolution.cpp
+++ b/libs/tkwsm/test/src/TestUtils/CheckedSolution.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/test/src/TestUtils/CheckedSolution.hpp
+++ b/libs/tkwsm/test/src/TestUtils/CheckedSolution.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/test/src/TestUtils/FixedArchitectures.cpp
+++ b/libs/tkwsm/test/src/TestUtils/FixedArchitectures.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/test/src/TestUtils/FixedArchitectures.hpp
+++ b/libs/tkwsm/test/src/TestUtils/FixedArchitectures.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/test/src/TestUtils/GraphGeneration.cpp
+++ b/libs/tkwsm/test/src/TestUtils/GraphGeneration.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/test/src/TestUtils/GraphGeneration.hpp
+++ b/libs/tkwsm/test/src/TestUtils/GraphGeneration.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/test/src/TestUtils/ProblemGeneration.cpp
+++ b/libs/tkwsm/test/src/TestUtils/ProblemGeneration.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/test/src/TestUtils/ProblemGeneration.hpp
+++ b/libs/tkwsm/test/src/TestUtils/ProblemGeneration.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/test/src/TestUtils/ResumedSolutionChecker.cpp
+++ b/libs/tkwsm/test/src/TestUtils/ResumedSolutionChecker.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/test/src/TestUtils/ResumedSolutionChecker.hpp
+++ b/libs/tkwsm/test/src/TestUtils/ResumedSolutionChecker.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/test/src/TestUtils/SquareGridGeneration.cpp
+++ b/libs/tkwsm/test/src/TestUtils/SquareGridGeneration.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/test/src/TestUtils/SquareGridGeneration.hpp
+++ b/libs/tkwsm/test/src/TestUtils/SquareGridGeneration.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/test/src/TestUtils/TestSettings.cpp
+++ b/libs/tkwsm/test/src/TestUtils/TestSettings.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/test/src/TestUtils/TestSettings.hpp
+++ b/libs/tkwsm/test/src/TestUtils/TestSettings.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/test/src/TestUtils/test_SquareGridGeneration.cpp
+++ b/libs/tkwsm/test/src/TestUtils/test_SquareGridGeneration.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/libs/tkwsm/test_package/CMakeLists.txt
+++ b/libs/tkwsm/test_package/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/libs/tkwsm/test_package/conanfile.py
+++ b/libs/tkwsm/test_package/conanfile.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/libs/tkwsm/test_package/src/example.cpp
+++ b/libs/tkwsm/test_package/src/example.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pytket/CMakeLists.txt
+++ b/pytket/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytket/binders/architecture.cpp
+++ b/pytket/binders/architecture.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pytket/binders/circuit/Circuit/add_classical_op.cpp
+++ b/pytket/binders/circuit/Circuit/add_classical_op.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pytket/binders/circuit/Circuit/add_op.cpp
+++ b/pytket/binders/circuit/Circuit/add_op.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pytket/binders/circuit/Circuit/main.cpp
+++ b/pytket/binders/circuit/Circuit/main.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pytket/binders/circuit/boxes.cpp
+++ b/pytket/binders/circuit/boxes.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pytket/binders/circuit/classical.cpp
+++ b/pytket/binders/circuit/classical.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pytket/binders/circuit/clexpr.cpp
+++ b/pytket/binders/circuit/clexpr.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pytket/binders/circuit/main.cpp
+++ b/pytket/binders/circuit/main.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pytket/binders/circuit_library.cpp
+++ b/pytket/binders/circuit_library.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pytket/binders/include/UnitRegister.hpp
+++ b/pytket/binders/include/UnitRegister.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pytket/binders/include/add_gate.hpp
+++ b/pytket/binders/include/add_gate.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pytket/binders/include/binder_json.hpp
+++ b/pytket/binders/include/binder_json.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pytket/binders/include/binder_utils.hpp
+++ b/pytket/binders/include/binder_utils.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pytket/binders/include/circuit_registers.hpp
+++ b/pytket/binders/include/circuit_registers.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pytket/binders/include/deleted_hash.hpp
+++ b/pytket/binders/include/deleted_hash.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pytket/binders/include/py_operators.hpp
+++ b/pytket/binders/include/py_operators.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pytket/binders/include/typecast.hpp
+++ b/pytket/binders/include/typecast.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pytket/binders/include/unit_downcast.hpp
+++ b/pytket/binders/include/unit_downcast.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pytket/binders/logging.cpp
+++ b/pytket/binders/logging.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pytket/binders/mapping.cpp
+++ b/pytket/binders/mapping.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pytket/binders/partition.cpp
+++ b/pytket/binders/partition.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pytket/binders/passes.cpp
+++ b/pytket/binders/passes.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pytket/binders/pauli.cpp
+++ b/pytket/binders/pauli.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pytket/binders/placement.cpp
+++ b/pytket/binders/placement.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pytket/binders/predicates.cpp
+++ b/pytket/binders/predicates.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pytket/binders/tableau.cpp
+++ b/pytket/binders/tableau.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pytket/binders/tailoring.cpp
+++ b/pytket/binders/tailoring.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pytket/binders/transform.cpp
+++ b/pytket/binders/transform.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pytket/binders/unitid.cpp
+++ b/pytket/binders/unitid.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pytket/binders/utils_serialization.cpp
+++ b/pytket/binders/utils_serialization.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pytket/binders/zx/diagram.cpp
+++ b/pytket/binders/zx/diagram.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pytket/binders/zx/rewrite.cpp
+++ b/pytket/binders/zx/rewrite.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pytket/conanfile.py
+++ b/pytket/conanfile.py
@@ -38,7 +38,7 @@ class pytketRecipe(ConanFile):
         self.requires("pybind11_json/0.2.15")
         self.requires("symengine/0.13.0")
         self.requires("tkassert/0.3.4@tket/stable")
-        self.requires("tket/1.3.64@tket/stable")
+        self.requires("tket/1.3.65@tket/stable")
         self.requires("tklog/0.3.3@tket/stable")
         self.requires("tkrng/0.3.3@tket/stable")
         self.requires("tktokenswap/0.3.9@tket/stable")

--- a/pytket/pytket/__init__.py
+++ b/pytket/pytket/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytket/pytket/architecture/__init__.py
+++ b/pytket/pytket/architecture/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytket/pytket/backends/__init__.py
+++ b/pytket/pytket/backends/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytket/pytket/backends/backend.py
+++ b/pytket/pytket/backends/backend.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytket/pytket/backends/backend_exceptions.py
+++ b/pytket/pytket/backends/backend_exceptions.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytket/pytket/backends/backendinfo.py
+++ b/pytket/pytket/backends/backendinfo.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytket/pytket/backends/backendresult.py
+++ b/pytket/pytket/backends/backendresult.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytket/pytket/backends/resulthandle.py
+++ b/pytket/pytket/backends/resulthandle.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytket/pytket/backends/status.py
+++ b/pytket/pytket/backends/status.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytket/pytket/circuit/__init__.py
+++ b/pytket/pytket/circuit/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytket/pytket/circuit/add_condition.py
+++ b/pytket/pytket/circuit/add_condition.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytket/pytket/circuit/clexpr.py
+++ b/pytket/pytket/circuit/clexpr.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytket/pytket/circuit/decompose_classical.py
+++ b/pytket/pytket/circuit/decompose_classical.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytket/pytket/circuit/display/__init__.py
+++ b/pytket/pytket/circuit/display/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytket/pytket/circuit/logic_exp.py
+++ b/pytket/pytket/circuit/logic_exp.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytket/pytket/circuit/named_types.py
+++ b/pytket/pytket/circuit/named_types.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytket/pytket/circuit_library/__init__.py
+++ b/pytket/pytket/circuit_library/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytket/pytket/config/__init__.py
+++ b/pytket/pytket/config/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytket/pytket/config/pytket_config.py
+++ b/pytket/pytket/config/pytket_config.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytket/pytket/logging/__init__.py
+++ b/pytket/pytket/logging/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytket/pytket/mapping/__init__.py
+++ b/pytket/pytket/mapping/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytket/pytket/partition/__init__.py
+++ b/pytket/pytket/partition/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytket/pytket/passes/__init__.py
+++ b/pytket/pytket/passes/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytket/pytket/passes/passselector.py
+++ b/pytket/pytket/passes/passselector.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytket/pytket/passes/resizeregpass.py
+++ b/pytket/pytket/passes/resizeregpass.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytket/pytket/passes/script.py
+++ b/pytket/pytket/passes/script.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytket/pytket/pauli/__init__.py
+++ b/pytket/pytket/pauli/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytket/pytket/placement/__init__.py
+++ b/pytket/pytket/placement/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytket/pytket/predicates/__init__.py
+++ b/pytket/pytket/predicates/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytket/pytket/qasm/__init__.py
+++ b/pytket/pytket/qasm/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytket/pytket/qasm/grammar.py
+++ b/pytket/pytket/qasm/grammar.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytket/pytket/qasm/includes/load_includes.py
+++ b/pytket/pytket/qasm/includes/load_includes.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytket/pytket/qasm/qasm.py
+++ b/pytket/pytket/qasm/qasm.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytket/pytket/quipper/__init__.py
+++ b/pytket/pytket/quipper/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytket/pytket/quipper/quipper.py
+++ b/pytket/pytket/quipper/quipper.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytket/pytket/tableau/__init__.py
+++ b/pytket/pytket/tableau/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytket/pytket/tailoring/__init__.py
+++ b/pytket/pytket/tailoring/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytket/pytket/transform/__init__.py
+++ b/pytket/pytket/transform/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytket/pytket/unit_id/__init__.py
+++ b/pytket/pytket/unit_id/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytket/pytket/utils/__init__.py
+++ b/pytket/pytket/utils/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytket/pytket/utils/distribution.py
+++ b/pytket/pytket/utils/distribution.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytket/pytket/utils/expectations.py
+++ b/pytket/pytket/utils/expectations.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytket/pytket/utils/graph.py
+++ b/pytket/pytket/utils/graph.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytket/pytket/utils/measurements.py
+++ b/pytket/pytket/utils/measurements.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytket/pytket/utils/operators.py
+++ b/pytket/pytket/utils/operators.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytket/pytket/utils/outcomearray.py
+++ b/pytket/pytket/utils/outcomearray.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytket/pytket/utils/prepare.py
+++ b/pytket/pytket/utils/prepare.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytket/pytket/utils/results.py
+++ b/pytket/pytket/utils/results.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytket/pytket/utils/serialization/__init__.py
+++ b/pytket/pytket/utils/serialization/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytket/pytket/utils/spam.py
+++ b/pytket/pytket/utils/spam.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytket/pytket/utils/stats.py
+++ b/pytket/pytket/utils/stats.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytket/pytket/utils/symbolic.py
+++ b/pytket/pytket/utils/symbolic.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytket/pytket/utils/term_sequence.py
+++ b/pytket/pytket/utils/term_sequence.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytket/pytket/wasm/__init__.py
+++ b/pytket/pytket/wasm/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytket/pytket/wasm/wasm.py
+++ b/pytket/pytket/wasm/wasm.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytket/pytket/zx/__init__.py
+++ b/pytket/pytket/zx/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytket/pytket/zx/tensor_eval.py
+++ b/pytket/pytket/zx/tensor_eval.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytket/setup.py
+++ b/pytket/setup.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytket/tests/add_circuit_test.py
+++ b/pytket/tests/add_circuit_test.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytket/tests/ansatz_sequence_test.py
+++ b/pytket/tests/ansatz_sequence_test.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytket/tests/architecture_aware_synthesis_test.py
+++ b/pytket/tests/architecture_aware_synthesis_test.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytket/tests/architecture_test.py
+++ b/pytket/tests/architecture_test.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytket/tests/assertion_test.py
+++ b/pytket/tests/assertion_test.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytket/tests/backend_test.py
+++ b/pytket/tests/backend_test.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytket/tests/backendinfo_test.py
+++ b/pytket/tests/backendinfo_test.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytket/tests/characterisation_test.py
+++ b/pytket/tests/characterisation_test.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytket/tests/circuit_test.py
+++ b/pytket/tests/circuit_test.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytket/tests/classical_test.py
+++ b/pytket/tests/classical_test.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytket/tests/clexpr_test.py
+++ b/pytket/tests/clexpr_test.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytket/tests/compilation_test.py
+++ b/pytket/tests/compilation_test.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytket/tests/distribution_test.py
+++ b/pytket/tests/distribution_test.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytket/tests/mapping_test.py
+++ b/pytket/tests/mapping_test.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytket/tests/measurement_setup_test.py
+++ b/pytket/tests/measurement_setup_test.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytket/tests/mitigation_test.py
+++ b/pytket/tests/mitigation_test.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytket/tests/passes_script_test.py
+++ b/pytket/tests/passes_script_test.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytket/tests/passes_serialisation_test.py
+++ b/pytket/tests/passes_serialisation_test.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytket/tests/placement_test.py
+++ b/pytket/tests/placement_test.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytket/tests/predicates_test.py
+++ b/pytket/tests/predicates_test.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytket/tests/pytket_config_test.py
+++ b/pytket/tests/pytket_config_test.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytket/tests/qasm_test.py
+++ b/pytket/tests/qasm_test.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytket/tests/qubitpaulioperator_test.py
+++ b/pytket/tests/qubitpaulioperator_test.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytket/tests/quipper_simulate
+++ b/pytket/tests/quipper_simulate
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytket/tests/quipper_test.py
+++ b/pytket/tests/quipper_test.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytket/tests/simulator/__init__.py
+++ b/pytket/tests/simulator/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytket/tests/simulator/tket_sim_backend.py
+++ b/pytket/tests/simulator/tket_sim_backend.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytket/tests/simulator/tket_sim_wrapper.py
+++ b/pytket/tests/simulator/tket_sim_wrapper.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytket/tests/strategies.py
+++ b/pytket/tests/strategies.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytket/tests/tableau_test.py
+++ b/pytket/tests/tableau_test.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytket/tests/tket_sim_test.py
+++ b/pytket/tests/tket_sim_test.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytket/tests/transform_test.py
+++ b/pytket/tests/transform_test.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytket/tests/unit_id/bitregister_test.py
+++ b/pytket/tests/unit_id/bitregister_test.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytket/tests/unit_id/copy_test.py
+++ b/pytket/tests/unit_id/copy_test.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytket/tests/unit_id/qubitregister_test.py
+++ b/pytket/tests/unit_id/qubitregister_test.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytket/tests/utils_test.py
+++ b/pytket/tests/utils_test.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytket/tests/zx_diagram_test.py
+++ b/pytket/tests/zx_diagram_test.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/pybind11/conanfile.py
+++ b/recipes/pybind11/conanfile.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tket/CMakeLists.txt
+++ b/tket/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tket/conanfile.py
+++ b/tket/conanfile.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tket/conanfile.py
+++ b/tket/conanfile.py
@@ -23,7 +23,7 @@ from conan.errors import ConanInvalidConfiguration
 
 class TketConan(ConanFile):
     name = "tket"
-    version = "1.3.64"
+    version = "1.3.65"
     package_type = "library"
     license = "Apache 2"
     homepage = "https://github.com/CQCL/tket"

--- a/tket/include/tket/ArchAwareSynth/Path.hpp
+++ b/tket/include/tket/ArchAwareSynth/Path.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/ArchAwareSynth/SteinerForest.hpp
+++ b/tket/include/tket/ArchAwareSynth/SteinerForest.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/ArchAwareSynth/SteinerTree.hpp
+++ b/tket/include/tket/ArchAwareSynth/SteinerTree.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Architecture/Architecture.hpp
+++ b/tket/include/tket/Architecture/Architecture.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Architecture/ArchitectureMapping.hpp
+++ b/tket/include/tket/Architecture/ArchitectureMapping.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Architecture/BestTsaWithArch.hpp
+++ b/tket/include/tket/Architecture/BestTsaWithArch.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Architecture/DistancesFromArchitecture.hpp
+++ b/tket/include/tket/Architecture/DistancesFromArchitecture.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Architecture/NeighboursFromArchitecture.hpp
+++ b/tket/include/tket/Architecture/NeighboursFromArchitecture.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Architecture/SubgraphMonomorphisms.hpp
+++ b/tket/include/tket/Architecture/SubgraphMonomorphisms.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Characterisation/Cycles.hpp
+++ b/tket/include/tket/Characterisation/Cycles.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Characterisation/DeviceCharacterisation.hpp
+++ b/tket/include/tket/Characterisation/DeviceCharacterisation.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Characterisation/ErrorTypes.hpp
+++ b/tket/include/tket/Characterisation/ErrorTypes.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Characterisation/FrameRandomisation.hpp
+++ b/tket/include/tket/Characterisation/FrameRandomisation.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Circuit/AssertionSynthesis.hpp
+++ b/tket/include/tket/Circuit/AssertionSynthesis.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Circuit/Boxes.hpp
+++ b/tket/include/tket/Circuit/Boxes.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Circuit/CircPool.hpp
+++ b/tket/include/tket/Circuit/CircPool.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Circuit/CircUtils.hpp
+++ b/tket/include/tket/Circuit/CircUtils.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Circuit/Circuit.hpp
+++ b/tket/include/tket/Circuit/Circuit.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Circuit/ClassicalExpBox.hpp
+++ b/tket/include/tket/Circuit/ClassicalExpBox.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Circuit/Command.hpp
+++ b/tket/include/tket/Circuit/Command.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Circuit/Conditional.hpp
+++ b/tket/include/tket/Circuit/Conditional.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Circuit/ConjugationBox.hpp
+++ b/tket/include/tket/Circuit/ConjugationBox.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Circuit/DAGDefs.hpp
+++ b/tket/include/tket/Circuit/DAGDefs.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Circuit/DiagonalBox.hpp
+++ b/tket/include/tket/Circuit/DiagonalBox.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Circuit/DummyBox.hpp
+++ b/tket/include/tket/Circuit/DummyBox.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Circuit/Multiplexor.hpp
+++ b/tket/include/tket/Circuit/Multiplexor.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Circuit/PauliExpBoxes.hpp
+++ b/tket/include/tket/Circuit/PauliExpBoxes.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Circuit/ResourceData.hpp
+++ b/tket/include/tket/Circuit/ResourceData.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Circuit/Simulation/CircuitSimulator.hpp
+++ b/tket/include/tket/Circuit/Simulation/CircuitSimulator.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Circuit/Simulation/PauliExpBoxUnitaryCalculator.hpp
+++ b/tket/include/tket/Circuit/Simulation/PauliExpBoxUnitaryCalculator.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Circuit/Slices.hpp
+++ b/tket/include/tket/Circuit/Slices.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Circuit/StatePreparation.hpp
+++ b/tket/include/tket/Circuit/StatePreparation.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Circuit/ThreeQubitConversion.hpp
+++ b/tket/include/tket/Circuit/ThreeQubitConversion.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Circuit/ToffoliBox.hpp
+++ b/tket/include/tket/Circuit/ToffoliBox.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Clifford/ChoiMixTableau.hpp
+++ b/tket/include/tket/Clifford/ChoiMixTableau.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Clifford/SymplecticTableau.hpp
+++ b/tket/include/tket/Clifford/SymplecticTableau.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Clifford/UnitaryTableau.hpp
+++ b/tket/include/tket/Clifford/UnitaryTableau.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Converters/Converters.hpp
+++ b/tket/include/tket/Converters/Converters.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Converters/Gauss.hpp
+++ b/tket/include/tket/Converters/Gauss.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Converters/PhasePoly.hpp
+++ b/tket/include/tket/Converters/PhasePoly.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Converters/UnitaryTableauBox.hpp
+++ b/tket/include/tket/Converters/UnitaryTableauBox.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Diagonalisation/DiagUtils.hpp
+++ b/tket/include/tket/Diagonalisation/DiagUtils.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Diagonalisation/Diagonalisation.hpp
+++ b/tket/include/tket/Diagonalisation/Diagonalisation.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Diagonalisation/PauliPartition.hpp
+++ b/tket/include/tket/Diagonalisation/PauliPartition.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Gate/Gate.hpp
+++ b/tket/include/tket/Gate/Gate.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Gate/GatePtr.hpp
+++ b/tket/include/tket/Gate/GatePtr.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Gate/GateUnitaryMatrix.hpp
+++ b/tket/include/tket/Gate/GateUnitaryMatrix.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Gate/GateUnitaryMatrixError.hpp
+++ b/tket/include/tket/Gate/GateUnitaryMatrixError.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Gate/GateUnitaryMatrixImplementations.hpp
+++ b/tket/include/tket/Gate/GateUnitaryMatrixImplementations.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Gate/GateUnitaryMatrixUtils.hpp
+++ b/tket/include/tket/Gate/GateUnitaryMatrixUtils.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Gate/OpPtrFunctions.hpp
+++ b/tket/include/tket/Gate/OpPtrFunctions.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Gate/Rotation.hpp
+++ b/tket/include/tket/Gate/Rotation.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Gate/SymTable.hpp
+++ b/tket/include/tket/Gate/SymTable.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Graphs/AbstractGraph.hpp
+++ b/tket/include/tket/Graphs/AbstractGraph.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Graphs/AdjacencyData.hpp
+++ b/tket/include/tket/Graphs/AdjacencyData.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Graphs/ArticulationPoints.hpp
+++ b/tket/include/tket/Graphs/ArticulationPoints.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Graphs/ArticulationPoints_impl.hpp
+++ b/tket/include/tket/Graphs/ArticulationPoints_impl.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Graphs/CompleteGraph.hpp
+++ b/tket/include/tket/Graphs/CompleteGraph.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Graphs/DirectedGraph.hpp
+++ b/tket/include/tket/Graphs/DirectedGraph.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Graphs/GraphColouring.hpp
+++ b/tket/include/tket/Graphs/GraphColouring.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Graphs/GraphRoutines.hpp
+++ b/tket/include/tket/Graphs/GraphRoutines.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Graphs/LargeCliquesResult.hpp
+++ b/tket/include/tket/Graphs/LargeCliquesResult.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Graphs/TreeSearch.hpp
+++ b/tket/include/tket/Graphs/TreeSearch.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Graphs/TreeSearch_impl.hpp
+++ b/tket/include/tket/Graphs/TreeSearch_impl.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Graphs/Utils.hpp
+++ b/tket/include/tket/Graphs/Utils.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Graphs/Utils_impl.hpp
+++ b/tket/include/tket/Graphs/Utils_impl.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Mapping/AASLabelling.hpp
+++ b/tket/include/tket/Mapping/AASLabelling.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Mapping/AASRoute.hpp
+++ b/tket/include/tket/Mapping/AASRoute.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Mapping/BoxDecomposition.hpp
+++ b/tket/include/tket/Mapping/BoxDecomposition.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Mapping/LexiLabelling.hpp
+++ b/tket/include/tket/Mapping/LexiLabelling.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Mapping/LexiRoute.hpp
+++ b/tket/include/tket/Mapping/LexiRoute.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Mapping/LexiRouteRoutingMethod.hpp
+++ b/tket/include/tket/Mapping/LexiRouteRoutingMethod.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Mapping/LexicographicalComparison.hpp
+++ b/tket/include/tket/Mapping/LexicographicalComparison.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Mapping/MappingFrontier.hpp
+++ b/tket/include/tket/Mapping/MappingFrontier.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Mapping/MappingManager.hpp
+++ b/tket/include/tket/Mapping/MappingManager.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Mapping/MultiGateReorder.hpp
+++ b/tket/include/tket/Mapping/MultiGateReorder.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Mapping/RoutingMethod.hpp
+++ b/tket/include/tket/Mapping/RoutingMethod.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Mapping/RoutingMethodCircuit.hpp
+++ b/tket/include/tket/Mapping/RoutingMethodCircuit.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Mapping/RoutingMethodJson.hpp
+++ b/tket/include/tket/Mapping/RoutingMethodJson.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Mapping/Verification.hpp
+++ b/tket/include/tket/Mapping/Verification.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/MeasurementSetup/MeasurementReduction.hpp
+++ b/tket/include/tket/MeasurementSetup/MeasurementReduction.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/MeasurementSetup/MeasurementSetup.hpp
+++ b/tket/include/tket/MeasurementSetup/MeasurementSetup.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/OpType/EdgeType.hpp
+++ b/tket/include/tket/OpType/EdgeType.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/OpType/OpDesc.hpp
+++ b/tket/include/tket/OpType/OpDesc.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/OpType/OpType.hpp
+++ b/tket/include/tket/OpType/OpType.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/OpType/OpTypeFunctions.hpp
+++ b/tket/include/tket/OpType/OpTypeFunctions.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/OpType/OpTypeInfo.hpp
+++ b/tket/include/tket/OpType/OpTypeInfo.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Ops/BarrierOp.hpp
+++ b/tket/include/tket/Ops/BarrierOp.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Ops/ClExpr.hpp
+++ b/tket/include/tket/Ops/ClExpr.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Ops/ClassicalOps.hpp
+++ b/tket/include/tket/Ops/ClassicalOps.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Ops/FlowOp.hpp
+++ b/tket/include/tket/Ops/FlowOp.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Ops/MetaOp.hpp
+++ b/tket/include/tket/Ops/MetaOp.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Ops/Op.hpp
+++ b/tket/include/tket/Ops/Op.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Ops/OpJsonFactory.hpp
+++ b/tket/include/tket/Ops/OpJsonFactory.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Ops/OpPtr.hpp
+++ b/tket/include/tket/Ops/OpPtr.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/PauliGraph/ConjugatePauliFunctions.hpp
+++ b/tket/include/tket/PauliGraph/ConjugatePauliFunctions.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/PauliGraph/PauliGraph.hpp
+++ b/tket/include/tket/PauliGraph/PauliGraph.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Placement/NeighbourPlacements.hpp
+++ b/tket/include/tket/Placement/NeighbourPlacements.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Placement/Placement.hpp
+++ b/tket/include/tket/Placement/Placement.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Placement/QubitGraph.hpp
+++ b/tket/include/tket/Placement/QubitGraph.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Predicates/CompilationUnit.hpp
+++ b/tket/include/tket/Predicates/CompilationUnit.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Predicates/CompilerPass.hpp
+++ b/tket/include/tket/Predicates/CompilerPass.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Predicates/PassGenerators.hpp
+++ b/tket/include/tket/Predicates/PassGenerators.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Predicates/PassLibrary.hpp
+++ b/tket/include/tket/Predicates/PassLibrary.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Predicates/Predicates.hpp
+++ b/tket/include/tket/Predicates/Predicates.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Transformations/BasicOptimisation.hpp
+++ b/tket/include/tket/Transformations/BasicOptimisation.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Transformations/CliffordOptimisation.hpp
+++ b/tket/include/tket/Transformations/CliffordOptimisation.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Transformations/CliffordReductionPass.hpp
+++ b/tket/include/tket/Transformations/CliffordReductionPass.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Transformations/CliffordResynthesis.hpp
+++ b/tket/include/tket/Transformations/CliffordResynthesis.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Transformations/Combinator.hpp
+++ b/tket/include/tket/Transformations/Combinator.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Transformations/ContextualReduction.hpp
+++ b/tket/include/tket/Transformations/ContextualReduction.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Transformations/Decomposition.hpp
+++ b/tket/include/tket/Transformations/Decomposition.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Transformations/GreedyPauliOptimisation.hpp
+++ b/tket/include/tket/Transformations/GreedyPauliOptimisation.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Transformations/GreedyPauliOptimisationLookupTables.hpp
+++ b/tket/include/tket/Transformations/GreedyPauliOptimisationLookupTables.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Transformations/MeasurePass.hpp
+++ b/tket/include/tket/Transformations/MeasurePass.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Transformations/OptimisationPass.hpp
+++ b/tket/include/tket/Transformations/OptimisationPass.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Transformations/PQPSquash.hpp
+++ b/tket/include/tket/Transformations/PQPSquash.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Transformations/PauliOptimisation.hpp
+++ b/tket/include/tket/Transformations/PauliOptimisation.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Transformations/PhaseOptimisation.hpp
+++ b/tket/include/tket/Transformations/PhaseOptimisation.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Transformations/PhasedXFrontier.hpp
+++ b/tket/include/tket/Transformations/PhasedXFrontier.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Transformations/Rebase.hpp
+++ b/tket/include/tket/Transformations/Rebase.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Transformations/Replacement.hpp
+++ b/tket/include/tket/Transformations/Replacement.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Transformations/RzPhasedXSquash.hpp
+++ b/tket/include/tket/Transformations/RzPhasedXSquash.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Transformations/SingleQubitSquash.hpp
+++ b/tket/include/tket/Transformations/SingleQubitSquash.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Transformations/StandardSquash.hpp
+++ b/tket/include/tket/Transformations/StandardSquash.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Transformations/ThreeQubitSquash.hpp
+++ b/tket/include/tket/Transformations/ThreeQubitSquash.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Transformations/Transform.hpp
+++ b/tket/include/tket/Transformations/Transform.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Utils/Constants.hpp
+++ b/tket/include/tket/Utils/Constants.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Utils/CosSinDecomposition.hpp
+++ b/tket/include/tket/Utils/CosSinDecomposition.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Utils/EigenConfig.hpp
+++ b/tket/include/tket/Utils/EigenConfig.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Utils/Expression.hpp
+++ b/tket/include/tket/Utils/Expression.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Utils/GraphHeaders.hpp
+++ b/tket/include/tket/Utils/GraphHeaders.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Utils/HelperFunctions.hpp
+++ b/tket/include/tket/Utils/HelperFunctions.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Utils/Json.hpp
+++ b/tket/include/tket/Utils/Json.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Utils/MatrixAnalysis.hpp
+++ b/tket/include/tket/Utils/MatrixAnalysis.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Utils/PauliTensor.hpp
+++ b/tket/include/tket/Utils/PauliTensor.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Utils/SequencedContainers.hpp
+++ b/tket/include/tket/Utils/SequencedContainers.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/Utils/UnitID.hpp
+++ b/tket/include/tket/Utils/UnitID.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/ZX/Flow.hpp
+++ b/tket/include/tket/ZX/Flow.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/ZX/Rewrite.hpp
+++ b/tket/include/tket/ZX/Rewrite.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/ZX/Types.hpp
+++ b/tket/include/tket/ZX/Types.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/ZX/ZXDiagram.hpp
+++ b/tket/include/tket/ZX/ZXDiagram.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/ZX/ZXDiagramImpl.hpp
+++ b/tket/include/tket/ZX/ZXDiagramImpl.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/include/tket/ZX/ZXGenerator.hpp
+++ b/tket/include/tket/ZX/ZXGenerator.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/proptest/CMakeLists.txt
+++ b/tket/proptest/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tket/proptest/src/ComparisonFunctions.cpp
+++ b/tket/proptest/src/ComparisonFunctions.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/proptest/src/ComparisonFunctions.hpp
+++ b/tket/proptest/src/ComparisonFunctions.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/proptest/src/proptest.cpp
+++ b/tket/proptest/src/proptest.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/ArchAwareSynth/Path.cpp
+++ b/tket/src/ArchAwareSynth/Path.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/ArchAwareSynth/SteinerForest.cpp
+++ b/tket/src/ArchAwareSynth/SteinerForest.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/ArchAwareSynth/SteinerTree.cpp
+++ b/tket/src/ArchAwareSynth/SteinerTree.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Architecture/Architecture.cpp
+++ b/tket/src/Architecture/Architecture.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Architecture/ArchitectureGraphClasses.cpp
+++ b/tket/src/Architecture/ArchitectureGraphClasses.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Architecture/ArchitectureMapping.cpp
+++ b/tket/src/Architecture/ArchitectureMapping.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Architecture/BestTsaWithArch.cpp
+++ b/tket/src/Architecture/BestTsaWithArch.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Architecture/DistancesFromArchitecture.cpp
+++ b/tket/src/Architecture/DistancesFromArchitecture.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Architecture/NeighboursFromArchitecture.cpp
+++ b/tket/src/Architecture/NeighboursFromArchitecture.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Architecture/SubgraphMonomorphisms.cpp
+++ b/tket/src/Architecture/SubgraphMonomorphisms.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Characterisation/Cycles.cpp
+++ b/tket/src/Characterisation/Cycles.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Characterisation/DeviceCharacterisation.cpp
+++ b/tket/src/Characterisation/DeviceCharacterisation.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Characterisation/FrameRandomisation.cpp
+++ b/tket/src/Characterisation/FrameRandomisation.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Circuit/AssertionSynthesis.cpp
+++ b/tket/src/Circuit/AssertionSynthesis.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Circuit/Boxes.cpp
+++ b/tket/src/Circuit/Boxes.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Circuit/CircPool.cpp
+++ b/tket/src/Circuit/CircPool.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Circuit/CircUtils.cpp
+++ b/tket/src/Circuit/CircUtils.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Circuit/Circuit.cpp
+++ b/tket/src/Circuit/Circuit.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Circuit/CircuitJson.cpp
+++ b/tket/src/Circuit/CircuitJson.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Circuit/CommandJson.cpp
+++ b/tket/src/Circuit/CommandJson.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Circuit/Conditional.cpp
+++ b/tket/src/Circuit/Conditional.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Circuit/ConjugationBox.cpp
+++ b/tket/src/Circuit/ConjugationBox.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Circuit/ControlledGates.cpp
+++ b/tket/src/Circuit/ControlledGates.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Circuit/DAGProperties.cpp
+++ b/tket/src/Circuit/DAGProperties.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Circuit/DAGProperties.hpp
+++ b/tket/src/Circuit/DAGProperties.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Circuit/DiagonalBox.cpp
+++ b/tket/src/Circuit/DiagonalBox.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Circuit/DummyBox.cpp
+++ b/tket/src/Circuit/DummyBox.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Circuit/Multiplexor.cpp
+++ b/tket/src/Circuit/Multiplexor.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Circuit/OpJson.cpp
+++ b/tket/src/Circuit/OpJson.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Circuit/PauliExpBoxes.cpp
+++ b/tket/src/Circuit/PauliExpBoxes.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Circuit/ResourceData.cpp
+++ b/tket/src/Circuit/ResourceData.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Circuit/Simulation/BitOperations.cpp
+++ b/tket/src/Circuit/Simulation/BitOperations.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Circuit/Simulation/BitOperations.hpp
+++ b/tket/src/Circuit/Simulation/BitOperations.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Circuit/Simulation/CircuitSimulator.cpp
+++ b/tket/src/Circuit/Simulation/CircuitSimulator.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Circuit/Simulation/DecomposeCircuit.cpp
+++ b/tket/src/Circuit/Simulation/DecomposeCircuit.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Circuit/Simulation/DecomposeCircuit.hpp
+++ b/tket/src/Circuit/Simulation/DecomposeCircuit.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Circuit/Simulation/GateNode.cpp
+++ b/tket/src/Circuit/Simulation/GateNode.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Circuit/Simulation/GateNode.hpp
+++ b/tket/src/Circuit/Simulation/GateNode.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Circuit/Simulation/GateNodesBuffer.cpp
+++ b/tket/src/Circuit/Simulation/GateNodesBuffer.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Circuit/Simulation/GateNodesBuffer.hpp
+++ b/tket/src/Circuit/Simulation/GateNodesBuffer.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Circuit/Simulation/PauliExpBoxUnitaryCalculator.cpp
+++ b/tket/src/Circuit/Simulation/PauliExpBoxUnitaryCalculator.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Circuit/Slices.cpp
+++ b/tket/src/Circuit/Slices.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Circuit/StatePreparation.cpp
+++ b/tket/src/Circuit/StatePreparation.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Circuit/SubcircuitFinder.cpp
+++ b/tket/src/Circuit/SubcircuitFinder.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Circuit/ThreeQubitConversion.cpp
+++ b/tket/src/Circuit/ThreeQubitConversion.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Circuit/ToffoliBox.cpp
+++ b/tket/src/Circuit/ToffoliBox.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Circuit/basic_circ_manip.cpp
+++ b/tket/src/Circuit/basic_circ_manip.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Circuit/latex_drawing.cpp
+++ b/tket/src/Circuit/latex_drawing.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Circuit/macro_circ_info.cpp
+++ b/tket/src/Circuit/macro_circ_info.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Circuit/macro_manipulation.cpp
+++ b/tket/src/Circuit/macro_manipulation.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Circuit/setters_and_getters.cpp
+++ b/tket/src/Circuit/setters_and_getters.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Clifford/ChoiMixTableau.cpp
+++ b/tket/src/Clifford/ChoiMixTableau.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Clifford/SymplecticTableau.cpp
+++ b/tket/src/Clifford/SymplecticTableau.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Clifford/UnitaryTableau.cpp
+++ b/tket/src/Clifford/UnitaryTableau.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Converters/ChoiMixTableauConverters.cpp
+++ b/tket/src/Converters/ChoiMixTableauConverters.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Converters/Gauss.cpp
+++ b/tket/src/Converters/Gauss.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Converters/PauliGraphConverters.cpp
+++ b/tket/src/Converters/PauliGraphConverters.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Converters/PhasePoly.cpp
+++ b/tket/src/Converters/PhasePoly.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Converters/UnitaryTableauBox.cpp
+++ b/tket/src/Converters/UnitaryTableauBox.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Converters/UnitaryTableauConverters.cpp
+++ b/tket/src/Converters/UnitaryTableauConverters.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Converters/ZXConverters.cpp
+++ b/tket/src/Converters/ZXConverters.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Diagonalisation/DiagUtils.cpp
+++ b/tket/src/Diagonalisation/DiagUtils.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Diagonalisation/Diagonalisation.cpp
+++ b/tket/src/Diagonalisation/Diagonalisation.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Diagonalisation/PauliPartition.cpp
+++ b/tket/src/Diagonalisation/PauliPartition.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Gate/Gate.cpp
+++ b/tket/src/Gate/Gate.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Gate/GatePtr.cpp
+++ b/tket/src/Gate/GatePtr.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Gate/GateUnitaryMatrix.cpp
+++ b/tket/src/Gate/GateUnitaryMatrix.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Gate/GateUnitaryMatrixComposites.cpp
+++ b/tket/src/Gate/GateUnitaryMatrixComposites.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Gate/GateUnitaryMatrixError.cpp
+++ b/tket/src/Gate/GateUnitaryMatrixError.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Gate/GateUnitaryMatrixFixedMatrices.cpp
+++ b/tket/src/Gate/GateUnitaryMatrixFixedMatrices.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Gate/GateUnitaryMatrixPrimitives.cpp
+++ b/tket/src/Gate/GateUnitaryMatrixPrimitives.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Gate/GateUnitaryMatrixUtils.cpp
+++ b/tket/src/Gate/GateUnitaryMatrixUtils.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Gate/GateUnitaryMatrixVariableQubits.cpp
+++ b/tket/src/Gate/GateUnitaryMatrixVariableQubits.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Gate/GateUnitaryMatrixVariableQubits.hpp
+++ b/tket/src/Gate/GateUnitaryMatrixVariableQubits.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Gate/GateUnitarySparseMatrix.cpp
+++ b/tket/src/Gate/GateUnitarySparseMatrix.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Gate/GateUnitarySparseMatrix.hpp
+++ b/tket/src/Gate/GateUnitarySparseMatrix.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Gate/OpPtrFunctions.cpp
+++ b/tket/src/Gate/OpPtrFunctions.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Gate/Rotation.cpp
+++ b/tket/src/Gate/Rotation.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Gate/SymTable.cpp
+++ b/tket/src/Gate/SymTable.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Graphs/AdjacencyData.cpp
+++ b/tket/src/Graphs/AdjacencyData.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Graphs/ArticulationPoints.cpp
+++ b/tket/src/Graphs/ArticulationPoints.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Graphs/BruteForceColouring.cpp
+++ b/tket/src/Graphs/BruteForceColouring.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Graphs/BruteForceColouring.hpp
+++ b/tket/src/Graphs/BruteForceColouring.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Graphs/ColouringPriority.cpp
+++ b/tket/src/Graphs/ColouringPriority.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Graphs/ColouringPriority.hpp
+++ b/tket/src/Graphs/ColouringPriority.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Graphs/GraphColouring.cpp
+++ b/tket/src/Graphs/GraphColouring.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Graphs/GraphRoutines.cpp
+++ b/tket/src/Graphs/GraphRoutines.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Graphs/LargeCliquesResult.cpp
+++ b/tket/src/Graphs/LargeCliquesResult.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Mapping/AASLabelling.cpp
+++ b/tket/src/Mapping/AASLabelling.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Mapping/AASRoute.cpp
+++ b/tket/src/Mapping/AASRoute.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Mapping/BoxDecomposition.cpp
+++ b/tket/src/Mapping/BoxDecomposition.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Mapping/LexiLabelling.cpp
+++ b/tket/src/Mapping/LexiLabelling.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Mapping/LexiRoute.cpp
+++ b/tket/src/Mapping/LexiRoute.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Mapping/LexiRouteRoutingMethod.cpp
+++ b/tket/src/Mapping/LexiRouteRoutingMethod.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Mapping/LexicographicalComparison.cpp
+++ b/tket/src/Mapping/LexicographicalComparison.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Mapping/MappingFrontier.cpp
+++ b/tket/src/Mapping/MappingFrontier.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Mapping/MappingManager.cpp
+++ b/tket/src/Mapping/MappingManager.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Mapping/MultiGateReorder.cpp
+++ b/tket/src/Mapping/MultiGateReorder.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Mapping/RoutingMethodCircuit.cpp
+++ b/tket/src/Mapping/RoutingMethodCircuit.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Mapping/RoutingMethodJson.cpp
+++ b/tket/src/Mapping/RoutingMethodJson.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Mapping/Verification.cpp
+++ b/tket/src/Mapping/Verification.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/MeasurementSetup/MeasurementReduction.cpp
+++ b/tket/src/MeasurementSetup/MeasurementReduction.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/MeasurementSetup/MeasurementSetup.cpp
+++ b/tket/src/MeasurementSetup/MeasurementSetup.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/OpType/OpDesc.cpp
+++ b/tket/src/OpType/OpDesc.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/OpType/OpTypeFunctions.cpp
+++ b/tket/src/OpType/OpTypeFunctions.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/OpType/OpTypeInfo.cpp
+++ b/tket/src/OpType/OpTypeInfo.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/OpType/OpTypeJson.cpp
+++ b/tket/src/OpType/OpTypeJson.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Ops/BarrierOp.cpp
+++ b/tket/src/Ops/BarrierOp.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Ops/ClExpr.cpp
+++ b/tket/src/Ops/ClExpr.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Ops/ClassicalOps.cpp
+++ b/tket/src/Ops/ClassicalOps.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Ops/FlowOp.cpp
+++ b/tket/src/Ops/FlowOp.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Ops/MetaOp.cpp
+++ b/tket/src/Ops/MetaOp.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Ops/Op.cpp
+++ b/tket/src/Ops/Op.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Ops/OpJsonFactory.cpp
+++ b/tket/src/Ops/OpJsonFactory.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/PauliGraph/ConjugatePauliFunctions.cpp
+++ b/tket/src/PauliGraph/ConjugatePauliFunctions.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/PauliGraph/PauliGraph.cpp
+++ b/tket/src/PauliGraph/PauliGraph.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Placement/Frontier.cpp
+++ b/tket/src/Placement/Frontier.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Placement/GraphPlacement.cpp
+++ b/tket/src/Placement/GraphPlacement.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Placement/LinePlacement.cpp
+++ b/tket/src/Placement/LinePlacement.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Placement/MonomorphismCalculation.cpp
+++ b/tket/src/Placement/MonomorphismCalculation.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Placement/NeighbourPlacements.cpp
+++ b/tket/src/Placement/NeighbourPlacements.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Placement/NoiseAwarePlacement.cpp
+++ b/tket/src/Placement/NoiseAwarePlacement.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Placement/Placement.cpp
+++ b/tket/src/Placement/Placement.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Placement/PlacementGraphClasses.cpp
+++ b/tket/src/Placement/PlacementGraphClasses.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Placement/RelabelledGraphWSM.hpp
+++ b/tket/src/Placement/RelabelledGraphWSM.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Predicates/CompilationUnit.cpp
+++ b/tket/src/Predicates/CompilationUnit.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Predicates/CompilerPass.cpp
+++ b/tket/src/Predicates/CompilerPass.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Predicates/PassGenerators.cpp
+++ b/tket/src/Predicates/PassGenerators.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Predicates/PassLibrary.cpp
+++ b/tket/src/Predicates/PassLibrary.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Predicates/Predicates.cpp
+++ b/tket/src/Predicates/Predicates.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Transformations/BasicOptimisation.cpp
+++ b/tket/src/Transformations/BasicOptimisation.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Transformations/CliffordOptimisation.cpp
+++ b/tket/src/Transformations/CliffordOptimisation.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Transformations/CliffordReductionPass.cpp
+++ b/tket/src/Transformations/CliffordReductionPass.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Transformations/CliffordResynthesis.cpp
+++ b/tket/src/Transformations/CliffordResynthesis.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Transformations/Combinator.cpp
+++ b/tket/src/Transformations/Combinator.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Transformations/ContextualReduction.cpp
+++ b/tket/src/Transformations/ContextualReduction.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Transformations/Decomposition.cpp
+++ b/tket/src/Transformations/Decomposition.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Transformations/GreedyPauliConverters.cpp
+++ b/tket/src/Transformations/GreedyPauliConverters.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Transformations/GreedyPauliOps.cpp
+++ b/tket/src/Transformations/GreedyPauliOps.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Transformations/GreedyPauliOptimisation.cpp
+++ b/tket/src/Transformations/GreedyPauliOptimisation.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Transformations/MeasurePass.cpp
+++ b/tket/src/Transformations/MeasurePass.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Transformations/OptimisationPass.cpp
+++ b/tket/src/Transformations/OptimisationPass.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Transformations/PQPSquash.cpp
+++ b/tket/src/Transformations/PQPSquash.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Transformations/PauliOptimisation.cpp
+++ b/tket/src/Transformations/PauliOptimisation.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Transformations/PhaseOptimisation.cpp
+++ b/tket/src/Transformations/PhaseOptimisation.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Transformations/PhasedXFrontier.cpp
+++ b/tket/src/Transformations/PhasedXFrontier.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Transformations/Rebase.cpp
+++ b/tket/src/Transformations/Rebase.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Transformations/RedundancyRemoval.cpp
+++ b/tket/src/Transformations/RedundancyRemoval.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Transformations/Replacement.cpp
+++ b/tket/src/Transformations/Replacement.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Transformations/RzPhasedXSquash.cpp
+++ b/tket/src/Transformations/RzPhasedXSquash.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Transformations/SingleQubitSquash.cpp
+++ b/tket/src/Transformations/SingleQubitSquash.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Transformations/StandardSquash.cpp
+++ b/tket/src/Transformations/StandardSquash.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Transformations/ThreeQubitSquash.cpp
+++ b/tket/src/Transformations/ThreeQubitSquash.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Transformations/std_clifford_decomp.py
+++ b/tket/src/Transformations/std_clifford_decomp.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tket/src/Utils/CosSinDecomposition.cpp
+++ b/tket/src/Utils/CosSinDecomposition.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Utils/Expression.cpp
+++ b/tket/src/Utils/Expression.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Utils/HelperFunctions.cpp
+++ b/tket/src/Utils/HelperFunctions.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Utils/MatrixAnalysis.cpp
+++ b/tket/src/Utils/MatrixAnalysis.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Utils/PauliTensor.cpp
+++ b/tket/src/Utils/PauliTensor.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/Utils/UnitID.cpp
+++ b/tket/src/Utils/UnitID.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/ZX/Flow.cpp
+++ b/tket/src/ZX/Flow.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/ZX/MBQCRewrites.cpp
+++ b/tket/src/ZX/MBQCRewrites.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/ZX/ZXDConstructors.cpp
+++ b/tket/src/ZX/ZXDConstructors.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/ZX/ZXDExpansions.cpp
+++ b/tket/src/ZX/ZXDExpansions.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/ZX/ZXDFormats.cpp
+++ b/tket/src/ZX/ZXDFormats.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/ZX/ZXDGettersSetters.cpp
+++ b/tket/src/ZX/ZXDGettersSetters.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/ZX/ZXDManipulation.cpp
+++ b/tket/src/ZX/ZXDManipulation.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/ZX/ZXDSubdiagram.cpp
+++ b/tket/src/ZX/ZXDSubdiagram.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/ZX/ZXGenerator.cpp
+++ b/tket/src/ZX/ZXGenerator.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/ZX/ZXRWAxioms.cpp
+++ b/tket/src/ZX/ZXRWAxioms.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/ZX/ZXRWCombinators.cpp
+++ b/tket/src/ZX/ZXRWCombinators.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/ZX/ZXRWDecompositions.cpp
+++ b/tket/src/ZX/ZXRWDecompositions.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/ZX/ZXRWGraphLikeForm.cpp
+++ b/tket/src/ZX/ZXRWGraphLikeForm.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/ZX/ZXRWGraphLikeSimplification.cpp
+++ b/tket/src/ZX/ZXRWGraphLikeSimplification.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/src/ZX/ZXRWSequences.cpp
+++ b/tket/src/ZX/ZXRWSequences.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/CMakeLists.txt
+++ b/tket/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tket/test/src/Architecture/test_SubgraphMonomorphisms.cpp
+++ b/tket/test/src/Architecture/test_SubgraphMonomorphisms.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/Circuit/test_Boxes.cpp
+++ b/tket/test/src/Circuit/test_Boxes.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/Circuit/test_Circ.cpp
+++ b/tket/test/src/Circuit/test_Circ.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/Circuit/test_CircPool.cpp
+++ b/tket/test/src/Circuit/test_CircPool.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/Circuit/test_ConjugationBox.cpp
+++ b/tket/test/src/Circuit/test_ConjugationBox.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/Circuit/test_DiagonalBox.cpp
+++ b/tket/test/src/Circuit/test_DiagonalBox.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/Circuit/test_DummyBox.cpp
+++ b/tket/test/src/Circuit/test_DummyBox.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/Circuit/test_Multiplexor.cpp
+++ b/tket/test/src/Circuit/test_Multiplexor.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/Circuit/test_PauliExpBoxes.cpp
+++ b/tket/test/src/Circuit/test_PauliExpBoxes.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/Circuit/test_Slices.cpp
+++ b/tket/test/src/Circuit/test_Slices.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/Circuit/test_StatePreparation.cpp
+++ b/tket/test/src/Circuit/test_StatePreparation.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/Circuit/test_Symbolic.cpp
+++ b/tket/test/src/Circuit/test_Symbolic.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/Circuit/test_ThreeQubitConversion.cpp
+++ b/tket/test/src/Circuit/test_ThreeQubitConversion.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/Circuit/test_ToffoliBox.cpp
+++ b/tket/test/src/Circuit/test_ToffoliBox.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/CircuitsForTesting.cpp
+++ b/tket/test/src/CircuitsForTesting.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/CircuitsForTesting.hpp
+++ b/tket/test/src/CircuitsForTesting.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/Gate/GatesData.cpp
+++ b/tket/test/src/Gate/GatesData.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/Gate/GatesData.hpp
+++ b/tket/test/src/Gate/GatesData.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/Gate/test_GateUnitaryMatrix.cpp
+++ b/tket/test/src/Gate/test_GateUnitaryMatrix.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/Gate/test_Rotation.cpp
+++ b/tket/test/src/Gate/test_Rotation.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/Graphs/EdgeSequence.cpp
+++ b/tket/test/src/Graphs/EdgeSequence.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/Graphs/EdgeSequence.hpp
+++ b/tket/test/src/Graphs/EdgeSequence.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/Graphs/EdgeSequenceColouringParameters.cpp
+++ b/tket/test/src/Graphs/EdgeSequenceColouringParameters.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/Graphs/EdgeSequenceColouringParameters.hpp
+++ b/tket/test/src/Graphs/EdgeSequenceColouringParameters.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/Graphs/GraphTestingRoutines.cpp
+++ b/tket/test/src/Graphs/GraphTestingRoutines.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/Graphs/GraphTestingRoutines.hpp
+++ b/tket/test/src/Graphs/GraphTestingRoutines.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/Graphs/RandomGraphGeneration.cpp
+++ b/tket/test/src/Graphs/RandomGraphGeneration.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/Graphs/RandomGraphGeneration.hpp
+++ b/tket/test/src/Graphs/RandomGraphGeneration.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/Graphs/RandomPlanarGraphs.cpp
+++ b/tket/test/src/Graphs/RandomPlanarGraphs.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/Graphs/RandomPlanarGraphs.hpp
+++ b/tket/test/src/Graphs/RandomPlanarGraphs.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/Graphs/test_ArticulationPoints.cpp
+++ b/tket/test/src/Graphs/test_ArticulationPoints.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/Graphs/test_DirectedGraph.cpp
+++ b/tket/test/src/Graphs/test_DirectedGraph.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/Graphs/test_GraphColouring.cpp
+++ b/tket/test/src/Graphs/test_GraphColouring.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/Graphs/test_GraphFindComponents.cpp
+++ b/tket/test/src/Graphs/test_GraphFindComponents.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/Graphs/test_GraphFindMaxClique.cpp
+++ b/tket/test/src/Graphs/test_GraphFindMaxClique.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/Graphs/test_GraphUtils.cpp
+++ b/tket/test/src/Graphs/test_GraphUtils.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/Graphs/test_TreeSearch.cpp
+++ b/tket/test/src/Graphs/test_TreeSearch.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/Ops/test_ClassicalOps.cpp
+++ b/tket/test/src/Ops/test_ClassicalOps.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/Ops/test_Expression.cpp
+++ b/tket/test/src/Ops/test_Expression.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/Ops/test_Ops.cpp
+++ b/tket/test/src/Ops/test_Ops.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/Passes/test_CliffordResynthesis.cpp
+++ b/tket/test/src/Passes/test_CliffordResynthesis.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/Passes/test_SynthesiseTK.cpp
+++ b/tket/test/src/Passes/test_SynthesiseTK.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/Passes/test_SynthesiseTket.cpp
+++ b/tket/test/src/Passes/test_SynthesiseTket.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/Placement/test_GraphPlacement.cpp
+++ b/tket/test/src/Placement/test_GraphPlacement.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/Placement/test_LinePlacement.cpp
+++ b/tket/test/src/Placement/test_LinePlacement.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/Placement/test_NeighbourPlacements.cpp
+++ b/tket/test/src/Placement/test_NeighbourPlacements.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/Placement/test_NoiseAwarePlacement.cpp
+++ b/tket/test/src/Placement/test_NoiseAwarePlacement.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/Placement/test_Placement.cpp
+++ b/tket/test/src/Placement/test_Placement.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/Simulation/ComparisonFunctions.cpp
+++ b/tket/test/src/Simulation/ComparisonFunctions.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/Simulation/ComparisonFunctions.hpp
+++ b/tket/test/src/Simulation/ComparisonFunctions.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/Simulation/test_CircuitSimulator.cpp
+++ b/tket/test/src/Simulation/test_CircuitSimulator.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/Simulation/test_PauliExpBoxUnitaryCalculator.cpp
+++ b/tket/test/src/Simulation/test_PauliExpBoxUnitaryCalculator.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/TokenSwapping/Data/FixedCompleteSolutions.cpp
+++ b/tket/test/src/TokenSwapping/Data/FixedCompleteSolutions.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/TokenSwapping/Data/FixedCompleteSolutions.hpp
+++ b/tket/test/src/TokenSwapping/Data/FixedCompleteSolutions.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/TokenSwapping/Data/FixedSwapSequences.cpp
+++ b/tket/test/src/TokenSwapping/Data/FixedSwapSequences.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/TokenSwapping/Data/FixedSwapSequences.hpp
+++ b/tket/test/src/TokenSwapping/Data/FixedSwapSequences.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/TokenSwapping/TestUtils/ArchitectureEdgesReimplementation.cpp
+++ b/tket/test/src/TokenSwapping/TestUtils/ArchitectureEdgesReimplementation.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/TokenSwapping/TestUtils/ArchitectureEdgesReimplementation.hpp
+++ b/tket/test/src/TokenSwapping/TestUtils/ArchitectureEdgesReimplementation.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/TokenSwapping/TestUtils/BestTsaTester.cpp
+++ b/tket/test/src/TokenSwapping/TestUtils/BestTsaTester.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/TokenSwapping/TestUtils/BestTsaTester.hpp
+++ b/tket/test/src/TokenSwapping/TestUtils/BestTsaTester.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/TokenSwapping/TestUtils/DebugFunctions.cpp
+++ b/tket/test/src/TokenSwapping/TestUtils/DebugFunctions.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/TokenSwapping/TestUtils/DebugFunctions.hpp
+++ b/tket/test/src/TokenSwapping/TestUtils/DebugFunctions.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/TokenSwapping/TestUtils/DecodedProblemData.cpp
+++ b/tket/test/src/TokenSwapping/TestUtils/DecodedProblemData.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/TokenSwapping/TestUtils/DecodedProblemData.hpp
+++ b/tket/test/src/TokenSwapping/TestUtils/DecodedProblemData.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/TokenSwapping/TestUtils/FullTsaTesting.cpp
+++ b/tket/test/src/TokenSwapping/TestUtils/FullTsaTesting.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/TokenSwapping/TestUtils/FullTsaTesting.hpp
+++ b/tket/test/src/TokenSwapping/TestUtils/FullTsaTesting.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/TokenSwapping/TestUtils/GetRandomSet.cpp
+++ b/tket/test/src/TokenSwapping/TestUtils/GetRandomSet.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/TokenSwapping/TestUtils/GetRandomSet.hpp
+++ b/tket/test/src/TokenSwapping/TestUtils/GetRandomSet.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/TokenSwapping/TestUtils/PartialTsaTesting.cpp
+++ b/tket/test/src/TokenSwapping/TestUtils/PartialTsaTesting.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/TokenSwapping/TestUtils/PartialTsaTesting.hpp
+++ b/tket/test/src/TokenSwapping/TestUtils/PartialTsaTesting.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/TokenSwapping/TestUtils/ProblemGeneration.cpp
+++ b/tket/test/src/TokenSwapping/TestUtils/ProblemGeneration.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/TokenSwapping/TestUtils/ProblemGeneration.hpp
+++ b/tket/test/src/TokenSwapping/TestUtils/ProblemGeneration.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/TokenSwapping/TestUtils/TestStatsStructs.cpp
+++ b/tket/test/src/TokenSwapping/TestUtils/TestStatsStructs.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/TokenSwapping/TestUtils/TestStatsStructs.hpp
+++ b/tket/test/src/TokenSwapping/TestUtils/TestStatsStructs.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/TokenSwapping/test_ArchitectureMappingEndToEnd.cpp
+++ b/tket/test/src/TokenSwapping/test_ArchitectureMappingEndToEnd.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/TokenSwapping/test_BestTsaFixedSwapSequences.cpp
+++ b/tket/test/src/TokenSwapping/test_BestTsaFixedSwapSequences.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/TokenSwapping/test_DistancesFromArchitecture.cpp
+++ b/tket/test/src/TokenSwapping/test_DistancesFromArchitecture.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/TokenSwapping/test_FullTsa.cpp
+++ b/tket/test/src/TokenSwapping/test_FullTsa.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/TokenSwapping/test_RiverFlowPathFinder.cpp
+++ b/tket/test/src/TokenSwapping/test_RiverFlowPathFinder.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/TokenSwapping/test_SwapsFromQubitMapping.cpp
+++ b/tket/test/src/TokenSwapping/test_SwapsFromQubitMapping.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/TokenSwapping/test_VariousPartialTsa.cpp
+++ b/tket/test/src/TokenSwapping/test_VariousPartialTsa.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/Transformations/test_RedundancyRemoval.cpp
+++ b/tket/test/src/Transformations/test_RedundancyRemoval.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/Utils/test_CosSinDecomposition.cpp
+++ b/tket/test/src/Utils/test_CosSinDecomposition.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/Utils/test_HelperFunctions.cpp
+++ b/tket/test/src/Utils/test_HelperFunctions.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/Utils/test_MatrixAnalysis.cpp
+++ b/tket/test/src/Utils/test_MatrixAnalysis.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/ZX/test_Flow.cpp
+++ b/tket/test/src/ZX/test_Flow.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/ZX/test_ZXAxioms.cpp
+++ b/tket/test/src/ZX/test_ZXAxioms.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/ZX/test_ZXConverters.cpp
+++ b/tket/test/src/ZX/test_ZXConverters.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/ZX/test_ZXDiagram.cpp
+++ b/tket/test/src/ZX/test_ZXDiagram.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/ZX/test_ZXExtraction.cpp
+++ b/tket/test/src/ZX/test_ZXExtraction.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/ZX/test_ZXRebase.cpp
+++ b/tket/test/src/ZX/test_ZXRebase.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/ZX/test_ZXSimp.cpp
+++ b/tket/test/src/ZX/test_ZXSimp.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/test_ArchitectureAwareSynthesis.cpp
+++ b/tket/test/src/test_ArchitectureAwareSynthesis.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/test_Architectures.cpp
+++ b/tket/test/src/test_Architectures.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/test_Assertion.cpp
+++ b/tket/test/src/test_Assertion.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/test_BoxDecompRoutingMethod.cpp
+++ b/tket/test/src/test_BoxDecompRoutingMethod.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/test_ChoiMixTableau.cpp
+++ b/tket/test/src/test_ChoiMixTableau.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/test_ClExpr.cpp
+++ b/tket/test/src/test_ClExpr.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/test_Clifford.cpp
+++ b/tket/test/src/test_Clifford.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/test_Combinators.cpp
+++ b/tket/test/src/test_Combinators.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/test_CompilerPass.cpp
+++ b/tket/test/src/test_CompilerPass.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/test_ContextOpt.cpp
+++ b/tket/test/src/test_ContextOpt.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/test_ControlDecomp.cpp
+++ b/tket/test/src/test_ControlDecomp.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/test_DeviceCharacterisation.cpp
+++ b/tket/test/src/test_DeviceCharacterisation.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/test_Diagonalisation.cpp
+++ b/tket/test/src/test_Diagonalisation.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/test_FrameRandomisation.cpp
+++ b/tket/test/src/test_FrameRandomisation.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/test_GlobalisePhasedX.cpp
+++ b/tket/test/src/test_GlobalisePhasedX.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/test_GreedyPauli.cpp
+++ b/tket/test/src/test_GreedyPauli.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/test_LexiRoute.cpp
+++ b/tket/test/src/test_LexiRoute.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/test_LexicographicalComparison.cpp
+++ b/tket/test/src/test_LexicographicalComparison.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/test_MappingFrontier.cpp
+++ b/tket/test/src/test_MappingFrontier.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/test_MappingManager.cpp
+++ b/tket/test/src/test_MappingManager.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/test_MappingVerification.cpp
+++ b/tket/test/src/test_MappingVerification.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/test_MeasurementReduction.cpp
+++ b/tket/test/src/test_MeasurementReduction.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/test_MeasurementSetup.cpp
+++ b/tket/test/src/test_MeasurementSetup.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/test_MultiGateReorder.cpp
+++ b/tket/test/src/test_MultiGateReorder.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/test_Partition.cpp
+++ b/tket/test/src/test_Partition.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/test_Path.cpp
+++ b/tket/test/src/test_Path.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/test_PauliGraph.cpp
+++ b/tket/test/src/test_PauliGraph.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/test_PauliTensor.cpp
+++ b/tket/test/src/test_PauliTensor.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/test_PhaseGadget.cpp
+++ b/tket/test/src/test_PhaseGadget.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/test_PhasePolynomials.cpp
+++ b/tket/test/src/test_PhasePolynomials.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/test_PhasedXFrontier.cpp
+++ b/tket/test/src/test_PhasedXFrontier.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/test_Predicates.cpp
+++ b/tket/test/src/test_Predicates.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/test_Rebase.cpp
+++ b/tket/test/src/test_Rebase.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/test_RoundAngles.cpp
+++ b/tket/test/src/test_RoundAngles.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/test_RoutingPasses.cpp
+++ b/tket/test/src/test_RoutingPasses.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/test_SteinerForest.cpp
+++ b/tket/test/src/test_SteinerForest.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/test_SteinerTree.cpp
+++ b/tket/test/src/test_SteinerTree.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/test_Synthesis.cpp
+++ b/tket/test/src/test_Synthesis.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/test_TwoQubitCanonical.cpp
+++ b/tket/test/src/test_TwoQubitCanonical.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/test_UnitaryTableau.cpp
+++ b/tket/test/src/test_UnitaryTableau.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/test_json.cpp
+++ b/tket/test/src/test_json.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/test_wasm.cpp
+++ b/tket/test/src/test_wasm.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/tests_main.cpp
+++ b/tket/test/src/tests_main.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/testutil.cpp
+++ b/tket/test/src/testutil.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test/src/testutil.hpp
+++ b/tket/test/src/testutil.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tket/test_package/CMakeLists.txt
+++ b/tket/test_package/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tket/test_package/conanfile.py
+++ b/tket/test_package/conanfile.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 Cambridge Quantum Computing
+# Copyright Quantinuum
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tket/test_package/src/test.cpp
+++ b/tket/test_package/src/test.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Cambridge Quantum Computing
+// Copyright Quantinuum
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
# Description
I have not found any more `Copyright 20` or `Cambridge Quantum` in the code.

I would recommend to review the commits individually.

I have not found any other years / dates that should be updated.

