### PR TITLE
Ignore mypy errors

### DIFF
--- a/pytket/pytket/backends/backendresult.py
+++ b/pytket/pytket/backends/backendresult.py
@@ -690,7 +690,7 @@ def _check_permuted_sequence(first: Collection[Any], second: Collection[Any]) ->
 
 def _complex_ar_to_dict(ar: np.ndarray) -> dict[str, list]:
     """Dictionary of real, imaginary parts of complex array, each in list form."""
-    return {"real": ar.real.tolist(), "imag": ar.imag.tolist()}
+    return {"real": ar.real.tolist(), "imag": ar.imag.tolist()}  # type: ignore
 
 
 def _complex_ar_from_dict(dic: dict[str, list]) -> np.ndarray:

--- a/pytket/pytket/utils/results.py
+++ b/pytket/pytket/utils/results.py
@@ -151,7 +151,7 @@ def _compute_probs_from_state(state: np.ndarray, min_p: float = 1e-10) -> np.nda
     ignore = probs < min_p
     probs[ignore] = 0
     probs /= sum(probs)
-    return probs
+    return probs  # type: ignore
 
 
 def probs_from_state(

--- a/pytket/tests/transform_test.py
+++ b/pytket/tests/transform_test.py
@@ -723,10 +723,10 @@ def test_symbol_squash() -> None:
     for x in np.arange(0.0, 4.0, 0.4):
         smap = {a: x}
         c = circ.copy()
-        c.symbol_substitution(smap)
+        c.symbol_substitution(smap)  # type: ignore
         u = c.get_unitary()
         c1 = circ1.copy()
-        c1.symbol_substitution(smap)
+        c1.symbol_substitution(smap)  # type: ignore
         u1 = c1.get_unitary()
         # PauliSquash does not preserve global phase.
         v = u @ u1.conjugate().transpose()
@@ -757,10 +757,10 @@ def test_symbol_pauli_squash_1() -> None:
     for x in np.arange(0.0, 4.0, 0.4):
         smap = {Symbol("a"): x}
         c = circ.copy()
-        c.symbol_substitution(smap)
+        c.symbol_substitution(smap)  # type: ignore
         u = c.get_unitary()
         c1 = circ1.copy()
-        c1.symbol_substitution(smap)
+        c1.symbol_substitution(smap)  # type: ignore
         u1 = c1.get_unitary()
         # PauliSquash does not preserve global phase.
         v = u @ u1.conjugate().transpose()
@@ -775,10 +775,10 @@ def test_symbol_pauli_squash_2() -> None:
     for x in np.arange(0.0, 4.0, 0.4):
         smap = {Symbol("a"): x}
         c = circ.copy()
-        c.symbol_substitution(smap)
+        c.symbol_substitution(smap)  # type: ignore
         u = c.get_unitary()
         c1 = circ1.copy()
-        c1.symbol_substitution(smap)
+        c1.symbol_substitution(smap)  # type: ignore
         u1 = c1.get_unitary()
         # PauliSquash does not preserve global phase.
         v = u @ u1.conjugate().transpose()


### PR DESCRIPTION
Just ignoring the errors for now in order to unblock CI.

These errors only appear with numpy 2.2.x. Previously we were constrained to numpy < 2.2 by numba, but numba recently released 0.61.2 which relaxes that constraint.

Closes #1844 .