### PR TITLE
feat: add `QubitPauliOperator.get_dict`

### DIFF
--- a/pytket/docs/changelog.rst
+++ b/pytket/docs/changelog.rst
@@ -7,7 +7,7 @@ Unreleased
 Features:
 
 * Add Python 3.13 support to the ZX module.
-* Add `QubitPauliOperator.get_dict` method.
+* Add :py:meth:`QubitPauliOperator.get_dict` method.
 
 Fixes:
 

--- a/pytket/docs/changelog.rst
+++ b/pytket/docs/changelog.rst
@@ -7,6 +7,7 @@ Unreleased
 Features:
 
 * Add Python 3.13 support to the ZX module.
+* Add `QubitPauliOperator.get_dict` method.
 
 Fixes:
 

--- a/pytket/pytket/utils/operators.py
+++ b/pytket/pytket/utils/operators.py
@@ -218,7 +218,8 @@ class QubitPauliOperator:
 
     def get_dict(self) -> dict[QubitPauliString, Expr]:
         """Generate a dict representation of QubitPauliOperator,
-        mapping each :py:class:`QubitPauliString` in the support to its corresponding value.
+        mapping each :py:class:`QubitPauliString` in the support
+        to its corresponding value.
 
         :return: A dict of Pauli strings and their coefficients
           as key-value pairs

--- a/pytket/pytket/utils/operators.py
+++ b/pytket/pytket/utils/operators.py
@@ -218,7 +218,7 @@ class QubitPauliOperator:
 
     def get_dict(self) -> dict[QubitPauliString, Expr]:
         """Generate a dict representation of QubitPauliOperator,
-        not suitable for writing to JSON.
+        mapping each :py:class:`QubitPauliString` in the support to its corresponding value.
 
         :return: A dict of Pauli strings and their coefficients
           as key-value pairs

--- a/pytket/pytket/utils/operators.py
+++ b/pytket/pytket/utils/operators.py
@@ -216,6 +216,15 @@ class QubitPauliOperator:
         for key, value in self._dict.items():
             self._dict[key] = value.subs(symbol_dict)
 
+    def get_dict(self) -> dict[QubitPauliString, Expr]:
+        """Generate a dict representation of QubitPauliOperator,
+        not suitable for writing to JSON.
+
+        :return: A dict of Pauli strings and their coefficients
+          as key-value pairs
+        """
+        return self._dict
+
     def to_list(self) -> list[dict[str, Any]]:
         """Generate a list serialized representation of QubitPauliOperator,
          suitable for writing to JSON.

--- a/pytket/tests/utils_test.py
+++ b/pytket/tests/utils_test.py
@@ -22,7 +22,7 @@ import pytest
 from hypothesis import HealthCheck, given, settings, strategies
 from hypothesis.strategies._internal import SearchStrategy
 from simulator import TketSimBackend, TketSimShotBackend  # type: ignore
-from sympy import symbols
+from sympy import I, symbols
 
 from pytket.backends.backend import Backend
 from pytket.circuit import Circuit, OpType, Qubit
@@ -94,7 +94,8 @@ def test_dict_export() -> None:
     qps1 = QubitPauliString(Qubit(0), Pauli.Y)
     qps2 = QubitPauliString(Qubit(0), Pauli.X)
     op = QubitPauliOperator({qps1: 1j, qps2: 0.5})
-    assert op.get_dict() == {qps1: 1j, qps2: 0.5}
+    # Do equality check with a sympy "I" for the imaginary part
+    assert op.get_dict() == {qps1: 1 * I, qps2: 0.5}
 
 
 def test_shots_to_counts() -> None:

--- a/pytket/tests/utils_test.py
+++ b/pytket/tests/utils_test.py
@@ -90,6 +90,13 @@ def test_all_paulis() -> None:
     assert len(list(circs)) == 3
 
 
+def test_dict_export() -> None:
+    qps1 = QubitPauliString(Qubit(0), Pauli.Y)
+    qps2 = QubitPauliString(Qubit(0), Pauli.X)
+    op = QubitPauliOperator({qps1: 1j, qps2: 0.5})
+    assert op.get_dict() == op._dict
+
+
 def test_shots_to_counts() -> None:
     shot_table = np.asarray([[0, 0], [0, 1], [0, 0]])
     counts = counts_from_shot_table(shot_table)

--- a/pytket/tests/utils_test.py
+++ b/pytket/tests/utils_test.py
@@ -94,7 +94,7 @@ def test_dict_export() -> None:
     qps1 = QubitPauliString(Qubit(0), Pauli.Y)
     qps2 = QubitPauliString(Qubit(0), Pauli.X)
     op = QubitPauliOperator({qps1: 1j, qps2: 0.5})
-    assert op.get_dict() == op._dict
+    assert op.get_dict() == {qps1: 1j, qps2: 0.5}
 
 
 def test_shots_to_counts() -> None:

--- a/pytket/tests/utils_test.py
+++ b/pytket/tests/utils_test.py
@@ -95,7 +95,7 @@ def test_dict_export() -> None:
     qps2 = QubitPauliString(Qubit(0), Pauli.X)
     op = QubitPauliOperator({qps1: 1j, qps2: 0.5})
     # Do equality check with a sympy "I" for the imaginary part
-    assert op.get_dict() == {qps1: 1 * I, qps2: 0.5}
+    assert op.get_dict() == {qps1: 1.0 * I, qps2: 0.5}
 
 
 def test_shots_to_counts() -> None:


### PR DESCRIPTION
# Description

Please summarise the changes.

Minor change adding a `get_dict` export for `QubitPauliOperator`. This avoids having to used the undocumented private `_dict` attribute` 

Using `.get_dict` as opposed to `to_dict` here as this new method is not intended for json serialisation.

# Related issues

Please mention any github issues addressed by this PR.

# Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented hard-to-understand parts of my code.
- [x] I have made corresponding changes to the public API documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have updated the changelog with any user-facing changes.
