### PR TITLE
Allow `GreedyPauliSimp` to accept `Phase` gates

### DIFF
--- a/pytket/conanfile.py
+++ b/pytket/conanfile.py
@@ -38,7 +38,7 @@ class pytketRecipe(ConanFile):
         self.requires("pybind11_json/0.2.15")
         self.requires("symengine/0.13.0")
         self.requires("tkassert/0.3.4@tket/stable")
-        self.requires("tket/2.0.1@tket/stable")
+        self.requires("tket/2.0.2@tket/stable")
         self.requires("tklog/0.3.3@tket/stable")
         self.requires("tkrng/0.3.3@tket/stable")
         self.requires("tktokenswap/0.3.9@tket/stable")

--- a/pytket/docs/changelog.rst
+++ b/pytket/docs/changelog.rst
@@ -7,6 +7,7 @@ Unreleased
 Features:
 
 * Add optional `allow_swaps` argument to :py:meth:`ZXGraphlikeOptimisation`.
+* Allow GreedyPauliSimp to accept circuits containing Phase gates.
 
 2.0.0 (February 2025)
 ---------------------

--- a/tket/conanfile.py
+++ b/tket/conanfile.py
@@ -23,7 +23,7 @@ from conan.errors import ConanInvalidConfiguration
 
 class TketConan(ConanFile):
     name = "tket"
-    version = "2.0.1"
+    version = "2.0.2"
     package_type = "library"
     license = "Apache 2"
     homepage = "https://github.com/CQCL/tket"

--- a/tket/src/Predicates/PassGenerators.cpp
+++ b/tket/src/Predicates/PassGenerators.cpp
@@ -1045,6 +1045,7 @@ PassPtr gen_greedy_pauli_simp(
     return gpo.apply(circ);
   });
   OpTypeSet ins = {
+      OpType::Phase,
       OpType::Z,
       OpType::X,
       OpType::Y,

--- a/tket/test/src/test_GreedyPauli.cpp
+++ b/tket/test/src/test_GreedyPauli.cpp
@@ -14,6 +14,8 @@
 
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
+#include <memory>
+#include <vector>
 
 #include "testutil.hpp"
 #include "tket/Circuit/Circuit.hpp"
@@ -21,6 +23,8 @@
 #include "tket/Circuit/Simulation/CircuitSimulator.hpp"
 #include "tket/Gate/SymTable.hpp"
 #include "tket/Ops/ClassicalOps.hpp"
+#include "tket/Predicates/CompilationUnit.hpp"
+#include "tket/Predicates/CompilerPass.hpp"
 #include "tket/Predicates/PassGenerators.hpp"
 #include "tket/Predicates/PassLibrary.hpp"
 #include "tket/Transformations/GreedyPauliOptimisation.hpp"
@@ -829,6 +833,17 @@ SCENARIO("Test GreedyPauliSimp with multiple trials and threads") {
                 .apply(d));
     REQUIRE(test_unitary_comparison(circ, d, true));
   }
+}
+SCENARIO("Following a rebase pass") {
+  PassPtr rebase =
+      gen_auto_rebase_pass({OpType::ZZPhase, OpType::PhasedX, OpType::Rz});
+  PassPtr paulisynth = gen_greedy_pauli_simp(0.3, 0.5);
+  std::vector<PassPtr> passes = {rebase, paulisynth};
+  PassPtr seq = std::make_shared<SequencePass>(passes);
+  Circuit circ(1);
+  circ.add_op<unsigned>(OpType::H, {0});
+  CompilationUnit cu(circ);
+  CHECK(seq->apply(cu));
 }
 
 }  // namespace test_GreedyPauliSimp


### PR DESCRIPTION
Needed for https://github.com/CQCL/pytket-quantinuum/issues/575 .

Note that `GreedyPauliSimp` [already handles](https://github.com/CQCL/tket/blob/8464c3346d78503fb7e4e5fc8cff28279c7748c4/tket/src/Transformations/GreedyPauliConverters.cpp#L384) `Phase` ops (as a no-op).