### PR TITLE
ci: check for `Circuit` class omissions in the docs build

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -316,6 +316,7 @@ jobs:
         poetry config virtualenvs.create false
         cd pytket/docs
         poetry install
+        poetry run python check_circuit_class_docs.py
         bash ./build-docs.sh
     - name: Upload artifact
       if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'

--- a/pytket/docs/check_circuit_class_docs.py
+++ b/pytket/docs/check_circuit_class_docs.py
@@ -6,11 +6,29 @@ from pytket._tket.circuit import Circuit
 # This script is used to check that no methods or properties of
 # the Circuit class are left out in the circuit_class.rst file.
 
-with open("circuit_class.rst", encoding="utf-8") as file:
-    rst = file.read()
 
-in_methods = {p[0] for p in inspect.getmembers(Circuit)}
-pattern = re.compile(r"(?:\bautomethod\b|\bautoproperty\b):: (\w+)\n")
-in_docs = set(pattern.findall(rst))
-missing = in_methods - in_docs
-print([s for s in missing if not s.startswith("_")])
+class MissingCircuitDocsError(Exception):
+    "Raised when the Circuit class has missing methods or properties."
+
+    def __init__(self, missing_list: list[str]) -> None:
+        super().__init__(
+            f"Missing Circuit class docs for {missing_list}! Please"
+            " update circuit_class.rst.",
+        )
+
+
+def main() -> None:
+    with open("circuit_class.rst", encoding="utf-8") as file:
+        rst = file.read()
+
+    in_methods = {p[0] for p in inspect.getmembers(Circuit)}
+    pattern = re.compile(r"(?:\bautomethod\b|\bautoproperty\b):: (\w+)\n")
+    in_docs = set(pattern.findall(rst))
+    missing = in_methods - in_docs
+    missing_public_docs = [s for s in missing if not s.startswith("_")]
+    if len(missing) != 0:
+        raise MissingCircuitDocsError(missing_list=missing_public_docs)
+
+
+if __name__ == "__main__":
+    main()

--- a/pytket/docs/check_circuit_class_docs.py
+++ b/pytket/docs/check_circuit_class_docs.py
@@ -26,7 +26,7 @@ def main() -> None:
     in_docs = set(pattern.findall(rst))
     missing = in_methods - in_docs
     missing_public_docs = [s for s in missing if not s.startswith("_")]
-    if len(missing) != 0:
+    if len(missing_public_docs) != 0:
         raise MissingCircuitDocsError(missing_list=missing_public_docs)
 
 

--- a/pytket/docs/circuit_class.rst
+++ b/pytket/docs/circuit_class.rst
@@ -50,6 +50,10 @@ condition on a specified set of bit values.)
 
    .. automethod:: add_phase
 
+   .. automethod:: add_clexpr_from_logicexp
+
+   .. automethod:: wasm_uid
+
    .. autoproperty:: name
 
    .. autoproperty:: n_qubits

--- a/pytket/docs/circuit_class.rst
+++ b/pytket/docs/circuit_class.rst
@@ -50,10 +50,6 @@ condition on a specified set of bit values.)
 
    .. automethod:: add_phase
 
-   .. automethod:: add_clexpr_from_logicexp
-
-   .. automethod:: wasm_uid
-
    .. autoproperty:: name
 
    .. autoproperty:: n_qubits


### PR DESCRIPTION
# Description

Checking for missing public methods/properties in the `Circuit` class as there have been significant omissions in the past.

I've tested this by deliberately removing some methods to make sure they are detected. See the change [3a24462](https://github.com/CQCL/tket/pull/1810/commits/3a24462fcd2515e0f1d408251a1f8903e5b75f00) and the corresponding C.I. failure https://github.com/CQCL/tket/actions/runs/13838854885/job/38720844929

There's a sphinx coverage extension that's supposed to detect these sorts of omissions but I haven't managed to configure it properly -> https://www.sphinx-doc.org/en/master/usage/extensions/coverage.html

I don't think the current hacky script will scale well to the rest of the docs. However I still think its worthwhile to check the `Circuit` class in C.I.
