### PR TITLE
Use tci-boost/1.87.0 in libs, bumping versions.

### DIFF
--- a/libs/tktokenswap/conanfile.py
+++ b/libs/tktokenswap/conanfile.py
@@ -19,7 +19,7 @@ from conan.errors import ConanInvalidConfiguration
 
 class TktokenswapConan(ConanFile):
     name = "tktokenswap"
-    version = "0.3.10"
+    version = "0.3.11"
     package_type = "library"
     license = "Apache 2"
     url = "https://github.com/CQCL/tket"
@@ -73,4 +73,4 @@ class TktokenswapConan(ConanFile):
         self.requires("tklog/0.3.3@tket/stable")
         self.requires("tkassert/0.3.4@tket/stable", transitive_headers=True)
         self.requires("tkrng/0.3.3@tket/stable")
-        self.requires("boost/1.87.0", transitive_libs=False)
+        self.requires("boost/tci-1.87.0@tket/stable", transitive_libs=False)

--- a/libs/tktokenswap/test/conanfile.py
+++ b/libs/tktokenswap/test/conanfile.py
@@ -19,7 +19,7 @@ from conan.errors import ConanInvalidConfiguration
 
 class test_tktokenswapRecipe(ConanFile):
     name = "test-tktokenswap"
-    version = "0.3.3"
+    version = "0.3.11"
     package_type = "application"
     license = "Apache 2"
     url = "https://github.com/CQCL/tket"
@@ -59,6 +59,6 @@ class test_tktokenswapRecipe(ConanFile):
         cmake.install()
 
     def requirements(self):
-        self.requires("tktokenswap/0.3.10")
+        self.requires("tktokenswap/0.3.11")
         self.requires("tkrng/0.3.3@tket/stable")
         self.requires("catch2/3.8.0")

--- a/libs/tkwsm/conanfile.py
+++ b/libs/tkwsm/conanfile.py
@@ -19,7 +19,7 @@ from conan.errors import ConanInvalidConfiguration
 
 class TkwsmConan(ConanFile):
     name = "tkwsm"
-    version = "0.3.10"
+    version = "0.3.11"
     package_type = "library"
     license = "Apache 2"
     url = "https://github.com/CQCL/tket"
@@ -72,4 +72,8 @@ class TkwsmConan(ConanFile):
     def requirements(self):
         self.requires("tkassert/0.3.4@tket/stable")
         self.requires("tkrng/0.3.3@tket/stable")
-        self.requires("boost/1.87.0", transitive_headers=True, transitive_libs=False)
+        self.requires(
+            "boost/tci-1.87.0@tket/stable",
+            transitive_headers=True,
+            transitive_libs=False,
+        )

--- a/libs/tkwsm/test/conanfile.py
+++ b/libs/tkwsm/test/conanfile.py
@@ -19,7 +19,7 @@ from conan.errors import ConanInvalidConfiguration
 
 class test_tkwsmRecipe(ConanFile):
     name = "test-tkwsm"
-    version = "0.3.3"
+    version = "0.3.11"
     package_type = "application"
     license = "Apache 2"
     url = "https://github.com/CQCL/tket"
@@ -59,7 +59,7 @@ class test_tkwsmRecipe(ConanFile):
         cmake.install()
 
     def requirements(self):
-        self.requires("tkwsm/0.3.10")
+        self.requires("tkwsm/0.3.11")
         self.requires("tkassert/0.3.4@tket/stable")
         self.requires("tkrng/0.3.3@tket/stable")
         self.requires("catch2/3.8.0")


### PR DESCRIPTION
I have started a repo ( https://github.com/CQCL/tket-conan-index ) for all the conan recipes from external sources that tket needs or wants to customize. Workflows in that repo build and upload them to the artifactory. (More documentation of this coming soon!) This PR is the first step in moving tket to use these new recipes. Afterwards I'll make a PR for the main library using these versions (and also removing the `recipes` folder and some related workflows from here).

In itself this PR has no effect on tket, which continues to use the existing versions.