### PR TITLE
Keep all classical wires in `FlattenRelabelRegistersPass`

### DIFF
--- a/pytket/conanfile.py
+++ b/pytket/conanfile.py
@@ -38,7 +38,7 @@ class pytketRecipe(ConanFile):
         self.requires("pybind11_json/tci-0.2.15@tket/stable")
         self.requires("symengine/tci-0.14.0@tket/stable")
         self.requires("tkassert/0.3.4@tket/stable")
-        self.requires("tket/2.1.5@tket/stable")
+        self.requires("tket/2.1.6@tket/stable")
         self.requires("tklog/0.3.3@tket/stable")
         self.requires("tkrng/0.3.3@tket/stable")
         self.requires("tktokenswap/0.3.11@tket/stable")

--- a/pytket/docs/changelog.rst
+++ b/pytket/docs/changelog.rst
@@ -14,6 +14,7 @@ Fixes:
 * Make `ZXGraphlikeOptimisation` pass preserve the circuit's name.
 * Fix handling of bitwise inequality conditions when parsing QASM.
 * Enable deserialization of `NormaliseTK2` pass.
+* Don't remove classical wires in `FlattenRelabelRegistersPass`.
 
 2.1.0 (March 2025)
 ------------------

--- a/pytket/tests/predicates_test.py
+++ b/pytket/tests/predicates_test.py
@@ -897,7 +897,7 @@ def test_remove_blank_wires_pass() -> None:
     cu = CompilationUnit(c)
     FlattenRelabelRegistersPass("a").apply(cu)
     assert cu.circuit.qubits == [Qubit("a", 0)]
-    assert cu.circuit.bits == [Bit("c", 0), Bit("c", 1)]
+    assert cu.circuit.bits == c.bits
 
 
 def test_round_angles_pass() -> None:

--- a/tket/conanfile.py
+++ b/tket/conanfile.py
@@ -23,7 +23,7 @@ from conan.errors import ConanInvalidConfiguration
 
 class TketConan(ConanFile):
     name = "tket"
-    version = "2.1.5"
+    version = "2.1.6"
     package_type = "library"
     license = "Apache 2"
     homepage = "https://github.com/CQCL/tket"

--- a/tket/src/Predicates/PassGenerators.cpp
+++ b/tket/src/Predicates/PassGenerators.cpp
@@ -357,7 +357,7 @@ PassPtr gen_flatten_relabel_registers_pass(const std::string& label) {
   Transform t =
       Transform([=](Circuit& circuit, std::shared_ptr<unit_bimaps_t> maps) {
         unsigned n_qubits = circuit.n_qubits();
-        circuit.remove_blank_wires(false);
+        circuit.remove_blank_wires(true);
         bool changed = circuit.n_qubits() < n_qubits;
         std::map<Qubit, Qubit> relabelling_map;
         std::vector<Qubit> all_qubits = circuit.all_qubits();


### PR DESCRIPTION
Fixes #1434 .

I've checked that this doesn't break any tests in pytket-{azure,qir,qiskit,quantinuum} which are the only extensions I can find that use this pass. Unfortunately I can't remember exactly why we [reverted](https://github.com/CQCL/tket/pull/1453) this change previously.