### PR TITLE
Document `scratch_reg_resize_pass()`

### DIFF
--- a/pytket/docs/passes.rst
+++ b/pytket/docs/passes.rst
@@ -16,6 +16,8 @@ For more on pytket passes see the `compilation <https://docs.quantinuum.com/tket
     :members:
     :special-members: __init__
 
+.. autofunction:: pytket.passes.scratch_reg_resize_pass
+
 .. autoclass:: pytket.passes.PassSelector
     :special-members: __init__
     :members:

--- a/pytket/pytket/passes/resizeregpass.py
+++ b/pytket/pytket/passes/resizeregpass.py
@@ -26,8 +26,11 @@ def _is_scratch(bit: Bit) -> bool:
 
 
 def scratch_reg_resize_pass(max_size: int = MAX_C_REG_WIDTH) -> BasePass:
-    """Given a max scratch register width, return a compiler pass that
-    breaks up the internal scratch bit registers into smaller registers
+    """Create a pass that breaks up the internal scratch bit registers into smaller
+    registers.
+
+    :param max_size: desired maximum size of scratch bit registers
+    :return: a pass to break up the scratch registers
     """
 
     def trans(circ: Circuit, max_size: int = max_size) -> Circuit:


### PR DESCRIPTION
Fixes #1749 .

From a local build:
![image](https://github.com/user-attachments/assets/8ef90070-bd93-4a8b-9823-fc2664564999)
