### PR TITLE
Updated the pytket tag to 2.0.0 inside the flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -17,7 +17,7 @@
             (import ./nix-support/symengine.nix)
             (import ./nix-support/tket.nix)
             (import ./nix-support/third-party-python-packages.nix)
-            (import ./nix-support/pytket.nix { package_version = "1.34.0"; })
+            (import ./nix-support/pytket.nix { package_version = "2.0.0"; })
           ];
         };
       in {


### PR DESCRIPTION
# Description

This just lets pytket, within a nix environment, know that its version is 2.0.0.

This is awkward, but versioning is currently managed with setuptools_scm, and nix can't access .git, so the version is hardcoded for the purposes of nix.

# Related issues

None

# Checklist

- [x] I have performed a self-review of my code.
- [ ] I have commented hard-to-understand parts of my code.
- [ ] I have made corresponding changes to the public API documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the changelog with any user-facing changes.
