### PR TITLE
Add option to `Circuit.remove_blank_wires()` to force removal of blank classical wires

### DIFF
--- a/pytket/binders/circuit/Circuit/main.cpp
+++ b/pytket/binders/circuit/Circuit/main.cpp
@@ -440,10 +440,14 @@ void def_circuit(nb::class_<Circuit> &pyCircuit) {
           "identity, or when routing adds wires to \"fill out\" the "
           "architecture. This operation will only remove empty classical wires "
           "if there are no used bits with a higher index in the same register. "
-          "\n\n:param "
-          "keep_blank_classical_wires: select if "
-          "empty classical wires should not be removed",
-          nb::arg("keep_blank_classical_wires") = false)
+          "\n\n:param keep_blank_classical_wires: if true, empty classical "
+          "wires are not removed"
+          "\n:param remove_classical_only_at_end_of_register: if true, empty "
+          "classical wires are not removed if they don't belong to a register "
+          "or there are any non-empty wires with a higher index in the same "
+          "register",
+          nb::arg("keep_blank_classical_wires") = false,
+          nb::arg("remove_classical_only_at_end_of_register") = true)
       .def(
           "add_blank_wires", &Circuit::add_blank_wires,
           "Adds a number of new qubits to the circuit. These will be "

--- a/pytket/conanfile.py
+++ b/pytket/conanfile.py
@@ -37,7 +37,7 @@ class pytketRecipe(ConanFile):
         self.requires("nanobind/tci-2.7.0@tket/stable")
         self.requires("symengine/tci-0.14.0@tket/stable")
         self.requires("tkassert/0.3.4@tket/stable")
-        self.requires("tket/2.1.11@tket/stable")
+        self.requires("tket/2.1.12@tket/stable")
         self.requires("tklog/0.3.3@tket/stable")
         self.requires("tkrng/0.3.3@tket/stable")
         self.requires("tktokenswap/0.3.11@tket/stable")

--- a/pytket/docs/changelog.rst
+++ b/pytket/docs/changelog.rst
@@ -4,6 +4,11 @@ Changelog
 Unreleased
 ----------
 
+Features:
+
+* Add option to `Circuit.remove_blank_wires` to force removal of all blank
+  classical wires.
+
 Fixes:
 
 * Apply special handling of multi-controlled gates with 0 or 1 controls when

--- a/pytket/tests/predicates_test.py
+++ b/pytket/tests/predicates_test.py
@@ -899,6 +899,23 @@ def test_remove_blank_wires_pass() -> None:
     assert cu.circuit.qubits == [Qubit("a", 0)]
     assert cu.circuit.bits == c.bits
 
+    c = Circuit()
+    c.add_bit(Bit(1))
+    c1 = c.copy()
+    c1.remove_blank_wires()
+    assert len(c1.bits) == 1  # the empty wire is not in a register
+    c1 = c.copy()
+    c1.remove_blank_wires(remove_classical_only_at_end_of_register=False)
+    assert len(c1.bits) == 0
+
+    c = Circuit(1, 2).H(0).Measure(0, 1)
+    c1 = c.copy()
+    c1.remove_blank_wires()
+    assert len(c1.bits) == 2  # the empty wire is not at the end of a register
+    c1 = c.copy()
+    c1.remove_blank_wires(remove_classical_only_at_end_of_register=False)
+    assert len(c1.bits) == 1
+
 
 def test_round_angles_pass() -> None:
     c0 = Circuit(2).H(0).TK2(0.001, -0.001, 0.001, 0, 1).Rz(0.50001, 0)

--- a/tket/conanfile.py
+++ b/tket/conanfile.py
@@ -23,7 +23,7 @@ from conan.errors import ConanInvalidConfiguration
 
 class TketConan(ConanFile):
     name = "tket"
-    version = "2.1.11"
+    version = "2.1.12"
     package_type = "library"
     license = "Apache 2"
     homepage = "https://github.com/CQCL/tket"

--- a/tket/include/tket/Circuit/Circuit.hpp
+++ b/tket/include/tket/Circuit/Circuit.hpp
@@ -666,10 +666,15 @@ class Circuit {
   /**
    * O(V), `V` the number of vertices
    * removes all blank wires
-   * @param keep_blank_classical_wires option to choose if empty classical wire
-   * should be removed as well
+   * @param keep_blank_classical_wires if true, empty classical wires are not
+   * removed
+   * @param remove_classical_only_at_end_of_register if true, empty classical
+   * wires are not removed if they don't belong to a register or there are any
+   * non-empty wires with a higher index in the same register
    */
-  void remove_blank_wires(bool keep_blank_classical_wires = false);
+  void remove_blank_wires(
+      bool keep_blank_classical_wires = false,
+      bool remove_classical_only_at_end_of_register = true);
 
   /**
    * Remove all gates in the circuits that are identities

--- a/tket/src/Circuit/basic_circ_manip.cpp
+++ b/tket/src/Circuit/basic_circ_manip.cpp
@@ -29,19 +29,18 @@
 
 namespace tket {
 
-// if there are any blank wires in the circuit,
-// this method removes them and removes the vertices
-// from boundaries, if they are quantum wires, or if
-// they are empty classical wires if there are no
-// used bits with a higher index in the same register.
-void Circuit::remove_blank_wires(bool keep_blank_classical_wires) {
+void Circuit::remove_blank_wires(
+    bool keep_blank_classical_wires,
+    bool remove_classical_only_at_end_of_register) {
   VertexList bin;
   unit_vector_t unused_units;
   const Op_ptr noop = get_op_ptr(OpType::noop);
   std::set<std::string> bit_names;
 
   for (const BoundaryElement& el : boundary.get<TagID>()) {
-    if (el.type() == UnitType::Qubit) {
+    if ((!keep_blank_classical_wires &&
+         !remove_classical_only_at_end_of_register) ||
+        el.type() == UnitType::Qubit) {
       Vertex in = el.in_;
       Vertex out = el.out_;
       VertexVec succs = get_successors(in);
@@ -53,29 +52,32 @@ void Circuit::remove_blank_wires(bool keep_blank_classical_wires) {
         unused_units.push_back(el.id_);
       }
     } else if (
-        !keep_blank_classical_wires && el.type() == UnitType::Bit &&
-        el.id_.reg_dim() == 1) {
+        !keep_blank_classical_wires &&
+        remove_classical_only_at_end_of_register &&
+        el.type() == UnitType::Bit && el.id_.reg_dim() == 1) {
       bit_names.insert(el.id_.reg_name());
     }
   }
 
-  for (auto bit_name : bit_names) {
-    for (unsigned reg_size = get_reg(bit_name).size(); reg_size > 0;
-         --reg_size) {
-      boundary_t::iterator unit_found =
-          boundary.get<TagID>().find(Bit(bit_name, reg_size - 1));
-      if (unit_found != boundary.get<TagID>().end()) {
-        Vertex in = unit_found->in_;
-        Vertex out = unit_found->out_;
-        VertexVec succs = get_successors(in);
-        if (succs.front() == out && succs.size() == 1) {
-          dag[in].op = noop;
-          bin.push_back(in);
-          dag[out].op = noop;
-          bin.push_back(out);
-          unused_units.push_back(unit_found->id_);
-        } else {
-          break;
+  if (keep_blank_classical_wires || remove_classical_only_at_end_of_register) {
+    for (auto bit_name : bit_names) {
+      for (unsigned reg_size = get_reg(bit_name).size(); reg_size > 0;
+           --reg_size) {
+        boundary_t::iterator unit_found =
+            boundary.get<TagID>().find(Bit(bit_name, reg_size - 1));
+        if (unit_found != boundary.get<TagID>().end()) {
+          Vertex in = unit_found->in_;
+          Vertex out = unit_found->out_;
+          VertexVec succs = get_successors(in);
+          if (succs.front() == out && succs.size() == 1) {
+            dag[in].op = noop;
+            bin.push_back(in);
+            dag[out].op = noop;
+            bin.push_back(out);
+            unused_units.push_back(unit_found->id_);
+          } else {
+            break;
+          }
         }
       }
     }


### PR DESCRIPTION
Also clarify documentation.

Fixes #1881 .