### PR TITLE
docs: fix minus sign in `gen_term_sequence_circuit` docstring

### DIFF
--- a/pytket/pytket/utils/term_sequence.py
+++ b/pytket/pytket/utils/term_sequence.py
@@ -33,7 +33,7 @@ def gen_term_sequence_circuit(
 ) -> Circuit:
     """
     Sequences the terms of a :py:class:`QubitPauliOperator` :math:`P` to generate
-    a circuit approximating :math:`e^{i \\frac{\\pi}{2} P}`. This method
+    a circuit approximating :math:`e^{-i \\frac{\\pi}{2} P}`. This method
     performs Trotterisation on :math:`P` with a single Trotter step.
 
     This method uses a given partitioning strategy and a graph colouring


### PR DESCRIPTION
# Description

Pretty sure [this gen_term_sequence_circuit docstring ](https://docs.quantinuum.com/tket/api-docs/utils.html#pytket.utils.gen_term_sequence_circuit) contains a minus sign error as of v.1.39.0. 

<img width="769" alt="Screenshot 2025-01-28 at 17 54 34" src="https://github.com/user-attachments/assets/89302cbb-20ac-4f39-8185-bf503c3f671f" />

I think it should be $e^{-i \frac{\pi}{2} P}$ rather than $e^{i \frac{\pi}{2} P}$.

`PauliExpBox` is used internally by this function which uses the following convention according to the [optype documentation](https://docs.quantinuum.com/tket/api-docs/optype.html)

<img width="621" alt="Screenshot 2025-01-28 at 17 52 04" src="https://github.com/user-attachments/assets/7a0dfddd-65fa-4130-a235-72c0935c550c" />

