### PR TITLE
Fix handling of `BitWiseOp.NEQ` when parsing QASM

### DIFF
--- a/pytket/docs/changelog.rst
+++ b/pytket/docs/changelog.rst
@@ -12,6 +12,7 @@ Features:
 Fixes:
 
 * Make `ZXGraphlikeOptimisation` pass preserve the circuit's name.
+* Fix handling of bitwise inequality conditions when parsing QASM.
 
 2.1.0 (March 2025)
 ------------------

--- a/pytket/pytket/qasm/qasm.py
+++ b/pytket/pytket/qasm/qasm.py
@@ -623,7 +623,11 @@ class CircuitTransformer(Transformer):
 
         if isinstance(var, Bit):
             assert condition.op in (BitWiseOp.EQ, BitWiseOp.NEQ)
+            assert isinstance(val, int)
             assert val in (0, 1)
+            if condition.op == BitWiseOp.NEQ:
+                condition.op = BitWiseOp.EQ
+                val = 1 ^ val
             condition_bits = [var.to_list()]
 
         else:

--- a/pytket/tests/qasm_test.py
+++ b/pytket/tests/qasm_test.py
@@ -1252,6 +1252,20 @@ c4x q[0],q[1],q[2],q[3],q[4];
     assert c4 == c4a
 
 
+def test_inequality_condition() -> None:
+    # https://github.com/CQCL/tket/issues/1833
+    qasm = """OPENQASM 2.0;
+include "qelib1.inc";
+creg c[2];
+if (c[0] != 1) c[1] = 1;
+"""
+    c = circuit_from_qasm_str(qasm)
+    c1 = Circuit(0, 2).add_c_setbits(
+        values=[True], args=[1], condition_bits=[0], condition_value=0
+    )
+    assert c == c1
+
+
 if __name__ == "__main__":
     test_qasm_correct()
     test_qasm_qubit()


### PR DESCRIPTION
Fixes #1833 .

I'd like to make a new release after this.