### PR TITLE
docs: Remove old warning from main page, docs fixes

### DIFF
--- a/pytket/docs/circuit_class.rst
+++ b/pytket/docs/circuit_class.rst
@@ -50,6 +50,10 @@ condition on a specified set of bit values.)
 
    .. automethod:: add_phase
 
+   .. automethod:: add_clexpr_from_logicexp
+
+   .. automethod:: wasm_uid
+
    .. autoproperty:: name
 
    .. autoproperty:: n_qubits

--- a/pytket/docs/index.rst
+++ b/pytket/docs/index.rst
@@ -13,17 +13,6 @@ and Windows. To install, run
     pip install pytket
 
 
-.. admonition:: Known issue installing pytket (Added 2nd August 2024)
-   :class: attention
-
-   Due to the removal of the `types-pkg_resources` package from pypi there will likely be issues when installing old versions of pytket. It is recommend to use pytket `>=1.31` where possible.
-
-   If you require using a version of pytket older than 1.31 then you can try the following.
-
-   
-    `pip install types-pkg-resources==0.1.3 pytket==<set version>` 
-
-
 If you have issues installing ``pytket`` please visit the `installation troubleshooting <https://docs.quantinuum.com/tket/api-docs/install.html>`_ page.
 
 To use ``pytket``, you can simply import the appropriate modules into your python code or in an interactive Python notebook. We can build circuits directly using the ``pytket`` interface by creating a blank circuit and adding gates in the order we want to apply them.


### PR DESCRIPTION
# Description

Removing this banner as I think its outdated and the issue won't impact any current users. Let me know if you disagree.


<img width="759" alt="Screenshot 2025-03-12 at 20 39 22" src="https://github.com/user-attachments/assets/56a98cb9-e97e-436d-99fd-738b948da512" />


Driveby: updated the docs theming submodule -> only impacts the local build of the docs.
Driveby II: add some missing Circuit methods into the docs