### PR TITLE
Add `Circuit.has_implicit_wireswaps` property

### DIFF
--- a/pytket/binders/circuit/Circuit/main.cpp
+++ b/pytket/binders/circuit/Circuit/main.cpp
@@ -831,6 +831,10 @@ void def_circuit(py::class_<Circuit, std::shared_ptr<Circuit>> &pyCircuit) {
           "implicit_qubit_permutation", &Circuit::implicit_qubit_permutation,
           ":return: dictionary mapping input qubit to output qubit on "
           "the same path")
+      .def_property_readonly(
+          "has_implicit_wireswaps", &Circuit::has_implicit_wireswaps,
+          "Indicates whether the circuit has a non-trivial qubit permutation "
+          "(i.e., whether there are any implicit wire swaps).")
       .def(
           "replace_SWAPs", &Circuit::replace_SWAPs,
           "Replace all SWAP gates with implicit wire swaps.")

--- a/pytket/docs/changelog.rst
+++ b/pytket/docs/changelog.rst
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+1.41.0 (Unreleased)
+----------------------
+Features:
+
+* Add :py:attr:`Circuit.has_implicit_wireswaps` property.
+
 1.40.0 (February 2025)
 ----------------------
 
@@ -9,7 +15,6 @@ Features:
 * Add Python 3.13 support to the ZX module.
 * Add :py:meth:`QubitPauliOperator.get_dict` method.
 * Add :py:meth:`Circuit.add_circuit_with_map` method.
-* Add :py:attr:`Circuit.has_implicit_wireswaps` property.
 
 Fixes:
 

--- a/pytket/docs/changelog.rst
+++ b/pytket/docs/changelog.rst
@@ -9,6 +9,7 @@ Features:
 * Add Python 3.13 support to the ZX module.
 * Add :py:meth:`QubitPauliOperator.get_dict` method.
 * Add :py:meth:`Circuit.add_circuit_with_map` method.
+* Add :py:attr:`Circuit.has_implicit_wireswaps` property.
 
 Fixes:
 

--- a/pytket/docs/circuit_class.rst
+++ b/pytket/docs/circuit_class.rst
@@ -66,6 +66,8 @@ condition on a specified set of bit values.)
 
    .. autoproperty:: is_symbolic
 
+   .. autoproperty:: has_implicit_wireswaps
+
    .. automethod:: add_q_register
 
    .. automethod:: get_q_register

--- a/pytket/pytket/_tket/circuit.pyi
+++ b/pytket/pytket/_tket/circuit.pyi
@@ -2583,6 +2583,12 @@ class Circuit:
         """
         :return: the unique WASM UID of the circuit, or `None` if the circuit has none
         """
+    @property
+    def has_implicit_wireswaps(self) -> bool:
+        """
+        Indicates whether the circuit has a non-trivial qubit permutation
+        (i.e., whether there are any implicit wire swaps).
+        """
 class ClBitVar:
     """
     A bit variable within an expression

--- a/pytket/tests/predicates_test.py
+++ b/pytket/tests/predicates_test.py
@@ -1148,7 +1148,7 @@ def test_has_implicit_wireswaps() -> None:
     assert c.has_implicit_wireswaps
 
     # Property should be read-only
-    with pytest.raises(AttributeError): # type: ignore[unreachable]
+    with pytest.raises(AttributeError):  # type: ignore[unreachable]
         c.has_implicit_wireswaps = True
 
 

--- a/pytket/tests/predicates_test.py
+++ b/pytket/tests/predicates_test.py
@@ -1140,6 +1140,18 @@ def test_decompose_inside_conditionals() -> None:
     assert op2.type == OpType.H
 
 
+def test_has_implicit_wireswaps() -> None:
+    c = Circuit(2)
+    c.SWAP(0, 1)
+    assert not c.has_implicit_wireswaps
+    c.replace_SWAPs()
+    assert c.has_implicit_wireswaps
+
+    # Property should be read-only
+    with pytest.raises(AttributeError):
+        c.has_implicit_wireswaps = True
+
+
 if __name__ == "__main__":
     test_predicate_generation()
     test_compilation_unit_generation()

--- a/pytket/tests/predicates_test.py
+++ b/pytket/tests/predicates_test.py
@@ -1148,7 +1148,7 @@ def test_has_implicit_wireswaps() -> None:
     assert c.has_implicit_wireswaps
 
     # Property should be read-only
-    with pytest.raises(AttributeError):
+    with pytest.raises(AttributeError): # type: ignore[unreachable]
         c.has_implicit_wireswaps = True
 
 

--- a/pytket/tests/predicates_test.py
+++ b/pytket/tests/predicates_test.py
@@ -803,6 +803,7 @@ def test_remove_implicit_qubit_permutation() -> None:
         Qubit(1): Qubit(0),
         Qubit(2): Qubit(1),
     }
+    assert c.has_implicit_wireswaps
     assert RemoveImplicitQubitPermutation().apply(c)
     assert c.n_gates_of_type(OpType.SWAP) == 2
     assert c.implicit_qubit_permutation() == {
@@ -810,6 +811,7 @@ def test_remove_implicit_qubit_permutation() -> None:
         Qubit(1): Qubit(1),
         Qubit(2): Qubit(2),
     }
+    assert not c.has_implicit_wireswaps
 
 
 def test_rz_phasedX_squash() -> None:
@@ -903,12 +905,10 @@ def test_round_angles_pass() -> None:
 def test_PeepholeOptimise2Q() -> None:
     c = Circuit(2).CX(0, 1).CX(1, 0)
     assert PeepholeOptimise2Q().apply(c)
-    perm = c.implicit_qubit_permutation()
-    assert any(k != v for k, v in perm.items())
+    assert c.has_implicit_wireswaps
     c = Circuit(2).CX(0, 1).CX(1, 0)
     assert not PeepholeOptimise2Q(allow_swaps=False).apply(c)
-    perm = c.implicit_qubit_permutation()
-    assert all(k == v for k, v in perm.items())
+    assert not c.has_implicit_wireswaps
 
 
 def test_rebase_custom_tk2() -> None:

--- a/pytket/tests/utils_test.py
+++ b/pytket/tests/utils_test.py
@@ -507,7 +507,7 @@ def test_dag_implicit_perm() -> None:
     # THET-701
     c = Circuit(3).CX(0, 1).CX(1, 0).CX(1, 2).CX(2, 1)
     Transform.OptimiseCliffords().apply(c)
-    assert not all(x == y for x, y in c.implicit_qubit_permutation().items())
+    assert c.has_implicit_wireswaps
     G = Graph(c)
     dag = G.get_DAG()
     assert dag.name == "Circuit"


### PR DESCRIPTION
# Description

* Added a readonly property bound to `Circuit::has_implicit_wireswaps()`
* Added a unit test
* Updated some existing tests -- replaced calls to `Circuit.implicit_qubit_permutation()` if the test only used the result to check for non-trivial permutations

# Related issues

Closes #1665.

# Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented hard-to-understand parts of my code.
- [x] I have made corresponding changes to the public API documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have updated the changelog with any user-facing changes.
