### PR TITLE
Make `ThreeQubitSquash` work with circuits containing (some) boxes

### DIFF
--- a/pytket/conanfile.py
+++ b/pytket/conanfile.py
@@ -38,7 +38,7 @@ class pytketRecipe(ConanFile):
         self.requires("pybind11_json/0.2.15")
         self.requires("symengine/0.13.0")
         self.requires("tkassert/0.3.4@tket/stable")
-        self.requires("tket/1.3.65@tket/stable")
+        self.requires("tket/1.3.66@tket/stable")
         self.requires("tklog/0.3.3@tket/stable")
         self.requires("tkrng/0.3.3@tket/stable")
         self.requires("tktokenswap/0.3.9@tket/stable")

--- a/pytket/docs/changelog.rst
+++ b/pytket/docs/changelog.rst
@@ -15,6 +15,8 @@ Fixes:
 * Make `DecomposeBoxes` pass recurse into conditional boxes.
 * Fix conversion of `ClOp.BitEq` and `ClOp.BitNeq` to QASM.
 * Fix conversion of `OpType.CnX` to QASM.
+* Make `ThreeQubitSquash` work with subcircuits containing boxes for which we
+  can compute the unitary.
 
 1.39.0 (January 2025)
 ---------------------

--- a/pytket/pytket/__init__.py
+++ b/pytket/pytket/__init__.py
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Python Interface to tket
-"""
+"""Python Interface to tket"""
 import pytket.architecture  # noqa: I001
 from pytket.circuit import (
     Circuit,

--- a/pytket/pytket/architecture/__init__.py
+++ b/pytket/pytket/architecture/__init__.py
@@ -13,6 +13,6 @@
 # limitations under the License.
 
 """The `architecture` module provides an API to interact with the
-    ::py:class:`Architecture` class."""
+::py:class:`Architecture` class."""
 
 from pytket._tket.architecture import *

--- a/pytket/pytket/backends/backend.py
+++ b/pytket/pytket/backends/backend.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-""" Abstract base class for all Backend encapsulations."""
+"""Abstract base class for all Backend encapsulations."""
 import warnings
 from abc import ABC, abstractmethod
 from collections.abc import Iterable, Sequence

--- a/pytket/pytket/backends/backendinfo.py
+++ b/pytket/pytket/backends/backendinfo.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-""" BackendInfo class: additional information on Backends """
+"""BackendInfo class: additional information on Backends"""
 
 from dataclasses import asdict, dataclass, field
 from typing import Any
@@ -25,7 +25,7 @@ _Edge = tuple[Node, Node]
 
 
 def _serialize_all_node_gate_errors(
-    d: dict[Node, _OpTypeErrs] | None
+    d: dict[Node, _OpTypeErrs] | None,
 ) -> list[list] | None:
     if d is None:
         return None
@@ -69,7 +69,7 @@ def _deserialize_all_edge_gate_errors(
 
 
 def _serialize_all_readout_errors(
-    d: dict[Node, list[list[float]]] | None
+    d: dict[Node, list[list[float]]] | None,
 ) -> list[list] | None:
     if d is None:
         return None
@@ -85,7 +85,7 @@ def _deserialize_all_readout_errors(
 
 
 def _serialize_averaged_node_gate_errors(
-    d: dict[Node, float] | None
+    d: dict[Node, float] | None,
 ) -> list[list] | None:
     if d is None:
         return None
@@ -101,7 +101,7 @@ def _deserialize_averaged_node_gate_errors(
 
 
 def _serialize_averaged_edge_gate_errors(
-    d: dict[_Edge, float] | None
+    d: dict[_Edge, float] | None,
 ) -> list[list] | None:
     if d is None:
         return None
@@ -117,7 +117,7 @@ def _deserialize_averaged_edge_gate_errors(
 
 
 def _serialize_averaged_readout_errors(
-    d: dict[Node, float] | None
+    d: dict[Node, float] | None,
 ) -> list[list] | None:
     if d is None:
         return None

--- a/pytket/pytket/backends/resulthandle.py
+++ b/pytket/pytket/backends/resulthandle.py
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""ResultHandle class
-"""
+"""ResultHandle class"""
 
 from ast import literal_eval
 from collections.abc import Iterator, Sequence

--- a/pytket/pytket/backends/status.py
+++ b/pytket/pytket/backends/status.py
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Status classes for circuits submitted to backends.
-"""
+"""Status classes for circuits submitted to backends."""
 from collections.abc import Callable
 from datetime import datetime
 from enum import Enum

--- a/pytket/pytket/circuit/__init__.py
+++ b/pytket/pytket/circuit/__init__.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 """The circuit module provides an API to interact with the
- tket :py:class:`Circuit` data structure.
-  This module is provided in binary form during the PyPI installation."""
+tket :py:class:`Circuit` data structure.
+ This module is provided in binary form during the PyPI installation."""
 from typing import (
     Any,
     Callable,

--- a/pytket/pytket/circuit/decompose_classical.py
+++ b/pytket/pytket/circuit/decompose_classical.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """Functions for decomposing Circuits containing classical expressions
- in to primitive logical operations."""
+in to primitive logical operations."""
 import copy
 from collections.abc import Callable
 from heapq import heappop, heappush

--- a/pytket/pytket/circuit/logic_exp.py
+++ b/pytket/pytket/circuit/logic_exp.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """Classes and functions for constructing logical
- expressions over Bit and BitRegister."""
+expressions over Bit and BitRegister."""
 from collections.abc import Iterable, Iterator, Sequence
 from dataclasses import dataclass
 from enum import Enum

--- a/pytket/pytket/mapping/__init__.py
+++ b/pytket/pytket/mapping/__init__.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 """The `mapping` module provides an API to interact with the
- :py:class:`MappingManager` class, with methods for
- mapping logical circuits to physical circuits and for
- defining custom routing solutions."""
+:py:class:`MappingManager` class, with methods for
+mapping logical circuits to physical circuits and for
+defining custom routing solutions."""
 
 from pytket._tket.mapping import *

--- a/pytket/pytket/placement/__init__.py
+++ b/pytket/pytket/placement/__init__.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 """The `placement` module provides an API to interact with the many
- :py:class:`Placement` options, providing methods for relabelling
- logical circuit qubit identifiers to physical architecture node identifiers,
- for the purpose of compilation."""
+:py:class:`Placement` options, providing methods for relabelling
+logical circuit qubit identifiers to physical architecture node identifiers,
+for the purpose of compilation."""
 
 from pytket._tket.placement import *

--- a/pytket/pytket/utils/distribution.py
+++ b/pytket/pytket/utils/distribution.py
@@ -261,7 +261,7 @@ class ProbabilityDistribution(Generic[T0]):
 
 
 def convex_combination(
-    dists: list[tuple[ProbabilityDistribution[T0], float]]
+    dists: list[tuple[ProbabilityDistribution[T0], float]],
 ) -> ProbabilityDistribution[T0]:
     """Return a convex combination of probability distributions.
 

--- a/pytket/pytket/utils/results.py
+++ b/pytket/pytket/utils/results.py
@@ -94,7 +94,7 @@ def counts_from_shot_table(shot_table: np.ndarray) -> dict[tuple[int, ...], int]
 
 
 def probs_from_counts(
-    counts: dict[tuple[int, ...], int]
+    counts: dict[tuple[int, ...], int],
 ) -> dict[tuple[int, ...], float]:
     """Converts raw counts of observed outcomes into the observed probability
     distribution.

--- a/pytket/tests/simulator/tket_sim_backend.py
+++ b/pytket/tests/simulator/tket_sim_backend.py
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Methods to allow tket circuits to be run with the tket_sim simulator
-"""
+"""Methods to allow tket circuits to be run with the tket_sim simulator"""
 ### WARNING: TketSimBackend accepts Measure gates but does not apply them
 ### TketSimBackend will not work properly if there are extra bits that are unwritten to.
 

--- a/tket/conanfile.py
+++ b/tket/conanfile.py
@@ -23,7 +23,7 @@ from conan.errors import ConanInvalidConfiguration
 
 class TketConan(ConanFile):
     name = "tket"
-    version = "1.3.65"
+    version = "1.3.66"
     package_type = "library"
     license = "Apache 2"
     homepage = "https://github.com/CQCL/tket"

--- a/tket/src/Circuit/ThreeQubitConversion.cpp
+++ b/tket/src/Circuit/ThreeQubitConversion.cpp
@@ -505,15 +505,10 @@ Eigen::MatrixXcd get_3q_unitary(const Circuit &c) {
   for (const Command &cmd : c) {
     qubit_vector_t qbs = cmd.get_qubits();
     Op_ptr op = cmd.get_op_ptr();
-    Gate_ptr gate = as_gate_ptr(op);
-    if (!gate) {
-      throw CircuitInvalidity("Circuit in get_3q_unitary not unitary");
-    }
+    Eigen::MatrixXcd u = op->get_unitary();
     Eigen::MatrixXcd M = Eigen::MatrixXcd::Zero(8, 8);
     switch (qbs.size()) {
       case 1: {
-        std::vector<Expr> angles = gate->get_tk1_angles();
-        Eigen::Matrix2cd u = get_matrix_from_tk1_angles(angles);
         // Construct the 8x8 matrix representing u.
         unsigned i = idx[qbs[0]];
         switch (i) {
@@ -541,7 +536,6 @@ Eigen::MatrixXcd get_3q_unitary(const Circuit &c) {
         break;
       }
       case 2: {
-        Eigen::Matrix4cd m = gate->get_unitary();
         // Note reversal of indices here:
         unsigned i = 2 - idx[qbs[0]];
         unsigned j = 2 - idx[qbs[1]];
@@ -553,7 +547,7 @@ Eigen::MatrixXcd get_3q_unitary(const Circuit &c) {
           unsigned s0_ = ((s0 >> 1) << i) + ((s0 & 1) << j);
           for (unsigned s1 = 0; s1 < 4; s1++) {
             unsigned s1_ = ((s1 >> 1) << i) + ((s1 & 1) << j);
-            M(s0_, s1_) = M(s0_ + t, s1_ + t) = m(s0, s1);
+            M(s0_, s1_) = M(s0_ + t, s1_ + t) = u(s0, s1);
           }
         }
         break;

--- a/tket/test/src/test_CompilerPass.cpp
+++ b/tket/test/src/test_CompilerPass.cpp
@@ -857,6 +857,19 @@ SCENARIO("PeepholeOptimise2Q and FullPeepholeOptimise") {
 
     REQUIRE(circ.count_gates(OpType::TK2) == 1);
   }
+  GIVEN("A circuit containing a Unitary1qBox") {
+    // https://github.com/CQCL/tket/issues/1750
+    Circuit circ(3);
+    circ.add_op<unsigned>(OpType::CX, {0, 2});
+    Eigen::Matrix2cd u;
+    u << 1.0, 0.0, 0.0, 1.0;
+    Unitary1qBox ubox(u);
+    circ.add_box(ubox, {2});
+    circ.add_op<unsigned>(OpType::CX, {1, 2});
+    circ.add_op<unsigned>(OpType::CX, {0, 2});
+    CompilationUnit cu(circ);
+    REQUIRE(FullPeepholeOptimise()->apply(cu));
+  }
 }
 
 SCENARIO("FullPeepholeOptimise with various options") {


### PR DESCRIPTION
Fixes #1750 .

Drive-by: Apply black formatting to a bunch of python files following black update.