### PR TITLE
fix: Correct pass name in automatic benchmarks

### DIFF
--- a/.github/workflows/pytket_benchmarking.yml
+++ b/.github/workflows/pytket_benchmarking.yml
@@ -84,8 +84,8 @@ jobs:
 
       - name: Perform Compilation
         run: |
-          pytket_benchmarking compile QiskitIBMQ pytket-benchmarking-store/benchmarking_circuits/quantum_volume automated_benchmarks_compiled
-          pytket_benchmarking compile PytketIBMQ pytket-benchmarking-store/benchmarking_circuits/quantum_volume automated_benchmarks_compiled
+          pytket_benchmarking compile QiskitL3 pytket-benchmarking-store/benchmarking_circuits/quantum_volume automated_benchmarks_compiled
+          pytket_benchmarking compile PytketL3 pytket-benchmarking-store/benchmarking_circuits/quantum_volume automated_benchmarks_compiled
 
       - name: Save compiled circuits
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Small correction to name of compiler used after pytlet-benchmarking 0.7 release

# Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have commented hard-to-understand parts of my code.
- [ ] I have made corresponding changes to the public API documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the changelog with any user-facing changes.
