### PR TITLE
Bump tket version.

### DIFF
--- a/pytket/conanfile.py
+++ b/pytket/conanfile.py
@@ -38,7 +38,7 @@ class pytketRecipe(ConanFile):
         self.requires("pybind11_json/tci-0.2.15@tket/stable")
         self.requires("symengine/tci-0.14.0@tket/stable")
         self.requires("tkassert/0.3.4@tket/stable")
-        self.requires("tket/2.1.2@tket/stable")
+        self.requires("tket/2.1.3@tket/stable")
         self.requires("tklog/0.3.3@tket/stable")
         self.requires("tkrng/0.3.3@tket/stable")
         self.requires("tktokenswap/0.3.11@tket/stable")

--- a/tket/conanfile.py
+++ b/tket/conanfile.py
@@ -23,7 +23,7 @@ from conan.errors import ConanInvalidConfiguration
 
 class TketConan(ConanFile):
     name = "tket"
-    version = "2.1.2"
+    version = "2.1.3"
     package_type = "library"
     license = "Apache 2"
     homepage = "https://github.com/CQCL/tket"


### PR DESCRIPTION
The new version should pull in the latest symengine revision. Without this it seems that conan can't find a suitable version of tket.