### PR TITLE
Zx optimisation swaps

### DIFF
--- a/pytket/binders/passes.cpp
+++ b/pytket/binders/passes.cpp
@@ -657,7 +657,7 @@ PYBIND11_MODULE(passes, m) {
       "beforehand and may increase the cost of the circuit."
       "\n:param allow_swaps: Whether to allow implicit wire swaps (default "
       "True).",
-      py::arg("allow_swaps") = false);
+      py::arg("allow_swaps") = true);
 
   /* Pass generators */
 

--- a/pytket/binders/passes.cpp
+++ b/pytket/binders/passes.cpp
@@ -655,7 +655,7 @@ PYBIND11_MODULE(passes, m) {
       "not work if the circuit contains created or discarded qubits. As a "
       "resynthesis pass, this will ignore almost all optimisations achieved "
       "beforehand and may increase the cost of the circuit."
-      "\n:param allow_swaps: Whether to allow implicit wire swaps (default "
+      "\n\n:param allow_swaps: Whether to allow implicit wire swaps (default "
       "True).",
       py::arg("allow_swaps") = true);
 

--- a/pytket/binders/passes.cpp
+++ b/pytket/binders/passes.cpp
@@ -654,7 +654,10 @@ PYBIND11_MODULE(passes, m) {
       "extracting a circuit back out. Due to limitations in extraction, may "
       "not work if the circuit contains created or discarded qubits. As a "
       "resynthesis pass, this will ignore almost all optimisations achieved "
-      "beforehand and may increase the cost of the circuit.");
+      "beforehand and may increase the cost of the circuit."
+      "\n:param allow_swaps: Whether to allow implicit wire swaps (default "
+      "True).",
+      py::arg("allow_swaps") = false);
 
   /* Pass generators */
 

--- a/pytket/conanfile.py
+++ b/pytket/conanfile.py
@@ -38,7 +38,7 @@ class pytketRecipe(ConanFile):
         self.requires("pybind11_json/0.2.15")
         self.requires("symengine/0.13.0")
         self.requires("tkassert/0.3.4@tket/stable")
-        self.requires("tket/2.0.0@tket/stable")
+        self.requires("tket/2.0.1@tket/stable")
         self.requires("tklog/0.3.3@tket/stable")
         self.requires("tkrng/0.3.3@tket/stable")
         self.requires("tktokenswap/0.3.9@tket/stable")

--- a/pytket/docs/changelog.rst
+++ b/pytket/docs/changelog.rst
@@ -23,6 +23,7 @@ Features:
 
 * Add :py:attr:`Circuit.has_implicit_wireswaps` property.
 * Make :py:meth:`PauliSimp` accept circuits with SX and SXdg gates.
+* Add optional `allow_swaps` argument to :py:meth:`ZXGraphlikeOptimisation`.
 
 1.40.0 (February 2025)
 ----------------------

--- a/pytket/docs/changelog.rst
+++ b/pytket/docs/changelog.rst
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+2.0.1 (Unreleased)
+---------------------
+
+Features:
+
+* Add optional `allow_swaps` argument to :py:meth:`ZXGraphlikeOptimisation`.
+
 2.0.0 (February 2025)
 ---------------------
 
@@ -23,7 +30,6 @@ Features:
 
 * Add :py:attr:`Circuit.has_implicit_wireswaps` property.
 * Make :py:meth:`PauliSimp` accept circuits with SX and SXdg gates.
-* Add optional `allow_swaps` argument to :py:meth:`ZXGraphlikeOptimisation`.
 
 1.40.0 (February 2025)
 ----------------------

--- a/pytket/docs/changelog.rst
+++ b/pytket/docs/changelog.rst
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-2.0.1 (Unreleased)
+Unreleased
 ---------------------
 
 Features:

--- a/pytket/pytket/_tket/passes.pyi
+++ b/pytket/pytket/_tket/passes.pyi
@@ -657,9 +657,11 @@ def ThreeQubitSquash(allow_swaps: bool = True) -> BasePass:
     
     :param allow_swaps: whether to allow implicit wire swaps
     """
-def ZXGraphlikeOptimisation() -> BasePass:
+def ZXGraphlikeOptimisation(allow_swaps: bool = True) -> BasePass:
     """
     Attempt to optimise the circuit by simplifying in ZX calculus and extracting a circuit back out. Due to limitations in extraction, may not work if the circuit contains created or discarded qubits. As a resynthesis pass, this will ignore almost all optimisations achieved beforehand and may increase the cost of the circuit.
+
+    :param allow_swaps: whether to allow implicit wire swaps (default True)
     """
 def ZZPhaseToRz() -> BasePass:
     """

--- a/pytket/pytket/_tket/passes.pyi
+++ b/pytket/pytket/_tket/passes.pyi
@@ -660,6 +660,7 @@ def ThreeQubitSquash(allow_swaps: bool = True) -> BasePass:
 def ZXGraphlikeOptimisation(allow_swaps: bool = True) -> BasePass:
     """
     Attempt to optimise the circuit by simplifying in ZX calculus and extracting a circuit back out. Due to limitations in extraction, may not work if the circuit contains created or discarded qubits. As a resynthesis pass, this will ignore almost all optimisations achieved beforehand and may increase the cost of the circuit.
+    
     :param allow_swaps: Whether to allow implicit wire swaps (default True).
     """
 def ZZPhaseToRz() -> BasePass:

--- a/pytket/pytket/_tket/passes.pyi
+++ b/pytket/pytket/_tket/passes.pyi
@@ -660,8 +660,7 @@ def ThreeQubitSquash(allow_swaps: bool = True) -> BasePass:
 def ZXGraphlikeOptimisation(allow_swaps: bool = True) -> BasePass:
     """
     Attempt to optimise the circuit by simplifying in ZX calculus and extracting a circuit back out. Due to limitations in extraction, may not work if the circuit contains created or discarded qubits. As a resynthesis pass, this will ignore almost all optimisations achieved beforehand and may increase the cost of the circuit.
-
-    :param allow_swaps: whether to allow implicit wire swaps (default True)
+    :param allow_swaps: Whether to allow implicit wire swaps (default True).
     """
 def ZZPhaseToRz() -> BasePass:
     """

--- a/pytket/tests/predicates_test.py
+++ b/pytket/tests/predicates_test.py
@@ -1155,6 +1155,19 @@ def test_has_implicit_wireswaps() -> None:
         c.has_implicit_wireswaps = True
 
 
+def test_zx_optimisation_wireswaps() -> None:
+    c = Circuit(3)
+    c.CX(0, 1)
+    c.CX(1, 2)
+    c.CX(2, 0)
+
+    ZXGraphlikeOptimisation(True).apply(c)
+    assert c.has_implicit_wireswaps
+
+    ZXGraphlikeOptimisation(False).apply(c)
+    assert not c.has_implicit_wireswaps
+
+
 if __name__ == "__main__":
     test_predicate_generation()
     test_compilation_unit_generation()

--- a/tket/conanfile.py
+++ b/tket/conanfile.py
@@ -23,7 +23,7 @@ from conan.errors import ConanInvalidConfiguration
 
 class TketConan(ConanFile):
     name = "tket"
-    version = "2.0.0"
+    version = "2.0.1"
     package_type = "library"
     license = "Apache 2"
     homepage = "https://github.com/CQCL/tket"

--- a/tket/include/tket/Predicates/PassLibrary.hpp
+++ b/tket/include/tket/Predicates/PassLibrary.hpp
@@ -141,9 +141,13 @@ const PassPtr &RemoveImplicitQubitPermutation();
  * As a resynthesis pass, this will ignore almost all optimisations achieved
  * beforehand and may increase the cost of the circuit.
  *
+ * @param allow_swaps Determines whether the extracted circuit may have
+ * implicit wire swaps. If set to false, implict wire swaps will be removed
+ * by adding SWAP gates at the end of the circuit.
+ *
  * @return compilation pass to perform this transformation
  */
-const PassPtr &ZXGraphlikeOptimisation();
+const PassPtr &ZXGraphlikeOptimisation(bool allow_swaps = true);
 
 /** Remove all \ref OpType::Phase (including conditionals) from the circuit. */
 const PassPtr &RemovePhaseOps();

--- a/tket/src/Predicates/PassLibrary.cpp
+++ b/tket/src/Predicates/PassLibrary.cpp
@@ -467,8 +467,8 @@ const PassPtr &RemoveImplicitQubitPermutation() {
   return pp;
 }
 
-const PassPtr &ZXGraphlikeOptimisation() {
-  static const PassPtr pp([]() {
+const PassPtr &ZXGraphlikeOptimisation(bool allow_swaps) {
+  auto create_pass_ptr = []<bool allow_wire_swaps>() -> PassPtr {
     Transform t = Transform([](Circuit &circ) {
       zx::ZXDiagram diag = circuit_to_zx(circ).first;
       zx::Rewrite::to_graphlike_form().apply(diag);
@@ -481,6 +481,9 @@ const PassPtr &ZXGraphlikeOptimisation() {
       for (unsigned i = 0; i < orig_qs.size(); ++i)
         qmap.insert({c_qs.at(i), orig_qs.at(i)});
       c.rename_units<Qubit, Qubit>(qmap);
+      if constexpr (!allow_wire_swaps) {
+        c.replace_all_implicit_wire_swaps();
+      }
       circ = c;
       return true;
     });
@@ -504,8 +507,16 @@ const PassPtr &ZXGraphlikeOptimisation() {
     nlohmann::json j;
     j["name"] = "ZXGraphlikeOptimisation";
     return std::make_shared<StandardPass>(precons, t, postcons, j);
-  }());
-  return pp;
+  };
+
+  static const PassPtr pp{create_pass_ptr.operator()<true>()};
+  if (allow_swaps) {
+    return pp;
+  }
+
+  static const PassPtr pp_no_implicit_swaps{
+      create_pass_ptr.operator()<false>()};
+  return pp_no_implicit_swaps;
 }
 
 const PassPtr &RemovePhaseOps() {

--- a/tket/test/src/ZX/test_ZXSimp.cpp
+++ b/tket/test/src/ZX/test_ZXSimp.cpp
@@ -228,6 +228,18 @@ SCENARIO("Testing for vertex reuse bug") {
   }
 }
 
+SCENARIO("ZX resynthesis with implicit permutation removed") {
+  {
+    Circuit circ(2);
+    circ.add_op<unsigned>(OpType::H, {0});
+    circ.add_op<unsigned>(OpType::CX, {0, 1});
+    CompilationUnit cu(circ);
+    ZXGraphlikeOptimisation(false)->apply(cu);
+    const auto& resynth = cu.get_circ_ref();
+    CHECK(!resynth.has_implicit_wireswaps());
+  }
+}
+
 }  // namespace test_ZXSimp
 }  // namespace zx
 }  // namespace tket


### PR DESCRIPTION
# Description

* Added an optional argument to `ZXGraphLikeOptimisation` so that the signature is now
```cpp
const PassPtr &ZXGraphlikeOptimisation(bool allow_swaps = true);
```
The functions in PassLibrary.cpp all use a pattern where we create a local `static const PassPtr` and return it by const reference. In this case, the logic in the `Transform` object used to create the `PassPtr` depends on the value of `allow_swaps`. So I think we need to have two `PassPtr`s, and `allow_swaps` just determines which one we return by reference.

* Added a C++ test, the Python binding, and a Python test.

# Related issues

Closes #1752.