### PR TITLE
Add "_gen_scratch_transformation"

### DIFF
--- a/pytket/docs/changelog.rst
+++ b/pytket/docs/changelog.rst
@@ -13,6 +13,7 @@ Fixes:
 
 * Make `ZXGraphlikeOptimisation` pass preserve the circuit's name.
 * Fix handling of bitwise inequality conditions when parsing QASM.
+* Define transform used in `scratch_reg_resize_pass` as as separate function.
 
 2.1.0 (March 2025)
 ------------------

--- a/pytket/pytket/passes/resizeregpass.py
+++ b/pytket/pytket/passes/resizeregpass.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from typing import Callable
+
 from pytket.circuit import Bit, Circuit
 from pytket.unit_id import _TEMP_BIT_NAME
 

--- a/pytket/pytket/passes/resizeregpass.py
+++ b/pytket/pytket/passes/resizeregpass.py
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Callable
 from pytket.circuit import Bit, Circuit
 from pytket.unit_id import _TEMP_BIT_NAME
-from typing import Callable
 
 from .._tket.passes import BasePass, CustomPass
 

--- a/pytket/pytket/passes/resizeregpass.py
+++ b/pytket/pytket/passes/resizeregpass.py
@@ -14,6 +14,7 @@
 
 from pytket.circuit import Bit, Circuit
 from pytket.unit_id import _TEMP_BIT_NAME
+from typing import Callable
 
 from .._tket.passes import BasePass, CustomPass
 
@@ -28,7 +29,7 @@ def _is_scratch(bit: Bit) -> bool:
 def _gen_scratch_transformation(max_size: int) -> Callable[[Circuit], Circuit]:
     def t(circuit: Circuit) -> Circuit:
         # Find all scratch bits
-        scratch_bits = list(filter(_is_scratch, circ.bits))
+        scratch_bits = list(filter(_is_scratch, circuit.bits))
         # If the total number of scratch bits exceeds the max width, rename them
         if len(scratch_bits) > max_size:
             bits_map = {}


### PR DESCRIPTION
# Description

`scratch_reg_resize_pass` defines the transform for a `CustomPass` within its function scope. However, deserialisation is now supported for `CustomPass` but requires the Circuit->Circuit transform as an argument. This PR moves the transform out of the function scope so that custom deserialisation can just import the correct function.

# Related issues

Please mention any github issues addressed by this PR.

# Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have commented hard-to-understand parts of my code.
- [ ] I have made corresponding changes to the public API documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the changelog with any user-facing changes.
