### PR TITLE
Use variants to merge methods in pybind

### DIFF
--- a/pytket/binders/circuit/Circuit/add_classical_op.cpp
+++ b/pytket/binders/circuit/Circuit/add_classical_op.cpp
@@ -29,6 +29,82 @@ namespace py = pybind11;
 
 namespace tket {
 
+typedef std::variant<
+    py::tket_custom::SequenceVec<unsigned>, py::tket_custom::SequenceVec<Bit>>
+    var_seq_bs_t;
+
+static std::variant<std::vector<unsigned>, std::vector<UnitID>>
+var_sequence_to_var_vecs(const var_seq_bs_t &var_seq) {
+  if (std::holds_alternative<py::tket_custom::SequenceVec<unsigned>>(var_seq)) {
+    return std::get<py::tket_custom::SequenceVec<unsigned>>(var_seq);
+  } else {
+    auto b_vec = std::get<py::tket_custom::SequenceVec<Bit>>(var_seq);
+    return std::vector<UnitID>{b_vec.begin(), b_vec.end()};
+  }
+}
+
+static std::variant<std::vector<unsigned>, std::vector<UnitID>>
+var_bs_b_to_var_vec(
+    const var_seq_bs_t &reg, const std::variant<unsigned, Bit> &b,
+    const std::string &method_name) {
+  bool is_unsigned =
+      std::holds_alternative<py::tket_custom::SequenceVec<unsigned>>(reg);
+  if (std::holds_alternative<unsigned>(b) != is_unsigned) {
+    throw CircuitInvalidity(
+        "Bits passed to `" + method_name +
+        "` must either all be `int` or all `Bit`.");
+  }
+  if (is_unsigned) {
+    std::vector<unsigned> bs =
+        std::get<py::tket_custom::SequenceVec<unsigned>>(reg);
+    bs.push_back(std::get<unsigned>(b));
+    return bs;
+  } else {
+    std::vector<UnitID> out;
+    for (const Bit &b : std::get<py::tket_custom::SequenceVec<Bit>>(reg))
+      out.push_back(b);
+    out.push_back(std::get<Bit>(b));
+    return out;
+  }
+}
+
+static std::variant<std::vector<unsigned>, std::vector<UnitID>>
+var_bs_bs_to_var_vec(
+    const var_seq_bs_t &reg0, const var_seq_bs_t &reg1,
+    const std::string &method_name) {
+  bool is_unsigned =
+      std::holds_alternative<py::tket_custom::SequenceVec<unsigned>>(reg0);
+  if (std::holds_alternative<py::tket_custom::SequenceVec<unsigned>>(reg1) !=
+      is_unsigned) {
+    throw CircuitInvalidity(
+        "Bits passed to `" + method_name +
+        "` must either all be `int` or all `Bit`.");
+  }
+  if (is_unsigned) {
+    std::vector<unsigned> bs0 =
+        std::get<py::tket_custom::SequenceVec<unsigned>>(reg0);
+    std::vector<unsigned> bs1 =
+        std::get<py::tket_custom::SequenceVec<unsigned>>(reg1);
+    bs0.insert(bs0.end(), bs1.begin(), bs1.end());
+    return bs0;
+  } else {
+    std::vector<UnitID> out;
+    for (const Bit &b : std::get<py::tket_custom::SequenceVec<Bit>>(reg0))
+      out.push_back(b);
+    for (const Bit &b : std::get<py::tket_custom::SequenceVec<Bit>>(reg1))
+      out.push_back(b);
+    return out;
+  }
+}
+
+static unsigned var_seq_len(const var_seq_bs_t &var_seq) {
+  if (std::holds_alternative<py::tket_custom::SequenceVec<unsigned>>(var_seq)) {
+    return std::get<py::tket_custom::SequenceVec<unsigned>>(var_seq).size();
+  } else {
+    return std::get<py::tket_custom::SequenceVec<Bit>>(var_seq).size();
+  }
+}
+
 static void apply_classical_op_to_registers(
     Circuit &circ, const std::shared_ptr<const ClassicalEvalOp> &op,
     const std::vector<BitRegister> &registers, const py::kwargs &kwargs) {
@@ -39,14 +115,14 @@ static void apply_classical_op_to_registers(
                                 return i.size() < j.size();
                               })
                               ->size();
-  std::vector<Bit> args(n_bits * n_op_args);
+  std::vector<UnitID> args(n_bits * n_op_args);
   for (unsigned i = 0; i < n_bits; i++) {
     for (unsigned j = 0; j < n_op_args; j++) {
       args[n_op_args * i + j] = registers[j][i];
     }
   }
   std::shared_ptr<MultiBitOp> mbop = std::make_shared<MultiBitOp>(op, n_bits);
-  add_gate_method<Bit>(&circ, mbop, args, kwargs);
+  add_gate_method_any(&circ, mbop, args, kwargs);
 }
 
 void init_circuit_add_classical_op(
@@ -54,12 +130,12 @@ void init_circuit_add_classical_op(
   c.def(
        "add_c_transform",
        [](Circuit &circ, const py::tket_custom::SequenceVec<_tket_uint_t> &values,
-          const py::tket_custom::SequenceVec<unsigned> &args, const std::string &name,
+          const var_seq_bs_t &args, const std::string &name,
           const py::kwargs &kwargs) {
-         unsigned n_args = args.size();
+         unsigned n_args = var_seq_len(args);
          std::shared_ptr<ClassicalTransformOp> op =
              std::make_shared<ClassicalTransformOp>(n_args, values, name);
-         return add_gate_method<unsigned>(&circ, op, args, kwargs);
+         return add_gate_method_any(&circ, op, var_sequence_to_var_vecs(args), kwargs);
        },
        "Appends a purely classical transformation, defined by a table of "
        "values, to "
@@ -78,44 +154,32 @@ void init_circuit_add_classical_op(
        py::arg("values"), py::arg("args"),
        py::arg("name") = "ClassicalTransform")
       .def(
-          "add_c_transform",
-          [](Circuit &circ, const py::tket_custom::SequenceVec<_tket_uint_t> &values,
-             const py::tket_custom::SequenceVec<Bit> &args, const std::string &name,
-             const py::kwargs &kwargs) {
-            unsigned n_args = args.size();
-            std::shared_ptr<ClassicalTransformOp> op =
-                std::make_shared<ClassicalTransformOp>(n_args, values, name);
-            return add_gate_method<Bit>(&circ, op, args, kwargs);
-          },
-          "See :py:meth:`add_c_transform`.", py::arg("values"), py::arg("args"),
-          py::arg("name") = "ClassicalTransform")
-      .def(
           "_add_wasm",
           [](Circuit &circ, const std::string &funcname,
              const std::string &wasm_uid,
              const py::tket_custom::SequenceVec<unsigned> &width_i_parameter,
              const py::tket_custom::SequenceVec<unsigned> &width_o_parameter,
-             const py::tket_custom::SequenceVec<unsigned> &args,
+             const var_seq_bs_t &args,
              const py::tket_custom::SequenceVec<unsigned> &wasm_wire_args,
              const py::kwargs &kwargs) -> Circuit * {
-
-            unsigned n_args = args.size();
-            unsigned ww_n = wasm_wire_args.size();
-
-            std::shared_ptr<WASMOp> op = std::make_shared<WASMOp>(
-                n_args, ww_n, width_i_parameter, width_o_parameter, funcname, wasm_uid);
-
             std::vector<UnitID> new_args;
-
-            for (auto i : args) {
-              new_args.push_back(Bit(i));
+            if (std::holds_alternative<py::tket_custom::SequenceVec<unsigned>>(args)) {
+              for (unsigned i : std::get<py::tket_custom::SequenceVec<unsigned>>(args)) {
+                new_args.push_back(Bit(i));
+              }
+            } else {
+              for (const Bit &b : std::get<py::tket_custom::SequenceVec<Bit>>(args)) {
+                new_args.push_back(b);
+              }
             }
-
+            unsigned n_args = new_args.size();
             for (auto i : wasm_wire_args) {
               new_args.push_back(WasmState(i));
             }
-
-            return add_gate_method<UnitID>(&circ, op, new_args, kwargs);
+            unsigned ww_n = wasm_wire_args.size();
+            std::shared_ptr<WASMOp> op = std::make_shared<WASMOp>(
+                n_args, ww_n, width_i_parameter, width_o_parameter, funcname, wasm_uid);
+            return add_gate_method_any(&circ, op, new_args, kwargs);
           },
           "Add a classical function call from a wasm file to the circuit. "
           "\n\n:param funcname: name of the function that is called"
@@ -126,48 +190,6 @@ void init_circuit_add_classical_op(
           "variables"
           "\n:param args: vector of circuit bits the wasm op should be added to"
           "\n:param wasm_wire_args: vector of circuit wasmwires the wasm op should be added to"
-          "\n:param kwargs: additional arguments passed to `add_gate_method` ."
-          " Allowed parameters are `opgroup`,  `condition` , `condition_bits`,"
-          " `condition_value`"
-          "\n:return: the new :py:class:`Circuit`",
-          py::arg("funcname"), py::arg("wasm_uid"), py::arg("width_i_parameter"),
-          py::arg("width_o_parameter"), py::arg("args"), py::arg("wasm_wire_args"))
-      .def(
-          "_add_wasm",
-          [](Circuit &circ, const std::string &funcname,
-             const std::string &wasm_uid,
-             const py::tket_custom::SequenceVec<unsigned> &width_i_parameter,
-             const py::tket_custom::SequenceVec<unsigned> &width_o_parameter,
-             const py::tket_custom::SequenceVec<Bit> &args,
-             const py::tket_custom::SequenceVec<unsigned> &wasm_wire_args,
-             const py::kwargs &kwargs) -> Circuit * {
-
-            unsigned n_args = args.size();
-            unsigned ww_n = wasm_wire_args.size();
-
-            std::shared_ptr<WASMOp> op = std::make_shared<WASMOp>(
-                n_args, ww_n, width_i_parameter, width_o_parameter, funcname, wasm_uid);
-
-            std::vector<UnitID> new_args;
-
-            for (const auto& b : args) {
-              new_args.push_back(b);
-            }
-
-            for (auto i : wasm_wire_args) {
-              new_args.push_back(WasmState(i));
-            }
-
-            return add_gate_method<UnitID>(&circ, op, new_args, kwargs);
-          },
-          "Add a classical function call from a wasm file to the circuit. "
-          "\n\n:param funcname: name of the function that is called"
-          "\n:param wasm_uid: unit id to identify the wasm file"
-          "\n:param width_i_parameter: list of the number of bits in the input "
-          "variables"
-          "\n:param width_o_parameter: list of the number of bits in the output "
-          "variables"
-          "\n:param args: vector of circuit bits the wasm op should be added to"
           "\n:param kwargs: additional arguments passed to `add_gate_method` ."
           " Allowed parameters are `opgroup`,  `condition` , `condition_bits`,"
           " `condition_value`"
@@ -233,7 +255,7 @@ void init_circuit_add_classical_op(
               new_args.push_back(WasmState(ii));
             }                 
 
-            return add_gate_method<UnitID>(&circ, op, new_args, kwargs);
+            return add_gate_method_any(&circ, op, new_args, kwargs);
           },
           "Add a classical function call from a wasm file to the circuit. "
           "\n\n:param funcname: name of the function that is called"
@@ -251,9 +273,9 @@ void init_circuit_add_classical_op(
       .def(
           "add_c_setbits",
           [](Circuit &circ, const py::tket_custom::SequenceVec<bool> &values,
-             const py::tket_custom::SequenceVec<unsigned>& args, const py::kwargs &kwargs) {
+             const var_seq_bs_t& args, const py::kwargs &kwargs) {
             std::shared_ptr<SetBitsOp> op = std::make_shared<SetBitsOp>(values);
-            return add_gate_method<unsigned>(&circ, op, args, kwargs);
+            return add_gate_method_any(&circ, op, var_sequence_to_var_vecs(args), kwargs);
           },
           "Appends an operation to set some bit values."
           "\n\n:param values: values to set"
@@ -264,14 +286,6 @@ void init_circuit_add_classical_op(
           "\n:return: the new :py:class:`Circuit`",
           py::arg("values"), py::arg("args"))
       .def(
-          "add_c_setbits",
-          [](Circuit &circ, const py::tket_custom::SequenceVec<bool> &values,
-             const py::tket_custom::SequenceVec<Bit>& args, const py::kwargs &kwargs) {
-            std::shared_ptr<SetBitsOp> op = std::make_shared<SetBitsOp>(values);
-            return add_gate_method<Bit>(&circ, op, args, kwargs);
-          },
-          "See :py:meth:`add_c_setbits`.", py::arg("values"), py::arg("args"))
-      .def(
           "add_c_setreg",
           [](Circuit &circ, const _tket_uint_t value, const BitRegister &reg,
              const py::kwargs &kwargs) {
@@ -279,15 +293,15 @@ void init_circuit_add_classical_op(
 	       throw std::runtime_error("Value " + std::to_string(value) + " cannot be held on a " + std::to_string(reg.size()) + "-bit register."); 
 	    }
             auto bs = std::bitset<_TKET_REG_WIDTH>(value);
-            std::vector<Bit> args(reg.size());
+            std::vector<UnitID> args(reg.size());
             std::vector<bool> vals(reg.size());
             for (unsigned i = 0; i < reg.size(); i++) {
               args[i] = reg[i];
-	      vals[i] = (i < _TKET_REG_WIDTH) && bs[i];
+	            vals[i] = (i < _TKET_REG_WIDTH) && bs[i];
             }
 
             std::shared_ptr<SetBitsOp> op = std::make_shared<SetBitsOp>(vals);
-            return add_gate_method<Bit>(&circ, op, args, kwargs);
+            return add_gate_method_any(&circ, op, args, kwargs);
           },
           "Set a classical register to an unsigned integer value. The "
           "little-endian bitwise representation of the integer is truncated to "
@@ -296,14 +310,12 @@ void init_circuit_add_classical_op(
           py::arg("value"), py::arg("arg"))
       .def(
           "add_c_copybits",
-          [](Circuit &circ, const py::tket_custom::SequenceVec<unsigned> &args_in,
-             const py::tket_custom::SequenceVec<unsigned> &args_out, const py::kwargs &kwargs) {
-            unsigned n_args_in = args_in.size();
+          [](Circuit &circ, const var_seq_bs_t &args_in,
+             const var_seq_bs_t &args_out, const py::kwargs &kwargs) {
+            unsigned n_args_in = var_seq_len(args_in);
             std::shared_ptr<CopyBitsOp> op =
                 std::make_shared<CopyBitsOp>(n_args_in);
-            std::vector<unsigned> args = args_in;
-            args.insert(args.end(), args_out.begin(), args_out.end());
-            return add_gate_method<unsigned>(&circ, op, args, kwargs);
+            return add_gate_method_any(&circ, op, var_bs_bs_to_var_vec(args_in, args_out, "add_c_copybits"), kwargs);
           },
           "Appends a classical copy operation"
           "\n\n:param args_in: source bits"
@@ -314,19 +326,6 @@ void init_circuit_add_classical_op(
           "\n:return: the new :py:class:`Circuit`",
           py::arg("args_in"), py::arg("args_out"))
       .def(
-          "add_c_copybits",
-          [](Circuit &circ, const py::tket_custom::SequenceVec<Bit> &args_in,
-             const py::tket_custom::SequenceVec<Bit> &args_out, const py::kwargs &kwargs) {
-            unsigned n_args_in = args_in.size();
-            std::shared_ptr<CopyBitsOp> op =
-                std::make_shared<CopyBitsOp>(n_args_in);
-            std::vector<Bit> args = args_in;
-            args.insert(args.end(), args_out.begin(), args_out.end());
-            return add_gate_method<Bit>(&circ, op, args, kwargs);
-          },
-          "See :py:meth:`add_c_copybits`.", py::arg("args_in"),
-          py::arg("args_out"))
-      .def(
           "add_c_copyreg",
           [](Circuit &circ, const BitRegister &input_reg,
              const BitRegister &output_reg, const py::kwargs &kwargs) {
@@ -335,12 +334,12 @@ void init_circuit_add_classical_op(
 
             std::shared_ptr<CopyBitsOp> op =
                 std::make_shared<CopyBitsOp>(width);
-            std::vector<Bit> args(width * 2);
+            std::vector<UnitID> args(width * 2);
             for (unsigned i = 0; i < width; i++) {
               args[i] = input_reg[i];
               args[i + width] = output_reg[i];
             }
-            return add_gate_method<Bit>(&circ, op, args, kwargs);
+            return add_gate_method_any(&circ, op, args, kwargs);
           },
           "Copy a classical register to another. Copying is truncated to the "
           "size of the smaller of the two registers.",
@@ -348,14 +347,12 @@ void init_circuit_add_classical_op(
       .def(
           "add_c_predicate",
           [](Circuit &circ, const py::tket_custom::SequenceVec<bool> &values,
-             const py::tket_custom::SequenceVec<unsigned> &args_in, unsigned arg_out,
+             const var_seq_bs_t &args_in, const std::variant<unsigned, Bit> &arg_out,
              const std::string &name, const py::kwargs &kwargs) {
-            unsigned n_args_in = args_in.size();
+            unsigned n_args_in = var_seq_len(args_in);
             std::shared_ptr<ExplicitPredicateOp> op =
                 std::make_shared<ExplicitPredicateOp>(n_args_in, values, name);
-            std::vector<unsigned> args = args_in;
-            args.push_back(arg_out);
-            return add_gate_method<unsigned>(&circ, op, args, kwargs);
+            return add_gate_method_any(&circ, op, var_bs_b_to_var_vec(args_in, arg_out, "add_c_predicate"), kwargs);
           },
           "Appends a classical predicate, defined by a truth table, to the end "
           "of the "
@@ -373,31 +370,14 @@ void init_circuit_add_classical_op(
           py::arg("values"), py::arg("args_in"), py::arg("arg_out"),
           py::arg("name") = "ExplicitPredicate")
       .def(
-          "add_c_predicate",
-          [](Circuit &circ, const py::tket_custom::SequenceVec<bool> &values,
-             const py::tket_custom::SequenceVec<Bit> &args_in, const Bit& arg_out,
-             const std::string &name, const py::kwargs &kwargs) {
-            unsigned n_args_in = args_in.size();
-            std::shared_ptr<ExplicitPredicateOp> op =
-                std::make_shared<ExplicitPredicateOp>(n_args_in, values, name);
-            std::vector<Bit> args = args_in;
-            args.push_back(arg_out);
-            return add_gate_method<Bit>(&circ, op, args, kwargs);
-          },
-          "See :py:meth:`add_c_predicate`.", py::arg("values"),
-          py::arg("args_in"), py::arg("arg_out"),
-          py::arg("name") = "ExplicitPredicate")
-      .def(
           "add_c_modifier",
           [](Circuit &circ, const py::tket_custom::SequenceVec<bool> &values,
-             const py::tket_custom::SequenceVec<unsigned> &args_in, unsigned arg_inout,
+             const var_seq_bs_t &args_in, const std::variant<unsigned, Bit> &arg_inout,
              const std::string &name, const py::kwargs &kwargs) {
-            unsigned n_args_in = args_in.size();
+            unsigned n_args_in = var_seq_len(args_in);
             std::shared_ptr<ExplicitModifierOp> op =
                 std::make_shared<ExplicitModifierOp>(n_args_in, values, name);
-            std::vector<unsigned> args = args_in;
-            args.push_back(arg_inout);
-            return add_gate_method<unsigned>(&circ, op, args, kwargs);
+            return add_gate_method_any(&circ, op, var_bs_b_to_var_vec(args_in, arg_inout, "add_c_modifier"), kwargs);
           },
           "Appends a classical modifying operation, defined by a truth table, "
           "to the "
@@ -417,37 +397,29 @@ void init_circuit_add_classical_op(
           py::arg("values"), py::arg("args_in"), py::arg("arg_inout"),
           py::arg("name") = "ExplicitModifier")
       .def(
-          "add_c_modifier",
-          [](Circuit &circ, const py::tket_custom::SequenceVec<bool> &values,
-             const py::tket_custom::SequenceVec<Bit> &args_in, const Bit& arg_inout,
-             const std::string &name, const py::kwargs &kwargs) {
-            unsigned n_args_in = args_in.size();
-            std::shared_ptr<ExplicitModifierOp> op =
-                std::make_shared<ExplicitModifierOp>(n_args_in, values, name);
-            std::vector<Bit> args = args_in;
-            args.push_back(arg_inout);
-            return add_gate_method<Bit>(&circ, op, args, kwargs);
-          },
-          "See :py:meth:`add_c_modifier`.", py::arg("values"),
-          py::arg("args_in"), py::arg("arg_inout"),
-          py::arg("name") = "ExplicitModifier")
-      .def(
           "add_c_and",
-          [](Circuit &circ, unsigned arg0_in, unsigned arg1_in,
-             unsigned arg_out, const py::kwargs &kwargs) {
-            Op_ptr op;
-            std::vector<unsigned> args;
-            if (arg0_in == arg_out) {
-              op = AndWithOp();
-              args = {arg1_in, arg_out};
-            } else if (arg1_in == arg_out) {
-              op = AndWithOp();
-              args = {arg0_in, arg_out};
-            } else {
-              op = AndOp();
-              args = {arg0_in, arg1_in, arg_out};
+          [](Circuit &circ, const std::variant<unsigned, Bit> &arg0_in, const std::variant<unsigned, Bit> &arg1_in,
+             const std::variant<unsigned, Bit> &arg_out, const py::kwargs &kwargs) {
+            bool is_unsigned = std::holds_alternative<unsigned>(arg0_in);
+            if (std::holds_alternative<unsigned>(arg1_in) != is_unsigned || std::holds_alternative<unsigned>(arg_out) != is_unsigned) {
+              throw CircuitInvalidity("Bits passed to `add_c_and` must either all be `int` or all `Bit`.");
             }
-            return add_gate_method<unsigned>(&circ, op, args, kwargs);
+            if (is_unsigned) {
+              unsigned uin0 = std::get<unsigned>(arg0_in);
+              unsigned uin1 = std::get<unsigned>(arg1_in);
+              unsigned uout = std::get<unsigned>(arg_out);
+              if (uin0 == uout) return add_gate_method_any(&circ, AndWithOp(), std::vector<unsigned>{uin1, uout}, kwargs);
+              else if (uin1 == uout) return add_gate_method_any(&circ, AndWithOp(), std::vector<unsigned>{uin0, uout}, kwargs);
+              else return add_gate_method_any(&circ, AndOp(), std::vector<unsigned>{uin0, uin1, uout}, kwargs);
+            }
+            else {
+              Bit bin0 = std::get<Bit>(arg0_in);
+              Bit bin1 = std::get<Bit>(arg1_in);
+              Bit bout = std::get<Bit>(arg_out);
+              if (bin0 == bout) return add_gate_method_any(&circ, AndWithOp(), std::vector<UnitID>{bin1, bout}, kwargs);
+              else if (bin1 == bout) return add_gate_method_any(&circ, AndWithOp(), std::vector<UnitID>{bin0, bout}, kwargs);
+              else return add_gate_method_any(&circ, AndOp(), std::vector<UnitID>{bin0, bin1, bout}, kwargs);
+            }
           },
           "Appends a binary AND operation to the end of the circuit."
           "\n\n:param arg0_in: first input bit"
@@ -458,44 +430,31 @@ void init_circuit_add_classical_op(
           " `condition_value`"
           "\n:return: the new :py:class:`Circuit`",
           py::arg("arg0_in"), py::arg("arg1_in"), py::arg("arg_out"))
-      .def(
-          "add_c_and",
-          [](Circuit &circ, const Bit& arg0_in, const Bit& arg1_in, const Bit& arg_out,
-             const py::kwargs &kwargs) {
-            Op_ptr op;
-            std::vector<Bit> args;
-            if (arg0_in == arg_out) {
-              op = AndWithOp();
-              args = {arg1_in, arg_out};
-            } else if (arg1_in == arg_out) {
-              op = AndWithOp();
-              args = {arg0_in, arg_out};
-            } else {
-              op = AndOp();
-              args = {arg0_in, arg1_in, arg_out};
-            }
-            return add_gate_method<Bit>(&circ, op, args, kwargs);
-          },
-          "See :py:meth:`add_c_and`.", py::arg("arg0_in"), py::arg("arg1_in"),
-          py::arg("arg_out"))
-      .def(
-          "add_c_or",
-          [](Circuit &circ, unsigned arg0_in, unsigned arg1_in,
-             unsigned arg_out, const py::kwargs &kwargs) {
-            Op_ptr op;
-            std::vector<unsigned> args;
-            if (arg0_in == arg_out) {
-              op = OrWithOp();
-              args = {arg1_in, arg_out};
-            } else if (arg1_in == arg_out) {
-              op = OrWithOp();
-              args = {arg0_in, arg_out};
-            } else {
-              op = OrOp();
-              args = {arg0_in, arg1_in, arg_out};
-            }
-            return add_gate_method<unsigned>(&circ, op, args, kwargs);
-          },
+          .def(
+            "add_c_or",
+            [](Circuit &circ, const std::variant<unsigned, Bit> &arg0_in, const std::variant<unsigned, Bit> &arg1_in,
+               const std::variant<unsigned, Bit> &arg_out, const py::kwargs &kwargs) {
+              bool is_unsigned = std::holds_alternative<unsigned>(arg0_in);
+              if (std::holds_alternative<unsigned>(arg1_in) != is_unsigned || std::holds_alternative<unsigned>(arg_out) != is_unsigned) {
+                throw CircuitInvalidity("Bits passed to `add_c_or` must either all be `int` or all `Bit`.");
+              }
+              if (is_unsigned) {
+                unsigned uin0 = std::get<unsigned>(arg0_in);
+                unsigned uin1 = std::get<unsigned>(arg1_in);
+                unsigned uout = std::get<unsigned>(arg_out);
+                if (uin0 == uout) return add_gate_method_any(&circ, OrWithOp(), std::vector<unsigned>{uin1, uout}, kwargs);
+                else if (uin1 == uout) return add_gate_method_any(&circ, OrWithOp(), std::vector<unsigned>{uin0, uout}, kwargs);
+                else return add_gate_method_any(&circ, OrOp(), std::vector<unsigned>{uin0, uin1, uout}, kwargs);
+              }
+              else {
+                Bit bin0 = std::get<Bit>(arg0_in);
+                Bit bin1 = std::get<Bit>(arg1_in);
+                Bit bout = std::get<Bit>(arg_out);
+                if (bin0 == bout) return add_gate_method_any(&circ, OrWithOp(), std::vector<UnitID>{bin1, bout}, kwargs);
+                else if (bin1 == bout) return add_gate_method_any(&circ, OrWithOp(), std::vector<UnitID>{bin0, bout}, kwargs);
+                else return add_gate_method_any(&circ, OrOp(), std::vector<UnitID>{bin0, bin1, bout}, kwargs);
+              }
+            },
           "Appends a binary OR operation to the end of the circuit."
           "\n\n:param arg0_in: first input bit"
           "\n:param arg1_in: second input bit"
@@ -506,42 +465,29 @@ void init_circuit_add_classical_op(
           "\n:return: the new :py:class:`Circuit`",
           py::arg("arg0_in"), py::arg("arg1_in"), py::arg("arg_out"))
       .def(
-          "add_c_or",
-          [](Circuit &circ, const Bit& arg0_in, const Bit& arg1_in, const Bit& arg_out,
-             const py::kwargs &kwargs) {
-            Op_ptr op;
-            std::vector<Bit> args;
-            if (arg0_in == arg_out) {
-              op = OrWithOp();
-              args = {arg1_in, arg_out};
-            } else if (arg1_in == arg_out) {
-              op = OrWithOp();
-              args = {arg0_in, arg_out};
-            } else {
-              op = OrOp();
-              args = {arg0_in, arg1_in, arg_out};
-            }
-            return add_gate_method<Bit>(&circ, op, args, kwargs);
-          },
-          "See :py:meth:`add_c_or`.", py::arg("arg0_in"), py::arg("arg1_in"),
-          py::arg("arg_out"))
-      .def(
           "add_c_xor",
-          [](Circuit &circ, unsigned arg0_in, unsigned arg1_in,
-             unsigned arg_out, const py::kwargs &kwargs) {
-            Op_ptr op;
-            std::vector<unsigned> args;
-            if (arg0_in == arg_out) {
-              op = XorWithOp();
-              args = {arg1_in, arg_out};
-            } else if (arg1_in == arg_out) {
-              op = XorWithOp();
-              args = {arg0_in, arg_out};
-            } else {
-              op = XorOp();
-              args = {arg0_in, arg1_in, arg_out};
+          [](Circuit &circ, const std::variant<unsigned, Bit> &arg0_in, const std::variant<unsigned, Bit> &arg1_in,
+             const std::variant<unsigned, Bit> &arg_out, const py::kwargs &kwargs) {
+            bool is_unsigned = std::holds_alternative<unsigned>(arg0_in);
+            if (std::holds_alternative<unsigned>(arg1_in) != is_unsigned || std::holds_alternative<unsigned>(arg_out) != is_unsigned) {
+              throw CircuitInvalidity("Bits passed to `add_c_xor` must either all be `int` or all `Bit`.");
             }
-            return add_gate_method<unsigned>(&circ, op, args, kwargs);
+            if (is_unsigned) {
+              unsigned uin0 = std::get<unsigned>(arg0_in);
+              unsigned uin1 = std::get<unsigned>(arg1_in);
+              unsigned uout = std::get<unsigned>(arg_out);
+              if (uin0 == uout) return add_gate_method_any(&circ, XorWithOp(), std::vector<unsigned>{uin1, uout}, kwargs);
+              else if (uin1 == uout) return add_gate_method_any(&circ, XorWithOp(), std::vector<unsigned>{uin0, uout}, kwargs);
+              else return add_gate_method_any(&circ, XorOp(), std::vector<unsigned>{uin0, uin1, uout}, kwargs);
+            }
+            else {
+              Bit bin0 = std::get<Bit>(arg0_in);
+              Bit bin1 = std::get<Bit>(arg1_in);
+              Bit bout = std::get<Bit>(arg_out);
+              if (bin0 == bout) return add_gate_method_any(&circ, XorWithOp(), std::vector<UnitID>{bin1, bout}, kwargs);
+              else if (bin1 == bout) return add_gate_method_any(&circ, XorWithOp(), std::vector<UnitID>{bin0, bout}, kwargs);
+              else return add_gate_method_any(&circ, XorOp(), std::vector<UnitID>{bin0, bin1, bout}, kwargs);
+            }
           },
           "Appends a binary XOR operation to the end of the circuit."
           "\n\n:param arg0_in: first input bit"
@@ -553,31 +499,23 @@ void init_circuit_add_classical_op(
           "\n:return: the new :py:class:`Circuit`",
           py::arg("arg0_in"), py::arg("arg1_in"), py::arg("arg_out"))
       .def(
-          "add_c_xor",
-          [](Circuit &circ, const Bit& arg0_in, const Bit& arg1_in, const Bit& arg_out,
-             const py::kwargs &kwargs) {
-            Op_ptr op;
-            std::vector<Bit> args;
-            if (arg0_in == arg_out) {
-              op = XorWithOp();
-              args = {arg1_in, arg_out};
-            } else if (arg1_in == arg_out) {
-              op = XorWithOp();
-              args = {arg0_in, arg_out};
-            } else {
-              op = XorOp();
-              args = {arg0_in, arg1_in, arg_out};
-            }
-            return add_gate_method<Bit>(&circ, op, args, kwargs);
-          },
-          "See :py:meth:`add_c_xor`.", py::arg("arg0_in"), py::arg("arg1_in"),
-          py::arg("arg_out"))
-      .def(
           "add_c_not",
-          [](Circuit &circ, unsigned arg_in, unsigned arg_out,
+          [](Circuit &circ, const std::variant<unsigned, Bit> &arg_in, const std::variant<unsigned, Bit> &arg_out,
              const py::kwargs &kwargs) {
-            return add_gate_method<unsigned>(
-                &circ, NotOp(), {arg_in, arg_out}, kwargs);
+            bool is_unsigned = std::holds_alternative<unsigned>(arg_in);
+            if (std::holds_alternative<unsigned>(arg_out) != is_unsigned) {
+              throw CircuitInvalidity("Bits passed to `add_c_not` must either all be `int` or all `Bit`.");
+            }
+            if (is_unsigned) {
+              unsigned uin = std::get<unsigned>(arg_in);
+              unsigned uout = std::get<unsigned>(arg_out);
+              return add_gate_method_any(&circ, NotOp(), std::vector<unsigned>{uin, uout}, kwargs);
+            }
+            else {
+              Bit bin = std::get<Bit>(arg_in);
+              Bit bout = std::get<Bit>(arg_out);
+              return add_gate_method_any(&circ, NotOp(), std::vector<UnitID>{bin, bout}, kwargs);
+            }
           },
           "Appends a NOT operation to the end of the circuit."
           "\n\n:param arg_in: input bit"
@@ -588,46 +526,14 @@ void init_circuit_add_classical_op(
           "\n:return: the new :py:class:`Circuit`",
           py::arg("arg_in"), py::arg("arg_out"))
       .def(
-          "add_c_not",
-          [](Circuit &circ, Bit arg_in, Bit arg_out, const py::kwargs &kwargs) {
-            return add_gate_method<Bit>(
-                &circ, NotOp(), {std::move(arg_in), std::move(arg_out)}, kwargs);
-          },
-          "See :py:meth:`add_c_not`.", py::arg("arg_in"), py::arg("arg_out"))
-      .def(
           "add_c_range_predicate",
           [](Circuit &circ, _tket_uint_t a, _tket_uint_t b,
-             const py::tket_custom::SequenceVec<unsigned> &args_in, unsigned arg_out,
+             const var_seq_bs_t &args_in, const std::variant<unsigned, Bit> &arg_out,
              const py::kwargs &kwargs) {
-            unsigned n_args_in = args_in.size();
+            unsigned n_args_in = var_seq_len(args_in);
             std::shared_ptr<RangePredicateOp> op =
                 std::make_shared<RangePredicateOp>(n_args_in, a, b);
-            std::vector<unsigned> args = args_in;
-            args.push_back(arg_out);
-            return add_gate_method<unsigned>(&circ, op, args, kwargs);
-          },
-          "Appends a range-predicate operation to the end of the circuit."
-          "\n\n:param minval: lower bound of input in little-endian encoding"
-          "\n:param maxval: upper bound of input in little-endian encoding"
-          "\n:param args_in: input bits"
-          "\n:param arg_out: output bit (distinct from input bits)"
-          "\n:param kwargs: additional arguments passed to `add_gate_method` ."
-          " Allowed parameters are `opgroup`,  `condition` , `condition_bits`,"
-          " `condition_value`"
-          "\n:return: the new :py:class:`Circuit`",
-          py::arg("minval"), py::arg("maxval"), py::arg("args_in"),
-          py::arg("arg_out"))
-      .def(
-          "add_c_range_predicate",
-          [](Circuit &circ, _tket_uint_t a, _tket_uint_t b,
-             const py::tket_custom::SequenceVec<Bit> &args_in, const Bit& arg_out,
-             const py::kwargs &kwargs) {
-            unsigned n_args_in = args_in.size();
-            std::shared_ptr<RangePredicateOp> op =
-                std::make_shared<RangePredicateOp>(n_args_in, a, b);
-            std::vector<Bit> args = args_in;
-            args.push_back(arg_out);
-            return add_gate_method<Bit>(&circ, op, args, kwargs);
+            return add_gate_method_any(&circ, op, var_bs_b_to_var_vec(args_in, arg_out, "add_c_range_predicate"), kwargs);
           },
           "Appends a range-predicate operation to the end of the circuit."
           "\n\n:param minval: lower bound of input in little-endian encoding"

--- a/pytket/binders/circuit/Circuit/add_op.cpp
+++ b/pytket/binders/circuit/Circuit/add_op.cpp
@@ -49,74 +49,379 @@ typedef py::tket_custom::SequenceVec<BitRegister> py_creg_vector_t;
 
 const bit_vector_t no_bits;
 
-template <typename ID>
-static Circuit *add_gate_method_sequence_args(
+Circuit *add_gate_method_any(
     Circuit *circ, const Op_ptr &op,
-    const py::tket_custom::SequenceVec<ID> &args, const py::kwargs &kwargs) {
-  return add_gate_method(circ, op, args, kwargs);
-}
-
-template <typename ID>
-static Circuit *add_gate_method_noparams(
-    Circuit *circ, OpType type, const py::tket_custom::SequenceVec<ID> &args,
+    const std::variant<std::vector<unsigned>, std::vector<UnitID>> &args,
     const py::kwargs &kwargs) {
-  return add_gate_method(
-      circ, get_op_ptr(type, std::vector<Expr>{}, args.size()), args, kwargs);
+  if (op->get_desc().is_meta()) {
+    throw CircuitInvalidity("Cannot add metaop to a circuit.");
+  }
+  if (op->get_desc().is_barrier()) {
+    throw CircuitInvalidity(
+        "Please use `add_barrier` to add a barrier to a circuit.");
+  }
+  static const std::set<std::string> allowed_kwargs = {
+      "opgroup", "condition", "condition_bits", "condition_value"};
+  for (const auto kwarg : kwargs) {
+    const std::string kwargstr = py::cast<std::string>(kwarg.first);
+    if (!allowed_kwargs.contains(kwargstr)) {
+      std::stringstream msg;
+      msg << "Unsupported keyword argument '" << kwargstr << "'";
+      throw CircuitInvalidity(msg.str());
+    }
+  }
+  std::optional<std::string> opgroup;
+  if (kwargs.contains("opgroup")) {
+    opgroup = py::cast<std::string>(kwargs["opgroup"]);
+  }
+  bool condition_given = kwargs.contains("condition");
+  bool condition_bits_given = kwargs.contains("condition_bits");
+  bool condition_value_given = kwargs.contains("condition_value");
+  if (condition_given && condition_bits_given) {
+    throw CircuitInvalidity("Both `condition` and `condition_bits` specified");
+  }
+  if (condition_value_given && !condition_bits_given) {
+    throw CircuitInvalidity(
+        "`condition_value` specified without `condition_bits`");
+  }
+  Op_ptr new_op = op;
+  unit_vector_t new_args;
+  if (condition_given) {
+    py::module condition = py::module::import("pytket.circuit.add_condition");
+    py::object add_condition = condition.attr("_add_condition");
+    auto conditions =
+        add_condition(circ, kwargs["condition"])
+            .cast<std::pair<std::variant<unsigned, UnitID>, bool>>();
+    if (std::holds_alternative<UnitID>(conditions.first)) {
+      new_args.push_back(std::get<UnitID>(conditions.first));
+    } else {
+      new_args.push_back(Bit(std::get<unsigned>(conditions.first)));
+    }
+    new_op = std::make_shared<Conditional>(op, 1, int(conditions.second));
+  } else if (condition_bits_given) {
+    auto condition_ids =
+        py::cast<std::variant<std::vector<unsigned>, std::vector<UnitID>>>(
+            kwargs["condition_bits"]);
+    if (std::holds_alternative<std::vector<UnitID>>(condition_ids)) {
+      new_args = std::get<std::vector<UnitID>>(condition_ids);
+    } else {
+      for (unsigned id : std::get<std::vector<unsigned>>(condition_ids)) {
+        new_args.push_back(Bit(id));
+      }
+    }
+    unsigned condition_width = new_args.size();
+    unsigned value = condition_value_given
+                         ? py::cast<unsigned>(kwargs["condition_value"])
+                         : (1u << condition_width) - 1;
+    new_op = std::make_shared<Conditional>(op, condition_width, value);
+  }
+  if (std::holds_alternative<std::vector<UnitID>>(args)) {
+    std::vector<UnitID> unit_args = std::get<std::vector<UnitID>>(args);
+    new_args.insert(new_args.end(), unit_args.begin(), unit_args.end());
+  } else {
+    op_signature_t sig = op->get_signature();
+    std::vector<unsigned> u_args = std::get<std::vector<unsigned>>(args);
+    for (unsigned i = 0; i < u_args.size(); ++i) {
+      unsigned uid = u_args.at(i);
+      switch (sig.at(i)) {
+        case EdgeType::Quantum: {
+          new_args.push_back(Qubit(uid));
+          break;
+        }
+        case EdgeType::WASM: {
+          new_args.push_back(WasmState(uid));
+          break;
+        }
+        case EdgeType::Classical:
+        case EdgeType::Boolean: {
+          new_args.push_back(Bit(uid));
+          break;
+        }
+        default: {
+          TKET_ASSERT(!"add_gate_method found invalid edge type in signature");
+        }
+      }
+    }
+  }
+  circ->add_op(new_op, new_args, opgroup);
+  return circ;
 }
 
-template <typename ID>
-static Circuit *add_gate_method_oneparam(
-    Circuit *circ, OpType type, const Expr &p,
-    const py::tket_custom::SequenceVec<ID> &args, const py::kwargs &kwargs) {
-  return add_gate_method(circ, get_op_ptr(type, p, args.size()), args, kwargs);
+typedef std::variant<
+    py::tket_custom::SequenceVec<unsigned>,
+    py::tket_custom::SequenceVec<UnitID>>
+    var_seq_ids_t;
+typedef std::variant<
+    py::tket_custom::SequenceVec<unsigned>, py::tket_custom::SequenceVec<Qubit>>
+    var_seq_qbs_t;
+
+static std::variant<std::vector<unsigned>, std::vector<UnitID>>
+var_sequence_to_var_vecs(const var_seq_ids_t &var_seq) {
+  if (std::holds_alternative<py::tket_custom::SequenceVec<unsigned>>(var_seq)) {
+    return std::get<py::tket_custom::SequenceVec<unsigned>>(var_seq);
+  } else {
+    return std::get<py::tket_custom::SequenceVec<UnitID>>(var_seq);
+  }
 }
 
-template <typename ID>
-static Circuit *add_gate_method_manyparams(
+static std::variant<std::vector<unsigned>, std::vector<UnitID>>
+var_sequence_to_var_vecs(const var_seq_qbs_t &var_seq) {
+  if (std::holds_alternative<py::tket_custom::SequenceVec<unsigned>>(var_seq)) {
+    return std::get<py::tket_custom::SequenceVec<unsigned>>(var_seq);
+  } else {
+    auto qb_vec = std::get<py::tket_custom::SequenceVec<Qubit>>(var_seq);
+    return std::vector<UnitID>{qb_vec.begin(), qb_vec.end()};
+  }
+}
+
+static std::variant<std::vector<unsigned>, std::vector<UnitID>>
+var_qq_to_var_vec(
+    const std::variant<unsigned, Qubit> &qb0,
+    const std::variant<unsigned, Qubit> &qb1, const std::string &method_name) {
+  if (std::holds_alternative<unsigned>(qb0) !=
+      std::holds_alternative<unsigned>(qb1)) {
+    throw CircuitInvalidity(
+        "Qubits passed to `" + method_name +
+        "` must either both be `int` or both `Qubit`.");
+  }
+  if (std::holds_alternative<unsigned>(qb0)) {
+    unsigned uq0 = std::get<unsigned>(qb0);
+    unsigned uq1 = std::get<unsigned>(qb1);
+    return std::vector<unsigned>{uq0, uq1};
+  } else {
+    Qubit qq0 = std::get<Qubit>(qb0);
+    Qubit qq1 = std::get<Qubit>(qb1);
+    return std::vector<UnitID>{qq0, qq1};
+  }
+}
+
+static std::variant<std::vector<unsigned>, std::vector<UnitID>>
+var_qqq_to_var_vec(
+    const std::variant<unsigned, Qubit> &qb0,
+    const std::variant<unsigned, Qubit> &qb1,
+    const std::variant<unsigned, Qubit> &qb2, const std::string &method_name) {
+  bool is_unsigned = std::holds_alternative<unsigned>(qb0);
+  if (std::holds_alternative<unsigned>(qb1) != is_unsigned ||
+      std::holds_alternative<unsigned>(qb2) != is_unsigned) {
+    throw CircuitInvalidity(
+        "Qubits passed to `" + method_name +
+        "` must either all be `int` or all `Qubit`.");
+  }
+  if (is_unsigned) {
+    unsigned uq0 = std::get<unsigned>(qb0);
+    unsigned uq1 = std::get<unsigned>(qb1);
+    unsigned uq2 = std::get<unsigned>(qb2);
+    return std::vector<unsigned>{uq0, uq1, uq2};
+  } else {
+    Qubit qq0 = std::get<Qubit>(qb0);
+    Qubit qq1 = std::get<Qubit>(qb1);
+    Qubit qq2 = std::get<Qubit>(qb2);
+    return std::vector<UnitID>{qq0, qq1, qq2};
+  }
+}
+
+static unsigned var_seq_len(const var_seq_ids_t &var_seq) {
+  if (std::holds_alternative<py::tket_custom::SequenceVec<unsigned>>(var_seq)) {
+    return std::get<py::tket_custom::SequenceVec<unsigned>>(var_seq).size();
+  } else {
+    return std::get<py::tket_custom::SequenceVec<UnitID>>(var_seq).size();
+  }
+}
+
+static Circuit *add_gate_method_sequence_args_any(
+    Circuit *circ, const Op_ptr &op, const var_seq_ids_t &args,
+    const py::kwargs &kwargs) {
+  return add_gate_method_any(circ, op, var_sequence_to_var_vecs(args), kwargs);
+}
+
+static Circuit *add_gate_method_noparams_any(
+    Circuit *circ, OpType type, const var_seq_ids_t &args,
+    const py::kwargs &kwargs) {
+  return add_gate_method_any(
+      circ, get_op_ptr(type, std::vector<Expr>{}, var_seq_len(args)),
+      var_sequence_to_var_vecs(args), kwargs);
+}
+
+static Circuit *add_gate_method_oneparam_any(
+    Circuit *circ, OpType type, const Expr &p, const var_seq_ids_t &args,
+    const py::kwargs &kwargs) {
+  return add_gate_method_any(
+      circ, get_op_ptr(type, p, var_seq_len(args)),
+      var_sequence_to_var_vecs(args), kwargs);
+}
+
+static Circuit *add_gate_method_manyparams_any(
     Circuit *circ, OpType type, const py::tket_custom::SequenceVec<Expr> &ps,
-    const py::tket_custom::SequenceVec<ID> &args, const py::kwargs &kwargs) {
-  return add_gate_method(circ, get_op_ptr(type, ps, args.size()), args, kwargs);
+    const var_seq_ids_t &args, const py::kwargs &kwargs) {
+  return add_gate_method_any(
+      circ, get_op_ptr(type, ps, var_seq_len(args)),
+      var_sequence_to_var_vecs(args), kwargs);
 }
 
-template <typename ID>
-static Circuit *add_box_method(
-    Circuit *circ, Op_ptr box_ptr, const std::vector<ID> &args,
-    const py::kwargs &kwargs) {
-  return add_gate_method(circ, box_ptr, args, kwargs);
+static std::variant<std::vector<unsigned>, std::vector<UnitID>>
+var_q_to_var_vecs(const std::variant<unsigned, Qubit> &qb) {
+  if (std::holds_alternative<unsigned>(qb))
+    return std::vector<unsigned>{std::get<unsigned>(qb)};
+  else
+    return std::vector<UnitID>{std::get<Qubit>(qb)};
+}
+
+static std::function<Circuit *(
+    Circuit *, const std::variant<unsigned, Qubit> &, const py::kwargs &)>
+add_gate_method_q(OpType ot) {
+  return [ot](
+             Circuit *circ, const std::variant<unsigned, Qubit> &qb,
+             const py::kwargs &kwargs) {
+    return add_gate_method_any(
+        circ, get_op_ptr(ot, std::vector<Expr>{}, 1), var_q_to_var_vecs(qb),
+        kwargs);
+  };
+}
+
+static std::function<Circuit *(
+    Circuit *, const Expr &, const std::variant<unsigned, Qubit> &,
+    const py::kwargs &)>
+add_gate_method_a_q(OpType ot) {
+  return
+      [ot](
+          Circuit *circ, const Expr &angle,
+          const std::variant<unsigned, Qubit> &qb, const py::kwargs &kwargs) {
+        return add_gate_method_any(
+            circ, get_op_ptr(ot, {angle}, 1), var_q_to_var_vecs(qb), kwargs);
+      };
+}
+
+static std::function<Circuit *(
+    Circuit *, const Expr &, const Expr &,
+    const std::variant<unsigned, Qubit> &, const py::kwargs &)>
+add_gate_method_aa_q(OpType ot) {
+  return
+      [ot](
+          Circuit *circ, const Expr &angle0, const Expr &angle1,
+          const std::variant<unsigned, Qubit> &qb, const py::kwargs &kwargs) {
+        return add_gate_method_any(
+            circ, get_op_ptr(ot, {angle0, angle1}, 1), var_q_to_var_vecs(qb),
+            kwargs);
+      };
+}
+
+static std::function<Circuit *(
+    Circuit *, const Expr &, const Expr &, const Expr &,
+    const std::variant<unsigned, Qubit> &, const py::kwargs &)>
+add_gate_method_aaa_q(OpType ot) {
+  return [ot](
+             Circuit *circ, const Expr &angle0, const Expr &angle1,
+             const Expr &angle2, const std::variant<unsigned, Qubit> &qb,
+             const py::kwargs &kwargs) {
+    return add_gate_method_any(
+        circ, get_op_ptr(ot, {angle0, angle1, angle2}, 1),
+        var_q_to_var_vecs(qb), kwargs);
+  };
+}
+
+static std::function<Circuit *(
+    Circuit *, const std::variant<unsigned, Qubit> &,
+    const std::variant<unsigned, Qubit> &, const py::kwargs &)>
+add_gate_method_qq(OpType ot, const std::string &method_name) {
+  return
+      [ot, method_name](
+          Circuit *circ, const std::variant<unsigned, Qubit> &qb0,
+          const std::variant<unsigned, Qubit> &qb1, const py::kwargs &kwargs) {
+        return add_gate_method_any(
+            circ, get_op_ptr(ot, std::vector<Expr>{}, 2),
+            var_qq_to_var_vec(qb0, qb1, method_name), kwargs);
+      };
+}
+
+static std::function<Circuit *(
+    Circuit *, const Expr &, const std::variant<unsigned, Qubit> &,
+    const std::variant<unsigned, Qubit> &, const py::kwargs &)>
+add_gate_method_a_qq(OpType ot, const std::string &method_name) {
+  return
+      [ot, method_name](
+          Circuit *circ, const Expr &angle,
+          const std::variant<unsigned, Qubit> &qb0,
+          const std::variant<unsigned, Qubit> &qb1, const py::kwargs &kwargs) {
+        return add_gate_method_any(
+            circ, get_op_ptr(ot, {angle}, 2),
+            var_qq_to_var_vec(qb0, qb1, method_name), kwargs);
+      };
+}
+
+static std::function<Circuit *(
+    Circuit *, const Expr &, const Expr &,
+    const std::variant<unsigned, Qubit> &,
+    const std::variant<unsigned, Qubit> &, const py::kwargs &)>
+add_gate_method_aa_qq(OpType ot, const std::string &method_name) {
+  return
+      [ot, method_name](
+          Circuit *circ, const Expr &angle0, const Expr &angle1,
+          const std::variant<unsigned, Qubit> &qb0,
+          const std::variant<unsigned, Qubit> &qb1, const py::kwargs &kwargs) {
+        return add_gate_method_any(
+            circ, get_op_ptr(ot, {angle0, angle1}, 2),
+            var_qq_to_var_vec(qb0, qb1, method_name), kwargs);
+      };
+}
+
+static std::function<Circuit *(
+    Circuit *, const Expr &, const Expr &, const Expr &,
+    const std::variant<unsigned, Qubit> &,
+    const std::variant<unsigned, Qubit> &, const py::kwargs &)>
+add_gate_method_aaa_qq(OpType ot, const std::string &method_name) {
+  return
+      [ot, method_name](
+          Circuit *circ, const Expr &angle0, const Expr &angle1,
+          const Expr &angle2, const std::variant<unsigned, Qubit> &qb0,
+          const std::variant<unsigned, Qubit> &qb1, const py::kwargs &kwargs) {
+        return add_gate_method_any(
+            circ, get_op_ptr(ot, {angle0, angle1, angle2}, 2),
+            var_qq_to_var_vec(qb0, qb1, method_name), kwargs);
+      };
+}
+
+static std::function<Circuit *(
+    Circuit *, const std::variant<unsigned, Qubit> &,
+    const std::variant<unsigned, Qubit> &,
+    const std::variant<unsigned, Qubit> &, const py::kwargs &)>
+add_gate_method_qqq(OpType ot, const std::string &method_name) {
+  return
+      [ot, method_name](
+          Circuit *circ, const std::variant<unsigned, Qubit> &qb0,
+          const std::variant<unsigned, Qubit> &qb1,
+          const std::variant<unsigned, Qubit> &qb2, const py::kwargs &kwargs) {
+        return add_gate_method_any(
+            circ, get_op_ptr(ot, std::vector<Expr>{}, 3),
+            var_qqq_to_var_vec(qb0, qb1, qb2, method_name), kwargs);
+      };
+}
+
+static std::function<Circuit *(
+    Circuit *, const Expr &, const std::variant<unsigned, Qubit> &,
+    const std::variant<unsigned, Qubit> &,
+    const std::variant<unsigned, Qubit> &, const py::kwargs &)>
+add_gate_method_a_qqq(OpType ot, const std::string &method_name) {
+  return
+      [ot, method_name](
+          Circuit *circ, const Expr &angle,
+          const std::variant<unsigned, Qubit> &qb0,
+          const std::variant<unsigned, Qubit> &qb1,
+          const std::variant<unsigned, Qubit> &qb2, const py::kwargs &kwargs) {
+        return add_gate_method_any(
+            circ, get_op_ptr(ot, {angle}, 3),
+            var_qqq_to_var_vec(qb0, qb1, qb2, method_name), kwargs);
+      };
 }
 
 void init_circuit_add_op(py::class_<Circuit, std::shared_ptr<Circuit>> &c) {
   c.def(
-       "add_gate", &add_gate_method_sequence_args<unsigned>,
+       "add_gate", &add_gate_method_sequence_args_any,
        "Appends a single operation to the end of the circuit on some "
        "particular qubits/bits. The number of qubits/bits specified "
        "must match the arity of the gate.",
        py::arg("Op"), py::arg("args"))
       .def(
-          "add_gate", &add_gate_method_sequence_args<UnitID>,
-          "Appends a single operation to the end of the circuit on some "
-          "particular qubits/bits. The number of qubits/bits specified "
-          "must match the arity of the gate.",
-          py::arg("Op"), py::arg("args"))
-      .def(
-          "add_gate", &add_gate_method_noparams<unsigned>,
-          "Appends a single (non-parameterised) gate to the end of the "
-          "circuit on some particular qubits from the default register "
-          "('q'). The number of qubits specified must match the arity "
-          "of the gate. For `OpType.Measure` operations the bit from "
-          "the default register should follow the qubit."
-          "\n\n>>> c.add_gate(OpType.H, [0]) # equivalent to "
-          "c.H(0)\n>>> c.add_gate(OpType.CX, [0,1]) # equivalent to "
-          "c.CX(0,1)"
-          "\n\n:param type: The type of operation to add"
-          "\n:param args: The list of indices for the qubits/bits to "
-          "which the operation is applied"
-          "\n:param kwargs: Additional properties for classical "
-          "conditions"
-          "\n:return: the new :py:class:`Circuit`",
-          py::arg("type"), py::arg("args"))
-      .def(
-          "add_gate", &add_gate_method_noparams<UnitID>,
+          "add_gate", &add_gate_method_noparams_any,
           "Appends a single (non-parameterised) gate to the end of the "
           "circuit on some particular qubits from the default register "
           "('q'). The number of qubits specified must match the arity "
@@ -132,20 +437,7 @@ void init_circuit_add_op(py::class_<Circuit, std::shared_ptr<Circuit>> &c) {
           "\n:return: the new :py:class:`Circuit`",
           py::arg("type"), py::arg("args"))
       .def(
-          "add_gate", &add_gate_method_oneparam<unsigned>,
-          "Appends a single gate, parameterised by an expression, to "
-          "the end of circuit on some particular qubits from the "
-          "default register ('q')."
-          "\n\n:param type: The type of gate to add"
-          "\n:param angle: The parameter for the gate in halfturns"
-          "\n:param args: The list of indices for the qubits to which "
-          "the operation is applied"
-          "\n:param kwargs: Additional properties for classical "
-          "conditions"
-          "\n:return: the new :py:class:`Circuit`",
-          py::arg("type"), py::arg("angle"), py::arg("args"))
-      .def(
-          "add_gate", &add_gate_method_oneparam<UnitID>,
+          "add_gate", &add_gate_method_oneparam_any,
           "Appends a single gate, parameterised by an expression, to "
           "the end of circuit on some particular qubits from the "
           "default register ('q')."
@@ -157,21 +449,7 @@ void init_circuit_add_op(py::class_<Circuit, std::shared_ptr<Circuit>> &c) {
           "\n:return: the new :py:class:`Circuit`",
           py::arg("type"), py::arg("angle"), py::arg("args"))
       .def(
-          "add_gate", &add_gate_method_manyparams<unsigned>,
-          "Appends a single gate, parameterised with a vector of "
-          "expressions corresponding to halfturns, to the end of "
-          "circuit on some particular qubits from the default register "
-          "('q')."
-          "\n\n:param type: The type of gate to add"
-          "\n:param angles: The parameters for the gate in halfturns"
-          "\n:param args: The list of indices for the qubits to which "
-          "the operation is applied"
-          "\n:param kwargs: Additional properties for classical "
-          "conditions"
-          "\n:return: the new :py:class:`Circuit`",
-          py::arg("type"), py::arg("angles"), py::arg("args"))
-      .def(
-          "add_gate", &add_gate_method_manyparams<UnitID>,
+          "add_gate", &add_gate_method_manyparams_any,
           "Appends a single gate to the end of the circuit"
           "\n\n:param type: The type of gate to add"
           "\n:param params: The parameters for the gate in halfturns"
@@ -217,203 +495,14 @@ void init_circuit_add_op(py::class_<Circuit, std::shared_ptr<Circuit>> &c) {
           py::arg("barrier_qubits"), py::arg("barrier_bits"),
           py::arg("condition_bits"), py::arg("value"), py::arg("data") = "")
       .def(
-          "add_circbox",
-          [](Circuit *circ, const CircBox &box,
-             const py::tket_custom::SequenceVec<unsigned> &args,
-             const py::kwargs &kwargs) {
-            return add_box_method(
-                circ, std::make_shared<CircBox>(box), args, kwargs);
-          },
-          "Append a :py:class:`CircBox` to the circuit."
-          "\n\nThe qubits and bits of the :py:class:`CircBox` are wired into "
-          "the circuit in lexicographic order. Bits follow qubits in the order "
-          "of arguments."
-          "\n\n:param circbox: The box to append"
-          "\n:param args: Indices of the (default-register) qubits/bits to "
-          "append the box to"
-          "\n:return: the new :py:class:`Circuit`",
-          py::arg("circbox"), py::arg("args"))
-      .def(
-          "add_unitary1qbox",
-          [](Circuit *circ, const Unitary1qBox &box, unsigned q0,
-             const py::kwargs &kwargs) {
-            return add_box_method<unsigned>(
-                circ, std::make_shared<Unitary1qBox>(box), {q0}, kwargs);
-          },
-          "Append a :py:class:`Unitary1qBox` to the "
-          "circuit.\n\n:param "
-          "unitarybox: The box to append\n:param qubit_0: Index of "
-          "the qubit to append the box to"
-          "\n:return: the new :py:class:`Circuit`",
-          py::arg("unitarybox"), py::arg("qubit_0"))
-      .def(
-          "add_unitary2qbox",
-          [](Circuit *circ, const Unitary2qBox &box, unsigned q0, unsigned q1,
-             const py::kwargs &kwargs) {
-            return add_box_method<unsigned>(
-                circ, std::make_shared<Unitary2qBox>(box), {q0, q1}, kwargs);
-          },
-          "Append a :py:class:`Unitary2qBox` to the circuit.\n\nThe "
-          "matrix representation is ILO-BE.\n\n:param unitarybox: "
-          "The box to append\n:param qubit_0: Index of the first "
-          "target "
-          "qubit\n:param qubit_1: Index of the second target qubit"
-          "\n:return: the new :py:class:`Circuit`",
-          py::arg("unitarybox"), py::arg("qubit_0"), py::arg("qubit_1"))
-      .def(
-          "add_unitary3qbox",
-          [](Circuit *circ, const Unitary3qBox &box, unsigned q0, unsigned q1,
-             unsigned q2, const py::kwargs &kwargs) {
-            return add_box_method<unsigned>(
-                circ, std::make_shared<Unitary3qBox>(box), {q0, q1, q2},
-                kwargs);
-          },
-          "Append a :py:class:`Unitary3qBox` to the circuit."
-          "\n\n:param unitarybox: box to append"
-          "\n:param qubit_0: index of target qubit 0"
-          "\n:param qubit_1: index of target qubit 1"
-          "\n:param qubit_2: index of target qubit 2"
-          "\n:return: the new :py:class:`Circuit`",
-          py::arg("unitarybox"), py::arg("qubit_0"), py::arg("qubit_1"),
-          py::arg("qubit_2"))
-      .def(
-          "add_expbox",
-          [](Circuit *circ, const ExpBox &box, unsigned q0, unsigned q1,
-             const py::kwargs &kwargs) {
-            return add_box_method<unsigned>(
-                circ, std::make_shared<ExpBox>(box), {q0, q1}, kwargs);
-          },
-          "Append an :py:class:`ExpBox` to the circuit.\n\nThe "
-          "matrix representation is ILO-BE.\n\n:param expbox: The "
-          "box to append\n:param qubit_0: Index of the first target "
-          "qubit\n:param qubit_1: Index of the second target qubit"
-          "\n:return: the new :py:class:`Circuit`",
-          py::arg("expbox"), py::arg("qubit_0"), py::arg("qubit_1"))
-      .def(
-          "add_pauliexpbox",
-          [](Circuit *circ, const PauliExpBox &box,
-             const py::tket_custom::SequenceVec<unsigned> &qubits,
-             const py::kwargs &kwargs) {
-            return add_box_method<unsigned>(
-                circ, std::make_shared<PauliExpBox>(box), qubits, kwargs);
-          },
-          "Append a :py:class:`PauliExpBox` to the "
-          "circuit.\n\n:param pauliexpbox: The box to append\n:param "
-          "qubits: Indices of the qubits to append the box to"
-          "\n:return: the new :py:class:`Circuit`",
-          py::arg("pauliexpbox"), py::arg("qubits"))
-      .def(
-          "add_pauliexppairbox",
-          [](Circuit *circ, const PauliExpPairBox &box,
-             const py::tket_custom::SequenceVec<unsigned> &qubits,
-             const py::kwargs &kwargs) {
-            return add_box_method<unsigned>(
-                circ, std::make_shared<PauliExpPairBox>(box), qubits, kwargs);
-          },
-          "Append a :py:class:`PauliExpPairBox` to the "
-          "circuit.\n\n:param pauliexppairbox: The box to append\n:param "
-          "qubits: Indices of the qubits to append the box to"
-          "\n:return: the new :py:class:`Circuit`",
-          py::arg("pauliexppairbox"), py::arg("qubits"))
-      .def(
-          "add_pauliexpcommutingsetbox",
-          [](Circuit *circ, const PauliExpCommutingSetBox &box,
-             const py::tket_custom::SequenceVec<unsigned> &qubits,
-             const py::kwargs &kwargs) {
-            return add_box_method<unsigned>(
-                circ, std::make_shared<PauliExpCommutingSetBox>(box), qubits,
-                kwargs);
-          },
-          "Append a :py:class:`PauliExpCommutingSetBox` to the "
-          "circuit.\n\n:param pauliexpcommutingsetbox: The box to "
-          "append\n:param "
-          "qubits: Indices of the qubits to append the box to"
-          "\n:return: the new :py:class:`Circuit`",
-          py::arg("pauliexpcommutingsetbox"), py::arg("qubits"))
-      .def(
-          "add_termsequencebox",
-          [](Circuit *circ, const TermSequenceBox &box,
-             const py::tket_custom::SequenceVec<unsigned> &qubits,
-             const py::kwargs &kwargs) {
-            return add_box_method<unsigned>(
-                circ, std::make_shared<TermSequenceBox>(box), qubits, kwargs);
-          },
-          "Append a :py:class:`TermSequenceBox` to the "
-          "circuit.\n\n:param termsequencebox: The box to "
-          "append\n:param "
-          "qubits: Indices of the qubits to append the box to"
-          "\n:return: the new :py:class:`Circuit`",
-          py::arg("termsequencebox"), py::arg("qubits"))
-      .def(
-          "add_toffolibox",
-          [](Circuit *circ, const ToffoliBox &box,
-             const py::tket_custom::SequenceVec<unsigned> &qubits,
-             const py::kwargs &kwargs) {
-            return add_box_method<unsigned>(
-                circ, std::make_shared<ToffoliBox>(box), qubits, kwargs);
-          },
-          "Append a :py:class:`ToffoliBox` to the "
-          "circuit.\n\n:param toffolibox: The box to append\n:param "
-          "qubits: Indices of the qubits to append the box to"
-          "\n:return: the new :py:class:`Circuit`",
-          py::arg("toffolibox"), py::arg("qubits"))
-      .def(
-          "add_dummybox",
-          [](Circuit *circ, const DummyBox &box,
-             const py::tket_custom::SequenceVec<unsigned> &qubits,
-             const py::tket_custom::SequenceVec<unsigned> &bits,
-             const py::kwargs &kwargs) {
-            std::vector<UnitID> args;
-            for (unsigned i : qubits) {
-              args.push_back(Qubit(i));
-            }
-            for (unsigned i : bits) {
-              args.push_back(Bit(i));
-            }
-            return add_box_method<UnitID>(
-                circ, std::make_shared<DummyBox>(box), args, kwargs);
-          },
-          "Append a :py:class:`DummyBox` to the circuit."
-          "\n\n:param dummybox: The box to append"
-          "\n:param qubits: Indices (in the default register) of the qubits to "
-          "append the box to"
-          "\n:param bits: Indices of the bits (in the default register) to "
-          "append the box to"
-          "\n:return: the new :py:class:`Circuit`",
-          py::arg("dummybox"), py::arg("qubits"), py::arg("bits"))
-      .def(
-          "add_qcontrolbox",
-          [](Circuit *circ, const QControlBox &box,
-             const py::tket_custom::SequenceVec<unsigned> &args,
-             const py::kwargs &kwargs) {
-            return add_box_method<unsigned>(
-                circ, std::make_shared<QControlBox>(box), args, kwargs);
-          },
-          "Append a :py:class:`QControlBox` to the circuit.\n\n"
-          ":param qcontrolbox: The box to append\n"
-          ":param args: Indices of the qubits to append the box to"
-          "\n:return: the new :py:class:`Circuit`",
-          py::arg("qcontrolbox"), py::arg("args"))
-      .def(
-          "add_phasepolybox",
-          [](Circuit *circ, const PhasePolyBox &box,
-             const py::tket_custom::SequenceVec<unsigned> &qubits,
-             const py::kwargs &kwargs) {
-            return add_box_method<unsigned>(
-                circ, std::make_shared<PhasePolyBox>(box), qubits, kwargs);
-          },
-          "Append a :py:class:`PhasePolyBox` to the "
-          "circuit.\n\n:param phasepolybox: The box to append\n:param "
-          "qubits: Indices of the qubits to append the box to"
-          "\n:return: the new :py:class:`Circuit`",
-          py::arg("phasepolybox"), py::arg("qubits"))
-      .def(
           "add_clexpr",
           [](Circuit *circ, const WiredClExpr &expr,
              const py::tket_custom::SequenceVec<Bit> &args,
              const py::kwargs &kwargs) {
             Op_ptr op = std::make_shared<ClExprOp>(expr);
-            return add_gate_method<Bit>(circ, op, args, kwargs);
+            std::vector<UnitID> uid_args;
+            for (const Bit &b : args) uid_args.push_back(b);
+            return add_gate_method_any(circ, op, uid_args, kwargs);
           },
           "Append a :py:class:`WiredClExpr` to the circuit.\n\n"
           ":param expr: The expression to append\n"
@@ -450,23 +539,6 @@ void init_circuit_add_op(py::class_<Circuit, std::shared_ptr<Circuit>> &c) {
           ":return: the updated circuit",
           py::arg("exp"), py::arg("output_bits"))
       .def(
-          "add_custom_gate",
-          [](Circuit *circ, const composite_def_ptr_t &definition,
-             const py::tket_custom::SequenceVec<Expr> &params,
-             const py::tket_custom::SequenceVec<unsigned> &qubits,
-             const py::kwargs &kwargs) {
-            return add_box_method<unsigned>(
-                circ, std::make_shared<CustomGate>(definition, params), qubits,
-                kwargs);
-          },
-          "Append an instance of a :py:class:`CustomGateDef` to the "
-          "circuit.\n\n:param def: The custom gate "
-          "definition\n:param params: List of parameters to "
-          "instantiate the gate with, in halfturns\n:param qubits: "
-          "Indices of the qubits to append the box to"
-          "\n:return: the new :py:class:`Circuit`",
-          py::arg("definition"), py::arg("params"), py::arg("qubits"))
-      .def(
           "add_barrier",
           [](Circuit *circ, const py_unit_vector_t &units,
              const std::string &data) {
@@ -499,9 +571,9 @@ void init_circuit_add_op(py::class_<Circuit, std::shared_ptr<Circuit>> &c) {
           py::arg("data") = "")
       .def(
           "add_circbox",
-          [](Circuit *circ, const CircBox &box, const py_unit_vector_t &args,
+          [](Circuit *circ, const CircBox &box, const var_seq_ids_t &args,
              const py::kwargs &kwargs) {
-            return add_box_method(
+            return add_gate_method_sequence_args_any(
                 circ, std::make_shared<CircBox>(box), args, kwargs);
           },
           "Append a :py:class:`CircBox` to the circuit."
@@ -530,7 +602,7 @@ void init_circuit_add_op(py::class_<Circuit, std::shared_ptr<Circuit>> &c) {
                 args.push_back(Bit(name, i));
               }
             }
-            return add_box_method(
+            return add_gate_method_any(
                 circ, std::make_shared<CircBox>(box), args, kwargs);
           },
           "Append a :py:class:`CircBox` to the circuit, wiring whole registers "
@@ -628,7 +700,7 @@ void init_circuit_add_op(py::class_<Circuit, std::shared_ptr<Circuit>> &c) {
             }
 
             // Add the box:
-            return add_box_method(
+            return add_gate_method_any(
                 circ, std::make_shared<CircBox>(box), args, kwargs);
           },
           "Append a :py:class:`CircBox` to the circuit, wiring whole registers "
@@ -649,10 +721,20 @@ void init_circuit_add_op(py::class_<Circuit, std::shared_ptr<Circuit>> &c) {
           py::arg("circbox"), py::arg("qregmap"), py::arg("cregmap"))
       .def(
           "add_unitary1qbox",
-          [](Circuit *circ, const Unitary1qBox &box, const Qubit &q0,
+          [](Circuit *circ, const Unitary1qBox &box,
+             const std::variant<unsigned, Qubit> &q0,
              const py::kwargs &kwargs) {
-            return add_box_method<UnitID>(
-                circ, std::make_shared<Unitary1qBox>(box), {q0}, kwargs);
+            if (std::holds_alternative<unsigned>(q0)) {
+              unsigned uq0 = std::get<unsigned>(q0);
+              return add_gate_method_any(
+                  circ, std::make_shared<Unitary1qBox>(box),
+                  std::vector<unsigned>{uq0}, kwargs);
+            } else {
+              Qubit qq0 = std::get<Qubit>(q0);
+              return add_gate_method_any(
+                  circ, std::make_shared<Unitary1qBox>(box),
+                  std::vector<UnitID>{qq0}, kwargs);
+            }
           },
           "Append a :py:class:`Unitary1qBox` to the "
           "circuit.\n\n:param unitarybox: The box to append\n:param "
@@ -661,10 +743,29 @@ void init_circuit_add_op(py::class_<Circuit, std::shared_ptr<Circuit>> &c) {
           py::arg("unitarybox"), py::arg("qubit_0"))
       .def(
           "add_unitary2qbox",
-          [](Circuit *circ, const Unitary2qBox &box, const Qubit &q0,
-             const Qubit &q1, const py::kwargs &kwargs) {
-            return add_box_method<UnitID>(
-                circ, std::make_shared<Unitary2qBox>(box), {q0, q1}, kwargs);
+          [](Circuit *circ, const Unitary2qBox &box,
+             const std::variant<unsigned, Qubit> &q0,
+             const std::variant<unsigned, Qubit> &q1,
+             const py::kwargs &kwargs) {
+            if (std::holds_alternative<unsigned>(q0) !=
+                std::holds_alternative<unsigned>(q1)) {
+              throw CircuitInvalidity(
+                  "Qubits passed to `add_unitary2qbox` must either both be "
+                  "`int` or both `Qubit`.");
+            }
+            if (std::holds_alternative<unsigned>(q0)) {
+              unsigned uq0 = std::get<unsigned>(q0);
+              unsigned uq1 = std::get<unsigned>(q1);
+              return add_gate_method_any(
+                  circ, std::make_shared<Unitary2qBox>(box),
+                  std::vector<unsigned>{uq0, uq1}, kwargs);
+            } else {
+              Qubit qq0 = std::get<Qubit>(q0);
+              Qubit qq1 = std::get<Qubit>(q1);
+              return add_gate_method_any(
+                  circ, std::make_shared<Unitary2qBox>(box),
+                  std::vector<UnitID>{qq0, qq1}, kwargs);
+            }
           },
           "Append a :py:class:`Unitary2qBox` to the circuit.\n\nThe "
           "matrix representation is ILO-BE.\n\n:param unitarybox: "
@@ -674,11 +775,33 @@ void init_circuit_add_op(py::class_<Circuit, std::shared_ptr<Circuit>> &c) {
           py::arg("unitarybox"), py::arg("qubit_0"), py::arg("qubit_1"))
       .def(
           "add_unitary3qbox",
-          [](Circuit *circ, const Unitary3qBox &box, const Qubit &q0,
-             const Qubit &q1, const Qubit &q2, const py::kwargs &kwargs) {
-            return add_box_method<UnitID>(
-                circ, std::make_shared<Unitary3qBox>(box), {q0, q1, q2},
-                kwargs);
+          [](Circuit *circ, const Unitary3qBox &box,
+             const std::variant<unsigned, Qubit> &q0,
+             const std::variant<unsigned, Qubit> &q1,
+             const std::variant<unsigned, Qubit> &q2,
+             const py::kwargs &kwargs) {
+            bool is_unsigned = std::holds_alternative<unsigned>(q0);
+            if (std::holds_alternative<unsigned>(q1) != is_unsigned ||
+                std::holds_alternative<unsigned>(q2) != is_unsigned) {
+              throw CircuitInvalidity(
+                  "Qubits passed to `add_unitary3qbox` must either all be "
+                  "`int` or all `Qubit`.");
+            }
+            if (is_unsigned) {
+              unsigned uq0 = std::get<unsigned>(q0);
+              unsigned uq1 = std::get<unsigned>(q1);
+              unsigned uq2 = std::get<unsigned>(q2);
+              return add_gate_method_any(
+                  circ, std::make_shared<Unitary3qBox>(box),
+                  std::vector<unsigned>{uq0, uq1, uq2}, kwargs);
+            } else {
+              Qubit qq0 = std::get<Qubit>(q0);
+              Qubit qq1 = std::get<Qubit>(q1);
+              Qubit qq2 = std::get<Qubit>(q2);
+              return add_gate_method_any(
+                  circ, std::make_shared<Unitary3qBox>(box),
+                  std::vector<UnitID>{qq0, qq1, qq2}, kwargs);
+            }
           },
           "Append a :py:class:`Unitary3qBox` to the circuit."
           "\n\n:param unitarybox: box to append"
@@ -690,10 +813,28 @@ void init_circuit_add_op(py::class_<Circuit, std::shared_ptr<Circuit>> &c) {
           py::arg("qubit_2"))
       .def(
           "add_expbox",
-          [](Circuit *circ, const ExpBox &box, const Qubit &q0, const Qubit &q1,
+          [](Circuit *circ, const ExpBox &box,
+             const std::variant<unsigned, Qubit> &q0,
+             const std::variant<unsigned, Qubit> &q1,
              const py::kwargs &kwargs) {
-            return add_box_method<UnitID>(
-                circ, std::make_shared<ExpBox>(box), {q0, q1}, kwargs);
+            if (std::holds_alternative<unsigned>(q0) !=
+                std::holds_alternative<unsigned>(q1))
+              throw CircuitInvalidity(
+                  "Qubits passed to `add_expbox` must either both be `int` or "
+                  "both `Qubit`.");
+            if (std::holds_alternative<unsigned>(q0)) {
+              unsigned uq0 = std::get<unsigned>(q0);
+              unsigned uq1 = std::get<unsigned>(q1);
+              return add_gate_method_any(
+                  circ, std::make_shared<ExpBox>(box),
+                  std::vector<unsigned>{uq0, uq1}, kwargs);
+            } else {
+              Qubit qq0 = std::get<Qubit>(q0);
+              Qubit qq1 = std::get<Qubit>(q1);
+              return add_gate_method_any(
+                  circ, std::make_shared<ExpBox>(box),
+                  std::vector<UnitID>{qq0, qq1}, kwargs);
+            }
           },
           "Append an :py:class:`ExpBox` to the circuit.\n\nThe "
           "matrix representation is ILO-BE.\n\n:param expbox: The "
@@ -703,11 +844,11 @@ void init_circuit_add_op(py::class_<Circuit, std::shared_ptr<Circuit>> &c) {
           py::arg("expbox"), py::arg("qubit_0"), py::arg("qubit_1"))
       .def(
           "add_pauliexpbox",
-          [](Circuit *circ, const PauliExpBox &box,
-             const py_qubit_vector_t &qubits, const py::kwargs &kwargs) {
-            return add_box_method<UnitID>(
+          [](Circuit *circ, const PauliExpBox &box, const var_seq_qbs_t &qubits,
+             const py::kwargs &kwargs) {
+            return add_gate_method_any(
                 circ, std::make_shared<PauliExpBox>(box),
-                {qubits.begin(), qubits.end()}, kwargs);
+                var_sequence_to_var_vecs(qubits), kwargs);
           },
           "Append a :py:class:`PauliExpBox` to the "
           "circuit.\n\n:param pauliexpbox: The box to append\n:param "
@@ -717,10 +858,10 @@ void init_circuit_add_op(py::class_<Circuit, std::shared_ptr<Circuit>> &c) {
       .def(
           "add_pauliexppairbox",
           [](Circuit *circ, const PauliExpPairBox &box,
-             const py_qubit_vector_t &qubits, const py::kwargs &kwargs) {
-            return add_box_method<UnitID>(
+             const var_seq_qbs_t &qubits, const py::kwargs &kwargs) {
+            return add_gate_method_any(
                 circ, std::make_shared<PauliExpPairBox>(box),
-                {qubits.begin(), qubits.end()}, kwargs);
+                var_sequence_to_var_vecs(qubits), kwargs);
           },
           "Append a :py:class:`PauliExpPairBox` to the "
           "circuit.\n\n:param pauliexppairbox: The box to append\n:param "
@@ -730,10 +871,10 @@ void init_circuit_add_op(py::class_<Circuit, std::shared_ptr<Circuit>> &c) {
       .def(
           "add_pauliexpcommutingsetbox",
           [](Circuit *circ, const PauliExpCommutingSetBox &box,
-             const py_qubit_vector_t &qubits, const py::kwargs &kwargs) {
-            return add_box_method<UnitID>(
+             const var_seq_qbs_t &qubits, const py::kwargs &kwargs) {
+            return add_gate_method_any(
                 circ, std::make_shared<PauliExpCommutingSetBox>(box),
-                {qubits.begin(), qubits.end()}, kwargs);
+                var_sequence_to_var_vecs(qubits), kwargs);
           },
           "Append a :py:class:`PauliExpCommutingSetBox` to the "
           "circuit.\n\n:param pauliexpcommutingsetbox: The box to "
@@ -744,10 +885,10 @@ void init_circuit_add_op(py::class_<Circuit, std::shared_ptr<Circuit>> &c) {
       .def(
           "add_termsequencebox",
           [](Circuit *circ, const TermSequenceBox &box,
-             const py_qubit_vector_t &qubits, const py::kwargs &kwargs) {
-            return add_box_method<UnitID>(
+             const var_seq_qbs_t &qubits, const py::kwargs &kwargs) {
+            return add_gate_method_any(
                 circ, std::make_shared<TermSequenceBox>(box),
-                {qubits.begin(), qubits.end()}, kwargs);
+                var_sequence_to_var_vecs(qubits), kwargs);
           },
           "Append a :py:class:`TermSequenceBox` to the "
           "circuit.\n\n:param termsequencebox: The box to "
@@ -757,11 +898,11 @@ void init_circuit_add_op(py::class_<Circuit, std::shared_ptr<Circuit>> &c) {
           py::arg("termsequencebox"), py::arg("qubits"))
       .def(
           "add_toffolibox",
-          [](Circuit *circ, const ToffoliBox &box,
-             const py_qubit_vector_t &qubits, const py::kwargs &kwargs) {
-            return add_box_method<UnitID>(
+          [](Circuit *circ, const ToffoliBox &box, const var_seq_qbs_t &qubits,
+             const py::kwargs &kwargs) {
+            return add_gate_method_any(
                 circ, std::make_shared<ToffoliBox>(box),
-                {qubits.begin(), qubits.end()}, kwargs);
+                var_sequence_to_var_vecs(qubits), kwargs);
           },
           "Append a :py:class:`ToffoliBox` to the "
           "circuit.\n\n:param toffolibox: The box to append\n:param "
@@ -770,13 +911,46 @@ void init_circuit_add_op(py::class_<Circuit, std::shared_ptr<Circuit>> &c) {
           py::arg("toffolibox"), py::arg("qubits"))
       .def(
           "add_dummybox",
-          [](Circuit *circ, const DummyBox &box,
-             const py_qubit_vector_t &qubits, const py_bit_vector_t &bits,
+          [](Circuit *circ, const DummyBox &box, const var_seq_qbs_t &qubits,
+             const std::variant<
+                 py::tket_custom::SequenceVec<unsigned>,
+                 py::tket_custom::SequenceVec<Bit>> &bits,
              const py::kwargs &kwargs) {
-            std::vector<UnitID> args = {qubits.begin(), qubits.end()};
-            args.insert(args.end(), bits.begin(), bits.end());
-            return add_box_method<UnitID>(
-                circ, std::make_shared<DummyBox>(box), args, kwargs);
+            if (std::holds_alternative<py::tket_custom::SequenceVec<unsigned>>(
+                    qubits)) {
+              auto qbs =
+                  std::get<py::tket_custom::SequenceVec<unsigned>>(qubits);
+              if (std::holds_alternative<
+                      py::tket_custom::SequenceVec<unsigned>>(bits)) {
+                auto bs =
+                    std::get<py::tket_custom::SequenceVec<unsigned>>(bits);
+                qbs.insert(qbs.end(), bs.begin(), bs.end());
+                return add_gate_method_any(
+                    circ, std::make_shared<DummyBox>(box), qbs, kwargs);
+              } else {
+                auto bs = std::get<py::tket_custom::SequenceVec<Bit>>(bits);
+                std::vector<UnitID> args;
+                for (unsigned q : qbs) args.push_back(Qubit(q));
+                args.insert(args.end(), bs.begin(), bs.end());
+                return add_gate_method_any(
+                    circ, std::make_shared<DummyBox>(box), args, kwargs);
+              }
+            } else {
+              auto qbs = std::get<py::tket_custom::SequenceVec<Qubit>>(qubits);
+              std::vector<UnitID> args;
+              args.insert(args.end(), qbs.begin(), qbs.end());
+              if (std::holds_alternative<
+                      py::tket_custom::SequenceVec<unsigned>>(bits)) {
+                auto bs =
+                    std::get<py::tket_custom::SequenceVec<unsigned>>(bits);
+                for (unsigned b : bs) args.push_back(Bit(b));
+              } else {
+                auto bs = std::get<py::tket_custom::SequenceVec<Bit>>(bits);
+                args.insert(args.end(), bs.begin(), bs.end());
+              }
+              return add_gate_method_any(
+                  circ, std::make_shared<DummyBox>(box), args, kwargs);
+            }
           },
           "Append a :py:class:`DummyBox` to the circuit."
           "\n\n:param dummybox: The box to append"
@@ -786,23 +960,24 @@ void init_circuit_add_op(py::class_<Circuit, std::shared_ptr<Circuit>> &c) {
           py::arg("dummybox"), py::arg("qubits"), py::arg("bits"))
       .def(
           "add_qcontrolbox",
-          [](Circuit *circ, const QControlBox &box,
-             const py_unit_vector_t &args, const py::kwargs &kwargs) {
-            return add_box_method(
-                circ, std::make_shared<QControlBox>(box), args, kwargs);
+          [](Circuit *circ, const QControlBox &box, const var_seq_qbs_t &qubits,
+             const py::kwargs &kwargs) {
+            return add_gate_method_any(
+                circ, std::make_shared<QControlBox>(box),
+                var_sequence_to_var_vecs(qubits), kwargs);
           },
           "Append a :py:class:`QControlBox` to the circuit.\n\n"
           ":param qcontrolbox: The box to append\n"
-          ":param args: The qubits to append the box to"
+          ":param qubits: The qubits to append the box to"
           "\n:return: the new :py:class:`Circuit`",
-          py::arg("qcontrolbox"), py::arg("args"))
+          py::arg("qcontrolbox"), py::arg("qubits"))
       .def(
           "add_phasepolybox",
           [](Circuit *circ, const PhasePolyBox &box,
-             const py_qubit_vector_t &qubits, const py::kwargs &kwargs) {
-            return add_box_method<UnitID>(
+             const var_seq_qbs_t &qubits, const py::kwargs &kwargs) {
+            return add_gate_method_any(
                 circ, std::make_shared<PhasePolyBox>(box),
-                {qubits.begin(), qubits.end()}, kwargs);
+                var_sequence_to_var_vecs(qubits), kwargs);
           },
           "Append a :py:class:`PhasePolyBox` to the "
           "circuit.\n\n:param phasepolybox: The box to append\n:param "
@@ -813,10 +988,10 @@ void init_circuit_add_op(py::class_<Circuit, std::shared_ptr<Circuit>> &c) {
           "add_custom_gate",
           [](Circuit *circ, const composite_def_ptr_t &definition,
              const py::tket_custom::SequenceVec<Expr> &params,
-             const py_qubit_vector_t &qubits, const py::kwargs &kwargs) {
-            return add_box_method<UnitID>(
+             const var_seq_qbs_t &qubits, const py::kwargs &kwargs) {
+            return add_gate_method_any(
                 circ, std::make_shared<CustomGate>(definition, params),
-                {qubits.begin(), qubits.end()}, kwargs);
+                var_sequence_to_var_vecs(qubits), kwargs);
           },
           "Append an instance of a :py:class:`CustomGateDef` to the "
           "circuit.\n\n:param def: The custom gate "
@@ -828,38 +1003,27 @@ void init_circuit_add_op(py::class_<Circuit, std::shared_ptr<Circuit>> &c) {
       .def(
           "add_assertion",
           [](Circuit *circ, const ProjectorAssertionBox &box,
-             const py::tket_custom::SequenceVec<unsigned> &qubits,
-             const std::optional<unsigned> &ancilla,
+             const var_seq_qbs_t &qubits,
+             const std::optional<std::variant<unsigned, Qubit>> &ancilla,
              const std::optional<std::string> &name) -> Circuit * {
             std::vector<Qubit> qubits_;
-            qubits_.reserve(qubits.size());
-            for (unsigned int qubit : qubits) {
-              qubits_.emplace_back(qubit);
-            }
-            std::optional<Qubit> ancilla_;
-            if (ancilla == std::nullopt) {
-              ancilla_ = std::nullopt;
+            if (std::holds_alternative<py::tket_custom::SequenceVec<unsigned>>(
+                    qubits)) {
+              for (unsigned q :
+                   std::get<py::tket_custom::SequenceVec<unsigned>>(qubits))
+                qubits_.push_back(Qubit(q));
             } else {
-              ancilla_ = Qubit(ancilla.value());
+              qubits_ = std::get<py::tket_custom::SequenceVec<Qubit>>(qubits);
+            }
+            std::optional<Qubit> ancilla_ = std::nullopt;
+            if (ancilla) {
+              if (std::holds_alternative<unsigned>(*ancilla)) {
+                ancilla_ = Qubit(std::get<unsigned>(*ancilla));
+              } else {
+                ancilla_ = std::get<Qubit>(*ancilla);
+              }
             }
             circ->add_assertion(box, qubits_, ancilla_, name);
-            return circ;
-          },
-          "Append a :py:class:`ProjectorAssertionBox` to the circuit."
-          "\n\n:param box: ProjectorAssertionBox to append"
-          "\n:param qubits: indices of target qubits"
-          "\n:param ancilla: index of ancilla qubit"
-          "\n:param name: name used to identify this assertion"
-          "\n:return: the new :py:class:`Circuit`",
-          py::arg("box"), py::arg("qubits"), py::arg("ancilla") = std::nullopt,
-          py::arg("name") = std::nullopt)
-      .def(
-          "add_assertion",
-          [](Circuit *circ, const ProjectorAssertionBox &box,
-             const py::tket_custom::SequenceVec<Qubit> &qubits,
-             const std::optional<Qubit> &ancilla,
-             const std::optional<std::string> &name) -> Circuit * {
-            circ->add_assertion(box, qubits, ancilla, name);
             return circ;
           },
           "Append a :py:class:`ProjectorAssertionBox` to the circuit."
@@ -873,33 +1037,25 @@ void init_circuit_add_op(py::class_<Circuit, std::shared_ptr<Circuit>> &c) {
       .def(
           "add_assertion",
           [](Circuit *circ, const StabiliserAssertionBox &box,
-             const py::tket_custom::SequenceVec<unsigned> &qubits,
-             const unsigned &ancilla,
+             const var_seq_qbs_t &qubits,
+             const std::variant<unsigned, Qubit> &ancilla,
              const std::optional<std::string> &name) -> Circuit * {
             std::vector<Qubit> qubits_;
-            qubits_.reserve(qubits.size());
-            for (unsigned int qubit : qubits) {
-              qubits_.emplace_back(qubit);
+            if (std::holds_alternative<py::tket_custom::SequenceVec<unsigned>>(
+                    qubits)) {
+              for (unsigned q :
+                   std::get<py::tket_custom::SequenceVec<unsigned>>(qubits))
+                qubits_.push_back(Qubit(q));
+            } else {
+              qubits_ = std::get<py::tket_custom::SequenceVec<Qubit>>(qubits);
             }
-            Qubit ancilla_(ancilla);
+            Qubit ancilla_;
+            if (std::holds_alternative<unsigned>(ancilla)) {
+              ancilla_ = Qubit(std::get<unsigned>(ancilla));
+            } else {
+              ancilla_ = std::get<Qubit>(ancilla);
+            }
             circ->add_assertion(box, qubits_, ancilla_, name);
-            return circ;
-          },
-          "Append a :py:class:`StabiliserAssertionBox` to the circuit."
-          "\n\n:param box: StabiliserAssertionBox to append"
-          "\n:param qubits: indices of target qubits"
-          "\n:param ancilla: index of ancilla qubit"
-          "\n:param name: name used to identify this assertion"
-          "\n:return: the new :py:class:`Circuit`",
-          py::arg("box"), py::arg("qubits"), py::arg("ancilla"),
-          py::arg("name") = std::nullopt)
-      .def(
-          "add_assertion",
-          [](Circuit *circ, const StabiliserAssertionBox &box,
-             const py::tket_custom::SequenceVec<Qubit> &qubits,
-             const Qubit &ancilla,
-             const std::optional<std::string> &name) -> Circuit * {
-            circ->add_assertion(box, qubits, ancilla, name);
             return circ;
           },
           "Append a :py:class:`StabiliserAssertionBox` to the circuit."
@@ -913,9 +1069,10 @@ void init_circuit_add_op(py::class_<Circuit, std::shared_ptr<Circuit>> &c) {
       .def(
           "add_multiplexor",
           [](Circuit *circ, const MultiplexorBox &box,
-             const py_unit_vector_t &args, const py::kwargs &kwargs) {
-            return add_box_method(
-                circ, std::make_shared<MultiplexorBox>(box), args, kwargs);
+             const var_seq_qbs_t &args, const py::kwargs &kwargs) {
+            return add_gate_method_any(
+                circ, std::make_shared<MultiplexorBox>(box),
+                var_sequence_to_var_vecs(args), kwargs);
           },
           "Append a :py:class:`MultiplexorBox` to the circuit.\n\n"
           ":param box: The box to append\n"
@@ -923,25 +1080,12 @@ void init_circuit_add_op(py::class_<Circuit, std::shared_ptr<Circuit>> &c) {
           "\n:return: the new :py:class:`Circuit`",
           py::arg("box"), py::arg("args"))
       .def(
-          "add_multiplexor",
-          [](Circuit *circ, const MultiplexorBox &box,
-             const py::tket_custom::SequenceVec<unsigned> &args,
-             const py::kwargs &kwargs) {
-            return add_box_method(
-                circ, std::make_shared<MultiplexorBox>(box), args, kwargs);
-          },
-          "Append a :py:class:`MultiplexorBox` to the circuit.\n\n"
-          ":param box: The box to append\n"
-          ":param args: Indices of the qubits to append the box to"
-          "\n:return: the new :py:class:`Circuit`",
-          py::arg("box"), py::arg("args"))
-      .def(
           "add_multiplexedrotation",
           [](Circuit *circ, const MultiplexedRotationBox &box,
-             const py_unit_vector_t &args, const py::kwargs &kwargs) {
-            return add_box_method(
-                circ, std::make_shared<MultiplexedRotationBox>(box), args,
-                kwargs);
+             const var_seq_qbs_t &args, const py::kwargs &kwargs) {
+            return add_gate_method_any(
+                circ, std::make_shared<MultiplexedRotationBox>(box),
+                var_sequence_to_var_vecs(args), kwargs);
           },
           "Append a :py:class:`MultiplexedRotationBox` to the circuit.\n\n"
           ":param box: The box to append\n"
@@ -949,25 +1093,12 @@ void init_circuit_add_op(py::class_<Circuit, std::shared_ptr<Circuit>> &c) {
           "\n:return: the new :py:class:`Circuit`",
           py::arg("box"), py::arg("args"))
       .def(
-          "add_multiplexedrotation",
-          [](Circuit *circ, const MultiplexedRotationBox &box,
-             const py::tket_custom::SequenceVec<unsigned> &args,
-             const py::kwargs &kwargs) {
-            return add_box_method(
-                circ, std::make_shared<MultiplexedRotationBox>(box), args,
-                kwargs);
-          },
-          "Append a :py:class:`MultiplexedRotationBox` to the circuit.\n\n"
-          ":param box: The box to append\n"
-          ":param args: Indices of the qubits to append the box to"
-          "\n:return: the new :py:class:`Circuit`",
-          py::arg("box"), py::arg("args"))
-      .def(
           "add_multiplexedu2",
           [](Circuit *circ, const MultiplexedU2Box &box,
-             const py_unit_vector_t &args, const py::kwargs &kwargs) {
-            return add_box_method(
-                circ, std::make_shared<MultiplexedU2Box>(box), args, kwargs);
+             const var_seq_qbs_t &args, const py::kwargs &kwargs) {
+            return add_gate_method_any(
+                circ, std::make_shared<MultiplexedU2Box>(box),
+                var_sequence_to_var_vecs(args), kwargs);
           },
           "Append a :py:class:`MultiplexedU2Box` to the circuit.\n\n"
           ":param box: The box to append\n"
@@ -975,25 +1106,12 @@ void init_circuit_add_op(py::class_<Circuit, std::shared_ptr<Circuit>> &c) {
           "\n:return: the new :py:class:`Circuit`",
           py::arg("box"), py::arg("args"))
       .def(
-          "add_multiplexedu2",
-          [](Circuit *circ, const MultiplexedU2Box &box,
-             const py::tket_custom::SequenceVec<unsigned> &args,
-             const py::kwargs &kwargs) {
-            return add_box_method(
-                circ, std::make_shared<MultiplexedU2Box>(box), args, kwargs);
-          },
-          "Append a :py:class:`MultiplexedU2Box` to the circuit.\n\n"
-          ":param box: The box to append\n"
-          ":param args: Indices of the qubits to append the box to"
-          "\n:return: the new :py:class:`Circuit`",
-          py::arg("box"), py::arg("args"))
-      .def(
           "add_multiplexed_tensored_u2",
           [](Circuit *circ, const MultiplexedTensoredU2Box &box,
-             const py_unit_vector_t &args, const py::kwargs &kwargs) {
-            return add_box_method(
-                circ, std::make_shared<MultiplexedTensoredU2Box>(box), args,
-                kwargs);
+             const var_seq_qbs_t &args, const py::kwargs &kwargs) {
+            return add_gate_method_any(
+                circ, std::make_shared<MultiplexedTensoredU2Box>(box),
+                var_sequence_to_var_vecs(args), kwargs);
           },
           "Append a :py:class:`MultiplexedTensoredU2Box` to the circuit.\n\n"
           ":param box: The box to append\n"
@@ -1001,25 +1119,12 @@ void init_circuit_add_op(py::class_<Circuit, std::shared_ptr<Circuit>> &c) {
           "\n:return: the new :py:class:`Circuit`",
           py::arg("box"), py::arg("args"))
       .def(
-          "add_multiplexed_tensored_u2",
-          [](Circuit *circ, const MultiplexedTensoredU2Box &box,
-             const py::tket_custom::SequenceVec<unsigned> &args,
-             const py::kwargs &kwargs) {
-            return add_box_method(
-                circ, std::make_shared<MultiplexedTensoredU2Box>(box), args,
-                kwargs);
-          },
-          "Append a :py:class:`MultiplexedTensoredU2Box` to the circuit.\n\n"
-          ":param box: The box to append\n"
-          ":param args: Indices of the qubits to append the box to"
-          "\n:return: the new :py:class:`Circuit`",
-          py::arg("box"), py::arg("args"))
-      .def(
           "add_state_preparation_box",
           [](Circuit *circ, const StatePreparationBox &box,
-             const py_unit_vector_t &args, const py::kwargs &kwargs) {
-            return add_box_method(
-                circ, std::make_shared<StatePreparationBox>(box), args, kwargs);
+             const var_seq_qbs_t &args, const py::kwargs &kwargs) {
+            return add_gate_method_any(
+                circ, std::make_shared<StatePreparationBox>(box),
+                var_sequence_to_var_vecs(args), kwargs);
           },
           "Append a :py:class:`StatePreparationBox` to the circuit.\n\n"
           ":param box: The box to append\n"
@@ -1027,24 +1132,12 @@ void init_circuit_add_op(py::class_<Circuit, std::shared_ptr<Circuit>> &c) {
           "\n:return: the new :py:class:`Circuit`",
           py::arg("box"), py::arg("args"))
       .def(
-          "add_state_preparation_box",
-          [](Circuit *circ, const StatePreparationBox &box,
-             const py::tket_custom::SequenceVec<unsigned> &args,
-             const py::kwargs &kwargs) {
-            return add_box_method(
-                circ, std::make_shared<StatePreparationBox>(box), args, kwargs);
-          },
-          "Append a :py:class:`StatePreparationBox` to the circuit.\n\n"
-          ":param box: The box to append\n"
-          ":param args: Indices of the qubits to append the box to"
-          "\n:return: the new :py:class:`Circuit`",
-          py::arg("box"), py::arg("args"))
-      .def(
           "add_diagonal_box",
-          [](Circuit *circ, const DiagonalBox &box,
-             const py_unit_vector_t &args, const py::kwargs &kwargs) {
-            return add_box_method(
-                circ, std::make_shared<DiagonalBox>(box), args, kwargs);
+          [](Circuit *circ, const DiagonalBox &box, const var_seq_qbs_t &args,
+             const py::kwargs &kwargs) {
+            return add_gate_method_any(
+                circ, std::make_shared<DiagonalBox>(box),
+                var_sequence_to_var_vecs(args), kwargs);
           },
           "Append a :py:class:`DiagonalBox` to the circuit.\n\n"
           ":param box: The box to append\n"
@@ -1052,24 +1145,12 @@ void init_circuit_add_op(py::class_<Circuit, std::shared_ptr<Circuit>> &c) {
           "\n:return: the new :py:class:`Circuit`",
           py::arg("box"), py::arg("args"))
       .def(
-          "add_diagonal_box",
-          [](Circuit *circ, const DiagonalBox &box,
-             const py::tket_custom::SequenceVec<unsigned> &args,
-             const py::kwargs &kwargs) {
-            return add_box_method(
-                circ, std::make_shared<DiagonalBox>(box), args, kwargs);
-          },
-          "Append a :py:class:`DiagonalBox` to the circuit.\n\n"
-          ":param box: The box to append\n"
-          ":param args: Indices of the qubits to append the box to"
-          "\n:return: the new :py:class:`Circuit`",
-          py::arg("box"), py::arg("args"))
-      .def(
           "add_conjugation_box",
           [](Circuit *circ, const ConjugationBox &box,
-             const py_unit_vector_t &args, const py::kwargs &kwargs) {
-            return add_box_method(
-                circ, std::make_shared<ConjugationBox>(box), args, kwargs);
+             const var_seq_qbs_t &args, const py::kwargs &kwargs) {
+            return add_gate_method_any(
+                circ, std::make_shared<ConjugationBox>(box),
+                var_sequence_to_var_vecs(args), kwargs);
           },
           "Append a :py:class:`ConjugationBox` to the circuit.\n\n"
           ":param box: The box to append\n"
@@ -1077,441 +1158,245 @@ void init_circuit_add_op(py::class_<Circuit, std::shared_ptr<Circuit>> &c) {
           "\n:return: the new :py:class:`Circuit`",
           py::arg("box"), py::arg("args"))
       .def(
-          "add_conjugation_box",
-          [](Circuit *circ, const ConjugationBox &box,
-             const py::tket_custom::SequenceVec<unsigned> &args,
-             const py::kwargs &kwargs) {
-            return add_box_method(
-                circ, std::make_shared<ConjugationBox>(box), args, kwargs);
-          },
-          "Append a :py:class:`ConjugationBox` to the circuit.\n\n"
-          ":param box: The box to append\n"
-          ":param args: Indices of the qubits to append the box to"
-          "\n:return: the new :py:class:`Circuit`",
-          py::arg("box"), py::arg("args"))
-      .def(
-          "H",
-          [](Circuit *circ, unsigned qb, const py::kwargs &kwargs) {
-            return add_gate_method_noparams<unsigned>(
-                circ, OpType::H, {qb}, kwargs);
-          },
+          "H", add_gate_method_q(OpType::H),
           "Appends a Hadamard gate."
           "\n\n:return: the new :py:class:`Circuit`",
           py::arg("qubit"))
       .def(
-          "X",
-          [](Circuit *circ, unsigned qb, const py::kwargs &kwargs) {
-            return add_gate_method_noparams<unsigned>(
-                circ, OpType::X, {qb}, kwargs);
-          },
-          "Appends an X gate.", "\n\n:return: the new :py:class:`Circuit`",
-          py::arg("qubit"))
+          "X", add_gate_method_q(OpType::X), "Appends an X gate.",
+          "\n\n:return: the new :py:class:`Circuit`", py::arg("qubit"))
       .def(
-          "Y",
-          [](Circuit *circ, unsigned qb, const py::kwargs &kwargs) {
-            return add_gate_method_noparams<unsigned>(
-                circ, OpType::Y, {qb}, kwargs);
-          },
-          "Appends a Y gate.", "\n\n:return: the new :py:class:`Circuit`",
-          py::arg("qubit"))
+          "Y", add_gate_method_q(OpType::Y), "Appends a Y gate.",
+          "\n\n:return: the new :py:class:`Circuit`", py::arg("qubit"))
       .def(
-          "Z",
-          [](Circuit *circ, unsigned qb, const py::kwargs &kwargs) {
-            return add_gate_method_noparams<unsigned>(
-                circ, OpType::Z, {qb}, kwargs);
-          },
-          "Appends a Z gate.", "\n\n:return: the new :py:class:`Circuit`",
-          py::arg("qubit"))
+          "Z", add_gate_method_q(OpType::Z), "Appends a Z gate.",
+          "\n\n:return: the new :py:class:`Circuit`", py::arg("qubit"))
       .def(
-          "T",
-          [](Circuit *circ, unsigned qb, const py::kwargs &kwargs) {
-            return add_gate_method_noparams<unsigned>(
-                circ, OpType::T, {qb}, kwargs);
-          },
+          "T", add_gate_method_q(OpType::T),
           "Appends a T gate (equivalent to U1(0.25,-))."
           "\n\n:return: the new :py:class:`Circuit`",
           py::arg("qubit"))
       .def(
-          "Tdg",
-          [](Circuit *circ, unsigned qb, const py::kwargs &kwargs) {
-            return add_gate_method_noparams<unsigned>(
-                circ, OpType::Tdg, {qb}, kwargs);
-          },
+          "Tdg", add_gate_method_q(OpType::Tdg),
           "Appends a T-dagger gate (equivalent to U1(-0.25,-))."
           "\n\n:return: the new :py:class:`Circuit`",
           py::arg("qubit"))
       .def(
-          "S",
-          [](Circuit *circ, unsigned qb, const py::kwargs &kwargs) {
-            return add_gate_method_noparams<unsigned>(
-                circ, OpType::S, {qb}, kwargs);
-          },
+          "S", add_gate_method_q(OpType::S),
           "Appends an S gate (equivalent to U1(0.5,-))."
           "\n\n:return: the new :py:class:`Circuit`",
           py::arg("qubit"))
       .def(
-          "Sdg",
-          [](Circuit *circ, unsigned qb, const py::kwargs &kwargs) {
-            return add_gate_method_noparams<unsigned>(
-                circ, OpType::Sdg, {qb}, kwargs);
-          },
+          "Sdg", add_gate_method_q(OpType::Sdg),
           "Appends an S-dagger gate (equivalent to U1(-0.5,-))."
           "\n\n:return: the new :py:class:`Circuit`",
           py::arg("qubit"))
       .def(
-          "V",
-          [](Circuit *circ, unsigned qb, const py::kwargs &kwargs) {
-            return add_gate_method_noparams<unsigned>(
-                circ, OpType::V, {qb}, kwargs);
-          },
+          "V", add_gate_method_q(OpType::V),
           "Appends a V gate (equivalent to Rx(0.5,-))."
           "\n\n:return: the new :py:class:`Circuit`",
           py::arg("qubit"))
       .def(
-          "Vdg",
-          [](Circuit *circ, unsigned qb, const py::kwargs &kwargs) {
-            return add_gate_method_noparams<unsigned>(
-                circ, OpType::Vdg, {qb}, kwargs);
-          },
+          "Vdg", add_gate_method_q(OpType::Vdg),
           "Appends a V-dagger gate (equivalent to Rx(-0.5,-))."
           "\n\n:return: the new :py:class:`Circuit`",
           py::arg("qubit"))
       .def(
-          "SX",
-          [](Circuit *circ, unsigned qb, const py::kwargs &kwargs) {
-            return add_gate_method_noparams<unsigned>(
-                circ, OpType::SX, {qb}, kwargs);
-          },
+          "SX", add_gate_method_q(OpType::SX),
           "Appends a SX gate (equivalent to Rx(0.5,-)"
           " up to a 0.25 global phase)."
           "\n\n:return: the new :py:class:`Circuit`",
           py::arg("qubit"))
       .def(
-          "SXdg",
-          [](Circuit *circ, unsigned qb, const py::kwargs &kwargs) {
-            return add_gate_method_noparams<unsigned>(
-                circ, OpType::SXdg, {qb}, kwargs);
-          },
+          "SXdg", add_gate_method_q(OpType::SXdg),
           "Appends a SXdg gate (equivalent to Rx(-0.5,-)"
           " up to a -0.25 global phase)."
           "\n\n:return: the new :py:class:`Circuit`",
           py::arg("qubit"))
       .def(
           "Measure",
-          [](Circuit *circ, unsigned qb, unsigned b, const py::kwargs &kwargs) {
-            return add_gate_method_noparams<unsigned>(
-                circ, OpType::Measure, {qb, b}, kwargs);
+          [](Circuit *circ, const std::variant<unsigned, Qubit> &qb,
+             std::variant<unsigned, Bit> &b, const py::kwargs &kwargs) {
+            Qubit qubit = std::holds_alternative<unsigned>(qb)
+                              ? Qubit(std::get<unsigned>(qb))
+                              : std::get<Qubit>(qb);
+            Bit bit = std::holds_alternative<unsigned>(b)
+                          ? Bit(std::get<unsigned>(b))
+                          : std::get<Bit>(b);
+            return add_gate_method_noparams_any(
+                circ, OpType::Measure,
+                py::tket_custom::SequenceVec<UnitID>{qubit, bit}, kwargs);
           },
           "Appends a single-qubit measurement in the computational "
           "(Z) basis."
           "\n\n:return: the new :py:class:`Circuit`",
-          py::arg("qubit"), py::arg("bit_index"))
+          py::arg("qubit"), py::arg("bit"))
       .def(
-          "Reset",
-          [](Circuit *circ, unsigned qb, const py::kwargs &kwargs) {
-            return add_gate_method_noparams<unsigned>(
-                circ, OpType::Reset, {qb}, kwargs);
-          },
+          "Reset", add_gate_method_q(OpType::Reset),
           "Appends a Reset operation. Sets a qubit to the Z-basis 0 state. "
           "Non-unitary operation."
           "\n\n:return: the new :py:class:`Circuit`",
           py::arg("qubit"))
       .def(
-          "Rz",
-          [](Circuit *circ, const Expr &angle, unsigned qb,
-             const py::kwargs &kwargs) {
-            return add_gate_method_oneparam<unsigned>(
-                circ, OpType::Rz, angle, {qb}, kwargs);
-          },
+          "Rz", add_gate_method_a_q(OpType::Rz),
           "Appends an Rz gate with a possibly symbolic angle "
           "(specified in half-turns)."
           "\n\n:return: the new :py:class:`Circuit`",
           py::arg("angle"), py::arg("qubit"))
       .def(
-          "Rx",
-          [](Circuit *circ, const Expr &angle, unsigned qb,
-             const py::kwargs &kwargs) {
-            return add_gate_method_oneparam<unsigned>(
-                circ, OpType::Rx, angle, {qb}, kwargs);
-          },
+          "Rx", add_gate_method_a_q(OpType::Rx),
           "Appends an Rx gate with a possibly symbolic angle "
           "(specified in half-turns)."
           "\n\n:return: the new :py:class:`Circuit`",
           py::arg("angle"), py::arg("qubit"))
       .def(
-          "Ry",
-          [](Circuit *circ, const Expr &angle, unsigned qb,
-             const py::kwargs &kwargs) {
-            return add_gate_method_oneparam<unsigned>(
-                circ, OpType::Ry, angle, {qb}, kwargs);
-          },
+          "Ry", add_gate_method_a_q(OpType::Ry),
           "Appends an Ry gate with a possibly symbolic angle "
           "(specified in half-turns)."
           "\n\n:return: the new :py:class:`Circuit`",
           py::arg("angle"), py::arg("qubit"))
       .def(
-          "U1",
-          [](Circuit *circ, const Expr &angle, unsigned qb,
-             const py::kwargs &kwargs) {
-            return add_gate_method_oneparam<unsigned>(
-                circ, OpType::U1, angle, {qb}, kwargs);
-          },
+          "U1", add_gate_method_a_q(OpType::U1),
           "Appends a U1 gate with a possibly symbolic angle "
           "(specified in half-turns)."
           "\n\n:return: the new :py:class:`Circuit`",
           py::arg("angle"), py::arg("qubit"))
       .def(
-          "U2",
-          [](Circuit *circ, const Expr &angle0, const Expr &angle1,
-             const unsigned &qb, const py::kwargs &kwargs) {
-            return add_gate_method_manyparams<unsigned>(
-                circ, OpType::U2, {angle0, angle1}, {qb}, kwargs);
-          },
+          "U2", add_gate_method_aa_q(OpType::U2),
           "Appends a U2 gate with possibly symbolic angles "
           "(specified in half-turns)."
           "\n\n:return: the new :py:class:`Circuit`",
           py::arg("angle0"), py::arg("angle1"), py::arg("qubit"))
       .def(
-          "U3",
-          [](Circuit *circ, const Expr &angle0, const Expr &angle1,
-             const Expr &angle2, const unsigned &qb, const py::kwargs &kwargs) {
-            return add_gate_method_manyparams<unsigned>(
-                circ, OpType::U3, {angle0, angle1, angle2}, {qb}, kwargs);
-          },
+          "U3", add_gate_method_aaa_q(OpType::U3),
           "Appends a U3 gate with possibly symbolic angles "
           "(specified in half-turns)."
           "\n\n:return: the new :py:class:`Circuit`",
           py::arg("angle0"), py::arg("angle1"), py::arg("angle2"),
           py::arg("qubit"))
       .def(
-          "GPI",
-          [](Circuit *circ, const Expr &angle, unsigned qb,
-             const py::kwargs &kwargs) {
-            return add_gate_method_oneparam<unsigned>(
-                circ, OpType::GPI, angle, {qb}, kwargs);
-          },
+          "GPI", add_gate_method_a_q(OpType::GPI),
           "Appends a GPI gate with a possibly symbolic angle "
           "(specified in half-turns)."
           "\n\n:return: the new :py:class:`Circuit`",
           py::arg("angle"), py::arg("qubit"))
       .def(
-          "GPI2",
-          [](Circuit *circ, const Expr &angle, unsigned qb,
-             const py::kwargs &kwargs) {
-            return add_gate_method_oneparam<unsigned>(
-                circ, OpType::GPI2, angle, {qb}, kwargs);
-          },
+          "GPI2", add_gate_method_a_q(OpType::GPI2),
           "Appends a GPI2 gate with a possibly symbolic angle "
           "(specified in half-turns)."
           "\n\n:return: the new :py:class:`Circuit`",
           py::arg("angle"), py::arg("qubit"))
       .def(
-          "AAMS",
-          [](Circuit *circ, const Expr &angle0, const Expr &angle1,
-             const Expr &angle2, const unsigned &qb0, const unsigned &qb1,
-             const py::kwargs &kwargs) {
-            return add_gate_method_manyparams<unsigned>(
-                circ, OpType::AAMS, {angle0, angle1, angle2}, {qb0, qb1},
-                kwargs);
-          },
+          "AAMS", add_gate_method_aaa_qq(OpType::AAMS, "AAMS"),
           "Appends an AAMS gate with possibly symbolic angles "
           "(specified in half-turns)."
           "\n\n:return: the new :py:class:`Circuit`",
           py::arg("angle0"), py::arg("angle1"), py::arg("angle2"),
           py::arg("qubit0"), py::arg("qubit1"))
       .def(
-          "TK1",
-          [](Circuit *circ, const Expr &angle0, const Expr &angle1,
-             const Expr &angle2, const unsigned &qb, const py::kwargs &kwargs) {
-            return add_gate_method_manyparams<unsigned>(
-                circ, OpType::TK1, {angle0, angle1, angle2}, {qb}, kwargs);
-          },
+          "TK1", add_gate_method_aaa_q(OpType::TK1),
           "Appends a TK1 gate with possibly symbolic angles "
           "(specified in half-turns)."
           "\n\n:return: the new :py:class:`Circuit`",
           py::arg("angle0"), py::arg("angle1"), py::arg("angle2"),
           py::arg("qubit"))
       .def(
-          "TK2",
-          [](Circuit *circ, const Expr &angle0, const Expr &angle1,
-             const Expr &angle2, const unsigned &qb0, const unsigned &qb1,
-             const py::kwargs &kwargs) {
-            return add_gate_method_manyparams<unsigned>(
-                circ, OpType::TK2, {angle0, angle1, angle2}, {qb0, qb1},
-                kwargs);
-          },
+          "TK2", add_gate_method_aaa_qq(OpType::TK2, "TK2"),
           "Appends a TK2 gate with possibly symbolic angles "
           "(specified in half-turns)."
           "\n\n:return: the new :py:class:`Circuit`",
           py::arg("angle0"), py::arg("angle1"), py::arg("angle2"),
           py::arg("qubit0"), py::arg("qubit1"))
       .def(
-          "CX",
-          [](Circuit *circ, unsigned ctrl, unsigned trgt,
-             const py::kwargs &kwargs) {
-            return add_gate_method_noparams<unsigned>(
-                circ, OpType::CX, {ctrl, trgt}, kwargs);
-          },
+          "CX", add_gate_method_qq(OpType::CX, "CX"),
           "Appends a CX gate on the wires for the specified control "
           "and target qubits."
           "\n\n:return: the new :py:class:`Circuit`",
           py::arg("control_qubit"), py::arg("target_qubit"))
       .def(
-          "CY",
-          [](Circuit *circ, unsigned ctrl, unsigned trgt,
-             const py::kwargs &kwargs) {
-            return add_gate_method_noparams<unsigned>(
-                circ, OpType::CY, {ctrl, trgt}, kwargs);
-          },
+          "CY", add_gate_method_qq(OpType::CY, "CY"),
           "Appends a CY gate on the wires for the specified control "
           "and target qubits."
           "\n\n:return: the new :py:class:`Circuit`",
           py::arg("control_qubit"), py::arg("target_qubit"))
       .def(
-          "CZ",
-          [](Circuit *circ, unsigned ctrl, unsigned trgt,
-             const py::kwargs &kwargs) {
-            return add_gate_method_noparams<unsigned>(
-                circ, OpType::CZ, {ctrl, trgt}, kwargs);
-          },
+          "CZ", add_gate_method_qq(OpType::CZ, "CZ"),
           "Appends a CZ gate on the wires for the specified control "
           "and target qubits."
           "\n\n:return: the new :py:class:`Circuit`",
           py::arg("control_qubit"), py::arg("target_qubit"))
       .def(
-          "CH",
-          [](Circuit *circ, unsigned ctrl, unsigned trgt,
-             const py::kwargs &kwargs) {
-            return add_gate_method_noparams<unsigned>(
-                circ, OpType::CH, {ctrl, trgt}, kwargs);
-          },
+          "CH", add_gate_method_qq(OpType::CH, "CH"),
           "Appends a CH gate on the wires for the specified control "
           "and target qubits."
           "\n\n:return: the new :py:class:`Circuit`",
           py::arg("control_qubit"), py::arg("target_qubit"))
       .def(
-          "CV",
-          [](Circuit *circ, unsigned ctrl, unsigned trgt,
-             const py::kwargs &kwargs) {
-            return add_gate_method_noparams<unsigned>(
-                circ, OpType::CV, {ctrl, trgt}, kwargs);
-          },
+          "CV", add_gate_method_qq(OpType::CV, "CV"),
           "Appends a CV gate on the wires for the specified control "
           "and target qubits."
           "\n\n:return: the new :py:class:`Circuit`",
           py::arg("control_qubit"), py::arg("target_qubit"))
       .def(
-          "CVdg",
-          [](Circuit *circ, unsigned ctrl, unsigned trgt,
-             const py::kwargs &kwargs) {
-            return add_gate_method_noparams<unsigned>(
-                circ, OpType::CVdg, {ctrl, trgt}, kwargs);
-          },
+          "CVdg", add_gate_method_qq(OpType::CVdg, "CVdg"),
           "Appends a CVdg gate on the wires for the specified control "
           "and target qubits."
           "\n\n:return: the new :py:class:`Circuit`",
           py::arg("control_qubit"), py::arg("target_qubit"))
       .def(
-          "CSX",
-          [](Circuit *circ, unsigned ctrl, unsigned trgt,
-             const py::kwargs &kwargs) {
-            return add_gate_method_noparams<unsigned>(
-                circ, OpType::CSX, {ctrl, trgt}, kwargs);
-          },
+          "CSX", add_gate_method_qq(OpType::CSX, "CSX"),
           "Appends a CSX gate on the wires for the specified control "
           "and target qubits."
           "\n\n:return: the new :py:class:`Circuit`",
           py::arg("control_qubit"), py::arg("target_qubit"))
       .def(
-          "CSXdg",
-          [](Circuit *circ, unsigned ctrl, unsigned trgt,
-             const py::kwargs &kwargs) {
-            return add_gate_method_noparams<unsigned>(
-                circ, OpType::CSXdg, {ctrl, trgt}, kwargs);
-          },
+          "CSXdg", add_gate_method_qq(OpType::CSXdg, "CSXdg"),
           "Appends a CSXdg gate on the wires for the specified control "
           "and target qubits."
           "\n\n:return: the new :py:class:`Circuit`",
           py::arg("control_qubit"), py::arg("target_qubit"))
       .def(
-          "CS",
-          [](Circuit *circ, unsigned ctrl, unsigned trgt,
-             const py::kwargs &kwargs) {
-            return add_gate_method_noparams<unsigned>(
-                circ, OpType::CS, {ctrl, trgt}, kwargs);
-          },
+          "CS", add_gate_method_qq(OpType::CS, "CS"),
           "Appends a CS gate on the wires for the specified control "
           "and target qubits."
           "\n\n:return: the new :py:class:`Circuit`",
           py::arg("control_qubit"), py::arg("target_qubit"))
       .def(
-          "CSdg",
-          [](Circuit *circ, unsigned ctrl, unsigned trgt,
-             const py::kwargs &kwargs) {
-            return add_gate_method_noparams<unsigned>(
-                circ, OpType::CSdg, {ctrl, trgt}, kwargs);
-          },
+          "CSdg", add_gate_method_qq(OpType::CSdg, "CSdg"),
           "Appends a CSdg gate on the wires for the specified control "
           "and target qubits."
           "\n\n:return: the new :py:class:`Circuit`",
           py::arg("control_qubit"), py::arg("target_qubit"))
       .def(
-          "CRz",
-          [](Circuit *circ, const Expr &angle, unsigned ctrl, unsigned trgt,
-             const py::kwargs &kwargs) {
-            return add_gate_method_oneparam<unsigned>(
-                circ, OpType::CRz, angle, {ctrl, trgt}, kwargs);
-          },
+          "CRz", add_gate_method_a_qq(OpType::CRz, "CRz"),
           "Appends a CRz gate with a possibly symbolic angle (specified in "
           "half-turns) on the wires for the specified control and "
           "target qubits."
           "\n\n:return: the new :py:class:`Circuit`",
           py::arg("angle"), py::arg("control_qubit"), py::arg("target_qubit"))
       .def(
-          "CRx",
-          [](Circuit *circ, const Expr &angle, unsigned ctrl, unsigned trgt,
-             const py::kwargs &kwargs) {
-            return add_gate_method_oneparam<unsigned>(
-                circ, OpType::CRx, angle, {ctrl, trgt}, kwargs);
-          },
+          "CRx", add_gate_method_a_qq(OpType::CRx, "CRx"),
           "Appends a CRx gate with a possibly symbolic angle (specified in "
           "half-turns) on the wires for the specified control and "
           "target qubits."
           "\n\n:return: the new :py:class:`Circuit`",
           py::arg("angle"), py::arg("control_qubit"), py::arg("target_qubit"))
       .def(
-          "CRy",
-          [](Circuit *circ, const Expr &angle, unsigned ctrl, unsigned trgt,
-             const py::kwargs &kwargs) {
-            return add_gate_method_oneparam<unsigned>(
-                circ, OpType::CRy, angle, {ctrl, trgt}, kwargs);
-          },
+          "CRy", add_gate_method_a_qq(OpType::CRy, "CRy"),
           "Appends a CRy gate with a possibly symbolic angle (specified in "
           "half-turns) on the wires for the specified control and "
           "target qubits."
           "\n\n:return: the new :py:class:`Circuit`",
           py::arg("angle"), py::arg("control_qubit"), py::arg("target_qubit"))
       .def(
-          "CU1",
-          [](Circuit *circ, const Expr &angle, unsigned ctrl, unsigned trgt,
-             const py::kwargs &kwargs) {
-            return add_gate_method_oneparam<unsigned>(
-                circ, OpType::CU1, angle, {ctrl, trgt}, kwargs);
-          },
+          "CU1", add_gate_method_a_qq(OpType::CU1, "CU1"),
           "Appends a CU1 gate with a possibly symbolic angle (specified in "
           "half-turns) on the wires for the specified control and "
           "target qubits."
           "\n\n:return: the new :py:class:`Circuit`",
           py::arg("angle"), py::arg("control_qubit"), py::arg("target_qubit"))
       .def(
-          "CU3",
-          [](Circuit *circ, const Expr &angle0, const Expr &angle1,
-             const Expr &angle2, unsigned ctrl, unsigned trgt,
-             const py::kwargs &kwargs) {
-            return add_gate_method_manyparams<unsigned>(
-                circ, OpType::CU3, {angle0, angle1, angle2}, {ctrl, trgt},
-                kwargs);
-          },
+          "CU3", add_gate_method_aaa_qq(OpType::CU3, "CU3"),
           "Appends a CU3 gate with possibly symbolic angles (specified in "
           "half-turns) on the wires for the specified control and "
           "target qubits."
@@ -1519,88 +1404,48 @@ void init_circuit_add_op(py::class_<Circuit, std::shared_ptr<Circuit>> &c) {
           py::arg("angle0"), py::arg("angle1"), py::arg("angle2"),
           py::arg("control_qubit"), py::arg("target_qubit"))
       .def(
-          "ZZPhase",
-          [](Circuit *circ, const Expr &angle, unsigned qb0, unsigned qb1,
-             const py::kwargs &kwargs) {
-            return add_gate_method_oneparam<unsigned>(
-                circ, OpType::ZZPhase, angle, {qb0, qb1}, kwargs);
-          },
+          "ZZPhase", add_gate_method_a_qq(OpType::ZZPhase, "ZZPhase"),
           "Appends a ZZ gate with a possibly symbolic angle (specified in "
           "half-turns) on the wires for the specified two qubits."
           "\n\n:return: the new :py:class:`Circuit`",
           py::arg("angle"), py::arg("qubit0"), py::arg("qubit1"))
       .def(
-          "ZZMax",
-          [](Circuit *circ, unsigned qb0, unsigned qb1,
-             const py::kwargs &kwargs) {
-            return add_gate_method_noparams<unsigned>(
-                circ, OpType::ZZMax, {qb0, qb1}, kwargs);
-          },
+          "ZZMax", add_gate_method_qq(OpType::ZZMax, "ZZMax"),
           "Appends a ZZMax gate on the wires for the specified two qubits."
           "\n\n:return: the new :py:class:`Circuit`",
           py::arg("qubit0"), py::arg("qubit1"))
       .def(
-          "ESWAP",
-          [](Circuit *circ, const Expr &angle, unsigned qb0, unsigned qb1,
-             const py::kwargs &kwargs) {
-            return add_gate_method_oneparam<unsigned>(
-                circ, OpType::ESWAP, angle, {qb0, qb1}, kwargs);
-          },
+          "ESWAP", add_gate_method_a_qq(OpType::ESWAP, "ESWAP"),
           "Appends an ESWAP gate with a possibly symbolic angle (specified in "
           "half-turns) on the wires for the specified two qubits."
           "\n\n:return: the new :py:class:`Circuit`",
           py::arg("angle"), py::arg("qubit0"), py::arg("qubit1"))
       .def(
-          "FSim",
-          [](Circuit *circ, const Expr &angle0, const Expr &angle1,
-             unsigned qb0, unsigned qb1, const py::kwargs &kwargs) {
-            return add_gate_method_manyparams<unsigned>(
-                circ, OpType::FSim, {angle0, angle1}, {qb0, qb1}, kwargs);
-          },
+          "FSim", add_gate_method_aa_qq(OpType::FSim, "FSim"),
           "Appends an FSim gate with possibly symbolic angles (specified in "
           "half-turns) on the wires for the specified qubits."
           "\n\n:return: the new :py:class:`Circuit`",
           py::arg("angle0"), py::arg("angle1"), py::arg("qubit0"),
           py::arg("qubit1"))
       .def(
-          "Sycamore",
-          [](Circuit *circ, unsigned qubit0, unsigned qubit1,
-             const py::kwargs &kwargs) {
-            return add_gate_method_noparams<unsigned>(
-                circ, OpType::Sycamore, {qubit0, qubit1}, kwargs);
-          },
+          "Sycamore", add_gate_method_qq(OpType::Sycamore, "Sycamore"),
           "Appends a Sycamore gate on the wires for the specified qubits."
           "\n\n:return: the new :py:class:`Circuit`",
           py::arg("qubit0"), py::arg("qubit1"))
       .def(
-          "XXPhase",
-          [](Circuit *circ, const Expr &angle, unsigned qb0, unsigned qb1,
-             const py::kwargs &kwargs) {
-            return add_gate_method_oneparam<unsigned>(
-                circ, OpType::XXPhase, angle, {qb0, qb1}, kwargs);
-          },
+          "XXPhase", add_gate_method_a_qq(OpType::XXPhase, "XXPhase"),
           "Appends a XX gate with a possibly symbolic angle (specified in "
           "half-turns) on the wires for the specified two qubits."
           "\n\n:return: the new :py:class:`Circuit`",
           py::arg("angle"), py::arg("qubit0"), py::arg("qubit1"))
       .def(
-          "YYPhase",
-          [](Circuit *circ, const Expr &angle, unsigned qb0, unsigned qb1,
-             const py::kwargs &kwargs) {
-            return add_gate_method_oneparam<unsigned>(
-                circ, OpType::YYPhase, angle, {qb0, qb1}, kwargs);
-          },
+          "YYPhase", add_gate_method_a_qq(OpType::YYPhase, "YYPhase"),
           "Appends a YY gate with a possibly symbolic angle (specified in "
           "half-turns) on the wires for the specified two qubits."
           "\n\n:return: the new :py:class:`Circuit`",
           py::arg("angle"), py::arg("qubit0"), py::arg("qubit1"))
       .def(
-          "XXPhase3",
-          [](Circuit *circ, const Expr &angle, unsigned qb0, unsigned qb1,
-             unsigned qb2, const py::kwargs &kwargs) {
-            return add_gate_method_oneparam<unsigned>(
-                circ, OpType::XXPhase3, angle, {qb0, qb1, qb2}, kwargs);
-          },
+          "XXPhase3", add_gate_method_a_qqq(OpType::XXPhase3, "XXPhase3"),
           "Appends a 3-qubit XX gate with a possibly symbolic angle (specified "
           "in "
           "half-turns) on the wires for the specified three qubits."
@@ -1608,87 +1453,47 @@ void init_circuit_add_op(py::class_<Circuit, std::shared_ptr<Circuit>> &c) {
           py::arg("angle"), py::arg("qubit0"), py::arg("qubit1"),
           py::arg("qubit2"))
       .def(
-          "PhasedX",
-          [](Circuit *circ, const Expr &angle0, const Expr &angle1, unsigned qb,
-             const py::kwargs &kwargs) {
-            return add_gate_method_manyparams<unsigned>(
-                circ, OpType::PhasedX, {angle0, angle1}, {qb}, kwargs);
-          },
+          "PhasedX", add_gate_method_aa_q(OpType::PhasedX),
           "Appends a PhasedX gate with possibly symbolic angles (specified in "
           "half-turns) on the wires for the specified qubits."
           "\n\n:return: the new :py:class:`Circuit`",
           py::arg("angle0"), py::arg("angle1"), py::arg("qubit"))
       .def(
-          "CCX",
-          [](Circuit *circ, unsigned ctrl1, unsigned ctrl2, unsigned trgt,
-             const py::kwargs &kwargs) {
-            return add_gate_method_noparams<unsigned>(
-                circ, OpType::CCX, {ctrl1, ctrl2, trgt}, kwargs);
-          },
+          "CCX", add_gate_method_qqq(OpType::CCX, "CCX"),
           "Appends a CCX gate on the wires for the specified control "
           "and target qubits."
           "\n\n:return: the new :py:class:`Circuit`",
           py::arg("control_0"), py::arg("control_1"), py::arg("target"))
       .def(
-          "ECR",
-          [](Circuit *circ, unsigned qb0, unsigned qb1,
-             const py::kwargs &kwargs) {
-            return add_gate_method_noparams<unsigned>(
-                circ, OpType::ECR, {qb0, qb1}, kwargs);
-          },
+          "ECR", add_gate_method_qq(OpType::ECR, "ECR"),
           "Appends an ECR gate on the wires for the specified qubits."
           "\n\n:return: the new :py:class:`Circuit`",
           py::arg("qubit_0"), py::arg("qubit_1"))
       .def(
-          "SWAP",
-          [](Circuit *circ, unsigned qb0, unsigned qb1,
-             const py::kwargs &kwargs) {
-            return add_gate_method_noparams<unsigned>(
-                circ, OpType::SWAP, {qb0, qb1}, kwargs);
-          },
+          "SWAP", add_gate_method_qq(OpType::SWAP, "SWAP"),
           "Appends a SWAP gate on the wires for the specified qubits."
           "\n\n:return: the new :py:class:`Circuit`",
           py::arg("qubit_0"), py::arg("qubit_1"))
       .def(
-          "CSWAP",
-          [](Circuit *circ, unsigned ctrl, unsigned trgt0, unsigned trgt1,
-             const py::kwargs &kwargs) {
-            return add_gate_method_noparams<unsigned>(
-                circ, OpType::CSWAP, {ctrl, trgt0, trgt1}, kwargs);
-          },
+          "CSWAP", add_gate_method_qqq(OpType::CSWAP, "CSWAP"),
           "Appends a CSWAP gate on the wires for the specified "
           "control and target qubits."
           "\n\n:return: the new :py:class:`Circuit`",
           py::arg("control"), py::arg("target_0"), py::arg("target_1"))
       .def(
-          "ISWAP",
-          [](Circuit *circ, const Expr &angle, unsigned qb0, unsigned qb1,
-             const py::kwargs &kwargs) {
-            return add_gate_method_oneparam<unsigned>(
-                circ, OpType::ISWAP, angle, {qb0, qb1}, kwargs);
-          },
+          "ISWAP", add_gate_method_a_qq(OpType::ISWAP, "ISWAP"),
           "Appends an ISWAP gate with a possibly symbolic angle (specified in "
           "half-turns) on the wires for the specified qubits."
           "\n\n:return: the new :py:class:`Circuit`",
           py::arg("angle"), py::arg("qubit0"), py::arg("qubit1"))
       .def(
-          "ISWAPMax",
-          [](Circuit *circ, unsigned qb0, unsigned qb1,
-             const py::kwargs &kwargs) {
-            return add_gate_method_noparams<unsigned>(
-                circ, OpType::ISWAPMax, {qb0, qb1}, kwargs);
-          },
+          "ISWAPMax", add_gate_method_qq(OpType::ISWAPMax, "ISWAPMax"),
           "Appends an ISWAPMax gate on the wires for the specified qubits."
           "\n\n:return: the new :py:class:`Circuit`",
           py::arg("qubit0"), py::arg("qubit1"))
       .def(
           "PhasedISWAP",
-          [](Circuit *circ, const Expr &angle0, const Expr &angle1,
-             unsigned qb0, unsigned qb1, const py::kwargs &kwargs) {
-            return add_gate_method_manyparams<unsigned>(
-                circ, OpType::PhasedISWAP, {angle0, angle1}, {qb0, qb1},
-                kwargs);
-          },
+          add_gate_method_aa_qq(OpType::PhasedISWAP, "PhasedISWAP"),
           "Appends a PhasedISWAP gate with possibly symbolic angles (specified "
           "in "
           "half-turns) on the wires for the specified qubits."
@@ -1745,620 +1550,11 @@ void init_circuit_add_op(py::class_<Circuit, std::shared_ptr<Circuit>> &c) {
           "\n:param creg_name: the name of the BitRegister to store the results"
           "\n:return: the new :py:class:`Circuit`")
       .def(
-          "H",
-          [](Circuit *circ, const Qubit &qb, const py::kwargs &kwargs) {
-            return add_gate_method_noparams<UnitID>(
-                circ, OpType::H, {qb}, kwargs);
-          },
-          "Appends a Hadamard gate."
-          "\n\n:return: the new :py:class:`Circuit`",
-          py::arg("qubit"))
-      .def(
-          "X",
-          [](Circuit *circ, const Qubit &qb, const py::kwargs &kwargs) {
-            return add_gate_method_noparams<UnitID>(
-                circ, OpType::X, {qb}, kwargs);
-          },
-          "Appends an X gate."
-          "\n\n:return: the new :py:class:`Circuit`",
-          py::arg("qubit"))
-      .def(
-          "Y",
-          [](Circuit *circ, const Qubit &qb, const py::kwargs &kwargs) {
-            return add_gate_method_noparams<UnitID>(
-                circ, OpType::Y, {qb}, kwargs);
-          },
-          "Appends a Y gate."
-          "\n\n:return: the new :py:class:`Circuit`",
-          py::arg("qubit"))
-      .def(
-          "Z",
-          [](Circuit *circ, const Qubit &qb, const py::kwargs &kwargs) {
-            return add_gate_method_noparams<UnitID>(
-                circ, OpType::Z, {qb}, kwargs);
-          },
-          "Appends a Z gate."
-          "\n\n:return: the new :py:class:`Circuit`",
-          py::arg("qubit"))
-      .def(
-          "T",
-          [](Circuit *circ, const Qubit &qb, const py::kwargs &kwargs) {
-            return add_gate_method_noparams<UnitID>(
-                circ, OpType::T, {qb}, kwargs);
-          },
-          "Appends a T gate (equivalent to Rz(0.25,-))."
-          "\n\n:return: the new :py:class:`Circuit`",
-          py::arg("qubit"))
-      .def(
-          "Tdg",
-          [](Circuit *circ, const Qubit &qb, const py::kwargs &kwargs) {
-            return add_gate_method_noparams<UnitID>(
-                circ, OpType::Tdg, {qb}, kwargs);
-          },
-          "Appends a T-dagger gate (equivalent to Rz(-0.25,-))."
-          "\n\n:return: the new :py:class:`Circuit`",
-          py::arg("qubit"))
-      .def(
-          "S",
-          [](Circuit *circ, const Qubit &qb, const py::kwargs &kwargs) {
-            return add_gate_method_noparams<UnitID>(
-                circ, OpType::S, {qb}, kwargs);
-          },
-          "Appends an S gate (equivalent to Rz(0.5,-))."
-          "\n\n:return: the new :py:class:`Circuit`",
-          py::arg("qubit"))
-      .def(
-          "Sdg",
-          [](Circuit *circ, const Qubit &qb, const py::kwargs &kwargs) {
-            return add_gate_method_noparams<UnitID>(
-                circ, OpType::Sdg, {qb}, kwargs);
-          },
-          "Appends an S-dagger gate (equivalent to Rz(-0.5,-))."
-          "\n\n:return: the new :py:class:`Circuit`",
-          py::arg("qubit"))
-      .def(
-          "V",
-          [](Circuit *circ, const Qubit &qb, const py::kwargs &kwargs) {
-            return add_gate_method_noparams<UnitID>(
-                circ, OpType::V, {qb}, kwargs);
-          },
-          "Appends a V gate (equivalent to Rx(0.5,-))."
-          "\n\n:return: the new :py:class:`Circuit`",
-          py::arg("qubit"))
-      .def(
-          "Vdg",
-          [](Circuit *circ, const Qubit &qb, const py::kwargs &kwargs) {
-            return add_gate_method_noparams<UnitID>(
-                circ, OpType::Vdg, {qb}, kwargs);
-          },
-          "Appends a V-dagger gate (equivalent to Rx(-0.5,-))."
-          "\n\n:return: the new :py:class:`Circuit`",
-          py::arg("qubit"))
-      .def(
-          "SX",
-          [](Circuit *circ, const Qubit &qb, const py::kwargs &kwargs) {
-            return add_gate_method_noparams<UnitID>(
-                circ, OpType::SX, {qb}, kwargs);
-          },
-          "Appends a SX gate (equivalent to Rx(0.5,-)"
-          " up to a 0.25 global phase)."
-          "\n\n:return: the new :py:class:`Circuit`",
-          py::arg("qubit"))
-      .def(
-          "SXdg",
-          [](Circuit *circ, const Qubit &qb, const py::kwargs &kwargs) {
-            return add_gate_method_noparams<UnitID>(
-                circ, OpType::SXdg, {qb}, kwargs);
-          },
-          "Appends a SXdg gate (equivalent to Rx(-0.5,-)"
-          " up to a -0.25 global phase)."
-          "\n\n:return: the new :py:class:`Circuit`",
-          py::arg("qubit"))
-      .def(
-          "Measure",
-          [](Circuit *circ, const Qubit &qb, const Bit &b,
-             const py::kwargs &kwargs) {
-            return add_gate_method_noparams<UnitID>(
-                circ, OpType::Measure, {qb, b}, kwargs);
-          },
-          "Appends a single-qubit measurement in the computational "
-          "(Z) basis."
-          "\n\n:return: the new :py:class:`Circuit`",
-          py::arg("qubit"), py::arg("bit"))
-      .def(
-          "Reset",
-          [](Circuit *circ, const Qubit &qb, const py::kwargs &kwargs) {
-            return add_gate_method_noparams<UnitID>(
-                circ, OpType::Reset, {qb}, kwargs);
-          },
-          "Appends a Reset operation. Sets a qubit to the Z-basis 0 state. "
-          "Non-unitary operation."
-          "\n\n:return: the new :py:class:`Circuit`",
-          py::arg("qubit"))
-      .def(
-          "Rz",
-          [](Circuit *circ, const Expr &angle, const Qubit &qb,
-             const py::kwargs &kwargs) {
-            return add_gate_method_oneparam<UnitID>(
-                circ, OpType::Rz, angle, {qb}, kwargs);
-          },
-          "Appends an Rz gate with a possibly symbolic angle "
-          "(specified in half-turns)."
-          "\n\n:return: the new :py:class:`Circuit`",
-          py::arg("angle"), py::arg("qubit"))
-      .def(
-          "Rx",
-          [](Circuit *circ, const Expr &angle, const Qubit &qb,
-             const py::kwargs &kwargs) {
-            return add_gate_method_oneparam<UnitID>(
-                circ, OpType::Rx, angle, {qb}, kwargs);
-          },
-          "Appends an Rx gate with a possibly symbolic angle "
-          "(specified in half-turns)."
-          "\n\n:return: the new :py:class:`Circuit`",
-          py::arg("angle"), py::arg("qubit"))
-      .def(
-          "Ry",
-          [](Circuit *circ, const Expr &angle, const Qubit &qb,
-             const py::kwargs &kwargs) {
-            return add_gate_method_oneparam<UnitID>(
-                circ, OpType::Ry, angle, {qb}, kwargs);
-          },
-          "Appends an Ry gate with a possibly symbolic angle "
-          "(specified in half-turns)."
-          "\n\n:return: the new :py:class:`Circuit`",
-          py::arg("angle"), py::arg("qubit"))
-      .def(
-          "U1",
-          [](Circuit *circ, const Expr &angle, const Qubit &qb,
-             const py::kwargs &kwargs) {
-            return add_gate_method_oneparam<UnitID>(
-                circ, OpType::U1, angle, {qb}, kwargs);
-          },
-          "Appends a U1 gate with a possibly symbolic angle "
-          "(specified in half-turns)."
-          "\n\n:return: the new :py:class:`Circuit`",
-          py::arg("angle"), py::arg("qubit"))
-      .def(
-          "U2",
-          [](Circuit *circ, const Expr &angle0, const Expr &angle1,
-             const Qubit &qb, const py::kwargs &kwargs) {
-            return add_gate_method_manyparams<UnitID>(
-                circ, OpType::U2, {angle0, angle1}, {qb}, kwargs);
-          },
-          "Appends a U2 gate with possibly symbolic angles "
-          "(specified in half-turns)."
-          "\n\n:return: the new :py:class:`Circuit`",
-          py::arg("angle0"), py::arg("angle1"), py::arg("qubit"))
-      .def(
-          "U3",
-          [](Circuit *circ, const Expr &angle0, const Expr &angle1,
-             const Expr &angle2, const Qubit &qb, const py::kwargs &kwargs) {
-            return add_gate_method_manyparams<UnitID>(
-                circ, OpType::U3, {angle0, angle1, angle2}, {qb}, kwargs);
-          },
-          "Appends a U3 gate with possibly symbolic angles "
-          "(specified in half-turns)."
-          "\n\n:return: the new :py:class:`Circuit`",
-          py::arg("angle0"), py::arg("angle1"), py::arg("angle2"),
-          py::arg("qubit"))
-      .def(
-          "GPI",
-          [](Circuit *circ, const Expr &angle, const Qubit &qb,
-             const py::kwargs &kwargs) {
-            return add_gate_method_oneparam<UnitID>(
-                circ, OpType::GPI, angle, {qb}, kwargs);
-          },
-          "Appends a GPI gate with a possibly symbolic angle "
-          "(specified in half-turns)."
-          "\n\n:return: the new :py:class:`Circuit`",
-          py::arg("angle"), py::arg("qubit"))
-      .def(
-          "GPI2",
-          [](Circuit *circ, const Expr &angle, const Qubit &qb,
-             const py::kwargs &kwargs) {
-            return add_gate_method_oneparam<UnitID>(
-                circ, OpType::GPI2, angle, {qb}, kwargs);
-          },
-          "Appends a GPI2 gate with a possibly symbolic angle "
-          "(specified in half-turns)."
-          "\n\n:return: the new :py:class:`Circuit`",
-          py::arg("angle"), py::arg("qubit"))
-      .def(
-          "AAMS",
-          [](Circuit *circ, const Expr &angle0, const Expr &angle1,
-             const Expr &angle2, const Qubit &qb0, const Qubit &qb1,
-             const py::kwargs &kwargs) {
-            return add_gate_method_manyparams<UnitID>(
-                circ, OpType::AAMS, {angle0, angle1, angle2}, {qb0, qb1},
-                kwargs);
-          },
-          "Appends an AAMS gate with possibly symbolic angles "
-          "(specified in half-turns)."
-          "\n\n:return: the new :py:class:`Circuit`",
-          py::arg("angle0"), py::arg("angle1"), py::arg("angle2"),
-          py::arg("qubit0"), py::arg("qubit1"))
-      .def(
-          "TK1",
-          [](Circuit *circ, const Expr &angle0, const Expr &angle1,
-             const Expr &angle2, const Qubit &qb, const py::kwargs &kwargs) {
-            return add_gate_method_manyparams<UnitID>(
-                circ, OpType::TK1, {angle0, angle1, angle2}, {qb}, kwargs);
-          },
-          "Appends a TK1 gate with possibly symbolic angles "
-          "(specified in half-turns)."
-          "\n\n:return: the new :py:class:`Circuit`",
-          py::arg("angle0"), py::arg("angle1"), py::arg("angle2"),
-          py::arg("qubit"))
-      .def(
-          "TK2",
-          [](Circuit *circ, const Expr &angle0, const Expr &angle1,
-             const Expr &angle2, const Qubit &qb0, const Qubit &qb1,
-             const py::kwargs &kwargs) {
-            return add_gate_method_manyparams<UnitID>(
-                circ, OpType::TK2, {angle0, angle1, angle2}, {qb0, qb1},
-                kwargs);
-          },
-          "Appends a TK2 gate with possibly symbolic angles "
-          "(specified in half-turns)."
-          "\n\n:return: the new :py:class:`Circuit`",
-          py::arg("angle0"), py::arg("angle1"), py::arg("angle2"),
-          py::arg("qubit0"), py::arg("qubit1"))
-      .def(
-          "CX",
-          [](Circuit *circ, const Qubit &ctrl, const Qubit &trgt,
-             const py::kwargs &kwargs) {
-            return add_gate_method_noparams<UnitID>(
-                circ, OpType::CX, {ctrl, trgt}, kwargs);
-          },
-          "Appends a CX gate on the wires for the specified control "
-          "and target qubits."
-          "\n\n:return: the new :py:class:`Circuit`",
-          py::arg("control_qubit"), py::arg("target_qubit"))
-      .def(
-          "CY",
-          [](Circuit *circ, const Qubit &ctrl, const Qubit &trgt,
-             const py::kwargs &kwargs) {
-            return add_gate_method_noparams<UnitID>(
-                circ, OpType::CY, {ctrl, trgt}, kwargs);
-          },
-          "Appends a CY gate on the wires for the specified control "
-          "and target qubits."
-          "\n\n:return: the new :py:class:`Circuit`",
-          py::arg("control_qubit"), py::arg("target_qubit"))
-      .def(
-          "CZ",
-          [](Circuit *circ, const Qubit &ctrl, const Qubit &trgt,
-             const py::kwargs &kwargs) {
-            return add_gate_method_noparams<UnitID>(
-                circ, OpType::CZ, {ctrl, trgt}, kwargs);
-          },
-          "Appends a CZ gate on the wires for the specified control "
-          "and target qubits."
-          "\n\n:return: the new :py:class:`Circuit`",
-          py::arg("control_qubit"), py::arg("target_qubit"))
-      .def(
-          "CH",
-          [](Circuit *circ, const Qubit &ctrl, const Qubit &trgt,
-             const py::kwargs &kwargs) {
-            return add_gate_method_noparams<UnitID>(
-                circ, OpType::CH, {ctrl, trgt}, kwargs);
-          },
-          "Appends a CH gate on the wires for the specified control "
-          "and target qubits."
-          "\n\n:return: the new :py:class:`Circuit`",
-          py::arg("control_qubit"), py::arg("target_qubit"))
-      .def(
-          "CV",
-          [](Circuit *circ, const Qubit &ctrl, const Qubit &trgt,
-             const py::kwargs &kwargs) {
-            return add_gate_method_noparams<UnitID>(
-                circ, OpType::CV, {ctrl, trgt}, kwargs);
-          },
-          "Appends a CV gate on the wires for the specified control "
-          "and target qubits."
-          "\n\n:return: the new :py:class:`Circuit`",
-          py::arg("control_qubit"), py::arg("target_qubit"))
-      .def(
-          "CVdg",
-          [](Circuit *circ, const Qubit &ctrl, const Qubit &trgt,
-             const py::kwargs &kwargs) {
-            return add_gate_method_noparams<UnitID>(
-                circ, OpType::CVdg, {ctrl, trgt}, kwargs);
-          },
-          "Appends a CVdg gate on the wires for the specified control "
-          "and target qubits."
-          "\n\n:return: the new :py:class:`Circuit`",
-          py::arg("control_qubit"), py::arg("target_qubit"))
-      .def(
-          "CSX",
-          [](Circuit *circ, const Qubit &ctrl, const Qubit &trgt,
-             const py::kwargs &kwargs) {
-            return add_gate_method_noparams<UnitID>(
-                circ, OpType::CSX, {ctrl, trgt}, kwargs);
-          },
-          "Appends a CSX gate on the wires for the specified control "
-          "and target qubits."
-          "\n\n:return: the new :py:class:`Circuit`",
-          py::arg("control_qubit"), py::arg("target_qubit"))
-      .def(
-          "CSXdg",
-          [](Circuit *circ, const Qubit &ctrl, const Qubit &trgt,
-             const py::kwargs &kwargs) {
-            return add_gate_method_noparams<UnitID>(
-                circ, OpType::CSXdg, {ctrl, trgt}, kwargs);
-          },
-          "Appends a CSXdg gate on the wires for the specified control "
-          "and target qubits."
-          "\n\n:return: the new :py:class:`Circuit`",
-          py::arg("control_qubit"), py::arg("target_qubit"))
-      .def(
-          "CS",
-          [](Circuit *circ, const Qubit &ctrl, const Qubit &trgt,
-             const py::kwargs &kwargs) {
-            return add_gate_method_noparams<UnitID>(
-                circ, OpType::CS, {ctrl, trgt}, kwargs);
-          },
-          "Appends a CS gate on the wires for the specified control "
-          "and target qubits."
-          "\n\n:return: the new :py:class:`Circuit`",
-          py::arg("control_qubit"), py::arg("target_qubit"))
-      .def(
-          "CSdg",
-          [](Circuit *circ, const Qubit &ctrl, const Qubit &trgt,
-             const py::kwargs &kwargs) {
-            return add_gate_method_noparams<UnitID>(
-                circ, OpType::CSdg, {ctrl, trgt}, kwargs);
-          },
-          "Appends a CSdg gate on the wires for the specified control "
-          "and target qubits."
-          "\n\n:return: the new :py:class:`Circuit`",
-          py::arg("control_qubit"), py::arg("target_qubit"))
-      .def(
-          "CRz",
-          [](Circuit *circ, const Expr &angle, const Qubit &ctrl,
-             const Qubit &trgt, const py::kwargs &kwargs) {
-            return add_gate_method_oneparam<UnitID>(
-                circ, OpType::CRz, angle, {ctrl, trgt}, kwargs);
-          },
-          "Appends a CRz gate with a symbolic angle (specified in "
-          "half-turns) on the wires for the specified control and "
-          "target qubits."
-          "\n\n:return: the new :py:class:`Circuit`",
-          py::arg("angle"), py::arg("control_qubit"), py::arg("target_qubit"))
-      .def(
-          "CRx",
-          [](Circuit *circ, const Expr &angle, const Qubit &ctrl,
-             const Qubit &trgt, const py::kwargs &kwargs) {
-            return add_gate_method_oneparam<UnitID>(
-                circ, OpType::CRx, angle, {ctrl, trgt}, kwargs);
-          },
-          "Appends a CRx gate with a symbolic angle (specified in "
-          "half-turns) on the wires for the specified control and "
-          "target qubits."
-          "\n\n:return: the new :py:class:`Circuit`",
-          py::arg("angle"), py::arg("control_qubit"), py::arg("target_qubit"))
-      .def(
-          "CRy",
-          [](Circuit *circ, const Expr &angle, const Qubit &ctrl,
-             const Qubit &trgt, const py::kwargs &kwargs) {
-            return add_gate_method_oneparam<UnitID>(
-                circ, OpType::CRy, angle, {ctrl, trgt}, kwargs);
-          },
-          "Appends a CRy gate with a symbolic angle (specified in "
-          "half-turns) on the wires for the specified control and "
-          "target qubits."
-          "\n\n:return: the new :py:class:`Circuit`",
-          py::arg("angle"), py::arg("control_qubit"), py::arg("target_qubit"))
-      .def(
-          "CU1",
-          [](Circuit *circ, const Expr &angle, const Qubit &ctrl,
-             const Qubit &trgt, const py::kwargs &kwargs) {
-            return add_gate_method_oneparam<UnitID>(
-                circ, OpType::CU1, angle, {ctrl, trgt}, kwargs);
-          },
-          "Appends a CU1 gate with a possibly symbolic angle (specified in "
-          "half-turns) on the wires for the specified control and "
-          "target qubits."
-          "\n\n:return: the new :py:class:`Circuit`",
-          py::arg("angle"), py::arg("control_qubit"), py::arg("target_qubit"))
-      .def(
-          "CU3",
-          [](Circuit *circ, const Expr &angle0, const Expr &angle1,
-             const Expr &angle2, const Qubit &ctrl, const Qubit &trgt,
-             const py::kwargs &kwargs) {
-            return add_gate_method_manyparams<UnitID>(
-                circ, OpType::CU3, {angle0, angle1, angle2}, {ctrl, trgt},
-                kwargs);
-          },
-          "Appends a CU3 gate with possibly symbolic angles (specified in "
-          "half-turns) on the wires for the specified control and "
-          "target qubits."
-          "\n\n:return: the new :py:class:`Circuit`",
-          py::arg("angle0"), py::arg("angle1"), py::arg("angle2"),
-          py::arg("control_qubit"), py::arg("target_qubit"))
-
-      .def(
-          "ZZPhase",
-          [](Circuit *circ, const Expr &angle, const Qubit &qb0,
-             const Qubit &qb1, const py::kwargs &kwargs) {
-            return add_gate_method_oneparam<UnitID>(
-                circ, OpType::ZZPhase, angle, {qb0, qb1}, kwargs);
-          },
-          "Appends a ZZ gate with a symbolic angle (specified in "
-          "half-turns) on the wires for the specified two qubits."
-          "\n\n:return: the new :py:class:`Circuit`",
-          py::arg("angle"), py::arg("qubit0"), py::arg("qubit1"))
-      .def(
-          "ZZMax",
-          [](Circuit *circ, const Qubit &qb0, const Qubit &qb1,
-             const py::kwargs &kwargs) {
-            return add_gate_method_noparams<UnitID>(
-                circ, OpType::ZZMax, {qb0, qb1}, kwargs);
-          },
-          "Appends a ZZMax gate on the wires for the specified two qubits."
-          "\n\n:return: the new :py:class:`Circuit`",
-          py::arg("qubit0"), py::arg("qubit1"))
-      .def(
-          "ESWAP",
-          [](Circuit *circ, const Expr &angle, const Qubit &qb0,
-             const Qubit &qb1, const py::kwargs &kwargs) {
-            return add_gate_method_oneparam<UnitID>(
-                circ, OpType::ESWAP, angle, {qb0, qb1}, kwargs);
-          },
-          "Appends an ESWAP gate with a possibly symbolic angle (specified in "
-          "half-turns) on the wires for the specified two qubits."
-          "\n\n:return: the new :py:class:`Circuit`",
-          py::arg("angle"), py::arg("qubit0"), py::arg("qubit1"))
-      .def(
-          "FSim",
-          [](Circuit *circ, const Expr &angle0, const Expr &angle1,
-             const Qubit &qb0, const Qubit &qb1, const py::kwargs &kwargs) {
-            return add_gate_method_manyparams<UnitID>(
-                circ, OpType::FSim, {angle0, angle1}, {qb0, qb1}, kwargs);
-          },
-          "Appends an FSim gate with possibly symbolic angles (specified in "
-          "half-turns) on the wires for the specified qubits."
-          "\n\n:return: the new :py:class:`Circuit`",
-          py::arg("angle0"), py::arg("angle1"), py::arg("qubit0"),
-          py::arg("qubit1"))
-      .def(
-          "Sycamore",
-          [](Circuit *circ, const Qubit &qubit0, const Qubit &qubit1,
-             const py::kwargs &kwargs) {
-            return add_gate_method_noparams<UnitID>(
-                circ, OpType::Sycamore, {qubit0, qubit1}, kwargs);
-          },
-          "Appends a Sycamore gate on the wires for the specified qubits."
-          "\n\n:return: the new :py:class:`Circuit`",
-          py::arg("qubit0"), py::arg("qubit1"))
-      .def(
-          "XXPhase",
-          [](Circuit *circ, const Expr &angle, const Qubit &qb0,
-             const Qubit &qb1, const py::kwargs &kwargs) {
-            return add_gate_method_oneparam<UnitID>(
-                circ, OpType::XXPhase, angle, {qb0, qb1}, kwargs);
-          },
-          "Appends a XX gate with a symbolic angle (specified in "
-          "half-turns) on the wires for the specified two qubits."
-          "\n\n:return: the new :py:class:`Circuit`",
-          py::arg("qubit0"), py::arg("qubit1"), py::arg("angle"))
-      .def(
-          "YYPhase",
-          [](Circuit *circ, const Expr &angle, const Qubit &qb0,
-             const Qubit &qb1, const py::kwargs &kwargs) {
-            return add_gate_method_oneparam<UnitID>(
-                circ, OpType::YYPhase, angle, {qb0, qb1}, kwargs);
-          },
-          "Appends a YY gate with a symbolic angle (specified in "
-          "half-turns) on the wires for the specified two qubits."
-          "\n\n:return: the new :py:class:`Circuit`",
-          py::arg("qubit0"), py::arg("qubit1"), py::arg("angle"))
-      .def(
-          "XXPhase3",
-          [](Circuit *circ, const Expr &angle, const Qubit &qb0,
-             const Qubit &qb1, const Qubit &qb2, const py::kwargs &kwargs) {
-            return add_gate_method_oneparam<UnitID>(
-                circ, OpType::XXPhase3, angle, {qb0, qb1, qb2}, kwargs);
-          },
-          "Appends a 3-qubit XX gate with a symbolic angle (specified in "
-          "half-turns) on the wires for the specified three qubits."
-          "\n\n:return: the new :py:class:`Circuit`",
-          py::arg("angle"), py::arg("qubit0"), py::arg("qubit1"),
-          py::arg("qubit2"))
-      .def(
-          "PhasedX",
-          [](Circuit *circ, const Expr &angle0, const Expr &angle1,
-             const Qubit &qubit, const py::kwargs &kwargs) {
-            return add_gate_method_manyparams<UnitID>(
-                circ, OpType::PhasedX, {angle0, angle1}, {qubit}, kwargs);
-          },
-          "Appends a PhasedX gate with possibly symbolic angles (specified in "
-          "half-turns) on the wires for the specified qubits."
-          "\n\n:return: the new :py:class:`Circuit`",
-          py::arg("angle0"), py::arg("angle1"), py::arg("qubit"))
-      .def(
-          "CCX",
-          [](Circuit *circ, const Qubit &ctrl1, const Qubit &ctrl2,
-             const Qubit &trgt, const py::kwargs &kwargs) {
-            return add_gate_method_noparams<UnitID>(
-                circ, OpType::CCX, {ctrl1, ctrl2, trgt}, kwargs);
-          },
-          "Appends a CCX gate on the wires for the specified control "
-          "and target qubits."
-          "\n\n:return: the new :py:class:`Circuit`",
-          py::arg("control_0"), py::arg("control_1"), py::arg("target"))
-      .def(
-          "ECR",
-          [](Circuit *circ, const Qubit &qb1, const Qubit &qb2,
-             const py::kwargs &kwargs) {
-            return add_gate_method_noparams<UnitID>(
-                circ, OpType::ECR, {qb1, qb2}, kwargs);
-          },
-          "Appends an ECR gate on the wires for the specified qubits."
-          "\n\n:return: the new :py:class:`Circuit`",
-          py::arg("qubit_0"), py::arg("qubit_1"))
-      .def(
-          "SWAP",
-          [](Circuit *circ, const Qubit &qb1, const Qubit &qb2,
-             const py::kwargs &kwargs) {
-            return add_gate_method_noparams<UnitID>(
-                circ, OpType::SWAP, {qb1, qb2}, kwargs);
-          },
-          "Appends a SWAP gate on the wires for the specified qubits."
-          "\n\n:return: the new :py:class:`Circuit`",
-          py::arg("qubit_0"), py::arg("qubit_1"))
-      .def(
-          "CSWAP",
-          [](Circuit *circ, const Qubit &ctrl, const Qubit &trgt1,
-             const Qubit &trgt2, const py::kwargs &kwargs) {
-            return add_gate_method_noparams<UnitID>(
-                circ, OpType::CSWAP, {ctrl, trgt1, trgt2}, kwargs);
-          },
-          "Appends a CSWAP gate on the wires for the specified "
-          "control and target qubits."
-          "\n\n:return: the new :py:class:`Circuit`",
-          py::arg("control"), py::arg("target_0"), py::arg("target_1"))
-      .def(
-          "ISWAP",
-          [](Circuit *circ, const Expr &angle, const Qubit &qb0,
-             const Qubit &qb1, const py::kwargs &kwargs) {
-            return add_gate_method_oneparam<UnitID>(
-                circ, OpType::ISWAP, angle, {qb0, qb1}, kwargs);
-          },
-          "Appends an ISWAP gate with a possibly symbolic angle (specified in "
-          "half-turns) on the wires for the specified qubits."
-          "\n\n:return: the new :py:class:`Circuit`",
-          py::arg("angle"), py::arg("qubit0"), py::arg("qubit1"))
-      .def(
-          "ISWAPMax",
-          [](Circuit *circ, const Qubit &qb0, const Qubit &qb1,
-             const py::kwargs &kwargs) {
-            return add_gate_method_noparams<UnitID>(
-                circ, OpType::ISWAPMax, {qb0, qb1}, kwargs);
-          },
-          "Appends an ISWAPMax gate on the wires for the specified qubits."
-          "\n\n:return: the new :py:class:`Circuit`",
-          py::arg("qubit0"), py::arg("qubit1"))
-      .def(
-          "PhasedISWAP",
-          [](Circuit *circ, const Expr &angle0, const Expr &angle1,
-             const Qubit &qb0, const Qubit &qb1, const py::kwargs &kwargs) {
-            return add_gate_method_manyparams<UnitID>(
-                circ, OpType::PhasedISWAP, {angle0, angle1}, {qb0, qb1},
-                kwargs);
-          },
-          "Appends a PhasedISWAP gate with posisbly symbolic angles (specified "
-          "in "
-          "half-turns) on the wires for the specified qubits."
-          "\n\n:return: the new :py:class:`Circuit`",
-          py::arg("angle0"), py::arg("angle1"), py::arg("qubit0"),
-          py::arg("qubit1"))
-      .def(
           "Phase",
           [](Circuit *circ, const Expr &angle, const py::kwargs &kwargs) {
-            return add_gate_method_oneparam<UnitID>(
-                circ, OpType::Phase, angle, {}, kwargs);
+            return add_gate_method_any(
+                circ, get_op_ptr(OpType::Phase, angle, 0),
+                std::vector<UnitID>{}, kwargs);
           });
 }
 

--- a/pytket/binders/include/add_gate.hpp
+++ b/pytket/binders/include/add_gate.hpp
@@ -15,6 +15,7 @@
 #pragma once
 #include <pybind11/pybind11.h>
 
+#include <variant>
 #include <vector>
 
 #include "tket/Circuit/Circuit.hpp"
@@ -22,95 +23,10 @@
 namespace py = pybind11;
 
 namespace tket {
-template <typename ID>
-static Circuit *add_gate_method_sequence(
+
+Circuit *add_gate_method_any(
     Circuit *circ, const Op_ptr &op,
-    const py::tket_custom::SequenceVec<ID> &args_seq,
-    const py::kwargs &kwargs) {
-  std::vector<ID> args = args_seq;
-  return add_gate_method(circ, op, args, kwargs);
-}
+    const std::variant<std::vector<unsigned>, std::vector<UnitID>> &args,
+    const py::kwargs &kwargs);
 
-template <typename ID>
-static Circuit *add_gate_method(
-    Circuit *circ, const Op_ptr &op, const std::vector<ID> &args,
-    const py::kwargs &kwargs) {
-  if (op->get_desc().is_meta()) {
-    throw CircuitInvalidity("Cannot add metaop to a circuit.");
-  }
-  if (op->get_desc().is_barrier()) {
-    throw CircuitInvalidity(
-        "Please use `add_barrier` to add a "
-        "barrier to a circuit.");
-  }
-  static const std::set<std::string> allowed_kwargs = {
-      "opgroup", "condition", "condition_bits", "condition_value"};
-  for (const auto kwarg : kwargs) {
-    const std::string kwargstr = py::cast<std::string>(kwarg.first);
-    if (!allowed_kwargs.contains(kwargstr)) {
-      std::stringstream msg;
-      msg << "Unsupported keyword argument '" << kwargstr << "'";
-      throw CircuitInvalidity(msg.str());
-    }
-  }
-  std::optional<std::string> opgroup;
-  if (kwargs.contains("opgroup")) {
-    opgroup = py::cast<std::string>(kwargs["opgroup"]);
-  }
-  bool condition_given = kwargs.contains("condition");
-  bool condition_bits_given = kwargs.contains("condition_bits");
-  bool condition_value_given = kwargs.contains("condition_value");
-  if (condition_given && condition_bits_given) {
-    throw CircuitInvalidity("Both `condition` and `condition_bits` specified");
-  }
-  if (condition_value_given && !condition_bits_given) {
-    throw CircuitInvalidity(
-        "`condition_value` specified without `condition_bits`");
-  }
-  if (condition_given) {
-    py::module condition = py::module::import("pytket.circuit.add_condition");
-    py::object add_condition = condition.attr("_add_condition");
-    auto conditions =
-        add_condition(circ, kwargs["condition"]).cast<std::pair<Bit, bool>>();
-    unit_vector_t new_args = {conditions.first};
-    unsigned n_new_args = new_args.size();
-    Op_ptr cond =
-        std::make_shared<Conditional>(op, n_new_args, int(conditions.second));
-    op_signature_t sig = op->get_signature();
-
-    for (unsigned i = 0; i < args.size(); ++i) {
-      switch (sig.at(i)) {
-        case EdgeType::Quantum: {
-          new_args.push_back(Qubit(args[i]));
-          break;
-        }
-        case EdgeType::WASM: {
-          new_args.push_back(WasmState(args[i]));
-          break;
-        }
-        case EdgeType::Classical:
-        case EdgeType::Boolean: {
-          new_args.push_back(Bit(args[i]));
-          break;
-        }
-        default: {
-          TKET_ASSERT(!"add_gate_method found invalid edge type in signature");
-        }
-      }
-    }
-    circ->add_op(cond, new_args, opgroup);
-  } else if (condition_bits_given) {
-    std::vector<ID> new_args =
-        py::cast<std::vector<ID>>(kwargs["condition_bits"]);
-    unsigned n_new_args = new_args.size();
-    unsigned value = condition_value_given
-                         ? py::cast<unsigned>(kwargs["condition_value"])
-                         : (1u << n_new_args) - 1;
-    Op_ptr cond = std::make_shared<Conditional>(op, n_new_args, value);
-    new_args.insert(new_args.end(), args.begin(), args.end());
-    circ->add_op(cond, new_args, opgroup);
-  } else
-    circ->add_op(op, args, opgroup);
-  return circ;
-}
 }  // namespace tket

--- a/pytket/docs/changelog.rst
+++ b/pytket/docs/changelog.rst
@@ -4,6 +4,13 @@ Changelog
 Unreleased
 ----------
 
+API changes:
+
+* Gate construction methods (e.g. :py:meth:`Circuit.X`) have a streamlined API 
+  by accepting ``Union`` types in place of overloaded methods, giving better 
+  error messages when mixing :py:class:`UnitID` /:py:class:`Qubit` /
+  :py:class:`Bit` and ``int`` for gate arguments.
+
 Features:
 
 * Add methods in `circuit_library` to convert `CX` and `TK2` to and from

--- a/pytket/pytket/_tket/circuit.pyi
+++ b/pytket/pytket/_tket/circuit.pyi
@@ -160,379 +160,163 @@ class Circuit:
         """
         Construct Circuit instance from JSON serializable dictionary representation of the Circuit.
         """
-    @typing.overload
-    def AAMS(self, angle0: sympy.Expr | float, angle1: sympy.Expr | float, angle2: sympy.Expr | float, qubit0: int, qubit1: int, **kwargs: Any) -> Circuit:
+    def AAMS(self, angle0: sympy.Expr | float, angle1: sympy.Expr | float, angle2: sympy.Expr | float, qubit0: int | pytket._tket.unit_id.Qubit, qubit1: int | pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends an AAMS gate with possibly symbolic angles (specified in half-turns).
         
         :return: the new :py:class:`Circuit`
         """
-    @typing.overload
-    def AAMS(self, angle0: sympy.Expr | float, angle1: sympy.Expr | float, angle2: sympy.Expr | float, qubit0: pytket._tket.unit_id.Qubit, qubit1: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
-        """
-        Appends an AAMS gate with possibly symbolic angles (specified in half-turns).
-        
-        :return: the new :py:class:`Circuit`
-        """
-    @typing.overload
-    def CCX(self, control_0: int, control_1: int, target: int, **kwargs: Any) -> Circuit:
+    def CCX(self, control_0: int | pytket._tket.unit_id.Qubit, control_1: int | pytket._tket.unit_id.Qubit, target: int | pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a CCX gate on the wires for the specified control and target qubits.
         
         :return: the new :py:class:`Circuit`
         """
-    @typing.overload
-    def CCX(self, control_0: pytket._tket.unit_id.Qubit, control_1: pytket._tket.unit_id.Qubit, target: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
-        """
-        Appends a CCX gate on the wires for the specified control and target qubits.
-        
-        :return: the new :py:class:`Circuit`
-        """
-    @typing.overload
-    def CH(self, control_qubit: int, target_qubit: int, **kwargs: Any) -> Circuit:
+    def CH(self, control_qubit: int | pytket._tket.unit_id.Qubit, target_qubit: int | pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a CH gate on the wires for the specified control and target qubits.
         
         :return: the new :py:class:`Circuit`
         """
-    @typing.overload
-    def CH(self, control_qubit: pytket._tket.unit_id.Qubit, target_qubit: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
-        """
-        Appends a CH gate on the wires for the specified control and target qubits.
-        
-        :return: the new :py:class:`Circuit`
-        """
-    @typing.overload
-    def CRx(self, angle: sympy.Expr | float, control_qubit: int, target_qubit: int, **kwargs: Any) -> Circuit:
+    def CRx(self, angle: sympy.Expr | float, control_qubit: int | pytket._tket.unit_id.Qubit, target_qubit: int | pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a CRx gate with a possibly symbolic angle (specified in half-turns) on the wires for the specified control and target qubits.
         
         :return: the new :py:class:`Circuit`
         """
-    @typing.overload
-    def CRx(self, angle: sympy.Expr | float, control_qubit: pytket._tket.unit_id.Qubit, target_qubit: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
-        """
-        Appends a CRx gate with a symbolic angle (specified in half-turns) on the wires for the specified control and target qubits.
-        
-        :return: the new :py:class:`Circuit`
-        """
-    @typing.overload
-    def CRy(self, angle: sympy.Expr | float, control_qubit: int, target_qubit: int, **kwargs: Any) -> Circuit:
+    def CRy(self, angle: sympy.Expr | float, control_qubit: int | pytket._tket.unit_id.Qubit, target_qubit: int | pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a CRy gate with a possibly symbolic angle (specified in half-turns) on the wires for the specified control and target qubits.
         
         :return: the new :py:class:`Circuit`
         """
-    @typing.overload
-    def CRy(self, angle: sympy.Expr | float, control_qubit: pytket._tket.unit_id.Qubit, target_qubit: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
-        """
-        Appends a CRy gate with a symbolic angle (specified in half-turns) on the wires for the specified control and target qubits.
-        
-        :return: the new :py:class:`Circuit`
-        """
-    @typing.overload
-    def CRz(self, angle: sympy.Expr | float, control_qubit: int, target_qubit: int, **kwargs: Any) -> Circuit:
+    def CRz(self, angle: sympy.Expr | float, control_qubit: int | pytket._tket.unit_id.Qubit, target_qubit: int | pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a CRz gate with a possibly symbolic angle (specified in half-turns) on the wires for the specified control and target qubits.
         
         :return: the new :py:class:`Circuit`
         """
-    @typing.overload
-    def CRz(self, angle: sympy.Expr | float, control_qubit: pytket._tket.unit_id.Qubit, target_qubit: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
-        """
-        Appends a CRz gate with a symbolic angle (specified in half-turns) on the wires for the specified control and target qubits.
-        
-        :return: the new :py:class:`Circuit`
-        """
-    @typing.overload
-    def CS(self, control_qubit: int, target_qubit: int, **kwargs: Any) -> Circuit:
+    def CS(self, control_qubit: int | pytket._tket.unit_id.Qubit, target_qubit: int | pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a CS gate on the wires for the specified control and target qubits.
         
         :return: the new :py:class:`Circuit`
         """
-    @typing.overload
-    def CS(self, control_qubit: pytket._tket.unit_id.Qubit, target_qubit: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
-        """
-        Appends a CS gate on the wires for the specified control and target qubits.
-        
-        :return: the new :py:class:`Circuit`
-        """
-    @typing.overload
-    def CSWAP(self, control: int, target_0: int, target_1: int, **kwargs: Any) -> Circuit:
+    def CSWAP(self, control: int | pytket._tket.unit_id.Qubit, target_0: int | pytket._tket.unit_id.Qubit, target_1: int | pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a CSWAP gate on the wires for the specified control and target qubits.
         
         :return: the new :py:class:`Circuit`
         """
-    @typing.overload
-    def CSWAP(self, control: pytket._tket.unit_id.Qubit, target_0: pytket._tket.unit_id.Qubit, target_1: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
-        """
-        Appends a CSWAP gate on the wires for the specified control and target qubits.
-        
-        :return: the new :py:class:`Circuit`
-        """
-    @typing.overload
-    def CSX(self, control_qubit: int, target_qubit: int, **kwargs: Any) -> Circuit:
+    def CSX(self, control_qubit: int | pytket._tket.unit_id.Qubit, target_qubit: int | pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a CSX gate on the wires for the specified control and target qubits.
         
         :return: the new :py:class:`Circuit`
         """
-    @typing.overload
-    def CSX(self, control_qubit: pytket._tket.unit_id.Qubit, target_qubit: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
-        """
-        Appends a CSX gate on the wires for the specified control and target qubits.
-        
-        :return: the new :py:class:`Circuit`
-        """
-    @typing.overload
-    def CSXdg(self, control_qubit: int, target_qubit: int, **kwargs: Any) -> Circuit:
+    def CSXdg(self, control_qubit: int | pytket._tket.unit_id.Qubit, target_qubit: int | pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a CSXdg gate on the wires for the specified control and target qubits.
         
         :return: the new :py:class:`Circuit`
         """
-    @typing.overload
-    def CSXdg(self, control_qubit: pytket._tket.unit_id.Qubit, target_qubit: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
-        """
-        Appends a CSXdg gate on the wires for the specified control and target qubits.
-        
-        :return: the new :py:class:`Circuit`
-        """
-    @typing.overload
-    def CSdg(self, control_qubit: int, target_qubit: int, **kwargs: Any) -> Circuit:
+    def CSdg(self, control_qubit: int | pytket._tket.unit_id.Qubit, target_qubit: int | pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a CSdg gate on the wires for the specified control and target qubits.
         
         :return: the new :py:class:`Circuit`
         """
-    @typing.overload
-    def CSdg(self, control_qubit: pytket._tket.unit_id.Qubit, target_qubit: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
-        """
-        Appends a CSdg gate on the wires for the specified control and target qubits.
-        
-        :return: the new :py:class:`Circuit`
-        """
-    @typing.overload
-    def CU1(self, angle: sympy.Expr | float, control_qubit: int, target_qubit: int, **kwargs: Any) -> Circuit:
+    def CU1(self, angle: sympy.Expr | float, control_qubit: int | pytket._tket.unit_id.Qubit, target_qubit: int | pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a CU1 gate with a possibly symbolic angle (specified in half-turns) on the wires for the specified control and target qubits.
         
         :return: the new :py:class:`Circuit`
         """
-    @typing.overload
-    def CU1(self, angle: sympy.Expr | float, control_qubit: pytket._tket.unit_id.Qubit, target_qubit: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
-        """
-        Appends a CU1 gate with a possibly symbolic angle (specified in half-turns) on the wires for the specified control and target qubits.
-        
-        :return: the new :py:class:`Circuit`
-        """
-    @typing.overload
-    def CU3(self, angle0: sympy.Expr | float, angle1: sympy.Expr | float, angle2: sympy.Expr | float, control_qubit: int, target_qubit: int, **kwargs: Any) -> Circuit:
+    def CU3(self, angle0: sympy.Expr | float, angle1: sympy.Expr | float, angle2: sympy.Expr | float, control_qubit: int | pytket._tket.unit_id.Qubit, target_qubit: int | pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a CU3 gate with possibly symbolic angles (specified in half-turns) on the wires for the specified control and target qubits.
         
         :return: the new :py:class:`Circuit`
         """
-    @typing.overload
-    def CU3(self, angle0: sympy.Expr | float, angle1: sympy.Expr | float, angle2: sympy.Expr | float, control_qubit: pytket._tket.unit_id.Qubit, target_qubit: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
-        """
-        Appends a CU3 gate with possibly symbolic angles (specified in half-turns) on the wires for the specified control and target qubits.
-        
-        :return: the new :py:class:`Circuit`
-        """
-    @typing.overload
-    def CV(self, control_qubit: int, target_qubit: int, **kwargs: Any) -> Circuit:
+    def CV(self, control_qubit: int | pytket._tket.unit_id.Qubit, target_qubit: int | pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a CV gate on the wires for the specified control and target qubits.
         
         :return: the new :py:class:`Circuit`
         """
-    @typing.overload
-    def CV(self, control_qubit: pytket._tket.unit_id.Qubit, target_qubit: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
-        """
-        Appends a CV gate on the wires for the specified control and target qubits.
-        
-        :return: the new :py:class:`Circuit`
-        """
-    @typing.overload
-    def CVdg(self, control_qubit: int, target_qubit: int, **kwargs: Any) -> Circuit:
+    def CVdg(self, control_qubit: int | pytket._tket.unit_id.Qubit, target_qubit: int | pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a CVdg gate on the wires for the specified control and target qubits.
         
         :return: the new :py:class:`Circuit`
         """
-    @typing.overload
-    def CVdg(self, control_qubit: pytket._tket.unit_id.Qubit, target_qubit: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
-        """
-        Appends a CVdg gate on the wires for the specified control and target qubits.
-        
-        :return: the new :py:class:`Circuit`
-        """
-    @typing.overload
-    def CX(self, control_qubit: int, target_qubit: int, **kwargs: Any) -> Circuit:
+    def CX(self, control_qubit: int | pytket._tket.unit_id.Qubit, target_qubit: int | pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a CX gate on the wires for the specified control and target qubits.
         
         :return: the new :py:class:`Circuit`
         """
-    @typing.overload
-    def CX(self, control_qubit: pytket._tket.unit_id.Qubit, target_qubit: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
-        """
-        Appends a CX gate on the wires for the specified control and target qubits.
-        
-        :return: the new :py:class:`Circuit`
-        """
-    @typing.overload
-    def CY(self, control_qubit: int, target_qubit: int, **kwargs: Any) -> Circuit:
+    def CY(self, control_qubit: int | pytket._tket.unit_id.Qubit, target_qubit: int | pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a CY gate on the wires for the specified control and target qubits.
         
         :return: the new :py:class:`Circuit`
         """
-    @typing.overload
-    def CY(self, control_qubit: pytket._tket.unit_id.Qubit, target_qubit: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
-        """
-        Appends a CY gate on the wires for the specified control and target qubits.
-        
-        :return: the new :py:class:`Circuit`
-        """
-    @typing.overload
-    def CZ(self, control_qubit: int, target_qubit: int, **kwargs: Any) -> Circuit:
+    def CZ(self, control_qubit: int | pytket._tket.unit_id.Qubit, target_qubit: int | pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a CZ gate on the wires for the specified control and target qubits.
         
         :return: the new :py:class:`Circuit`
         """
-    @typing.overload
-    def CZ(self, control_qubit: pytket._tket.unit_id.Qubit, target_qubit: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
-        """
-        Appends a CZ gate on the wires for the specified control and target qubits.
-        
-        :return: the new :py:class:`Circuit`
-        """
-    @typing.overload
-    def ECR(self, qubit_0: int, qubit_1: int, **kwargs: Any) -> Circuit:
+    def ECR(self, qubit_0: int | pytket._tket.unit_id.Qubit, qubit_1: int | pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends an ECR gate on the wires for the specified qubits.
         
         :return: the new :py:class:`Circuit`
         """
-    @typing.overload
-    def ECR(self, qubit_0: pytket._tket.unit_id.Qubit, qubit_1: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
-        """
-        Appends an ECR gate on the wires for the specified qubits.
-        
-        :return: the new :py:class:`Circuit`
-        """
-    @typing.overload
-    def ESWAP(self, angle: sympy.Expr | float, qubit0: int, qubit1: int, **kwargs: Any) -> Circuit:
+    def ESWAP(self, angle: sympy.Expr | float, qubit0: int | pytket._tket.unit_id.Qubit, qubit1: int | pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends an ESWAP gate with a possibly symbolic angle (specified in half-turns) on the wires for the specified two qubits.
         
         :return: the new :py:class:`Circuit`
         """
-    @typing.overload
-    def ESWAP(self, angle: sympy.Expr | float, qubit0: pytket._tket.unit_id.Qubit, qubit1: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
-        """
-        Appends an ESWAP gate with a possibly symbolic angle (specified in half-turns) on the wires for the specified two qubits.
-        
-        :return: the new :py:class:`Circuit`
-        """
-    @typing.overload
-    def FSim(self, angle0: sympy.Expr | float, angle1: sympy.Expr | float, qubit0: int, qubit1: int, **kwargs: Any) -> Circuit:
+    def FSim(self, angle0: sympy.Expr | float, angle1: sympy.Expr | float, qubit0: int | pytket._tket.unit_id.Qubit, qubit1: int | pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends an FSim gate with possibly symbolic angles (specified in half-turns) on the wires for the specified qubits.
         
         :return: the new :py:class:`Circuit`
         """
-    @typing.overload
-    def FSim(self, angle0: sympy.Expr | float, angle1: sympy.Expr | float, qubit0: pytket._tket.unit_id.Qubit, qubit1: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
-        """
-        Appends an FSim gate with possibly symbolic angles (specified in half-turns) on the wires for the specified qubits.
-        
-        :return: the new :py:class:`Circuit`
-        """
-    @typing.overload
-    def GPI(self, angle: sympy.Expr | float, qubit: int, **kwargs: Any) -> Circuit:
+    def GPI(self, angle: sympy.Expr | float, qubit: int | pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a GPI gate with a possibly symbolic angle (specified in half-turns).
         
         :return: the new :py:class:`Circuit`
         """
-    @typing.overload
-    def GPI(self, angle: sympy.Expr | float, qubit: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
-        """
-        Appends a GPI gate with a possibly symbolic angle (specified in half-turns).
-        
-        :return: the new :py:class:`Circuit`
-        """
-    @typing.overload
-    def GPI2(self, angle: sympy.Expr | float, qubit: int, **kwargs: Any) -> Circuit:
+    def GPI2(self, angle: sympy.Expr | float, qubit: int | pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a GPI2 gate with a possibly symbolic angle (specified in half-turns).
         
         :return: the new :py:class:`Circuit`
         """
-    @typing.overload
-    def GPI2(self, angle: sympy.Expr | float, qubit: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
-        """
-        Appends a GPI2 gate with a possibly symbolic angle (specified in half-turns).
-        
-        :return: the new :py:class:`Circuit`
-        """
-    @typing.overload
-    def H(self, qubit: int, **kwargs: Any) -> Circuit:
+    def H(self, qubit: int | pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a Hadamard gate.
         
         :return: the new :py:class:`Circuit`
         """
-    @typing.overload
-    def H(self, qubit: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
-        """
-        Appends a Hadamard gate.
-        
-        :return: the new :py:class:`Circuit`
-        """
-    @typing.overload
-    def ISWAP(self, angle: sympy.Expr | float, qubit0: int, qubit1: int, **kwargs: Any) -> Circuit:
+    def ISWAP(self, angle: sympy.Expr | float, qubit0: int | pytket._tket.unit_id.Qubit, qubit1: int | pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends an ISWAP gate with a possibly symbolic angle (specified in half-turns) on the wires for the specified qubits.
         
         :return: the new :py:class:`Circuit`
         """
-    @typing.overload
-    def ISWAP(self, angle: sympy.Expr | float, qubit0: pytket._tket.unit_id.Qubit, qubit1: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
-        """
-        Appends an ISWAP gate with a possibly symbolic angle (specified in half-turns) on the wires for the specified qubits.
-        
-        :return: the new :py:class:`Circuit`
-        """
-    @typing.overload
-    def ISWAPMax(self, qubit0: int, qubit1: int, **kwargs: Any) -> Circuit:
+    def ISWAPMax(self, qubit0: int | pytket._tket.unit_id.Qubit, qubit1: int | pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends an ISWAPMax gate on the wires for the specified qubits.
         
         :return: the new :py:class:`Circuit`
         """
-    @typing.overload
-    def ISWAPMax(self, qubit0: pytket._tket.unit_id.Qubit, qubit1: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
-        """
-        Appends an ISWAPMax gate on the wires for the specified qubits.
-        
-        :return: the new :py:class:`Circuit`
-        """
-    @typing.overload
-    def Measure(self, qubit: int, bit_index: int, **kwargs: Any) -> Circuit:
-        """
-        Appends a single-qubit measurement in the computational (Z) basis.
-        
-        :return: the new :py:class:`Circuit`
-        """
-    @typing.overload
-    def Measure(self, qubit: pytket._tket.unit_id.Qubit, bit: pytket._tket.unit_id.Bit, **kwargs: Any) -> Circuit:
+    def Measure(self, qubit: int | pytket._tket.unit_id.Qubit, bit: int | pytket._tket.unit_id.Bit, **kwargs: Any) -> Circuit:
         """
         Appends a single-qubit measurement in the computational (Z) basis.
         
@@ -540,403 +324,171 @@ class Circuit:
         """
     def Phase(self, arg0: sympy.Expr | float, **kwargs: Any) -> Circuit:
         ...
-    @typing.overload
-    def PhasedISWAP(self, angle0: sympy.Expr | float, angle1: sympy.Expr | float, qubit0: int, qubit1: int, **kwargs: Any) -> Circuit:
+    def PhasedISWAP(self, angle0: sympy.Expr | float, angle1: sympy.Expr | float, qubit0: int | pytket._tket.unit_id.Qubit, qubit1: int | pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a PhasedISWAP gate with possibly symbolic angles (specified in half-turns) on the wires for the specified qubits.
         
         :return: the new :py:class:`Circuit`
         """
-    @typing.overload
-    def PhasedISWAP(self, angle0: sympy.Expr | float, angle1: sympy.Expr | float, qubit0: pytket._tket.unit_id.Qubit, qubit1: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
-        """
-        Appends a PhasedISWAP gate with posisbly symbolic angles (specified in half-turns) on the wires for the specified qubits.
-        
-        :return: the new :py:class:`Circuit`
-        """
-    @typing.overload
-    def PhasedX(self, angle0: sympy.Expr | float, angle1: sympy.Expr | float, qubit: int, **kwargs: Any) -> Circuit:
+    def PhasedX(self, angle0: sympy.Expr | float, angle1: sympy.Expr | float, qubit: int | pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a PhasedX gate with possibly symbolic angles (specified in half-turns) on the wires for the specified qubits.
         
         :return: the new :py:class:`Circuit`
         """
-    @typing.overload
-    def PhasedX(self, angle0: sympy.Expr | float, angle1: sympy.Expr | float, qubit: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
-        """
-        Appends a PhasedX gate with possibly symbolic angles (specified in half-turns) on the wires for the specified qubits.
-        
-        :return: the new :py:class:`Circuit`
-        """
-    @typing.overload
-    def Reset(self, qubit: int, **kwargs: Any) -> Circuit:
+    def Reset(self, qubit: int | pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a Reset operation. Sets a qubit to the Z-basis 0 state. Non-unitary operation.
         
         :return: the new :py:class:`Circuit`
         """
-    @typing.overload
-    def Reset(self, qubit: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
-        """
-        Appends a Reset operation. Sets a qubit to the Z-basis 0 state. Non-unitary operation.
-        
-        :return: the new :py:class:`Circuit`
-        """
-    @typing.overload
-    def Rx(self, angle: sympy.Expr | float, qubit: int, **kwargs: Any) -> Circuit:
+    def Rx(self, angle: sympy.Expr | float, qubit: int | pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends an Rx gate with a possibly symbolic angle (specified in half-turns).
         
         :return: the new :py:class:`Circuit`
         """
-    @typing.overload
-    def Rx(self, angle: sympy.Expr | float, qubit: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
-        """
-        Appends an Rx gate with a possibly symbolic angle (specified in half-turns).
-        
-        :return: the new :py:class:`Circuit`
-        """
-    @typing.overload
-    def Ry(self, angle: sympy.Expr | float, qubit: int, **kwargs: Any) -> Circuit:
+    def Ry(self, angle: sympy.Expr | float, qubit: int | pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends an Ry gate with a possibly symbolic angle (specified in half-turns).
         
         :return: the new :py:class:`Circuit`
         """
-    @typing.overload
-    def Ry(self, angle: sympy.Expr | float, qubit: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
-        """
-        Appends an Ry gate with a possibly symbolic angle (specified in half-turns).
-        
-        :return: the new :py:class:`Circuit`
-        """
-    @typing.overload
-    def Rz(self, angle: sympy.Expr | float, qubit: int, **kwargs: Any) -> Circuit:
+    def Rz(self, angle: sympy.Expr | float, qubit: int | pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends an Rz gate with a possibly symbolic angle (specified in half-turns).
         
         :return: the new :py:class:`Circuit`
         """
-    @typing.overload
-    def Rz(self, angle: sympy.Expr | float, qubit: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
-        """
-        Appends an Rz gate with a possibly symbolic angle (specified in half-turns).
-        
-        :return: the new :py:class:`Circuit`
-        """
-    @typing.overload
-    def S(self, qubit: int, **kwargs: Any) -> Circuit:
+    def S(self, qubit: int | pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends an S gate (equivalent to U1(0.5,-)).
         
         :return: the new :py:class:`Circuit`
         """
-    @typing.overload
-    def S(self, qubit: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
-        """
-        Appends an S gate (equivalent to Rz(0.5,-)).
-        
-        :return: the new :py:class:`Circuit`
-        """
-    @typing.overload
-    def SWAP(self, qubit_0: int, qubit_1: int, **kwargs: Any) -> Circuit:
+    def SWAP(self, qubit_0: int | pytket._tket.unit_id.Qubit, qubit_1: int | pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a SWAP gate on the wires for the specified qubits.
         
         :return: the new :py:class:`Circuit`
         """
-    @typing.overload
-    def SWAP(self, qubit_0: pytket._tket.unit_id.Qubit, qubit_1: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
-        """
-        Appends a SWAP gate on the wires for the specified qubits.
-        
-        :return: the new :py:class:`Circuit`
-        """
-    @typing.overload
-    def SX(self, qubit: int, **kwargs: Any) -> Circuit:
+    def SX(self, qubit: int | pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a SX gate (equivalent to Rx(0.5,-) up to a 0.25 global phase).
         
         :return: the new :py:class:`Circuit`
         """
-    @typing.overload
-    def SX(self, qubit: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
-        """
-        Appends a SX gate (equivalent to Rx(0.5,-) up to a 0.25 global phase).
-        
-        :return: the new :py:class:`Circuit`
-        """
-    @typing.overload
-    def SXdg(self, qubit: int, **kwargs: Any) -> Circuit:
+    def SXdg(self, qubit: int | pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a SXdg gate (equivalent to Rx(-0.5,-) up to a -0.25 global phase).
         
         :return: the new :py:class:`Circuit`
         """
-    @typing.overload
-    def SXdg(self, qubit: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
-        """
-        Appends a SXdg gate (equivalent to Rx(-0.5,-) up to a -0.25 global phase).
-        
-        :return: the new :py:class:`Circuit`
-        """
-    @typing.overload
-    def Sdg(self, qubit: int, **kwargs: Any) -> Circuit:
+    def Sdg(self, qubit: int | pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends an S-dagger gate (equivalent to U1(-0.5,-)).
         
         :return: the new :py:class:`Circuit`
         """
-    @typing.overload
-    def Sdg(self, qubit: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
-        """
-        Appends an S-dagger gate (equivalent to Rz(-0.5,-)).
-        
-        :return: the new :py:class:`Circuit`
-        """
-    @typing.overload
-    def Sycamore(self, qubit0: int, qubit1: int, **kwargs: Any) -> Circuit:
+    def Sycamore(self, qubit0: int | pytket._tket.unit_id.Qubit, qubit1: int | pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a Sycamore gate on the wires for the specified qubits.
         
         :return: the new :py:class:`Circuit`
         """
-    @typing.overload
-    def Sycamore(self, qubit0: pytket._tket.unit_id.Qubit, qubit1: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
-        """
-        Appends a Sycamore gate on the wires for the specified qubits.
-        
-        :return: the new :py:class:`Circuit`
-        """
-    @typing.overload
-    def T(self, qubit: int, **kwargs: Any) -> Circuit:
+    def T(self, qubit: int | pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a T gate (equivalent to U1(0.25,-)).
         
         :return: the new :py:class:`Circuit`
         """
-    @typing.overload
-    def T(self, qubit: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
-        """
-        Appends a T gate (equivalent to Rz(0.25,-)).
-        
-        :return: the new :py:class:`Circuit`
-        """
-    @typing.overload
-    def TK1(self, angle0: sympy.Expr | float, angle1: sympy.Expr | float, angle2: sympy.Expr | float, qubit: int, **kwargs: Any) -> Circuit:
+    def TK1(self, angle0: sympy.Expr | float, angle1: sympy.Expr | float, angle2: sympy.Expr | float, qubit: int | pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a TK1 gate with possibly symbolic angles (specified in half-turns).
         
         :return: the new :py:class:`Circuit`
         """
-    @typing.overload
-    def TK1(self, angle0: sympy.Expr | float, angle1: sympy.Expr | float, angle2: sympy.Expr | float, qubit: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
-        """
-        Appends a TK1 gate with possibly symbolic angles (specified in half-turns).
-        
-        :return: the new :py:class:`Circuit`
-        """
-    @typing.overload
-    def TK2(self, angle0: sympy.Expr | float, angle1: sympy.Expr | float, angle2: sympy.Expr | float, qubit0: int, qubit1: int, **kwargs: Any) -> Circuit:
+    def TK2(self, angle0: sympy.Expr | float, angle1: sympy.Expr | float, angle2: sympy.Expr | float, qubit0: int | pytket._tket.unit_id.Qubit, qubit1: int | pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a TK2 gate with possibly symbolic angles (specified in half-turns).
         
         :return: the new :py:class:`Circuit`
         """
-    @typing.overload
-    def TK2(self, angle0: sympy.Expr | float, angle1: sympy.Expr | float, angle2: sympy.Expr | float, qubit0: pytket._tket.unit_id.Qubit, qubit1: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
-        """
-        Appends a TK2 gate with possibly symbolic angles (specified in half-turns).
-        
-        :return: the new :py:class:`Circuit`
-        """
-    @typing.overload
-    def Tdg(self, qubit: int, **kwargs: Any) -> Circuit:
+    def Tdg(self, qubit: int | pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a T-dagger gate (equivalent to U1(-0.25,-)).
         
         :return: the new :py:class:`Circuit`
         """
-    @typing.overload
-    def Tdg(self, qubit: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
-        """
-        Appends a T-dagger gate (equivalent to Rz(-0.25,-)).
-        
-        :return: the new :py:class:`Circuit`
-        """
-    @typing.overload
-    def U1(self, angle: sympy.Expr | float, qubit: int, **kwargs: Any) -> Circuit:
+    def U1(self, angle: sympy.Expr | float, qubit: int | pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a U1 gate with a possibly symbolic angle (specified in half-turns).
         
         :return: the new :py:class:`Circuit`
         """
-    @typing.overload
-    def U1(self, angle: sympy.Expr | float, qubit: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
-        """
-        Appends a U1 gate with a possibly symbolic angle (specified in half-turns).
-        
-        :return: the new :py:class:`Circuit`
-        """
-    @typing.overload
-    def U2(self, angle0: sympy.Expr | float, angle1: sympy.Expr | float, qubit: int, **kwargs: Any) -> Circuit:
+    def U2(self, angle0: sympy.Expr | float, angle1: sympy.Expr | float, qubit: int | pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a U2 gate with possibly symbolic angles (specified in half-turns).
         
         :return: the new :py:class:`Circuit`
         """
-    @typing.overload
-    def U2(self, angle0: sympy.Expr | float, angle1: sympy.Expr | float, qubit: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
-        """
-        Appends a U2 gate with possibly symbolic angles (specified in half-turns).
-        
-        :return: the new :py:class:`Circuit`
-        """
-    @typing.overload
-    def U3(self, angle0: sympy.Expr | float, angle1: sympy.Expr | float, angle2: sympy.Expr | float, qubit: int, **kwargs: Any) -> Circuit:
+    def U3(self, angle0: sympy.Expr | float, angle1: sympy.Expr | float, angle2: sympy.Expr | float, qubit: int | pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a U3 gate with possibly symbolic angles (specified in half-turns).
         
         :return: the new :py:class:`Circuit`
         """
-    @typing.overload
-    def U3(self, angle0: sympy.Expr | float, angle1: sympy.Expr | float, angle2: sympy.Expr | float, qubit: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
-        """
-        Appends a U3 gate with possibly symbolic angles (specified in half-turns).
-        
-        :return: the new :py:class:`Circuit`
-        """
-    @typing.overload
-    def V(self, qubit: int, **kwargs: Any) -> Circuit:
+    def V(self, qubit: int | pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a V gate (equivalent to Rx(0.5,-)).
         
         :return: the new :py:class:`Circuit`
         """
-    @typing.overload
-    def V(self, qubit: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
-        """
-        Appends a V gate (equivalent to Rx(0.5,-)).
-        
-        :return: the new :py:class:`Circuit`
-        """
-    @typing.overload
-    def Vdg(self, qubit: int, **kwargs: Any) -> Circuit:
+    def Vdg(self, qubit: int | pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a V-dagger gate (equivalent to Rx(-0.5,-)).
         
         :return: the new :py:class:`Circuit`
         """
-    @typing.overload
-    def Vdg(self, qubit: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
-        """
-        Appends a V-dagger gate (equivalent to Rx(-0.5,-)).
-        
-        :return: the new :py:class:`Circuit`
-        """
-    @typing.overload
-    def X(self, qubit: int, **kwargs: Any) -> Circuit:
+    def X(self, qubit: int | pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         :return: the new :py:class:`Circuit`
         """
-    @typing.overload
-    def X(self, qubit: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
-        """
-        Appends an X gate.
-        
-        :return: the new :py:class:`Circuit`
-        """
-    @typing.overload
-    def XXPhase(self, angle: sympy.Expr | float, qubit0: int, qubit1: int, **kwargs: Any) -> Circuit:
+    def XXPhase(self, angle: sympy.Expr | float, qubit0: int | pytket._tket.unit_id.Qubit, qubit1: int | pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a XX gate with a possibly symbolic angle (specified in half-turns) on the wires for the specified two qubits.
         
         :return: the new :py:class:`Circuit`
         """
-    @typing.overload
-    def XXPhase(self, qubit0: sympy.Expr | float, qubit1: pytket._tket.unit_id.Qubit, angle: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
-        """
-        Appends a XX gate with a symbolic angle (specified in half-turns) on the wires for the specified two qubits.
-        
-        :return: the new :py:class:`Circuit`
-        """
-    @typing.overload
-    def XXPhase3(self, angle: sympy.Expr | float, qubit0: int, qubit1: int, qubit2: int, **kwargs: Any) -> Circuit:
+    def XXPhase3(self, angle: sympy.Expr | float, qubit0: int | pytket._tket.unit_id.Qubit, qubit1: int | pytket._tket.unit_id.Qubit, qubit2: int | pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a 3-qubit XX gate with a possibly symbolic angle (specified in half-turns) on the wires for the specified three qubits.
         
         :return: the new :py:class:`Circuit`
         """
-    @typing.overload
-    def XXPhase3(self, angle: sympy.Expr | float, qubit0: pytket._tket.unit_id.Qubit, qubit1: pytket._tket.unit_id.Qubit, qubit2: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
-        """
-        Appends a 3-qubit XX gate with a symbolic angle (specified in half-turns) on the wires for the specified three qubits.
-        
-        :return: the new :py:class:`Circuit`
-        """
-    @typing.overload
-    def Y(self, qubit: int, **kwargs: Any) -> Circuit:
+    def Y(self, qubit: int | pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         :return: the new :py:class:`Circuit`
         """
-    @typing.overload
-    def Y(self, qubit: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
-        """
-        Appends a Y gate.
-        
-        :return: the new :py:class:`Circuit`
-        """
-    @typing.overload
-    def YYPhase(self, angle: sympy.Expr | float, qubit0: int, qubit1: int, **kwargs: Any) -> Circuit:
+    def YYPhase(self, angle: sympy.Expr | float, qubit0: int | pytket._tket.unit_id.Qubit, qubit1: int | pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a YY gate with a possibly symbolic angle (specified in half-turns) on the wires for the specified two qubits.
         
         :return: the new :py:class:`Circuit`
         """
-    @typing.overload
-    def YYPhase(self, qubit0: sympy.Expr | float, qubit1: pytket._tket.unit_id.Qubit, angle: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
-        """
-        Appends a YY gate with a symbolic angle (specified in half-turns) on the wires for the specified two qubits.
-        
-        :return: the new :py:class:`Circuit`
-        """
-    @typing.overload
-    def Z(self, qubit: int, **kwargs: Any) -> Circuit:
+    def Z(self, qubit: int | pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         :return: the new :py:class:`Circuit`
         """
-    @typing.overload
-    def Z(self, qubit: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
-        """
-        Appends a Z gate.
-        
-        :return: the new :py:class:`Circuit`
-        """
-    @typing.overload
-    def ZZMax(self, qubit0: int, qubit1: int, **kwargs: Any) -> Circuit:
+    def ZZMax(self, qubit0: int | pytket._tket.unit_id.Qubit, qubit1: int | pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a ZZMax gate on the wires for the specified two qubits.
         
         :return: the new :py:class:`Circuit`
         """
-    @typing.overload
-    def ZZMax(self, qubit0: pytket._tket.unit_id.Qubit, qubit1: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
-        """
-        Appends a ZZMax gate on the wires for the specified two qubits.
-        
-        :return: the new :py:class:`Circuit`
-        """
-    @typing.overload
-    def ZZPhase(self, angle: sympy.Expr | float, qubit0: int, qubit1: int, **kwargs: Any) -> Circuit:
+    def ZZPhase(self, angle: sympy.Expr | float, qubit0: int | pytket._tket.unit_id.Qubit, qubit1: int | pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Appends a ZZ gate with a possibly symbolic angle (specified in half-turns) on the wires for the specified two qubits.
-        
-        :return: the new :py:class:`Circuit`
-        """
-    @typing.overload
-    def ZZPhase(self, angle: sympy.Expr | float, qubit0: pytket._tket.unit_id.Qubit, qubit1: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
-        """
-        Appends a ZZ gate with a symbolic angle (specified in half-turns) on the wires for the specified two qubits.
         
         :return: the new :py:class:`Circuit`
         """
@@ -1009,7 +561,7 @@ class Circuit:
         :param size: Number of wasm bits that should be added to the circuit
         """
     @typing.overload
-    def _add_wasm(self, funcname: str, wasm_uid: str, width_i_parameter: typing.Sequence[int], width_o_parameter: typing.Sequence[int], args: typing.Sequence[int], wasm_wire_args: typing.Sequence[int], **kwargs: Any) -> Circuit:
+    def _add_wasm(self, funcname: str, wasm_uid: str, width_i_parameter: typing.Sequence[int], width_o_parameter: typing.Sequence[int], args: typing.Sequence[int] | typing.Sequence[pytket._tket.unit_id.Bit], wasm_wire_args: typing.Sequence[int], **kwargs: Any) -> Circuit:
         """
         Add a classical function call from a wasm file to the circuit. 
         
@@ -1019,19 +571,6 @@ class Circuit:
         :param width_o_parameter: list of the number of bits in the output variables
         :param args: vector of circuit bits the wasm op should be added to
         :param wasm_wire_args: vector of circuit wasmwires the wasm op should be added to
-        :param kwargs: additional arguments passed to `add_gate_method` . Allowed parameters are `opgroup`,  `condition` , `condition_bits`, `condition_value`
-        :return: the new :py:class:`Circuit`
-        """
-    @typing.overload
-    def _add_wasm(self, funcname: str, wasm_uid: str, width_i_parameter: typing.Sequence[int], width_o_parameter: typing.Sequence[int], args: typing.Sequence[pytket._tket.unit_id.Bit], wasm_wire_args: typing.Sequence[int], **kwargs: Any) -> Circuit:
-        """
-        Add a classical function call from a wasm file to the circuit. 
-        
-        :param funcname: name of the function that is called
-        :param wasm_uid: unit id to identify the wasm file
-        :param width_i_parameter: list of the number of bits in the input variables
-        :param width_o_parameter: list of the number of bits in the output variables
-        :param args: vector of circuit bits the wasm op should be added to
         :param kwargs: additional arguments passed to `add_gate_method` . Allowed parameters are `opgroup`,  `condition` , `condition_bits`, `condition_value`
         :return: the new :py:class:`Circuit`
         """
@@ -1058,18 +597,7 @@ class Circuit:
         Saves a visualisation of a circuit's DAG to a ".dot" file
         """
     @typing.overload
-    def add_assertion(self, box: ProjectorAssertionBox, qubits: typing.Sequence[int], ancilla: int | None = None, name: str | None = None) -> Circuit:
-        """
-        Append a :py:class:`ProjectorAssertionBox` to the circuit.
-        
-        :param box: ProjectorAssertionBox to append
-        :param qubits: indices of target qubits
-        :param ancilla: index of ancilla qubit
-        :param name: name used to identify this assertion
-        :return: the new :py:class:`Circuit`
-        """
-    @typing.overload
-    def add_assertion(self, box: ProjectorAssertionBox, qubits: typing.Sequence[pytket._tket.unit_id.Qubit], ancilla: pytket._tket.unit_id.Qubit | None = None, name: str | None = None) -> Circuit:
+    def add_assertion(self, box: ProjectorAssertionBox, qubits: typing.Sequence[int] | typing.Sequence[pytket._tket.unit_id.Qubit], ancilla: int | pytket._tket.unit_id.Qubit | None = None, name: str | None = None) -> Circuit:
         """
         Append a :py:class:`ProjectorAssertionBox` to the circuit.
         
@@ -1080,18 +608,7 @@ class Circuit:
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
-    def add_assertion(self, box: StabiliserAssertionBox, qubits: typing.Sequence[int], ancilla: int, name: str | None = None) -> Circuit:
-        """
-        Append a :py:class:`StabiliserAssertionBox` to the circuit.
-        
-        :param box: StabiliserAssertionBox to append
-        :param qubits: indices of target qubits
-        :param ancilla: index of ancilla qubit
-        :param name: name used to identify this assertion
-        :return: the new :py:class:`Circuit`
-        """
-    @typing.overload
-    def add_assertion(self, box: StabiliserAssertionBox, qubits: typing.Sequence[pytket._tket.unit_id.Qubit], ancilla: pytket._tket.unit_id.Qubit, name: str | None = None) -> Circuit:
+    def add_assertion(self, box: StabiliserAssertionBox, qubits: typing.Sequence[int] | typing.Sequence[pytket._tket.unit_id.Qubit], ancilla: int | pytket._tket.unit_id.Qubit, name: str | None = None) -> Circuit:
         """
         Append a :py:class:`StabiliserAssertionBox` to the circuit.
         
@@ -1130,8 +647,7 @@ class Circuit:
         
         :param number: Number of qubits to add
         """
-    @typing.overload
-    def add_c_and(self, arg0_in: int, arg1_in: int, arg_out: int, **kwargs: Any) -> Circuit:
+    def add_c_and(self, arg0_in: int | pytket._tket.unit_id.Bit, arg1_in: int | pytket._tket.unit_id.Bit, arg_out: int | pytket._tket.unit_id.Bit, **kwargs: Any) -> Circuit:
         """
         Appends a binary AND operation to the end of the circuit.
         
@@ -1140,11 +656,6 @@ class Circuit:
         :param arg_out: output bit
         :param kwargs: additional arguments passed to `add_gate_method` . Allowed parameters are `opgroup`,  `condition` , `condition_bits`, `condition_value`
         :return: the new :py:class:`Circuit`
-        """
-    @typing.overload
-    def add_c_and(self, arg0_in: pytket._tket.unit_id.Bit, arg1_in: pytket._tket.unit_id.Bit, arg_out: pytket._tket.unit_id.Bit, **kwargs: Any) -> Circuit:
-        """
-        See :py:meth:`add_c_and`.
         """
     def add_c_and_to_registers(self, reg0_in: pytket._tket.unit_id.BitRegister, reg1_in: pytket._tket.unit_id.BitRegister, reg_out: pytket._tket.unit_id.BitRegister, **kwargs: Any) -> Circuit:
         """
@@ -1158,8 +669,7 @@ class Circuit:
         :param kwargs: additional arguments passed to `add_gate_method` . Allowed parameters are `opgroup`,  `condition` , `condition_bits`, `condition_value`
         :return: the new :py:class:`Circuit`
         """
-    @typing.overload
-    def add_c_copybits(self, args_in: typing.Sequence[int], args_out: typing.Sequence[int], **kwargs: Any) -> Circuit:
+    def add_c_copybits(self, args_in: typing.Sequence[int] | typing.Sequence[pytket._tket.unit_id.Bit], args_out: typing.Sequence[int] | typing.Sequence[pytket._tket.unit_id.Bit], **kwargs: Any) -> Circuit:
         """
         Appends a classical copy operation
         
@@ -1168,29 +678,17 @@ class Circuit:
         :param kwargs: additional arguments passed to `add_gate_method` . Allowed parameters are `opgroup`,  `condition` , `condition_bits`, `condition_value`
         :return: the new :py:class:`Circuit`
         """
-    @typing.overload
-    def add_c_copybits(self, args_in: typing.Sequence[pytket._tket.unit_id.Bit], args_out: typing.Sequence[pytket._tket.unit_id.Bit], **kwargs: Any) -> Circuit:
-        """
-        See :py:meth:`add_c_copybits`.
-        """
     def add_c_copyreg(self, input_reg: pytket._tket.unit_id.BitRegister, output_reg: pytket._tket.unit_id.BitRegister, **kwargs: Any) -> Circuit:
         """
         Copy a classical register to another. Copying is truncated to the size of the smaller of the two registers.
         """
-    @typing.overload
-    def add_c_modifier(self, values: typing.Sequence[bool], args_in: typing.Sequence[int], arg_inout: int, name: str = 'ExplicitModifier', **kwargs: Any) -> Circuit:
+    def add_c_modifier(self, values: typing.Sequence[bool], args_in: typing.Sequence[int] | typing.Sequence[pytket._tket.unit_id.Bit], arg_inout: int | pytket._tket.unit_id.Bit, name: str = 'ExplicitModifier', **kwargs: Any) -> Circuit:
         """
         :param name: operation name
         :param kwargs: additional arguments passed to `add_gate_method` . Allowed parameters are `opgroup`,  `condition` , `condition_bits`, `condition_value`
         :return: the new :py:class:`Circuit`
         """
-    @typing.overload
-    def add_c_modifier(self, values: typing.Sequence[bool], args_in: typing.Sequence[pytket._tket.unit_id.Bit], arg_inout: pytket._tket.unit_id.Bit, name: str = 'ExplicitModifier', **kwargs: Any) -> Circuit:
-        """
-        See :py:meth:`add_c_modifier`.
-        """
-    @typing.overload
-    def add_c_not(self, arg_in: int, arg_out: int, **kwargs: Any) -> Circuit:
+    def add_c_not(self, arg_in: int | pytket._tket.unit_id.Bit, arg_out: int | pytket._tket.unit_id.Bit, **kwargs: Any) -> Circuit:
         """
         Appends a NOT operation to the end of the circuit.
         
@@ -1198,11 +696,6 @@ class Circuit:
         :param arg_out: output bit
         :param kwargs: additional arguments passed to `add_gate_method` . Allowed parameters are `opgroup`,  `condition` , `condition_bits`, `condition_value`
         :return: the new :py:class:`Circuit`
-        """
-    @typing.overload
-    def add_c_not(self, arg_in: pytket._tket.unit_id.Bit, arg_out: pytket._tket.unit_id.Bit, **kwargs: Any) -> Circuit:
-        """
-        See :py:meth:`add_c_not`.
         """
     def add_c_not_to_registers(self, reg_in: pytket._tket.unit_id.BitRegister, reg_out: pytket._tket.unit_id.BitRegister, **kwargs: Any) -> Circuit:
         """
@@ -1215,8 +708,7 @@ class Circuit:
         :param kwargs: additional arguments passed to `add_gate_method` . Allowed parameters are `opgroup`,  `condition` , `condition_bits`, `condition_value`
         :return: the new :py:class:`Circuit`
         """
-    @typing.overload
-    def add_c_or(self, arg0_in: int, arg1_in: int, arg_out: int, **kwargs: Any) -> Circuit:
+    def add_c_or(self, arg0_in: int | pytket._tket.unit_id.Bit, arg1_in: int | pytket._tket.unit_id.Bit, arg_out: int | pytket._tket.unit_id.Bit, **kwargs: Any) -> Circuit:
         """
         Appends a binary OR operation to the end of the circuit.
         
@@ -1225,11 +717,6 @@ class Circuit:
         :param arg_out: output bit
         :param kwargs: additional arguments passed to `add_gate_method` . Allowed parameters are `opgroup`,  `condition` , `condition_bits`, `condition_value`
         :return: the new :py:class:`Circuit`
-        """
-    @typing.overload
-    def add_c_or(self, arg0_in: pytket._tket.unit_id.Bit, arg1_in: pytket._tket.unit_id.Bit, arg_out: pytket._tket.unit_id.Bit, **kwargs: Any) -> Circuit:
-        """
-        See :py:meth:`add_c_or`.
         """
     def add_c_or_to_registers(self, reg0_in: pytket._tket.unit_id.BitRegister, reg1_in: pytket._tket.unit_id.BitRegister, reg_out: pytket._tket.unit_id.BitRegister, **kwargs: Any) -> Circuit:
         """
@@ -1243,32 +730,13 @@ class Circuit:
         :param kwargs: additional arguments passed to `add_gate_method` . Allowed parameters are `opgroup`,  `condition` , `condition_bits`, `condition_value`
         :return: the new :py:class:`Circuit`
         """
-    @typing.overload
-    def add_c_predicate(self, values: typing.Sequence[bool], args_in: typing.Sequence[int], arg_out: int, name: str = 'ExplicitPredicate', **kwargs: Any) -> Circuit:
+    def add_c_predicate(self, values: typing.Sequence[bool], args_in: typing.Sequence[int] | typing.Sequence[pytket._tket.unit_id.Bit], arg_out: int | pytket._tket.unit_id.Bit, name: str = 'ExplicitPredicate', **kwargs: Any) -> Circuit:
         """
         :param name: operation name
         :param kwargs: additional arguments passed to `add_gate_method` . Allowed parameters are `opgroup`,  `condition` , `condition_bits`, `condition_value`
         :return: the new :py:class:`Circuit`
         """
-    @typing.overload
-    def add_c_predicate(self, values: typing.Sequence[bool], args_in: typing.Sequence[pytket._tket.unit_id.Bit], arg_out: pytket._tket.unit_id.Bit, name: str = 'ExplicitPredicate', **kwargs: Any) -> Circuit:
-        """
-        See :py:meth:`add_c_predicate`.
-        """
-    @typing.overload
-    def add_c_range_predicate(self, minval: int, maxval: int, args_in: typing.Sequence[int], arg_out: int, **kwargs: Any) -> Circuit:
-        """
-        Appends a range-predicate operation to the end of the circuit.
-        
-        :param minval: lower bound of input in little-endian encoding
-        :param maxval: upper bound of input in little-endian encoding
-        :param args_in: input bits
-        :param arg_out: output bit (distinct from input bits)
-        :param kwargs: additional arguments passed to `add_gate_method` . Allowed parameters are `opgroup`,  `condition` , `condition_bits`, `condition_value`
-        :return: the new :py:class:`Circuit`
-        """
-    @typing.overload
-    def add_c_range_predicate(self, minval: int, maxval: int, args_in: typing.Sequence[pytket._tket.unit_id.Bit], arg_out: pytket._tket.unit_id.Bit, **kwargs: Any) -> Circuit:
+    def add_c_range_predicate(self, minval: int, maxval: int, args_in: typing.Sequence[int] | typing.Sequence[pytket._tket.unit_id.Bit], arg_out: int | pytket._tket.unit_id.Bit, **kwargs: Any) -> Circuit:
         """
         Appends a range-predicate operation to the end of the circuit.
         
@@ -1295,8 +763,7 @@ class Circuit:
         
         :param register: BitRegister 
         """
-    @typing.overload
-    def add_c_setbits(self, values: typing.Sequence[bool], args: typing.Sequence[int], **kwargs: Any) -> Circuit:
+    def add_c_setbits(self, values: typing.Sequence[bool], args: typing.Sequence[int] | typing.Sequence[pytket._tket.unit_id.Bit], **kwargs: Any) -> Circuit:
         """
         Appends an operation to set some bit values.
         
@@ -1305,17 +772,11 @@ class Circuit:
         :param kwargs: additional arguments passed to `add_gate_method` . Allowed parameters are `opgroup`,  `condition` , `condition_bits`, `condition_value`
         :return: the new :py:class:`Circuit`
         """
-    @typing.overload
-    def add_c_setbits(self, values: typing.Sequence[bool], args: typing.Sequence[pytket._tket.unit_id.Bit], **kwargs: Any) -> Circuit:
-        """
-        See :py:meth:`add_c_setbits`.
-        """
     def add_c_setreg(self, value: int, arg: pytket._tket.unit_id.BitRegister, **kwargs: Any) -> Circuit:
         """
         Set a classical register to an unsigned integer value. The little-endian bitwise representation of the integer is truncated to the register size, up to _TKET_REG_WIDTH bit width. It is zero-padded if the width of the register is greater than _TKET_REG_WIDTH.
         """
-    @typing.overload
-    def add_c_transform(self, values: typing.Sequence[int], args: typing.Sequence[int], name: str = 'ClassicalTransform', **kwargs: Any) -> Circuit:
+    def add_c_transform(self, values: typing.Sequence[int], args: typing.Sequence[int] | typing.Sequence[pytket._tket.unit_id.Bit], name: str = 'ClassicalTransform', **kwargs: Any) -> Circuit:
         """
         Appends a purely classical transformation, defined by a table of values, to the end of the circuit.
         
@@ -1325,13 +786,7 @@ class Circuit:
         :param kwargs: additional arguments passed to `add_gate_method` . Allowed parameters are `opgroup`,  `condition` , `condition_bits`, `condition_value`
         :return: the new :py:class:`Circuit`
         """
-    @typing.overload
-    def add_c_transform(self, values: typing.Sequence[int], args: typing.Sequence[pytket._tket.unit_id.Bit], name: str = 'ClassicalTransform', **kwargs: Any) -> Circuit:
-        """
-        See :py:meth:`add_c_transform`.
-        """
-    @typing.overload
-    def add_c_xor(self, arg0_in: int, arg1_in: int, arg_out: int, **kwargs: Any) -> Circuit:
+    def add_c_xor(self, arg0_in: int | pytket._tket.unit_id.Bit, arg1_in: int | pytket._tket.unit_id.Bit, arg_out: int | pytket._tket.unit_id.Bit, **kwargs: Any) -> Circuit:
         """
         Appends a binary XOR operation to the end of the circuit.
         
@@ -1340,11 +795,6 @@ class Circuit:
         :param arg_out: output bit
         :param kwargs: additional arguments passed to `add_gate_method` . Allowed parameters are `opgroup`,  `condition` , `condition_bits`, `condition_value`
         :return: the new :py:class:`Circuit`
-        """
-    @typing.overload
-    def add_c_xor(self, arg0_in: pytket._tket.unit_id.Bit, arg1_in: pytket._tket.unit_id.Bit, arg_out: pytket._tket.unit_id.Bit, **kwargs: Any) -> Circuit:
-        """
-        See :py:meth:`add_c_xor`.
         """
     def add_c_xor_to_registers(self, reg0_in: pytket._tket.unit_id.BitRegister, reg1_in: pytket._tket.unit_id.BitRegister, reg_out: pytket._tket.unit_id.BitRegister, **kwargs: Any) -> Circuit:
         """
@@ -1358,19 +808,7 @@ class Circuit:
         :param kwargs: additional arguments passed to `add_gate_method` . Allowed parameters are `opgroup`,  `condition` , `condition_bits`, `condition_value`
         :return: the new :py:class:`Circuit`
         """
-    @typing.overload
-    def add_circbox(self, circbox: CircBox, args: typing.Sequence[int], **kwargs: Any) -> Circuit:
-        """
-        Append a :py:class:`CircBox` to the circuit.
-        
-        The qubits and bits of the :py:class:`CircBox` are wired into the circuit in lexicographic order. Bits follow qubits in the order of arguments.
-        
-        :param circbox: The box to append
-        :param args: Indices of the (default-register) qubits/bits to append the box to
-        :return: the new :py:class:`Circuit`
-        """
-    @typing.overload
-    def add_circbox(self, circbox: CircBox, args: typing.Sequence[pytket._tket.unit_id.UnitID], **kwargs: Any) -> Circuit:
+    def add_circbox(self, circbox: CircBox, args: typing.Sequence[int] | typing.Sequence[pytket._tket.unit_id.UnitID], **kwargs: Any) -> Circuit:
         """
         Append a :py:class:`CircBox` to the circuit.
         
@@ -1474,8 +912,7 @@ class Circuit:
         :param data: Additional data stored in Barrier operation.
         :return: the new :py:class:`Circuit`
         """
-    @typing.overload
-    def add_conjugation_box(self, box: ConjugationBox, args: typing.Sequence[pytket._tket.unit_id.UnitID], **kwargs: Any) -> Circuit:
+    def add_conjugation_box(self, box: ConjugationBox, args: typing.Sequence[int] | typing.Sequence[pytket._tket.unit_id.Qubit], **kwargs: Any) -> Circuit:
         """
         Append a :py:class:`ConjugationBox` to the circuit.
         
@@ -1483,27 +920,7 @@ class Circuit:
         :param args: The qubits to append the box to
         :return: the new :py:class:`Circuit`
         """
-    @typing.overload
-    def add_conjugation_box(self, box: ConjugationBox, args: typing.Sequence[int], **kwargs: Any) -> Circuit:
-        """
-        Append a :py:class:`ConjugationBox` to the circuit.
-        
-        :param box: The box to append
-        :param args: Indices of the qubits to append the box to
-        :return: the new :py:class:`Circuit`
-        """
-    @typing.overload
-    def add_custom_gate(self, definition: CustomGateDef, params: typing.Sequence[sympy.Expr | float], qubits: typing.Sequence[int], **kwargs: Any) -> Circuit:
-        """
-        Append an instance of a :py:class:`CustomGateDef` to the circuit.
-        
-        :param def: The custom gate definition
-        :param params: List of parameters to instantiate the gate with, in halfturns
-        :param qubits: Indices of the qubits to append the box to
-        :return: the new :py:class:`Circuit`
-        """
-    @typing.overload
-    def add_custom_gate(self, definition: CustomGateDef, params: typing.Sequence[sympy.Expr | float], qubits: typing.Sequence[pytket._tket.unit_id.Qubit], **kwargs: Any) -> Circuit:
+    def add_custom_gate(self, definition: CustomGateDef, params: typing.Sequence[sympy.Expr | float], qubits: typing.Sequence[int] | typing.Sequence[pytket._tket.unit_id.Qubit], **kwargs: Any) -> Circuit:
         """
         Append an instance of a :py:class:`CustomGateDef` to the circuit.
         
@@ -1512,8 +929,7 @@ class Circuit:
         :param qubits: The qubits to append the box to
         :return: the new :py:class:`Circuit`
         """
-    @typing.overload
-    def add_diagonal_box(self, box: DiagonalBox, args: typing.Sequence[pytket._tket.unit_id.UnitID], **kwargs: Any) -> Circuit:
+    def add_diagonal_box(self, box: DiagonalBox, args: typing.Sequence[int] | typing.Sequence[pytket._tket.unit_id.Qubit], **kwargs: Any) -> Circuit:
         """
         Append a :py:class:`DiagonalBox` to the circuit.
         
@@ -1521,27 +937,7 @@ class Circuit:
         :param args: The qubits to append the box to
         :return: the new :py:class:`Circuit`
         """
-    @typing.overload
-    def add_diagonal_box(self, box: DiagonalBox, args: typing.Sequence[int], **kwargs: Any) -> Circuit:
-        """
-        Append a :py:class:`DiagonalBox` to the circuit.
-        
-        :param box: The box to append
-        :param args: Indices of the qubits to append the box to
-        :return: the new :py:class:`Circuit`
-        """
-    @typing.overload
-    def add_dummybox(self, dummybox: DummyBox, qubits: typing.Sequence[int], bits: typing.Sequence[int], **kwargs: Any) -> Circuit:
-        """
-        Append a :py:class:`DummyBox` to the circuit.
-        
-        :param dummybox: The box to append
-        :param qubits: Indices (in the default register) of the qubits to append the box to
-        :param bits: Indices of the bits (in the default register) to append the box to
-        :return: the new :py:class:`Circuit`
-        """
-    @typing.overload
-    def add_dummybox(self, dummybox: DummyBox, qubits: typing.Sequence[pytket._tket.unit_id.Qubit], bits: typing.Sequence[pytket._tket.unit_id.Bit], **kwargs: Any) -> Circuit:
+    def add_dummybox(self, dummybox: DummyBox, qubits: typing.Sequence[int] | typing.Sequence[pytket._tket.unit_id.Qubit], bits: typing.Sequence[int] | typing.Sequence[pytket._tket.unit_id.Bit], **kwargs: Any) -> Circuit:
         """
         Append a :py:class:`DummyBox` to the circuit.
         
@@ -1550,20 +946,7 @@ class Circuit:
         :param bits: Bits to append the box to
         :return: the new :py:class:`Circuit`
         """
-    @typing.overload
-    def add_expbox(self, expbox: ExpBox, qubit_0: int, qubit_1: int, **kwargs: Any) -> Circuit:
-        """
-        Append an :py:class:`ExpBox` to the circuit.
-        
-        The matrix representation is ILO-BE.
-        
-        :param expbox: The box to append
-        :param qubit_0: Index of the first target qubit
-        :param qubit_1: Index of the second target qubit
-        :return: the new :py:class:`Circuit`
-        """
-    @typing.overload
-    def add_expbox(self, expbox: ExpBox, qubit_0: pytket._tket.unit_id.Qubit, qubit_1: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
+    def add_expbox(self, expbox: ExpBox, qubit_0: int | pytket._tket.unit_id.Qubit, qubit_1: int | pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Append an :py:class:`ExpBox` to the circuit.
         
@@ -1575,30 +958,12 @@ class Circuit:
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
-    def add_gate(self, Op: Op, args: typing.Sequence[int], **kwargs: Any) -> Circuit:
+    def add_gate(self, Op: Op, args: typing.Sequence[int] | typing.Sequence[pytket._tket.unit_id.UnitID], **kwargs: Any) -> Circuit:
         """
         Appends a single operation to the end of the circuit on some particular qubits/bits. The number of qubits/bits specified must match the arity of the gate.
         """
     @typing.overload
-    def add_gate(self, Op: Op, args: typing.Sequence[pytket._tket.unit_id.UnitID], **kwargs: Any) -> Circuit:
-        """
-        Appends a single operation to the end of the circuit on some particular qubits/bits. The number of qubits/bits specified must match the arity of the gate.
-        """
-    @typing.overload
-    def add_gate(self, type: OpType, args: typing.Sequence[int], **kwargs: Any) -> Circuit:
-        """
-        Appends a single (non-parameterised) gate to the end of the circuit on some particular qubits from the default register ('q'). The number of qubits specified must match the arity of the gate. For `OpType.Measure` operations the bit from the default register should follow the qubit.
-        
-        >>> c.add_gate(OpType.H, [0]) # equivalent to c.H(0)
-        >>> c.add_gate(OpType.CX, [0,1]) # equivalent to c.CX(0,1)
-        
-        :param type: The type of operation to add
-        :param args: The list of indices for the qubits/bits to which the operation is applied
-        :param kwargs: Additional properties for classical conditions
-        :return: the new :py:class:`Circuit`
-        """
-    @typing.overload
-    def add_gate(self, type: OpType, args: typing.Sequence[pytket._tket.unit_id.UnitID], **kwargs: Any) -> Circuit:
+    def add_gate(self, type: OpType, args: typing.Sequence[int] | typing.Sequence[pytket._tket.unit_id.UnitID], **kwargs: Any) -> Circuit:
         """
         Appends a single (non-parameterised) gate to the end of the circuit on some particular qubits from the default register ('q'). The number of qubits specified must match the arity of the gate. For `OpType.Measure` operations the bit from the default register should follow the qubit.
         
@@ -1611,18 +976,7 @@ class Circuit:
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
-    def add_gate(self, type: OpType, angle: sympy.Expr | float, args: typing.Sequence[int], **kwargs: Any) -> Circuit:
-        """
-        Appends a single gate, parameterised by an expression, to the end of circuit on some particular qubits from the default register ('q').
-        
-        :param type: The type of gate to add
-        :param angle: The parameter for the gate in halfturns
-        :param args: The list of indices for the qubits to which the operation is applied
-        :param kwargs: Additional properties for classical conditions
-        :return: the new :py:class:`Circuit`
-        """
-    @typing.overload
-    def add_gate(self, type: OpType, angle: sympy.Expr | float, args: typing.Sequence[pytket._tket.unit_id.UnitID], **kwargs: Any) -> Circuit:
+    def add_gate(self, type: OpType, angle: sympy.Expr | float, args: typing.Sequence[int] | typing.Sequence[pytket._tket.unit_id.UnitID], **kwargs: Any) -> Circuit:
         """
         Appends a single gate, parameterised by an expression, to the end of circuit on some particular qubits from the default register ('q').
         
@@ -1633,18 +987,7 @@ class Circuit:
         :return: the new :py:class:`Circuit`
         """
     @typing.overload
-    def add_gate(self, type: OpType, angles: typing.Sequence[sympy.Expr | float], args: typing.Sequence[int], **kwargs: Any) -> Circuit:
-        """
-        Appends a single gate, parameterised with a vector of expressions corresponding to halfturns, to the end of circuit on some particular qubits from the default register ('q').
-        
-        :param type: The type of gate to add
-        :param angles: The parameters for the gate in halfturns
-        :param args: The list of indices for the qubits to which the operation is applied
-        :param kwargs: Additional properties for classical conditions
-        :return: the new :py:class:`Circuit`
-        """
-    @typing.overload
-    def add_gate(self, type: OpType, angles: typing.Sequence[sympy.Expr | float], args: typing.Sequence[pytket._tket.unit_id.UnitID], **kwargs: Any) -> Circuit:
+    def add_gate(self, type: OpType, angles: typing.Sequence[sympy.Expr | float], args: typing.Sequence[int] | typing.Sequence[pytket._tket.unit_id.UnitID], **kwargs: Any) -> Circuit:
         """
         Appends a single gate to the end of the circuit
         
@@ -1654,8 +997,7 @@ class Circuit:
         :param kwargs: Additional properties for classical conditions
         :return: the new :py:class:`Circuit`
         """
-    @typing.overload
-    def add_multiplexed_tensored_u2(self, box: MultiplexedTensoredU2Box, args: typing.Sequence[pytket._tket.unit_id.UnitID], **kwargs: Any) -> Circuit:
+    def add_multiplexed_tensored_u2(self, box: MultiplexedTensoredU2Box, args: typing.Sequence[int] | typing.Sequence[pytket._tket.unit_id.Qubit], **kwargs: Any) -> Circuit:
         """
         Append a :py:class:`MultiplexedTensoredU2Box` to the circuit.
         
@@ -1663,17 +1005,7 @@ class Circuit:
         :param args: The qubits to append the box to
         :return: the new :py:class:`Circuit`
         """
-    @typing.overload
-    def add_multiplexed_tensored_u2(self, box: MultiplexedTensoredU2Box, args: typing.Sequence[int], **kwargs: Any) -> Circuit:
-        """
-        Append a :py:class:`MultiplexedTensoredU2Box` to the circuit.
-        
-        :param box: The box to append
-        :param args: Indices of the qubits to append the box to
-        :return: the new :py:class:`Circuit`
-        """
-    @typing.overload
-    def add_multiplexedrotation(self, box: MultiplexedRotationBox, args: typing.Sequence[pytket._tket.unit_id.UnitID], **kwargs: Any) -> Circuit:
+    def add_multiplexedrotation(self, box: MultiplexedRotationBox, args: typing.Sequence[int] | typing.Sequence[pytket._tket.unit_id.Qubit], **kwargs: Any) -> Circuit:
         """
         Append a :py:class:`MultiplexedRotationBox` to the circuit.
         
@@ -1681,17 +1013,7 @@ class Circuit:
         :param args: The qubits to append the box to
         :return: the new :py:class:`Circuit`
         """
-    @typing.overload
-    def add_multiplexedrotation(self, box: MultiplexedRotationBox, args: typing.Sequence[int], **kwargs: Any) -> Circuit:
-        """
-        Append a :py:class:`MultiplexedRotationBox` to the circuit.
-        
-        :param box: The box to append
-        :param args: Indices of the qubits to append the box to
-        :return: the new :py:class:`Circuit`
-        """
-    @typing.overload
-    def add_multiplexedu2(self, box: MultiplexedU2Box, args: typing.Sequence[pytket._tket.unit_id.UnitID], **kwargs: Any) -> Circuit:
+    def add_multiplexedu2(self, box: MultiplexedU2Box, args: typing.Sequence[int] | typing.Sequence[pytket._tket.unit_id.Qubit], **kwargs: Any) -> Circuit:
         """
         Append a :py:class:`MultiplexedU2Box` to the circuit.
         
@@ -1699,17 +1021,7 @@ class Circuit:
         :param args: The qubits to append the box to
         :return: the new :py:class:`Circuit`
         """
-    @typing.overload
-    def add_multiplexedu2(self, box: MultiplexedU2Box, args: typing.Sequence[int], **kwargs: Any) -> Circuit:
-        """
-        Append a :py:class:`MultiplexedU2Box` to the circuit.
-        
-        :param box: The box to append
-        :param args: Indices of the qubits to append the box to
-        :return: the new :py:class:`Circuit`
-        """
-    @typing.overload
-    def add_multiplexor(self, box: MultiplexorBox, args: typing.Sequence[pytket._tket.unit_id.UnitID], **kwargs: Any) -> Circuit:
+    def add_multiplexor(self, box: MultiplexorBox, args: typing.Sequence[int] | typing.Sequence[pytket._tket.unit_id.Qubit], **kwargs: Any) -> Circuit:
         """
         Append a :py:class:`MultiplexorBox` to the circuit.
         
@@ -1717,26 +1029,7 @@ class Circuit:
         :param args: The qubits to append the box to
         :return: the new :py:class:`Circuit`
         """
-    @typing.overload
-    def add_multiplexor(self, box: MultiplexorBox, args: typing.Sequence[int], **kwargs: Any) -> Circuit:
-        """
-        Append a :py:class:`MultiplexorBox` to the circuit.
-        
-        :param box: The box to append
-        :param args: Indices of the qubits to append the box to
-        :return: the new :py:class:`Circuit`
-        """
-    @typing.overload
-    def add_pauliexpbox(self, pauliexpbox: PauliExpBox, qubits: typing.Sequence[int], **kwargs: Any) -> Circuit:
-        """
-        Append a :py:class:`PauliExpBox` to the circuit.
-        
-        :param pauliexpbox: The box to append
-        :param qubits: Indices of the qubits to append the box to
-        :return: the new :py:class:`Circuit`
-        """
-    @typing.overload
-    def add_pauliexpbox(self, pauliexpbox: PauliExpBox, qubits: typing.Sequence[pytket._tket.unit_id.Qubit], **kwargs: Any) -> Circuit:
+    def add_pauliexpbox(self, pauliexpbox: PauliExpBox, qubits: typing.Sequence[int] | typing.Sequence[pytket._tket.unit_id.Qubit], **kwargs: Any) -> Circuit:
         """
         Append a :py:class:`PauliExpBox` to the circuit.
         
@@ -1744,17 +1037,7 @@ class Circuit:
         :param qubits: The qubits to append the box to
         :return: the new :py:class:`Circuit`
         """
-    @typing.overload
-    def add_pauliexpcommutingsetbox(self, pauliexpcommutingsetbox: PauliExpCommutingSetBox, qubits: typing.Sequence[int], **kwargs: Any) -> Circuit:
-        """
-        Append a :py:class:`PauliExpCommutingSetBox` to the circuit.
-        
-        :param pauliexpcommutingsetbox: The box to append
-        :param qubits: Indices of the qubits to append the box to
-        :return: the new :py:class:`Circuit`
-        """
-    @typing.overload
-    def add_pauliexpcommutingsetbox(self, pauliexpcommutingsetbox: PauliExpCommutingSetBox, qubits: typing.Sequence[pytket._tket.unit_id.Qubit], **kwargs: Any) -> Circuit:
+    def add_pauliexpcommutingsetbox(self, pauliexpcommutingsetbox: PauliExpCommutingSetBox, qubits: typing.Sequence[int] | typing.Sequence[pytket._tket.unit_id.Qubit], **kwargs: Any) -> Circuit:
         """
         Append a :py:class:`PauliExpCommutingSetBox` to the circuit.
         
@@ -1762,17 +1045,7 @@ class Circuit:
         :param qubits: The qubits to append the box to
         :return: the new :py:class:`Circuit`
         """
-    @typing.overload
-    def add_pauliexppairbox(self, pauliexppairbox: PauliExpPairBox, qubits: typing.Sequence[int], **kwargs: Any) -> Circuit:
-        """
-        Append a :py:class:`PauliExpPairBox` to the circuit.
-        
-        :param pauliexppairbox: The box to append
-        :param qubits: Indices of the qubits to append the box to
-        :return: the new :py:class:`Circuit`
-        """
-    @typing.overload
-    def add_pauliexppairbox(self, pauliexppairbox: PauliExpPairBox, qubits: typing.Sequence[pytket._tket.unit_id.Qubit], **kwargs: Any) -> Circuit:
+    def add_pauliexppairbox(self, pauliexppairbox: PauliExpPairBox, qubits: typing.Sequence[int] | typing.Sequence[pytket._tket.unit_id.Qubit], **kwargs: Any) -> Circuit:
         """
         Append a :py:class:`PauliExpPairBox` to the circuit.
         
@@ -1788,17 +1061,7 @@ class Circuit:
         
         :return: circuit with added phase
         """
-    @typing.overload
-    def add_phasepolybox(self, phasepolybox: PhasePolyBox, qubits: typing.Sequence[int], **kwargs: Any) -> Circuit:
-        """
-        Append a :py:class:`PhasePolyBox` to the circuit.
-        
-        :param phasepolybox: The box to append
-        :param qubits: Indices of the qubits to append the box to
-        :return: the new :py:class:`Circuit`
-        """
-    @typing.overload
-    def add_phasepolybox(self, phasepolybox: PhasePolyBox, qubits: typing.Sequence[pytket._tket.unit_id.Qubit], **kwargs: Any) -> Circuit:
+    def add_phasepolybox(self, phasepolybox: PhasePolyBox, qubits: typing.Sequence[int] | typing.Sequence[pytket._tket.unit_id.Qubit], **kwargs: Any) -> Circuit:
         """
         Append a :py:class:`PhasePolyBox` to the circuit.
         
@@ -1822,22 +1085,12 @@ class Circuit:
         
         :param register: QubitRegister 
         """
-    @typing.overload
-    def add_qcontrolbox(self, qcontrolbox: QControlBox, args: typing.Sequence[int], **kwargs: Any) -> Circuit:
+    def add_qcontrolbox(self, qcontrolbox: QControlBox, qubits: typing.Sequence[int] | typing.Sequence[pytket._tket.unit_id.Qubit], **kwargs: Any) -> Circuit:
         """
         Append a :py:class:`QControlBox` to the circuit.
         
         :param qcontrolbox: The box to append
-        :param args: Indices of the qubits to append the box to
-        :return: the new :py:class:`Circuit`
-        """
-    @typing.overload
-    def add_qcontrolbox(self, qcontrolbox: QControlBox, args: typing.Sequence[pytket._tket.unit_id.UnitID], **kwargs: Any) -> Circuit:
-        """
-        Append a :py:class:`QControlBox` to the circuit.
-        
-        :param qcontrolbox: The box to append
-        :param args: The qubits to append the box to
+        :param qubits: The qubits to append the box to
         :return: the new :py:class:`Circuit`
         """
     def add_qubit(self, id: pytket._tket.unit_id.Qubit, reject_dups: bool = True) -> None:
@@ -1847,8 +1100,7 @@ class Circuit:
         :param id: Unique id for the qubit
         :param reject_dups: Fail if there is already a qubit in this circuit with the id. Default to True
         """
-    @typing.overload
-    def add_state_preparation_box(self, box: StatePreparationBox, args: typing.Sequence[pytket._tket.unit_id.UnitID], **kwargs: Any) -> Circuit:
+    def add_state_preparation_box(self, box: StatePreparationBox, args: typing.Sequence[int] | typing.Sequence[pytket._tket.unit_id.Qubit], **kwargs: Any) -> Circuit:
         """
         Append a :py:class:`StatePreparationBox` to the circuit.
         
@@ -1856,26 +1108,7 @@ class Circuit:
         :param args: The qubits to append the box to
         :return: the new :py:class:`Circuit`
         """
-    @typing.overload
-    def add_state_preparation_box(self, box: StatePreparationBox, args: typing.Sequence[int], **kwargs: Any) -> Circuit:
-        """
-        Append a :py:class:`StatePreparationBox` to the circuit.
-        
-        :param box: The box to append
-        :param args: Indices of the qubits to append the box to
-        :return: the new :py:class:`Circuit`
-        """
-    @typing.overload
-    def add_termsequencebox(self, termsequencebox: TermSequenceBox, qubits: typing.Sequence[int], **kwargs: Any) -> Circuit:
-        """
-        Append a :py:class:`TermSequenceBox` to the circuit.
-        
-        :param termsequencebox: The box to append
-        :param qubits: Indices of the qubits to append the box to
-        :return: the new :py:class:`Circuit`
-        """
-    @typing.overload
-    def add_termsequencebox(self, termsequencebox: TermSequenceBox, qubits: typing.Sequence[pytket._tket.unit_id.Qubit], **kwargs: Any) -> Circuit:
+    def add_termsequencebox(self, termsequencebox: TermSequenceBox, qubits: typing.Sequence[int] | typing.Sequence[pytket._tket.unit_id.Qubit], **kwargs: Any) -> Circuit:
         """
         Append a :py:class:`TermSequenceBox` to the circuit.
         
@@ -1883,8 +1116,7 @@ class Circuit:
         :param qubits: The qubits to append the box to
         :return: the new :py:class:`Circuit`
         """
-    @typing.overload
-    def add_toffolibox(self, toffolibox: ToffoliBox, qubits: typing.Sequence[int], **kwargs: Any) -> Circuit:
+    def add_toffolibox(self, toffolibox: ToffoliBox, qubits: typing.Sequence[int] | typing.Sequence[pytket._tket.unit_id.Qubit], **kwargs: Any) -> Circuit:
         """
         Append a :py:class:`ToffoliBox` to the circuit.
         
@@ -1892,26 +1124,7 @@ class Circuit:
         :param qubits: Indices of the qubits to append the box to
         :return: the new :py:class:`Circuit`
         """
-    @typing.overload
-    def add_toffolibox(self, toffolibox: ToffoliBox, qubits: typing.Sequence[pytket._tket.unit_id.Qubit], **kwargs: Any) -> Circuit:
-        """
-        Append a :py:class:`ToffoliBox` to the circuit.
-        
-        :param toffolibox: The box to append
-        :param qubits: Indices of the qubits to append the box to
-        :return: the new :py:class:`Circuit`
-        """
-    @typing.overload
-    def add_unitary1qbox(self, unitarybox: Unitary1qBox, qubit_0: int, **kwargs: Any) -> Circuit:
-        """
-        Append a :py:class:`Unitary1qBox` to the circuit.
-        
-        :param unitarybox: The box to append
-        :param qubit_0: Index of the qubit to append the box to
-        :return: the new :py:class:`Circuit`
-        """
-    @typing.overload
-    def add_unitary1qbox(self, unitarybox: Unitary1qBox, qubit_0: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
+    def add_unitary1qbox(self, unitarybox: Unitary1qBox, qubit_0: int | pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Append a :py:class:`Unitary1qBox` to the circuit.
         
@@ -1919,20 +1132,7 @@ class Circuit:
         :param qubit_0: The qubit to append the box to
         :return: the new :py:class:`Circuit`
         """
-    @typing.overload
-    def add_unitary2qbox(self, unitarybox: Unitary2qBox, qubit_0: int, qubit_1: int, **kwargs: Any) -> Circuit:
-        """
-        Append a :py:class:`Unitary2qBox` to the circuit.
-        
-        The matrix representation is ILO-BE.
-        
-        :param unitarybox: The box to append
-        :param qubit_0: Index of the first target qubit
-        :param qubit_1: Index of the second target qubit
-        :return: the new :py:class:`Circuit`
-        """
-    @typing.overload
-    def add_unitary2qbox(self, unitarybox: Unitary2qBox, qubit_0: pytket._tket.unit_id.Qubit, qubit_1: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
+    def add_unitary2qbox(self, unitarybox: Unitary2qBox, qubit_0: int | pytket._tket.unit_id.Qubit, qubit_1: int | pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Append a :py:class:`Unitary2qBox` to the circuit.
         
@@ -1943,19 +1143,7 @@ class Circuit:
         :param qubit_1: The second target qubit
         :return: the new :py:class:`Circuit`
         """
-    @typing.overload
-    def add_unitary3qbox(self, unitarybox: Unitary3qBox, qubit_0: int, qubit_1: int, qubit_2: int, **kwargs: Any) -> Circuit:
-        """
-        Append a :py:class:`Unitary3qBox` to the circuit.
-        
-        :param unitarybox: box to append
-        :param qubit_0: index of target qubit 0
-        :param qubit_1: index of target qubit 1
-        :param qubit_2: index of target qubit 2
-        :return: the new :py:class:`Circuit`
-        """
-    @typing.overload
-    def add_unitary3qbox(self, unitarybox: Unitary3qBox, qubit_0: pytket._tket.unit_id.Qubit, qubit_1: pytket._tket.unit_id.Qubit, qubit_2: pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
+    def add_unitary3qbox(self, unitarybox: Unitary3qBox, qubit_0: int | pytket._tket.unit_id.Qubit, qubit_1: int | pytket._tket.unit_id.Qubit, qubit_2: int | pytket._tket.unit_id.Qubit, **kwargs: Any) -> Circuit:
         """
         Append a :py:class:`Unitary3qBox` to the circuit.
         


### PR DESCRIPTION
# Description

Many of the methods on the pytket `Circuit` class are overloaded to account for the ability for the user to specify arguments as either integers (which implicitly refer to the corresponding index in the standard register for qubits or bits) or explicitly using `Qubit`/`Bit`. This change makes use of variant types (a.k.a. unions) to combine methods whenever possible. This allows us to do things like providing custom error messages for certain kinds of type errors, since we are handling some of the type inference ourselves rather than it all being auto-generated by pybind.

If we like this and wish to push this further, I can imagine further changes off the back of this PR where we take more of the control away from pybind in order to have better control of error messages and API docs by performing more of the type inference ourselves.

# Related issues

Issue #1580 gives examples of some of the non-obvious error messages that occur from pybind's defaults. From the examples there, the changes here just allow the first example to work perfectly fine.

# Checklist

- [x] I have performed a self-review of my code.
- [ ] I have commented hard-to-understand parts of my code.
- [x] I have made corresponding changes to the public API documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have updated the changelog with any user-facing changes.
