### PR TITLE
Handle case of unindexed units in `Circuit.q_registers` and `Circuit.c_registers`

### DIFF
--- a/pytket/binders/include/circuit_registers.hpp
+++ b/pytket/binders/include/circuit_registers.hpp
@@ -38,7 +38,7 @@ std::vector<T> get_unit_registers(Circuit &circ) {
   std::vector<T> regs;
   for (const T2 &unitid : unitids) {
     // UnitRegisters only describe registers with 1-d indices
-    if (unitid.reg_dim() > 1) continue;
+    if (unitid.reg_dim() != 1) continue;
     auto it = unit_map.find(unitid.reg_name());
     if (it == unit_map.end()) {
       unit_map.insert({unitid.reg_name(), {unitid.index()[0]}});

--- a/pytket/docs/changelog.rst
+++ b/pytket/docs/changelog.rst
@@ -12,6 +12,10 @@ API changes:
   methods.
 * Remove `ClassicalExpBox` and related methods.
 
+Fixes:
+
+* Fix segfault listing registers of circuit containing unindexed units.
+
 1.41.0 (Unreleased)
 ----------------------
 
@@ -19,10 +23,6 @@ Features:
 
 * Add :py:attr:`Circuit.has_implicit_wireswaps` property.
 * Make :py:meth:`PauliSimp` accept circuits with SX and SXdg gates.
-
-Fixes:
-
-* Fix segfault listing registers of circuit containing unindexed units.
 
 1.40.0 (February 2025)
 ----------------------

--- a/pytket/docs/changelog.rst
+++ b/pytket/docs/changelog.rst
@@ -20,6 +20,10 @@ Features:
 * Add :py:attr:`Circuit.has_implicit_wireswaps` property.
 * Make :py:meth:`PauliSimp` accept circuits with SX and SXdg gates.
 
+Fixes:
+
+* Fix segfault listing registers of circuit containing unindexed units.
+
 1.40.0 (February 2025)
 ----------------------
 

--- a/pytket/tests/circuit_test.py
+++ b/pytket/tests/circuit_test.py
@@ -1217,6 +1217,18 @@ def test_getting_registers_with_non_consective_indices() -> None:
     assert q_regs[0] == QubitRegister("a", 3)
 
 
+def test_getting_registers_with_unindexed_bits() -> None:
+    # https://github.com/CQCL/tket/issues/1785
+    c = Circuit()
+    qubit = Qubit("q", [])
+    bit = Bit("a", [])
+    c.add_qubit(qubit)
+    c.add_bit(bit)
+    c.PhasedX(0.5, 0.5, qubit).Measure(qubit, bit)
+    assert c.q_registers == []
+    assert c.c_registers == []
+
+
 def test_measuring_registers() -> None:
     c = Circuit()
     with pytest.raises(RuntimeError) as e:


### PR DESCRIPTION
Fixes #1785 .