### PR TITLE
Use clang-format v20.

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -88,7 +88,7 @@ jobs:
       - name: Check C++ code formatting
         run: |
           brew update
-          brew install clang-format@19
+          brew install clang-format@20
           git ls-files "*.cpp" "*.hpp" | xargs clang-format -style=file -i
           git diff --exit-code
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ repo.
 C++20 features may be used whenever they are supported by all the compilers
 used on the CI (listed in the README).
 
-All C++ code should be formatted with `clang-format` (v19) using the
+All C++ code should be formatted with `clang-format` (v20) using the
 configuration file `.clang-format` in the root directory. This is checked on
 the CI. The script `do-clang-format` will run this over all C++ files in the
 repository and fix them up.

--- a/libs/tktokenswap/src/RiverFlowPathFinder.cpp
+++ b/libs/tktokenswap/src/RiverFlowPathFinder.cpp
@@ -148,8 +148,9 @@ void RiverFlowPathFinder::Impl::update_data_with_path() {
 RiverFlowPathFinder::RiverFlowPathFinder(
     DistancesInterface& distances_interface,
     NeighboursInterface& neighbours_interface, RNG& rng)
-    : m_pimpl(std::make_unique<Impl>(
-          distances_interface, neighbours_interface, rng)) {}
+    : m_pimpl(
+          std::make_unique<Impl>(
+              distances_interface, neighbours_interface, rng)) {}
 
 RiverFlowPathFinder::~RiverFlowPathFinder() {}
 

--- a/libs/tktokenswap/test/src/TableLookup/test_ExactMappingLookup.cpp
+++ b/libs/tktokenswap/test/src/TableLookup/test_ExactMappingLookup.cpp
@@ -62,8 +62,9 @@ struct ResultChecker {
     // So initially, (token at i) = (target vertex).
     // Then, performing the swaps, all tokens should reach their home.
     for (const auto& swap : lookup_result.swaps) {
-      REQUIRE(std::binary_search(
-          sorted_edges_vect.cbegin(), sorted_edges_vect.cend(), swap));
+      REQUIRE(
+          std::binary_search(
+              sorted_edges_vect.cbegin(), sorted_edges_vect.cend(), swap));
       std::swap(desired_mapping[swap.first], desired_mapping[swap.second]);
     }
     CHECK(all_tokens_home(desired_mapping));

--- a/libs/tkwsm/src/GraphTheoretic/GeneralStructs.cpp
+++ b/libs/tkwsm/src/GraphTheoretic/GeneralStructs.cpp
@@ -110,10 +110,12 @@ WeightWSM get_checked_scalar_product(
   std::set<VertexWSM> used_tv;
 
   for (const auto& assignment : solution) {
-    TKET_ASSERT(std::binary_search(
-        sorted_pv.cbegin(), sorted_pv.cend(), assignment.first));
-    TKET_ASSERT(std::binary_search(
-        sorted_tv.cbegin(), sorted_tv.cend(), assignment.second));
+    TKET_ASSERT(
+        std::binary_search(
+            sorted_pv.cbegin(), sorted_pv.cend(), assignment.first));
+    TKET_ASSERT(
+        std::binary_search(
+            sorted_tv.cbegin(), sorted_tv.cend(), assignment.second));
     TKET_ASSERT(used_tv.count(assignment.second) == 0);
     used_tv.insert(assignment.second);
     assignments_map.emplace(assignment);

--- a/libs/tkwsm/test/src/InitPlacement/test_PrunedTargetEdges.cpp
+++ b/libs/tkwsm/test/src/InitPlacement/test_PrunedTargetEdges.cpp
@@ -76,9 +76,10 @@ static void test_validity_of_new_graph_data(
     if (!std::binary_search(
             assigned_target_vertices.cbegin(), assigned_target_vertices.cend(),
             edge.first)) {
-      REQUIRE(std::binary_search(
-          assigned_target_vertices.cbegin(), assigned_target_vertices.cend(),
-          edge.second));
+      REQUIRE(
+          std::binary_search(
+              assigned_target_vertices.cbegin(),
+              assigned_target_vertices.cend(), edge.second));
     }
   }
 }

--- a/pytket/binders/circuit/Circuit/main.cpp
+++ b/pytket/binders/circuit/Circuit/main.cpp
@@ -390,7 +390,7 @@ void def_circuit(py::class_<Circuit, std::shared_ptr<Circuit>> &pyCircuit) {
           "to corresponding qubits and bits in `self`",
           py::arg("circuit"), py::arg("unit_map"))
       .def(
-          "append", (void(Circuit::*)(const Circuit &)) & Circuit::append,
+          "append", (void (Circuit::*)(const Circuit &))&Circuit::append,
           "In-place sequential composition of circuits, appending a "
           "copy of the argument onto the end of the circuit. Inputs and "
           "Outputs are unified if they share the same id, defaulting to "
@@ -584,14 +584,15 @@ void def_circuit(py::class_<Circuit, std::shared_ptr<Circuit>> &pyCircuit) {
           },
           "Construct Circuit instance from JSON serializable "
           "dictionary representation of the Circuit.")
-      .def(py::pickle(
-          [](const py::object &self) {  // __getstate__
-            return py::make_tuple(self.attr("to_dict")());
-          },
-          [](const py::tuple &t) {  // __setstate__
-            const json j = t[0].cast<json>();
-            return j.get<Circuit>();
-          }))
+      .def(
+          py::pickle(
+              [](const py::object &self) {  // __getstate__
+                return py::make_tuple(self.attr("to_dict")());
+              },
+              [](const py::tuple &t) {  // __setstate__
+                const json j = t[0].cast<json>();
+                return j.get<Circuit>();
+              }))
       .def(
           "to_latex_file", &Circuit::to_latex_file,
           "Produces a latex file with a visualisation of the circuit "
@@ -626,8 +627,8 @@ void def_circuit(py::class_<Circuit, std::shared_ptr<Circuit>> &pyCircuit) {
           ":return: an identical copy of the circuit")
       .def(
           "symbol_substitution",
-          (void(Circuit::*)(const symbol_map_t &)) &
-              Circuit::symbol_substitution,
+          (void (Circuit::*)(
+              const symbol_map_t &))&Circuit::symbol_substitution,
           "In-place substitution for symbolic expressions; iterates "
           "through each parameterised gate/box and performs the "
           "substitution. \n\n:param symbol_map: A map from "
@@ -635,9 +636,9 @@ void def_circuit(py::class_<Circuit, std::shared_ptr<Circuit>> &pyCircuit) {
           py::arg("symbol_map"))
       .def(
           "symbol_substitution",
-          (void(Circuit::*)(
-              const std::map<Sym, double, SymEngine::RCPBasicKeyLess> &)) &
-              Circuit::symbol_substitution,
+          (void (Circuit::*)(
+              const std::map<Sym, double, SymEngine::RCPBasicKeyLess>
+                  &))&Circuit::symbol_substitution,
           "In-place substitution for symbolic expressions; iterates "
           "through each gate/box and performs the "
           "substitution. \n\n:param symbol_map: A map from "

--- a/pytket/binders/circuit/boxes.cpp
+++ b/pytket/binders/circuit/boxes.cpp
@@ -726,9 +726,10 @@ void init_boxes(py::module &m) {
       m, "CustomGateDef",
       "A custom unitary gate definition, given as a composition of other "
       "gates")
-      .def(py::init<
-           const std::string &, const Circuit &,
-           const py::tket_custom::SequenceVec<Sym> &>())
+      .def(
+          py::init<
+              const std::string &, const Circuit &,
+              const py::tket_custom::SequenceVec<Sym> &>())
       .def_static(
           "define",
           [](const std::string &name, const Circuit &def,

--- a/pytket/binders/partition.cpp
+++ b/pytket/binders/partition.cpp
@@ -125,10 +125,10 @@ PYBIND11_MODULE(partition, m) {
           py::arg("circ"))
       .def(
           "add_result_for_term",
-          (void(MeasurementSetup::*)(
+          (void (MeasurementSetup::*)(
               const SpPauliString &,
-              const MeasurementSetup::MeasurementBitMap &)) &
-              MeasurementSetup::add_result_for_term,
+              const MeasurementSetup::MeasurementBitMap
+                  &))&MeasurementSetup::add_result_for_term,
           "Add a new Pauli string with a corresponding BitMap", py::arg("term"),
           py::arg("result"))
       .def(

--- a/pytket/binders/passes.cpp
+++ b/pytket/binders/passes.cpp
@@ -342,14 +342,15 @@ PYBIND11_MODULE(passes, m) {
           py::arg("base_pass_dict"),
           py::arg("custom_deserialisation") =
               std::map<std::string, std::function<Circuit(const Circuit &)>>{})
-      .def(py::pickle(
-          [](py::object self) {  // __getstate__
-            return py::make_tuple(self.attr("to_dict")());
-          },
-          [](const py::tuple &t) {  // __setstate__
-            const json j = t[0].cast<json>();
-            return deserialise(j);
-          }));
+      .def(
+          py::pickle(
+              [](py::object self) {  // __getstate__
+                return py::make_tuple(self.attr("to_dict")());
+              },
+              [](const py::tuple &t) {  // __setstate__
+                const json j = t[0].cast<json>();
+                return deserialise(j);
+              }));
   py::class_<SequencePass, std::shared_ptr<SequencePass>, BasePass>(
       m, "SequencePass", "A sequence of compilation passes.")
       .def(

--- a/pytket/binders/pauli.cpp
+++ b/pytket/binders/pauli.cpp
@@ -100,8 +100,8 @@ PYBIND11_MODULE(pauli, m) {
           py::arg("other"))
       .def(
           "to_sparse_matrix",
-          (CmplxSpMat(SpPauliString::*)(void)
-               const)&SpPauliString::to_sparse_matrix,
+          (CmplxSpMat (SpPauliString::*)(void) const) &
+              SpPauliString::to_sparse_matrix,
           "Represents the sparse string as a dense string (without "
           "padding for extra qubits) and generates the matrix for the "
           "tensor. Uses the ILO-BE convention, so ``Qubit(\"a\", 0)`` "
@@ -110,8 +110,8 @@ PYBIND11_MODULE(pauli, m) {
           "\n\n:return: a sparse matrix corresponding to the operator")
       .def(
           "to_sparse_matrix",
-          (CmplxSpMat(SpPauliString::*)(const unsigned)
-               const)&SpPauliString::to_sparse_matrix,
+          (CmplxSpMat (SpPauliString::*)(const unsigned) const) &
+              SpPauliString::to_sparse_matrix,
           "Represents the sparse string as a dense string over "
           "`n_qubits` qubits (sequentially indexed from 0 in the "
           "default register) and generates the matrix for the tensor. "
@@ -137,8 +137,9 @@ PYBIND11_MODULE(pauli, m) {
           py::arg("qubits"))
       .def(
           "dot_state",
-          (Eigen::VectorXcd(SpPauliString::*)(const Eigen::VectorXcd &)
-               const)&SpPauliString::dot_state,
+          (Eigen::VectorXcd (SpPauliString::*)(const Eigen::VectorXcd &)
+               const) &
+              SpPauliString::dot_state,
           "Performs the dot product of the state with the pauli string. "
           "Maps the qubits of the statevector with sequentially-indexed "
           "qubits in the default register, with ``Qubit(0)`` being the "
@@ -191,24 +192,27 @@ PYBIND11_MODULE(pauli, m) {
           "\n:return: expectation value with respect to state",
           py::arg("state"), py::arg("qubits"))
 
-      .def(py::pickle(
-          [](const SpPauliString &qps) {
-            /* Hackery to avoid pickling an opaque object */
-            std::list<Qubit> qubits;
-            std::list<Pauli> paulis;
-            for (const std::pair<const Qubit, Pauli> &qp_pair : qps.string) {
-              qubits.push_back(qp_pair.first);
-              paulis.push_back(qp_pair.second);
-            }
-            return py::make_tuple(qubits, paulis);
-          },
-          [](const py::tuple &t) {
-            if (t.size() != 2)
-              throw std::runtime_error(
-                  "Invalid state: tuple size: " + std::to_string(t.size()));
-            return SpPauliString(
-                t[0].cast<std::list<Qubit>>(), t[1].cast<std::list<Pauli>>());
-          }));
+      .def(
+          py::pickle(
+              [](const SpPauliString &qps) {
+                /* Hackery to avoid pickling an opaque object */
+                std::list<Qubit> qubits;
+                std::list<Pauli> paulis;
+                for (const std::pair<const Qubit, Pauli> &qp_pair :
+                     qps.string) {
+                  qubits.push_back(qp_pair.first);
+                  paulis.push_back(qp_pair.second);
+                }
+                return py::make_tuple(qubits, paulis);
+              },
+              [](const py::tuple &t) {
+                if (t.size() != 2)
+                  throw std::runtime_error(
+                      "Invalid state: tuple size: " + std::to_string(t.size()));
+                return SpPauliString(
+                    t[0].cast<std::list<Qubit>>(),
+                    t[1].cast<std::list<Pauli>>());
+              }));
 
   m.def(
       "pauli_string_mult",
@@ -419,23 +423,25 @@ PYBIND11_MODULE(pauli, m) {
           "\n:return: expectation value with respect to state",
           py::arg("state"), py::arg("qubits"))
 
-      .def(py::pickle(
-          [](const SpCxPauliTensor &qpt) {
-            std::list<Qubit> qubits;
-            std::list<Pauli> paulis;
-            for (const std::pair<const Qubit, Pauli> &qp_pair : qpt.string) {
-              qubits.push_back(qp_pair.first);
-              paulis.push_back(qp_pair.second);
-            }
-            return py::make_tuple(qubits, paulis, qpt.coeff);
-          },
-          [](const py::tuple &t) {
-            if (t.size() != 3)
-              throw std::runtime_error(
-                  "Invalid state: tuple size: " + std::to_string(t.size()));
-            return SpCxPauliTensor(
-                t[0].cast<std::list<Qubit>>(), t[1].cast<std::list<Pauli>>(),
-                t[2].cast<Complex>());
-          }));
+      .def(
+          py::pickle(
+              [](const SpCxPauliTensor &qpt) {
+                std::list<Qubit> qubits;
+                std::list<Pauli> paulis;
+                for (const std::pair<const Qubit, Pauli> &qp_pair :
+                     qpt.string) {
+                  qubits.push_back(qp_pair.first);
+                  paulis.push_back(qp_pair.second);
+                }
+                return py::make_tuple(qubits, paulis, qpt.coeff);
+              },
+              [](const py::tuple &t) {
+                if (t.size() != 3)
+                  throw std::runtime_error(
+                      "Invalid state: tuple size: " + std::to_string(t.size()));
+                return SpCxPauliTensor(
+                    t[0].cast<std::list<Qubit>>(),
+                    t[1].cast<std::list<Pauli>>(), t[2].cast<Complex>());
+              }));
 }
 }  // namespace tket

--- a/pytket/binders/unitid.cpp
+++ b/pytket/binders/unitid.cpp
@@ -152,17 +152,19 @@ PYBIND11_MODULE(unit_id, m) {
           "index\n\n:param name: The readable name for the "
           "register\n:param index: The index vector",
           py::arg("name"), py::arg("index"))
-      .def(py::pickle(
-          [](const Qubit &q) {
-            return py::make_tuple(q.reg_name(), q.index());
-          },
-          [](const py::tuple &t) {
-            if (t.size() != 2)
-              throw std::runtime_error(
-                  "Invalid state: tuple size: " + std::to_string(t.size()));
-            return Qubit(
-                t[0].cast<std::string>(), t[1].cast<std::vector<unsigned>>());
-          }))
+      .def(
+          py::pickle(
+              [](const Qubit &q) {
+                return py::make_tuple(q.reg_name(), q.index());
+              },
+              [](const py::tuple &t) {
+                if (t.size() != 2)
+                  throw std::runtime_error(
+                      "Invalid state: tuple size: " + std::to_string(t.size()));
+                return Qubit(
+                    t[0].cast<std::string>(),
+                    t[1].cast<std::vector<unsigned>>());
+              }))
       .def(
           "to_list",
           [](const Qubit &q) { return py::object(json(q)).cast<py::list>(); },
@@ -211,15 +213,19 @@ PYBIND11_MODULE(unit_id, m) {
           py::arg("name"), py::arg("index"))
       .def("__eq__", &py_equals<Bit>)
       .def("__hash__", [](const Bit &b) { return hash_value(b); })
-      .def(py::pickle(
-          [](const Bit &b) { return py::make_tuple(b.reg_name(), b.index()); },
-          [](const py::tuple &t) {
-            if (t.size() != 2)
-              throw std::runtime_error(
-                  "Invalid state: tuple size: " + std::to_string(t.size()));
-            return Bit(
-                t[0].cast<std::string>(), t[1].cast<std::vector<unsigned>>());
-          }))
+      .def(
+          py::pickle(
+              [](const Bit &b) {
+                return py::make_tuple(b.reg_name(), b.index());
+              },
+              [](const py::tuple &t) {
+                if (t.size() != 2)
+                  throw std::runtime_error(
+                      "Invalid state: tuple size: " + std::to_string(t.size()));
+                return Bit(
+                    t[0].cast<std::string>(),
+                    t[1].cast<std::vector<unsigned>>());
+              }))
       .def(
           "to_list",
           [](const Bit &b) { return py::object(json(b)).cast<py::list>(); },
@@ -244,17 +250,19 @@ PYBIND11_MODULE(unit_id, m) {
           py::arg("index"))
       .def("__eq__", &py_equals<WasmState>)
       .def("__hash__", [](const WasmState &b) { return hash_value(b); })
-      .def(py::pickle(
-          [](const WasmState &b) {
-            return py::make_tuple(b.reg_name(), b.index());
-          },
-          [](const py::tuple &t) {
-            if (t.size() != 2)
-              throw std::runtime_error(
-                  "Invalid state: tuple size: " + std::to_string(t.size()));
-            return WasmState(
-                t[0].cast<std::string>(), t[1].cast<std::vector<unsigned>>());
-          }))
+      .def(
+          py::pickle(
+              [](const WasmState &b) {
+                return py::make_tuple(b.reg_name(), b.index());
+              },
+              [](const py::tuple &t) {
+                if (t.size() != 2)
+                  throw std::runtime_error(
+                      "Invalid state: tuple size: " + std::to_string(t.size()));
+                return WasmState(
+                    t[0].cast<std::string>(),
+                    t[1].cast<std::vector<unsigned>>());
+              }))
       .def(
           "to_list",
           [](const WasmState &b) {

--- a/pytket/binders/zx/diagram.cpp
+++ b/pytket/binders/zx/diagram.cpp
@@ -183,7 +183,7 @@ void ZXDiagramPybind::init_zxdiagram(py::module& m) {
           "Counts the number of edges in the diagram.")
       .def(
           "count_vertices",
-          (unsigned(ZXDiagram::*)(ZXType) const) & ZXDiagram::count_vertices,
+          (unsigned (ZXDiagram::*)(ZXType) const) & ZXDiagram::count_vertices,
           "Counts the number of vertices of a given :py:class:`ZXType` in the "
           "diagram.",
           py::arg("type"))
@@ -278,7 +278,8 @@ void ZXDiagramPybind::init_zxdiagram(py::module& m) {
           py::arg("v"), py::arg("gen"))
       .def(
           "get_wire_qtype",
-          (QuantumType(ZXDiagram::*)(const Wire&) const)&ZXDiagram::get_qtype,
+          (QuantumType (ZXDiagram::*)(const Wire&) const) &
+              ZXDiagram::get_qtype,
           "Returns the :py:class:`QuantumType` of the given wire.",
           py::arg("w"))
       .def(
@@ -327,8 +328,8 @@ void ZXDiagramPybind::init_zxdiagram(py::module& m) {
           ":py:class:`QuantumType` s of the ports they attach to.")
       .def(
           "symbol_substitution",
-          (void(ZXDiagram::*)(const symbol_map_t&)) &
-              ZXDiagram::symbol_substitution,
+          (void (ZXDiagram::*)(
+              const symbol_map_t&))&ZXDiagram::symbol_substitution,
           "In-place substitution for symbolic expressions; iterated through "
           "each parameterised vertex and performs the substitution. This will "
           "not affect any symbols captured within boxed operations.\n\n"
@@ -336,9 +337,10 @@ void ZXDiagramPybind::init_zxdiagram(py::module& m) {
           py::arg("symbol_map"))
       .def(
           "symbol_substitution",
-          (void(ZXDiagram::*)(
-              const std::map<Sym, double, SymEngine::RCPBasicKeyLess>&)) &
-              ZXDiagram::symbol_substitution,
+          (void (ZXDiagram::*)(
+              const std::map<
+                  Sym, double,
+                  SymEngine::RCPBasicKeyLess>&))&ZXDiagram::symbol_substitution,
           "In-place substitution for symbolic expressions; iterated through "
           "each parameterised vertex and performs the substitution. This will "
           "not affect any symbols captured within boxed operations.\n\n"
@@ -445,7 +447,7 @@ void ZXDiagramPybind::init_zxdiagram(py::module& m) {
           py::arg("v"))
       .def(
           "remove_wire",
-          (void(ZXDiagram::*)(const Wire&)) & ZXDiagram::remove_wire,
+          (void (ZXDiagram::*)(const Wire&))&ZXDiagram::remove_wire,
           "Removes the given wire from the diagram.", py::arg("w"))
       .def(
           "to_circuit", &wrapped_zx_to_circuit,

--- a/pytket/conanfile.py
+++ b/pytket/conanfile.py
@@ -38,7 +38,7 @@ class pytketRecipe(ConanFile):
         self.requires("pybind11_json/0.2.15")
         self.requires("symengine/0.13.0")
         self.requires("tkassert/0.3.4@tket/stable")
-        self.requires("tket/2.0.3@tket/stable")
+        self.requires("tket/2.0.4@tket/stable")
         self.requires("tklog/0.3.3@tket/stable")
         self.requires("tkrng/0.3.3@tket/stable")
         self.requires("tktokenswap/0.3.10@tket/stable")

--- a/tket/conanfile.py
+++ b/tket/conanfile.py
@@ -23,7 +23,7 @@ from conan.errors import ConanInvalidConfiguration
 
 class TketConan(ConanFile):
     name = "tket"
-    version = "2.0.3"
+    version = "2.0.4"
     package_type = "library"
     license = "Apache 2"
     homepage = "https://github.com/CQCL/tket"

--- a/tket/proptest/src/proptest.cpp
+++ b/tket/proptest/src/proptest.cpp
@@ -247,8 +247,9 @@ static void check_correctness(
   try {
     const auto u1 = tket_sim::get_unitary(c1);
     const auto u0 = tket_sim::get_unitary(c0_copy);
-    RC_ASSERT(tket_sim::compare_statevectors_or_unitaries(
-        u0, m_inv_fin * u1 * m_ini, equivalence));
+    RC_ASSERT(
+        tket_sim::compare_statevectors_or_unitaries(
+            u0, m_inv_fin * u1 * m_ini, equivalence));
   } catch (const Unsupported &) {
   } catch (const BadOpType &) {
   }
@@ -393,8 +394,10 @@ bool check_initial_simplification() {
         try {
           const auto s = tket_sim::get_statevector(c);
           const auto s1 = tket_sim::get_statevector(c1);
-          RC_ASSERT(tket_sim::compare_statevectors_or_unitaries(
-              s, s1, tket_sim::MatrixEquivalence::EQUAL_UP_TO_GLOBAL_PHASE));
+          RC_ASSERT(
+              tket_sim::compare_statevectors_or_unitaries(
+                  s, s1,
+                  tket_sim::MatrixEquivalence::EQUAL_UP_TO_GLOBAL_PHASE));
         } catch (const Unsupported &) {
         } catch (const BadOpType &) {
         }

--- a/tket/src/Architecture/BestTsaWithArch.cpp
+++ b/tket/src/Architecture/BestTsaWithArch.cpp
@@ -69,9 +69,10 @@ std::vector<std::pair<Node, Node>> BestTsaWithArch::get_swaps(
   for (auto id_opt = raw_swap_list.front_id(); id_opt;
        id_opt = raw_swap_list.next(id_opt.value())) {
     const auto& raw_swap = raw_swap_list.at(id_opt.value());
-    swaps.emplace_back(std::make_pair(
-        arch_mapping.get_node(raw_swap.first),
-        arch_mapping.get_node(raw_swap.second)));
+    swaps.emplace_back(
+        std::make_pair(
+            arch_mapping.get_node(raw_swap.first),
+            arch_mapping.get_node(raw_swap.second)));
   }
   return swaps;
 }

--- a/tket/src/Characterisation/Cycles.cpp
+++ b/tket/src/Characterisation/Cycles.cpp
@@ -53,8 +53,9 @@ void CycleFinder::update_cycle_out_edges(const UnitID& uid, const Edge& e) {
       return;
     }
   }
-  throw CycleError(std::string(
-      "UnitID " + uid.repr() + " not in std::map<Edge, UnitID> object."));
+  throw CycleError(
+      std::string(
+          "UnitID " + uid.repr() + " not in std::map<Edge, UnitID> object."));
   return;
 }
 

--- a/tket/src/Characterisation/FrameRandomisation.cpp
+++ b/tket/src/Characterisation/FrameRandomisation.cpp
@@ -212,9 +212,10 @@ PauliFrameRandomisation::get_out_frame(
         qpm[Qubit("frame", i)] = Pauli::Z;
         break;
       default: {
-        throw FrameRandomisationError(std::string(
-            "Frame OpType " + OpDesc(in_frame[i]).name() +
-            " not a Pauli OpType."));
+        throw FrameRandomisationError(
+            std::string(
+                "Frame OpType " + OpDesc(in_frame[i]).name() +
+                " not a Pauli OpType."));
       }
     }
   }
@@ -249,9 +250,10 @@ PauliFrameRandomisation::get_out_frame(
             Qubit("frame", cycle_op.indices[1]));
         break;
       default: {
-        throw FrameRandomisationError(std::string(
-            "Cycle OpType " + OpDesc(cycle_op.type).name() +
-            " not supported for PauliFrameRandomisation."));
+        throw FrameRandomisationError(
+            std::string(
+                "Cycle OpType " + OpDesc(cycle_op.type).name() +
+                " not supported for PauliFrameRandomisation."));
       }
     }
   }
@@ -296,9 +298,10 @@ UniversalFrameRandomisation::get_out_frame(
         qpm[Qubit("frame", i)] = Pauli::Z;
         break;
       default: {
-        throw FrameRandomisationError(std::string(
-            "Frame OpType " + OpDesc(in_frame[i]).name() +
-            " not a Pauli OpType."));
+        throw FrameRandomisationError(
+            std::string(
+                "Frame OpType " + OpDesc(in_frame[i]).name() +
+                " not a Pauli OpType."));
       }
     }
   }
@@ -353,14 +356,16 @@ std::vector<Circuit> FrameRandomisation::label_frames(
     std::vector<Vertex> dagger_vertices;
     if (cycle_frames.size() != cycles.size()) {
       throw FrameRandomisationError(
-          std::string("Length of combination of Frame Permutations does not "
-                      "equal number of Cycles."));
+          std::string(
+              "Length of combination of Frame Permutations does not "
+              "equal number of Cycles."));
     }
     for (unsigned i = 0; i < cycle_frames.size(); i++) {
       if (cycle_frames[i].size() != cycles[i].size()) {
         throw FrameRandomisationError(
-            std::string("Size of frame does not match the number "
-                        "of qubits in Cycles."));
+            std::string(
+                "Size of frame does not match the number "
+                "of qubits in Cycles."));
       }
       OpTypeVector in_frame = cycle_frames[i];
       std::pair<OpTypeVector, std::vector<Vertex>> frame_and_vertices =
@@ -455,8 +460,9 @@ void FrameRandomisation::assign_vertices(
   if (in_frame.size() != out_frame.size() ||
       in_frame.size() != frame_vertices.size()) {
     throw FrameRandomisationError(
-        std::string("Number of gates in sampled frame doesn't match "
-                    "number of qubits in frame"));
+        std::string(
+            "Number of gates in sampled frame doesn't match "
+            "number of qubits in frame"));
   }
   for (unsigned i = 0; i < frame_vertices.size(); i++) {
     circuit_.set_vertex_Op_ptr(

--- a/tket/src/Circuit/CircUtils.cpp
+++ b/tket/src/Circuit/CircUtils.cpp
@@ -108,8 +108,8 @@ Eigen::Matrix4cd get_matrix_from_2qb_circ(const Circuit &circ) {
         case OpType::TK2: {
           auto params = o->get_params();
           TKET_ASSERT(params.size() == 3);
-          v_to_op[it->first] =
-              get_matrix_from_2qb_circ(CircPool::normalised_TK2_using_CX(
+          v_to_op[it->first] = get_matrix_from_2qb_circ(
+              CircPool::normalised_TK2_using_CX(
                   params[0], params[1], params[2]));
           break;
         }

--- a/tket/src/Converters/ChoiMixTableauConverters.cpp
+++ b/tket/src/Converters/ChoiMixTableauConverters.cpp
@@ -202,16 +202,18 @@ ChoiMixBuilder::ChoiMixBuilder(
       out_circ_tp.add_qubit(key.first);
   }
   for (const Qubit& init_q : unitary_init_names) {
-    if (tab.col_index_.left.find(ChoiMixTableau::col_key_t{
-            init_q, ChoiMixTableau::TableauSegment::Input}) !=
+    if (tab.col_index_.left.find(
+            ChoiMixTableau::col_key_t{
+                init_q, ChoiMixTableau::TableauSegment::Input}) !=
         tab.col_index_.left.end())
       throw std::logic_error(
           "Free qubit name for initialisation conflicts with existing live "
           "input of ChoiMixTableau");
   }
   for (const Qubit& post_q : unitary_post_names) {
-    if (tab.col_index_.left.find(ChoiMixTableau::col_key_t{
-            post_q, ChoiMixTableau::TableauSegment::Output}) !=
+    if (tab.col_index_.left.find(
+            ChoiMixTableau::col_key_t{
+                post_q, ChoiMixTableau::TableauSegment::Output}) !=
         tab.col_index_.left.end())
       throw std::logic_error(
           "Free qubit name for post-selection conflicts with existing live "
@@ -336,8 +338,9 @@ void ChoiMixBuilder::solve_id_subspace() {
       // Remove these solved qubits from other rows; by commutation of rows, a
       // row contains Z@in_diag_circ.second iff it contains
       // Z@out_diag_circ_dag.second and similarly for X
-      unsigned in_c = tab.col_index_.left.at(ChoiMixTableau::col_key_t{
-          in_diag_circ.second, ChoiMixTableau::TableauSegment::Input});
+      unsigned in_c = tab.col_index_.left.at(
+          ChoiMixTableau::col_key_t{
+              in_diag_circ.second, ChoiMixTableau::TableauSegment::Input});
       for (unsigned r3 = 0; r3 < tab.get_n_rows(); ++r3) {
         if (r3 != r && tab.tab_.xmat(r3, in_c)) tab.tab_.row_mult(r, r3);
         if (r3 != r2 && tab.tab_.zmat(r3, in_c)) tab.tab_.row_mult(r2, r3);
@@ -469,8 +472,9 @@ void ChoiMixBuilder::solve_postselected_subspace() {
           "ChoiMixTableau synthesis");
     Qubit post_selected_qb = row.first.string.begin()->first;
     // Multiply other rows to remove Z_qb components
-    unsigned qb_col = tab.col_index_.left.at(ChoiMixTableau::col_key_t{
-        post_selected_qb, ChoiMixTableau::TableauSegment::Input});
+    unsigned qb_col = tab.col_index_.left.at(
+        ChoiMixTableau::col_key_t{
+            post_selected_qb, ChoiMixTableau::TableauSegment::Input});
     for (unsigned s = 0; s < final_row; ++s)
       if (tab.tab_.zmat(s, qb_col)) tab.tab_.row_mult(final_row, s);
     // Post-select on correct phase
@@ -522,8 +526,9 @@ void ChoiMixBuilder::solve_initialised_subspace() {
           "ChoiMixTableau synthesis");
     Qubit initialised_qb = row.second.string.begin()->first;
     // Multiply other rows to remove Z_qb components
-    unsigned qb_col = tab.col_index_.left.at(ChoiMixTableau::col_key_t{
-        initialised_qb, ChoiMixTableau::TableauSegment::Output});
+    unsigned qb_col = tab.col_index_.left.at(
+        ChoiMixTableau::col_key_t{
+            initialised_qb, ChoiMixTableau::TableauSegment::Output});
     for (unsigned s = 0; s < r; ++s)
       if (tab.tab_.zmat(s, qb_col)) tab.tab_.row_mult(r, s);
     // Initialise with correct phase

--- a/tket/src/Mapping/RoutingMethodJson.cpp
+++ b/tket/src/Mapping/RoutingMethodJson.cpp
@@ -39,25 +39,31 @@ void from_json(const nlohmann::json& j, std::vector<RoutingMethodPtr>& rmp_v) {
   for (const auto& c : j) {
     std::string name = c.at("name").get<std::string>();
     if (name == "LexiLabellingMethod") {
-      rmp_v.push_back(std::make_shared<LexiLabellingMethod>(
-          LexiLabellingMethod::deserialize(c)));
+      rmp_v.push_back(
+          std::make_shared<LexiLabellingMethod>(
+              LexiLabellingMethod::deserialize(c)));
     } else if (name == "LexiRouteRoutingMethod") {
-      rmp_v.push_back(std::make_shared<LexiRouteRoutingMethod>(
-          LexiRouteRoutingMethod::deserialize(c)));
+      rmp_v.push_back(
+          std::make_shared<LexiRouteRoutingMethod>(
+              LexiRouteRoutingMethod::deserialize(c)));
     } else if (name == "RoutingMethod") {
       rmp_v.push_back(std::make_shared<RoutingMethod>());
     } else if (name == "AASRouteRoutingMethod") {
-      rmp_v.push_back(std::make_shared<AASRouteRoutingMethod>(
-          AASRouteRoutingMethod::deserialize(c)));
+      rmp_v.push_back(
+          std::make_shared<AASRouteRoutingMethod>(
+              AASRouteRoutingMethod::deserialize(c)));
     } else if (name == "AASLabellingMethod") {
-      rmp_v.push_back(std::make_shared<AASLabellingMethod>(
-          AASLabellingMethod::deserialize(c)));
+      rmp_v.push_back(
+          std::make_shared<AASLabellingMethod>(
+              AASLabellingMethod::deserialize(c)));
     } else if (name == "MultiGateReorderRoutingMethod") {
-      rmp_v.push_back(std::make_shared<MultiGateReorderRoutingMethod>(
-          MultiGateReorderRoutingMethod::deserialize(c)));
+      rmp_v.push_back(
+          std::make_shared<MultiGateReorderRoutingMethod>(
+              MultiGateReorderRoutingMethod::deserialize(c)));
     } else if (name == "BoxDecompositionRoutingMethod") {
-      rmp_v.push_back(std::make_shared<BoxDecompositionRoutingMethod>(
-          BoxDecompositionRoutingMethod::deserialize(c)));
+      rmp_v.push_back(
+          std::make_shared<BoxDecompositionRoutingMethod>(
+              BoxDecompositionRoutingMethod::deserialize(c)));
     } else {
       std::logic_error(
           "Deserialization for given RoutingMethod not supported.");

--- a/tket/src/Transformations/Decomposition.cpp
+++ b/tket/src/Transformations/Decomposition.cpp
@@ -632,12 +632,13 @@ static double best_noise_aware_decomposition(
     for (unsigned n_zz = 0; n_zz <= max_nzz; ++n_zz) {
       if (n_zz > 0) {
         double gate_fid = std::visit(
-            overloaded{// Constant value
-                       [](double arg) { return arg; },
-                       // A value depending on the angle
-                       [angles, n_zz](std::function<double(double)> arg) {
-                         return (arg)(angles[n_zz - 1]);
-                       }},
+            overloaded{
+                // Constant value
+                [](double arg) { return arg; },
+                // A value depending on the angle
+                [angles, n_zz](std::function<double(double)> arg) {
+                  return (arg)(angles[n_zz - 1]);
+                }},
             *fid.ZZPhase_fidelity);
         if (gate_fid < 0 || gate_fid > 1) {
           throw std::domain_error(
@@ -880,10 +881,11 @@ Transform decompose_TK2(const TwoQbFidelities &fid, bool allow_swaps) {
   }
   if (fid.ZZMax_fidelity && fid.ZZPhase_fidelity) {
     double ZZPhase_half = std::visit(
-        overloaded{// A constant value.
-                   [](double arg) { return arg; },
-                   // A value depending on the input.
-                   [](std::function<double(double)> arg) { return (arg)(.5); }},
+        overloaded{
+            // A constant value.
+            [](double arg) { return arg; },
+            // A value depending on the input.
+            [](std::function<double(double)> arg) { return (arg)(.5); }},
         *fid.ZZPhase_fidelity);
     if (*fid.ZZMax_fidelity < ZZPhase_half) {
       throw std::domain_error(

--- a/tket/src/Transformations/GreedyPauliConverters.cpp
+++ b/tket/src/Transformations/GreedyPauliConverters.cpp
@@ -42,8 +42,9 @@ static std::vector<PauliNode_ptr> get_nodes_from_tableau(
       z_string.push_back(z_stab.string.at(Qubit(j)));
       x_string.push_back(x_stab.string.at(Qubit(j)));
     }
-    rows.push_back(std::make_shared<PauliPropagation>(
-        z_string, x_string, z_sign, x_sign, i));
+    rows.push_back(
+        std::make_shared<PauliPropagation>(
+            z_string, x_string, z_sign, x_sign, i));
   }
   return rows;
 }

--- a/tket/test/src/Architecture/test_SubgraphMonomorphisms.cpp
+++ b/tket/test/src/Architecture/test_SubgraphMonomorphisms.cpp
@@ -63,26 +63,28 @@ static void test(
 
 SCENARIO("get all embeddings") {
   // Diamond with extra edge
-  Architecture pattern(std::vector<Connection>{
-      {Node(0), Node(1)},
-      {Node(0), Node(2)},
-      {Node(1), Node(2)},
-      {Node(1), Node(3)},
-      {Node(3), Node(4)},
-      {Node(2), Node(3)}});
+  Architecture pattern(
+      std::vector<Connection>{
+          {Node(0), Node(1)},
+          {Node(0), Node(2)},
+          {Node(1), Node(2)},
+          {Node(1), Node(3)},
+          {Node(3), Node(4)},
+          {Node(2), Node(3)}});
 
   // Four triangles - beginning of Sierpinski triangle!
-  Architecture target(std::vector<Connection>{
-      {Node(0), Node(1)},
-      {Node(1), Node(2)},
-      {Node(2), Node(3)},
-      {Node(3), Node(4)},
-      {Node(4), Node(5)},
-      {Node(5), Node(0)},
-      {Node(1), Node(3)},
-      {Node(3), Node(5)},
-      {Node(5), Node(1)},
-  });
+  Architecture target(
+      std::vector<Connection>{
+          {Node(0), Node(1)},
+          {Node(1), Node(2)},
+          {Node(2), Node(3)},
+          {Node(3), Node(4)},
+          {Node(4), Node(5)},
+          {Node(5), Node(0)},
+          {Node(1), Node(3)},
+          {Node(3), Node(5)},
+          {Node(5), Node(1)},
+      });
 
   test(
       pattern, target,

--- a/tket/test/src/Circuit/test_Multiplexor.cpp
+++ b/tket/test/src/Circuit/test_Multiplexor.cpp
@@ -371,23 +371,26 @@ SCENARIO("Exception handling", "[boxes]") {
         {{1}, get_op_ptr(OpType::Rz, 0.3)}, {{0}, get_op_ptr(OpType::Rx, 1.4)}};
     REQUIRE_THROWS_MATCHES(
         MultiplexedRotationBox(op_map), std::invalid_argument,
-        MessageContains("Ops passed to MultiplexedRotationBox must have the "
-                        "same rotation type"));
+        MessageContains(
+            "Ops passed to MultiplexedRotationBox must have the "
+            "same rotation type"));
   }
   GIVEN("Non-rotation type") {
     ctrl_op_map_t op_map = {{{1}, get_op_ptr(OpType::H)}};
     REQUIRE_THROWS_MATCHES(
         MultiplexedRotationBox(op_map), BadOpType,
-        MessageContains("Ops passed to MultiplexedRotationBox must be either "
-                        "Rx, Ry, or Rz"));
+        MessageContains(
+            "Ops passed to MultiplexedRotationBox must be either "
+            "Rx, Ry, or Rz"));
   }
   GIVEN("MultiplexedU2Box unsupported gate") {
     ctrl_op_map_t op_map = {
         {{0, 1}, get_op_ptr(OpType::H)}, {{1, 0}, get_op_ptr(OpType::CX)}};
     REQUIRE_THROWS_MATCHES(
         MultiplexedU2Box(op_map), BadOpType,
-        MessageContains("Ops passed to MultiplexedU2Box must be single-qubit "
-                        "unitary gate types or Unitary1qBox"));
+        MessageContains(
+            "Ops passed to MultiplexedU2Box must be single-qubit "
+            "unitary gate types or Unitary1qBox"));
   }
   GIVEN("Decompose symbolic MultiplexedU2Box") {
     Sym a = SymTable::fresh_symbol("a");
@@ -773,8 +776,9 @@ SCENARIO("Test MultiplexedTensoredU2Box exceptions", "[boxes]") {
     ctrl_tensored_op_map_t op_map;
     REQUIRE_THROWS_MATCHES(
         MultiplexedTensoredU2Box(op_map), std::invalid_argument,
-        MessageContains("The op_map argument passed to "
-                        "MultiplexedTensoredU2Box cannot be empty."));
+        MessageContains(
+            "The op_map argument passed to "
+            "MultiplexedTensoredU2Box cannot be empty."));
   }
   GIVEN("Bitstrings are too long") {
     std::vector<bool> bits(33);
@@ -789,8 +793,9 @@ SCENARIO("Test MultiplexedTensoredU2Box exceptions", "[boxes]") {
         {{0, 1}, {get_op_ptr(OpType::H)}}, {{1}, {get_op_ptr(OpType::X)}}};
     REQUIRE_THROWS_MATCHES(
         MultiplexedTensoredU2Box(op_map), std::invalid_argument,
-        MessageContains("The bitstrings passed to MultiplexedTensoredU2Box "
-                        "must have the same width."));
+        MessageContains(
+            "The bitstrings passed to MultiplexedTensoredU2Box "
+            "must have the same width."));
   }
   GIVEN("Unmatched op sizes") {
     ctrl_tensored_op_map_t op_map = {
@@ -807,8 +812,9 @@ SCENARIO("Test MultiplexedTensoredU2Box exceptions", "[boxes]") {
         {{0, 1}, {get_op_ptr(OpType::H)}}, {{1, 0}, {get_op_ptr(OpType::CX)}}};
     REQUIRE_THROWS_MATCHES(
         MultiplexedTensoredU2Box(op_map), BadOpType,
-        MessageContains("Ops passed to MultiplexedTensoredU2Box must be "
-                        "single-qubit unitary gate types or Unitary1qBox"));
+        MessageContains(
+            "Ops passed to MultiplexedTensoredU2Box must be "
+            "single-qubit unitary gate types or Unitary1qBox"));
   }
 }
 SCENARIO("Test MultiplexedTensoredU2Box value error") {

--- a/tket/test/src/Circuit/test_StatePreparation.cpp
+++ b/tket/test/src/Circuit/test_StatePreparation.cpp
@@ -72,8 +72,10 @@ SCENARIO("Test state preparation") {
     test_states.push_back(Eigen::Vector4cd(0, 1, 0, 0));
     test_states.push_back(Eigen::Vector4cd(0, 0, 0, 1));
     test_states.push_back(Eigen::Vector4cd(1, 0, 0, 0));
-    test_states.push_back(Eigen::Vector4cd(
-        -std::sqrt(0.25), std::sqrt(0.25), std::sqrt(0.25), -std::sqrt(0.25)));
+    test_states.push_back(
+        Eigen::Vector4cd(
+            -std::sqrt(0.25), std::sqrt(0.25), std::sqrt(0.25),
+            -std::sqrt(0.25)));
     for (unsigned i = 0; i < 5; i++) {
       test_states.push_back(random_state(8, i));
       test_states.push_back(random_state(16, i));

--- a/tket/test/src/Gate/test_GateUnitaryMatrix.cpp
+++ b/tket/test/src/Gate/test_GateUnitaryMatrix.cpp
@@ -518,10 +518,12 @@ SCENARIO("Trivial unitary matrix identities") {
         const auto other_op = inner_entry.second.other_type;
         const auto& params = inner_entry.second.params;
 
-        CHECK(GateUnitaryMatrix::get_unitary(
-                  op_with_no_params, number_of_qubits, no_params)
-                  .isApprox(GateUnitaryMatrix::get_unitary(
-                      other_op, number_of_qubits, params)));
+        CHECK(
+            GateUnitaryMatrix::get_unitary(
+                op_with_no_params, number_of_qubits, no_params)
+                .isApprox(
+                    GateUnitaryMatrix::get_unitary(
+                        other_op, number_of_qubits, params)));
       }
     }
   }

--- a/tket/test/src/Simulation/test_CircuitSimulator.cpp
+++ b/tket/test/src/Simulation/test_CircuitSimulator.cpp
@@ -140,8 +140,9 @@ SCENARIO("Simple circuits produce the correct statevectors") {
     circ2.add_op<unsigned>(OpType::H, {0});
     circ2.add_op<unsigned>(OpType::CZ, {1, 0});
     circ2.add_op<unsigned>(OpType::H, {0});
-    REQUIRE(tket_sim::compare_statevectors_or_unitaries(
-        tket_sim::get_statevector(circ), tket_sim::get_statevector(circ2)));
+    REQUIRE(
+        tket_sim::compare_statevectors_or_unitaries(
+            tket_sim::get_statevector(circ), tket_sim::get_statevector(circ2)));
   }
 
   GIVEN("A circuit with 0 qubits and a global phase") {
@@ -700,16 +701,18 @@ SCENARIO(
   GIVEN("Equal up to roundoff") {
     for (const auto& entry : almost_equal_pairs) {
       for (auto equiv : equivalences) {
-        CHECK(tket_sim::compare_statevectors_or_unitaries(
-            entry.first, entry.second, equiv));
+        CHECK(
+            tket_sim::compare_statevectors_or_unitaries(
+                entry.first, entry.second, equiv));
       }
       const auto almost_phase_equivalent_matrix =
           get_almost_phase_equivalent_matrix(entry.second);
       CHECK(!tket_sim::compare_statevectors_or_unitaries(
           entry.first, almost_phase_equivalent_matrix));
-      CHECK(tket_sim::compare_statevectors_or_unitaries(
-          entry.first, almost_phase_equivalent_matrix,
-          tket_sim::MatrixEquivalence::EQUAL_UP_TO_GLOBAL_PHASE));
+      CHECK(
+          tket_sim::compare_statevectors_or_unitaries(
+              entry.first, almost_phase_equivalent_matrix,
+              tket_sim::MatrixEquivalence::EQUAL_UP_TO_GLOBAL_PHASE));
     }
   }
   GIVEN("Different inputs") {

--- a/tket/test/src/ZX/test_ZXSimp.cpp
+++ b/tket/test/src/ZX/test_ZXSimp.cpp
@@ -106,9 +106,10 @@ SCENARIO("Testing graph state simplification") {
    **/
 
   CHECK(Rewrite::remove_interior_cliffords().apply(diag1));
-  CHECK_FALSE(Rewrite::extend_at_boundary_paulis().apply(
-      diag1));  // If remove_interior_cliffords is exhaustive, this should not
-                // need to be applied
+  CHECK_FALSE(
+      Rewrite::extend_at_boundary_paulis().apply(
+          diag1));  // If remove_interior_cliffords is exhaustive, this should
+                    // not need to be applied
   CHECK(Rewrite::remove_interior_paulis().apply(diag1));
   // This example will have no gadgets to gadgetise
   CHECK_FALSE(Rewrite::gadgetise_interior_paulis().apply(diag1));

--- a/tket/test/src/test_ArchitectureAwareSynthesis.cpp
+++ b/tket/test/src/test_ArchitectureAwareSynthesis.cpp
@@ -25,8 +25,9 @@ namespace tket {
 using Connection = Architecture::Connection;
 SCENARIO("Routing of aas example") {
   GIVEN("aas routing - simple example") {
-    Architecture arc(std::vector<Connection>{
-        {Node(0), Node(1)}, {Node(1), Node(2)}, {Node(2), Node(3)}});
+    Architecture arc(
+        std::vector<Connection>{
+            {Node(0), Node(1)}, {Node(1), Node(2)}, {Node(2), Node(3)}});
     PassPtr pass = gen_full_mapping_pass_phase_poly(arc);
     Circuit circ(4);
     circ.add_op<unsigned>(OpType::H, {0});
@@ -51,8 +52,9 @@ SCENARIO("Routing of aas example") {
     REQUIRE(test_unitary_comparison(circ, result));
   }
   GIVEN("aas routing - simple example II") {
-    Architecture arc(std::vector<Connection>{
-        {Node(0), Node(1)}, {Node(1), Node(2)}, {Node(2), Node(3)}});
+    Architecture arc(
+        std::vector<Connection>{
+            {Node(0), Node(1)}, {Node(1), Node(2)}, {Node(2), Node(3)}});
     PassPtr pass = gen_full_mapping_pass_phase_poly(arc);
     Circuit circ(4);
     circ.add_op<unsigned>(OpType::H, {0});
@@ -84,8 +86,9 @@ SCENARIO("Routing of aas example") {
     REQUIRE(test_unitary_comparison(circ, result));
   }
   GIVEN("aas routing - simple example III") {
-    Architecture arc(std::vector<Connection>{
-        {Node(0), Node(1)}, {Node(1), Node(2)}, {Node(2), Node(3)}});
+    Architecture arc(
+        std::vector<Connection>{
+            {Node(0), Node(1)}, {Node(1), Node(2)}, {Node(2), Node(3)}});
     PassPtr pass = gen_full_mapping_pass_phase_poly(arc);
     Circuit circ(4);
     circ.add_op<unsigned>(OpType::H, {0});
@@ -122,8 +125,9 @@ SCENARIO("Routing of aas example") {
     REQUIRE(test_unitary_comparison(circ, result));
   }
   GIVEN("aas routing - simple example IV") {
-    Architecture arc(std::vector<Connection>{
-        {Node(0), Node(1)}, {Node(1), Node(2)}, {Node(2), Node(3)}});
+    Architecture arc(
+        std::vector<Connection>{
+            {Node(0), Node(1)}, {Node(1), Node(2)}, {Node(2), Node(3)}});
     PassPtr pass = gen_full_mapping_pass_phase_poly(arc);
     Circuit circ(4);
     circ.add_op<unsigned>(OpType::H, {0});
@@ -206,12 +210,14 @@ SCENARIO("Routing of aas example") {
 
     const auto s = tket_sim::get_unitary(circ);
     const auto s1 = tket_sim::get_unitary(result);
-    REQUIRE(tket_sim::compare_statevectors_or_unitaries(
-        s, s1, tket_sim::MatrixEquivalence::EQUAL));
+    REQUIRE(
+        tket_sim::compare_statevectors_or_unitaries(
+            s, s1, tket_sim::MatrixEquivalence::EQUAL));
   }
   GIVEN("aas routing - simple example VII") {
-    Architecture arc(std::vector<Connection>{
-        {Node(0), Node(2)}, {Node(2), Node(4)}, {Node(4), Node(6)}});
+    Architecture arc(
+        std::vector<Connection>{
+            {Node(0), Node(2)}, {Node(2), Node(4)}, {Node(4), Node(6)}});
     PassPtr pass = gen_full_mapping_pass_phase_poly(arc);
     Circuit circ(4);
     circ.add_op<unsigned>(OpType::H, {0});
@@ -240,12 +246,16 @@ SCENARIO("Routing of aas example") {
 
     const auto s = tket_sim::get_unitary(circ);
     const auto s1 = tket_sim::get_unitary(result);
-    REQUIRE(tket_sim::compare_statevectors_or_unitaries(
-        s, s1, tket_sim::MatrixEquivalence::EQUAL));
+    REQUIRE(
+        tket_sim::compare_statevectors_or_unitaries(
+            s, s1, tket_sim::MatrixEquivalence::EQUAL));
   }
   GIVEN("aas routing - simple example VIII") {
-    Architecture arc(std::vector<Connection>{
-        {Node(1000), Node(10)}, {Node(10), Node(100)}, {Node(100), Node(1)}});
+    Architecture arc(
+        std::vector<Connection>{
+            {Node(1000), Node(10)},
+            {Node(10), Node(100)},
+            {Node(100), Node(1)}});
     PassPtr pass = gen_full_mapping_pass_phase_poly(arc);
     Circuit circ(4);
     circ.add_op<unsigned>(OpType::H, {0});
@@ -273,8 +283,11 @@ SCENARIO("Routing of aas example") {
     REQUIRE(test_unitary_comparison(circ, result));
   }
   GIVEN("aas routing - simple example IX, other gate set") {
-    Architecture arc(std::vector<Connection>{
-        {Node(1000), Node(10)}, {Node(10), Node(100)}, {Node(100), Node(1)}});
+    Architecture arc(
+        std::vector<Connection>{
+            {Node(1000), Node(10)},
+            {Node(10), Node(100)},
+            {Node(100), Node(1)}});
     PassPtr pass = gen_full_mapping_pass_phase_poly(arc);
     Circuit circ(4);
     circ.add_op<unsigned>(OpType::X, {0});
@@ -320,8 +333,9 @@ SCENARIO("Routing of aas example") {
     REQUIRE(pass->apply(cu));
   }
   GIVEN("aas routing - circuit with fewer qubits then nodes in the arch") {
-    Architecture arc(std::vector<Connection>{
-        {Node(0), Node(1)}, {Node(1), Node(2)}, {Node(2), Node(3)}});
+    Architecture arc(
+        std::vector<Connection>{
+            {Node(0), Node(1)}, {Node(1), Node(2)}, {Node(2), Node(3)}});
     PassPtr pass = gen_full_mapping_pass_phase_poly(arc);
     Circuit circ(3);
     circ.add_op<unsigned>(OpType::X, {0});
@@ -343,11 +357,12 @@ SCENARIO("Routing of aas example") {
     REQUIRE(test_unitary_comparison(circ, result));
   }
   GIVEN("aas routing - circuit with fewer qubits then nodes in the arch II") {
-    Architecture arc(std::vector<Connection>{
-        {Node(0), Node(1)},
-        {Node(1), Node(2)},
-        {Node(2), Node(3)},
-        {Node(3), Node(4)}});
+    Architecture arc(
+        std::vector<Connection>{
+            {Node(0), Node(1)},
+            {Node(1), Node(2)},
+            {Node(2), Node(3)},
+            {Node(3), Node(4)}});
     PassPtr pass = gen_full_mapping_pass_phase_poly(arc);
     Circuit circ(3);
     circ.add_op<unsigned>(OpType::X, {0});

--- a/tket/test/src/test_BoxDecompRoutingMethod.cpp
+++ b/tket/test/src/test_BoxDecompRoutingMethod.cpp
@@ -53,8 +53,9 @@ SCENARIO("Decompose boxes") {
     bd.solve();
     const auto u = tket_sim::get_unitary(circ);
     const auto u1 = tket_sim::get_unitary(circ_copy);
-    REQUIRE(tket_sim::compare_statevectors_or_unitaries(
-        u, u1, tket_sim::MatrixEquivalence::EQUAL));
+    REQUIRE(
+        tket_sim::compare_statevectors_or_unitaries(
+            u, u1, tket_sim::MatrixEquivalence::EQUAL));
     std::vector<Command> commands = mf->circuit_.get_commands();
     for (Command c : commands) {
       REQUIRE(!c.get_op_ptr()->get_desc().is_box());

--- a/tket/test/src/test_CompilerPass.cpp
+++ b/tket/test/src/test_CompilerPass.cpp
@@ -692,8 +692,8 @@ SCENARIO("gen_placement_pass test") {
     avg_node_errors_t empty_node_errors = {};
     avg_readout_errors_t empty_readout_errors = {};
     avg_link_errors_t empty_link_errors = {};
-    PassPtr noise_place =
-        gen_placement_pass(std::make_shared<NoiseAwarePlacement>(
+    PassPtr noise_place = gen_placement_pass(
+        std::make_shared<NoiseAwarePlacement>(
             line_arc, empty_node_errors, empty_link_errors,
             empty_readout_errors, 10, 1000000));
     CompilationUnit noise_cu((Circuit(circ)));
@@ -710,8 +710,8 @@ SCENARIO("gen_placement_pass test") {
     graph_fall_back_place->apply(graph_fall_back_cu);
     // Get a fall back placement from a noise -
     // aware placement
-    PassPtr noise_fall_back_place =
-        gen_placement_pass(std::make_shared<NoiseAwarePlacement>(
+    PassPtr noise_fall_back_place = gen_placement_pass(
+        std::make_shared<NoiseAwarePlacement>(
             line_arc, empty_node_errors, empty_link_errors,
             empty_readout_errors, 1000000, 0));
     CompilationUnit noise_fall_back_cu((Circuit(circ)));

--- a/tket/test/src/test_ContextOpt.cpp
+++ b/tket/test/src/test_ContextOpt.cpp
@@ -149,8 +149,9 @@ SCENARIO("Create and Discard operations") {
     const auto s = tket_sim::get_statevector(c);
     REQUIRE(Transforms::simplify_initial().apply(c));
     const auto s1 = tket_sim::get_statevector(c);
-    REQUIRE(tket_sim::compare_statevectors_or_unitaries(
-        s, s1, tket_sim::MatrixEquivalence::EQUAL_UP_TO_GLOBAL_PHASE));
+    REQUIRE(
+        tket_sim::compare_statevectors_or_unitaries(
+            s, s1, tket_sim::MatrixEquivalence::EQUAL_UP_TO_GLOBAL_PHASE));
   }
   GIVEN("Circuit with zero-preserving ops") {
     Circuit c(3);
@@ -172,8 +173,9 @@ SCENARIO("Create and Discard operations") {
     REQUIRE(c.count_gates(OpType::Z) == 0);
     REQUIRE(c.count_gates(OpType::X) == 1);
     const auto s1 = tket_sim::get_statevector(c);
-    REQUIRE(tket_sim::compare_statevectors_or_unitaries(
-        s, s1, tket_sim::MatrixEquivalence::EQUAL_UP_TO_GLOBAL_PHASE));
+    REQUIRE(
+        tket_sim::compare_statevectors_or_unitaries(
+            s, s1, tket_sim::MatrixEquivalence::EQUAL_UP_TO_GLOBAL_PHASE));
   }
   GIVEN("Circuit tracking known computational-basis states") {
     Circuit c(2);

--- a/tket/test/src/test_GreedyPauli.cpp
+++ b/tket/test/src/test_GreedyPauli.cpp
@@ -569,10 +569,12 @@ SCENARIO("Complete synthesis") {
         PauliExpBox(SymPauliTensor({Pauli::X, Pauli::X}, 0.3)), {0, 1});
     Circuit d1(circ);
     Circuit d2(circ);
-    REQUIRE(Transforms::greedy_pauli_optimisation(0.7, 0.3, 500, 500, 0, true)
-                .apply(d1));
-    REQUIRE(Transforms::greedy_pauli_optimisation(0.7, 0.3, 500, 500, 0, false)
-                .apply(d2));
+    REQUIRE(
+        Transforms::greedy_pauli_optimisation(0.7, 0.3, 500, 500, 0, true)
+            .apply(d1));
+    REQUIRE(
+        Transforms::greedy_pauli_optimisation(0.7, 0.3, 500, 500, 0, false)
+            .apply(d2));
     REQUIRE(test_unitary_comparison(circ, d1, true));
     REQUIRE(test_unitary_comparison(circ, d2, true));
     REQUIRE(d1.count_n_qubit_gates(2) == 1);
@@ -587,8 +589,9 @@ SCENARIO("Complete synthesis") {
     circ.add_box(
         PauliExpBox(SymPauliTensor({Pauli::X, Pauli::Y}, 0.2)), {4, 5});
     Circuit d(circ);
-    REQUIRE(Transforms::greedy_pauli_optimisation(0.7, 0.3, 500, 500, 0, true)
-                .apply(d));
+    REQUIRE(
+        Transforms::greedy_pauli_optimisation(0.7, 0.3, 500, 500, 0, true)
+            .apply(d));
     REQUIRE(test_unitary_comparison(circ, d, true));
     REQUIRE(d.count_n_qubit_gates(2) == 3);
   }
@@ -669,8 +672,9 @@ SCENARIO("Complete synthesis") {
         PauliExpBox(SymPauliTensor({Pauli::Z, Pauli::Y, Pauli::X}, 0.15)),
         {0, 1, 2});
     Circuit d(circ);
-    REQUIRE(Transforms::greedy_pauli_optimisation(0.7, 0.3, 500, 500, 0, true)
-                .apply(d));
+    REQUIRE(
+        Transforms::greedy_pauli_optimisation(0.7, 0.3, 500, 500, 0, true)
+            .apply(d));
     REQUIRE(test_unitary_comparison(circ, d, true));
     // if the first XY was implemented using a ZZPhase
     // then 2 TQEs is needed to conjugate the remaining two strings to weight 2
@@ -828,9 +832,10 @@ SCENARIO("Test GreedyPauliSimp with multiple trials and threads") {
     REQUIRE(!Transforms::greedy_pauli_optimisation(
                  0.7, 0.3, 500, 500, 0, true, 1, 10)
                  .apply(d));
-    REQUIRE(Transforms::greedy_pauli_optimisation(
-                0.7, 0.3, 500, 500, 0, true, 100, 10)
-                .apply(d));
+    REQUIRE(
+        Transforms::greedy_pauli_optimisation(
+            0.7, 0.3, 500, 500, 0, true, 100, 10)
+            .apply(d));
     REQUIRE(test_unitary_comparison(circ, d, true));
   }
 }

--- a/tket/test/src/test_LexiRoute.cpp
+++ b/tket/test/src/test_LexiRoute.cpp
@@ -1113,13 +1113,15 @@ SCENARIO("Dense CX circuits route succesfully") {
         }
       }
     }
-    Architecture arc(std::vector<std::pair<unsigned, unsigned>>{
-        {0, 1},   {1, 2},   {2, 3},   {3, 4},   {0, 5},   {1, 6},   {1, 7},
-        {2, 6},   {2, 7},   {3, 8},   {3, 9},   {4, 8},   {4, 9},   {5, 6},
-        {5, 10},  {5, 11},  {6, 10},  {6, 11},  {6, 7},   {7, 12},  {7, 13},
-        {7, 8},   {8, 12},  {8, 13},  {8, 9},   {10, 11}, {11, 16}, {11, 17},
-        {11, 12}, {12, 16}, {12, 17}, {12, 13}, {13, 18}, {13, 19}, {13, 14},
-        {14, 18}, {14, 19}, {15, 16}, {16, 17}, {17, 18}, {18, 19}});
+    Architecture arc(
+        std::vector<std::pair<unsigned, unsigned>>{
+            {0, 1},   {1, 2},   {2, 3},   {3, 4},   {0, 5},   {1, 6},
+            {1, 7},   {2, 6},   {2, 7},   {3, 8},   {3, 9},   {4, 8},
+            {4, 9},   {5, 6},   {5, 10},  {5, 11},  {6, 10},  {6, 11},
+            {6, 7},   {7, 12},  {7, 13},  {7, 8},   {8, 12},  {8, 13},
+            {8, 9},   {10, 11}, {11, 16}, {11, 17}, {11, 12}, {12, 16},
+            {12, 17}, {12, 13}, {13, 18}, {13, 19}, {13, 14}, {14, 18},
+            {14, 19}, {15, 16}, {16, 17}, {17, 18}, {18, 19}});
     MappingManager mm(std::make_shared<Architecture>(arc));
     REQUIRE(mm.route_circuit(
         circ, {std::make_shared<LexiLabellingMethod>(),
@@ -1171,22 +1173,23 @@ SCENARIO(
         }
       }
     }
-    Architecture arc(std::vector<std::pair<unsigned, unsigned>>{
-        {0, 1},
-        {2, 0},
-        {2, 4},
-        {6, 4},
-        {8, 6},
-        {8, 10},
-        {12, 10},
-        {3, 1},
-        {3, 5},
-        {7, 5},
-        {7, 9},
-        {11, 9},
-        {11, 13},
-        {12, 13},
-        {6, 7}});
+    Architecture arc(
+        std::vector<std::pair<unsigned, unsigned>>{
+            {0, 1},
+            {2, 0},
+            {2, 4},
+            {6, 4},
+            {8, 6},
+            {8, 10},
+            {12, 10},
+            {3, 1},
+            {3, 5},
+            {7, 5},
+            {7, 9},
+            {11, 9},
+            {11, 13},
+            {12, 13},
+            {6, 7}});
     MappingManager mm(std::make_shared<Architecture>(arc));
     REQUIRE(mm.route_circuit(
         circ, {std::make_shared<LexiLabellingMethod>(),
@@ -1628,11 +1631,13 @@ SCENARIO("Test failing case") {
   std::ifstream circuit_file("lexiroute_circuit.json");
   nlohmann::json j = nlohmann::json::parse(circuit_file);
   auto c = j.get<Circuit>();
-  Architecture arc(std::vector<std::pair<unsigned, unsigned>>{
-      {0, 1},   {1, 2},   {2, 3},   {3, 5},   {4, 1},   {4, 7},   {5, 8},
-      {6, 7},   {7, 10},  {8, 9},   {8, 11},  {10, 12}, {11, 14}, {12, 13},
-      {14, 13}, {14, 16}, {12, 15}, {15, 18}, {17, 18}, {16, 19}, {19, 20},
-      {18, 21}, {21, 23}, {19, 22}, {22, 25}, {23, 24}, {24, 25}, {25, 26}});
+  Architecture arc(
+      std::vector<std::pair<unsigned, unsigned>>{
+          {0, 1},   {1, 2},   {2, 3},   {3, 5},   {4, 1},   {4, 7},
+          {5, 8},   {6, 7},   {7, 10},  {8, 9},   {8, 11},  {10, 12},
+          {11, 14}, {12, 13}, {14, 13}, {14, 16}, {12, 15}, {15, 18},
+          {17, 18}, {16, 19}, {19, 20}, {18, 21}, {21, 23}, {19, 22},
+          {22, 25}, {23, 24}, {24, 25}, {25, 26}});
 
   CompilationUnit cu(c);
   PassPtr r_p = gen_routing_pass(
@@ -1823,9 +1828,10 @@ SCENARIO(
     circuit.add_op<unsigned>(OpType::CX, {0, 2});
     circuit.add_op<unsigned>(OpType::CX, {0, 4});
 
-    std::map<Qubit, Node> p_map = {// mapping for qbs with 2qb gates
-                                   {Qubit(0), nodes[0]},
-                                   {Qubit(1), nodes[8]}};
+    std::map<Qubit, Node> p_map = {
+        // mapping for qbs with 2qb gates
+        {Qubit(0), nodes[0]},
+        {Qubit(1), nodes[8]}};
     Placement::place_with_map(circuit, p_map);
     CompilationUnit cu(circuit);
     PassPtr r_p = gen_routing_pass(
@@ -1883,9 +1889,10 @@ SCENARIO(
     }
     circuit.add_op<unsigned>(OpType::CX, {2, 3});
     circuit.add_op<unsigned>(OpType::CX, {2, 4});
-    std::map<Qubit, Node> p_map = {// mapping for qbs with 2qb gates
-                                   {Qubit(0), nodes[6]},
-                                   {Qubit(1), nodes[n_nodes - 1]}};
+    std::map<Qubit, Node> p_map = {
+        // mapping for qbs with 2qb gates
+        {Qubit(0), nodes[6]},
+        {Qubit(1), nodes[n_nodes - 1]}};
 
     Placement::place_with_map(circuit, p_map);
     CompilationUnit cu(circuit);
@@ -1980,9 +1987,10 @@ SCENARIO(
     circuit.add_op<unsigned>(OpType::CZ, {3, 4});
     circuit.add_op<unsigned>(OpType::CZ, {4, 10});
 
-    std::map<Qubit, Node> p_map = {// mapping for qbs with 2qb gates
-                                   {Qubit(3), nodes[14]},
-                                   {Qubit(10), nodes[n_nodes - 1]}};
+    std::map<Qubit, Node> p_map = {
+        // mapping for qbs with 2qb gates
+        {Qubit(3), nodes[14]},
+        {Qubit(10), nodes[n_nodes - 1]}};
 
     Placement::place_with_map(circuit, p_map);
     CompilationUnit cu(circuit);

--- a/tket/test/src/test_MultiGateReorder.cpp
+++ b/tket/test/src/test_MultiGateReorder.cpp
@@ -62,8 +62,9 @@ SCENARIO("Reorder circuits") {
     }
     const auto u = tket_sim::get_unitary(circ);
     const auto u1 = tket_sim::get_unitary(circ_copy);
-    REQUIRE(tket_sim::compare_statevectors_or_unitaries(
-        u, u1, tket_sim::MatrixEquivalence::EQUAL));
+    REQUIRE(
+        tket_sim::compare_statevectors_or_unitaries(
+            u, u1, tket_sim::MatrixEquivalence::EQUAL));
   }
 
   GIVEN("Simple CZ circuit 2.") {
@@ -103,8 +104,9 @@ SCENARIO("Reorder circuits") {
     }
     const auto u = tket_sim::get_unitary(circ);
     const auto u1 = tket_sim::get_unitary(circ_copy);
-    REQUIRE(tket_sim::compare_statevectors_or_unitaries(
-        u, u1, tket_sim::MatrixEquivalence::EQUAL));
+    REQUIRE(
+        tket_sim::compare_statevectors_or_unitaries(
+            u, u1, tket_sim::MatrixEquivalence::EQUAL));
   }
   GIVEN("Simple CZ circuit with single_qs.") {
     Circuit circ(4, 1);
@@ -148,8 +150,9 @@ SCENARIO("Reorder circuits") {
     }
     const auto u = tket_sim::get_unitary(circ);
     const auto u1 = tket_sim::get_unitary(circ_copy);
-    REQUIRE(tket_sim::compare_statevectors_or_unitaries(
-        u, u1, tket_sim::MatrixEquivalence::EQUAL));
+    REQUIRE(
+        tket_sim::compare_statevectors_or_unitaries(
+            u, u1, tket_sim::MatrixEquivalence::EQUAL));
   }
 
   GIVEN("Circuit with multi qubit gates.") {
@@ -195,8 +198,9 @@ SCENARIO("Reorder circuits") {
     }
     const auto u = tket_sim::get_unitary(circ);
     const auto u1 = tket_sim::get_unitary(circ_copy);
-    REQUIRE(tket_sim::compare_statevectors_or_unitaries(
-        u, u1, tket_sim::MatrixEquivalence::EQUAL));
+    REQUIRE(
+        tket_sim::compare_statevectors_or_unitaries(
+            u, u1, tket_sim::MatrixEquivalence::EQUAL));
   }
 
   GIVEN("Reorder that frees up physically permitted gates") {
@@ -228,8 +232,9 @@ SCENARIO("Reorder circuits") {
     REQUIRE(*subc.verts.begin() == v1);
     const auto u = tket_sim::get_unitary(circ);
     const auto u1 = tket_sim::get_unitary(circ_copy);
-    REQUIRE(tket_sim::compare_statevectors_or_unitaries(
-        u, u1, tket_sim::MatrixEquivalence::EQUAL));
+    REQUIRE(
+        tket_sim::compare_statevectors_or_unitaries(
+            u, u1, tket_sim::MatrixEquivalence::EQUAL));
   }
 }
 
@@ -272,8 +277,9 @@ SCENARIO("Reorder circuits with limited search space") {
         {Node(commands[1].get_args()[0]), Node(commands[1].get_args()[1])}));
     const auto u = tket_sim::get_unitary(circ);
     const auto u1 = tket_sim::get_unitary(circ_copy);
-    REQUIRE(tket_sim::compare_statevectors_or_unitaries(
-        u, u1, tket_sim::MatrixEquivalence::EQUAL));
+    REQUIRE(
+        tket_sim::compare_statevectors_or_unitaries(
+            u, u1, tket_sim::MatrixEquivalence::EQUAL));
   }
 }
 
@@ -325,8 +331,9 @@ SCENARIO("Test MultiGateReorderRoutingMethod") {
     }
     const auto u = tket_sim::get_unitary(circ);
     const auto u1 = tket_sim::get_unitary(circ_copy);
-    REQUIRE(tket_sim::compare_statevectors_or_unitaries(
-        u, u1, tket_sim::MatrixEquivalence::EQUAL));
+    REQUIRE(
+        tket_sim::compare_statevectors_or_unitaries(
+            u, u1, tket_sim::MatrixEquivalence::EQUAL));
 
     // Test with limits
     Circuit circ2(circ_copy);
@@ -355,8 +362,9 @@ SCENARIO("Test MultiGateReorderRoutingMethod") {
     REQUIRE(!mf2->valid_boundary_operation(
         shared_arc, commands2[4].get_op_ptr(), nodes));
     const auto u2 = tket_sim::get_unitary(circ2);
-    REQUIRE(tket_sim::compare_statevectors_or_unitaries(
-        u2, u1, tket_sim::MatrixEquivalence::EQUAL));
+    REQUIRE(
+        tket_sim::compare_statevectors_or_unitaries(
+            u2, u1, tket_sim::MatrixEquivalence::EQUAL));
   }
 }
 

--- a/tket/test/src/test_UnitaryTableau.cpp
+++ b/tket/test/src/test_UnitaryTableau.cpp
@@ -750,14 +750,15 @@ SCENARIO("Unitary inversions") {
 
 SCENARIO("Compare SymplecticTableau and UnitaryTableau") {
   GIVEN("The same sequence of gates, compare string representations") {
-    SymplecticTableau stab(PauliStabiliserVec{
-        {DensePauliMap{Pauli::X, Pauli::I, Pauli::I}},
-        {DensePauliMap{Pauli::I, Pauli::X, Pauli::I}},
-        {DensePauliMap{Pauli::I, Pauli::I, Pauli::X}},
-        {DensePauliMap{Pauli::Z, Pauli::I, Pauli::I}},
-        {DensePauliMap{Pauli::I, Pauli::Z, Pauli::I}},
-        {DensePauliMap{Pauli::I, Pauli::I, Pauli::Z}},
-    });
+    SymplecticTableau stab(
+        PauliStabiliserVec{
+            {DensePauliMap{Pauli::X, Pauli::I, Pauli::I}},
+            {DensePauliMap{Pauli::I, Pauli::X, Pauli::I}},
+            {DensePauliMap{Pauli::I, Pauli::I, Pauli::X}},
+            {DensePauliMap{Pauli::Z, Pauli::I, Pauli::I}},
+            {DensePauliMap{Pauli::I, Pauli::Z, Pauli::I}},
+            {DensePauliMap{Pauli::I, Pauli::I, Pauli::Z}},
+        });
     // Paulis cancel with subsequent gadget
     stab.apply_gate(OpType::X, uvec{0});
     stab.apply_gate(OpType::Y, uvec{1});

--- a/tket/test/src/test_json.cpp
+++ b/tket/test/src/test_json.cpp
@@ -784,9 +784,10 @@ SCENARIO("Test RoutingMethod serializations") {
   CHECK(!loaded_rmp_j[0]
              ->routing_method(mf_sp, std::make_shared<SquareGrid>(2, 2))
              .first);
-  CHECK(loaded_rmp_j[1]
-            ->routing_method(mf_sp, std::make_shared<SquareGrid>(2, 2))
-            .first);
+  CHECK(
+      loaded_rmp_j[1]
+          ->routing_method(mf_sp, std::make_shared<SquareGrid>(2, 2))
+          .first);
 }
 
 SCENARIO("Test predicate serializations") {


### PR DESCRIPTION
Homebrew has removed clang-format v19 and added v20.

Apply necessary reformatting. (No semantic changes.)