### PR TITLE
Fix error in `separate_classical` when quantum ops succeed final measures

### DIFF
--- a/pytket/conanfile.py
+++ b/pytket/conanfile.py
@@ -38,7 +38,7 @@ class pytketRecipe(ConanFile):
         self.requires("pybind11_json/0.2.15")
         self.requires("symengine/0.13.0")
         self.requires("tkassert/0.3.4@tket/stable")
-        self.requires("tket/2.0.5@tket/stable")
+        self.requires("tket/2.0.6@tket/stable")
         self.requires("tklog/0.3.3@tket/stable")
         self.requires("tkrng/0.3.3@tket/stable")
         self.requires("tktokenswap/0.3.10@tket/stable")

--- a/pytket/docs/changelog.rst
+++ b/pytket/docs/changelog.rst
@@ -11,6 +11,11 @@ Features:
 * Add `tk2_to_cx` parameter to `RebaseToCliffordSingles` transform.
 * Reduce depth of circuits resulting from `FullPeepholeOptimise` in some cases.
 
+Fixes:
+
+* Fix error in `separate_classical` when quantum operations come after final
+  measurements.
+
 2.0.1 (March 2025)
 ------------------
 

--- a/tket/conanfile.py
+++ b/tket/conanfile.py
@@ -23,7 +23,7 @@ from conan.errors import ConanInvalidConfiguration
 
 class TketConan(ConanFile):
     name = "tket"
-    version = "2.0.5"
+    version = "2.0.6"
     package_type = "library"
     license = "Apache 2"
     homepage = "https://github.com/CQCL/tket"

--- a/tket/src/Transformations/ContextualReduction.cpp
+++ b/tket/src/Transformations/ContextualReduction.cpp
@@ -424,7 +424,8 @@ std::pair<Circuit, Circuit> separate_classical(const Circuit &circ) {
   for (const Command &cmd : cmds) {
     Vertex v = cmd.get_vertex();
     VertexVec preds = circ.get_predecessors(v);
-    if (std::all_of(preds.begin(), preds.end(), [&c1_verts](const Vertex &v) {
+    if (circ.get_in_edges_of_type(v, EdgeType::Quantum).empty() &&
+        std::all_of(preds.begin(), preds.end(), [&c1_verts](const Vertex &v) {
           return c1_verts.find(v) != c1_verts.end();
         })) {
       c1_verts.insert(v);

--- a/tket/test/src/test_ContextOpt.cpp
+++ b/tket/test/src/test_ContextOpt.cpp
@@ -336,6 +336,16 @@ SCENARIO("Contextual optimization") {
       REQUIRE(new_values[Bit(1)] == new_values[Bit(0)]);
     }
   }
+  GIVEN("Circuit with quantum op following final measurement") {
+    // https://github.com/CQCL/tket/issues/1794
+    Circuit c(1, 1);
+    c.add_op<unsigned>(OpType::X, {0});
+    c.add_op<unsigned>(OpType::Measure, {0, 0});
+    c.add_op<unsigned>(OpType::X, {0});
+    auto [c0, ppc] = Transforms::separate_classical(c);
+    CHECK(c0 == c);
+    CHECK(ppc == Circuit(0, 1));
+  }
 }
 
 }  // namespace test_ContextOpt


### PR DESCRIPTION
Fixes #1794 .