### PR TITLE
Undefine move-assignment for `Circuit`

### DIFF
--- a/pytket/conanfile.py
+++ b/pytket/conanfile.py
@@ -37,7 +37,7 @@ class pytketRecipe(ConanFile):
         self.requires("nanobind/tci-2.7.0@tket/stable")
         self.requires("symengine/tci-0.14.0@tket/stable")
         self.requires("tkassert/0.3.4@tket/stable")
-        self.requires("tket/2.1.9@tket/stable")
+        self.requires("tket/2.1.10@tket/stable")
         self.requires("tklog/0.3.3@tket/stable")
         self.requires("tkrng/0.3.3@tket/stable")
         self.requires("tktokenswap/0.3.11@tket/stable")

--- a/tket/conanfile.py
+++ b/tket/conanfile.py
@@ -23,7 +23,7 @@ from conan.errors import ConanInvalidConfiguration
 
 class TketConan(ConanFile):
     name = "tket"
-    version = "2.1.9"
+    version = "2.1.10"
     package_type = "library"
     license = "Apache 2"
     homepage = "https://github.com/CQCL/tket"

--- a/tket/include/tket/Circuit/Circuit.hpp
+++ b/tket/include/tket/Circuit/Circuit.hpp
@@ -322,9 +322,6 @@ class Circuit {
   // copy assignment. Moves boundary pointers.
   Circuit &operator=(const Circuit &other);
 
-  // move assigment
-  Circuit &operator=(Circuit &&circ);
-
   /**
    * Run a suite of checks for internal circuit validity.
    *

--- a/tket/src/Circuit/setters_and_getters.cpp
+++ b/tket/src/Circuit/setters_and_getters.cpp
@@ -65,22 +65,6 @@ Circuit &Circuit::operator=(const Circuit &other)  // (1)
   return *this;
 }
 
-// Move assignment
-Circuit &Circuit::operator=(Circuit &&other) {
-  if (this == &other) {
-    return *this;
-  }
-
-  boundary = std::move(other.boundary);
-  dag.m_vertices = std::move(other.dag.m_vertices);
-  dag.m_edges = std::move(other.dag.m_edges);
-  _number_of_wasm_wires = other._number_of_wasm_wires;
-  name = std::move(other.name);
-  phase = other.get_phase();
-  opgroupsigs = std::move(other.opgroupsigs);
-  return *this;
-}
-
 void Circuit::assert_valid() const {  //
   TKET_ASSERT(is_valid(dag));
 }

--- a/tket/src/Transformations/GreedyPauliOptimisation.cpp
+++ b/tket/src/Transformations/GreedyPauliOptimisation.cpp
@@ -864,7 +864,7 @@ Transform greedy_pauli_optimisation(
     // thread_timeout
     // If none are found then return false
     if (circuits.empty()) return false;
-    auto min = std::min_element(
+    circ = *std::min_element(
         circuits.begin(), circuits.end(),
         [](const Circuit& a, const Circuit& b) {
           const auto two_qubit_gates_a = a.count_n_qubit_gates(2);
@@ -879,7 +879,6 @@ Transform greedy_pauli_optimisation(
           }
           return a.depth() < b.depth();
         });
-    circ = std::move(*min);
     return true;
   });
 }

--- a/tket/src/Transformations/GreedyPauliOptimisation.cpp
+++ b/tket/src/Transformations/GreedyPauliOptimisation.cpp
@@ -864,7 +864,7 @@ Transform greedy_pauli_optimisation(
     // thread_timeout
     // If none are found then return false
     if (circuits.empty()) return false;
-    circ = *std::min_element(
+    auto min = std::min_element(
         circuits.begin(), circuits.end(),
         [](const Circuit& a, const Circuit& b) {
           const auto two_qubit_gates_a = a.count_n_qubit_gates(2);
@@ -879,6 +879,7 @@ Transform greedy_pauli_optimisation(
           }
           return a.depth() < b.depth();
         });
+    circ = std::move(*min);
     return true;
   });
 }


### PR DESCRIPTION
I am suspicious of the move assignment operator, especially of the assignment of the DAG.

While investigating #1858 I found that avoiding its use in `GreedyPauliSimp` stopped one source of leaks. This doesn't prove anything, since the causes of the leaks are quite complicated and it may have just hidden the problem somehow, but when I looked at the move assignment code I couldn't convince myself that all the information was being preserved.

This will mean moves become copies. I don't think this change will have a big effect on performance of `GreedyPauliSimp` as it's only used in one place as far as I can see.