### PR TITLE
Build stable-ABI wheels for Python >= 3.12

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        python3-version: ['10', '11', '12', '13']
+        python3-version: ['10', '11', '12']
     steps:
     - uses: actions/checkout@v4
       with:
@@ -41,7 +41,7 @@ jobs:
     runs-on: 'buildjet-8vcpu-ubuntu-2204-arm'
     strategy:
       matrix:
-        python3-version: ['10', '11', '12', '13']
+        python3-version: ['10', '11', '12']
     steps:
     - uses: actions/checkout@v4
       with:
@@ -67,7 +67,7 @@ jobs:
     runs-on: macos-13
     strategy:
       matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.10', '3.11', '3.12']
     steps:
     - uses: actions/checkout@v4
       with:
@@ -109,7 +109,7 @@ jobs:
         MACOSX_DEPLOYMENT_TARGET: '13.0'
     strategy:
       matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.10', '3.11', '3.12']
     steps:
     - uses: actions/checkout@v4
       with:
@@ -149,7 +149,7 @@ jobs:
     runs-on: windows-2025
     strategy:
       matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.10', '3.11', '3.12']
     steps:
     - uses: actions/checkout@v4
       with:
@@ -194,10 +194,17 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.${{ matrix.python3-version }}"
-      - name: Download wheels
+      - name: Download wheel (non-stable-ABI)
+        if: matrix.python3-version == '10' || matrix.python3-version == '11'
         uses: actions/download-artifact@v4
         with:
           name: Linux_3.${{ matrix.python3-version }}_wheel
+          path: wheelhouse/
+      - name: Download wheel (stable-ABI)
+        if: matrix.python3-version == '12' || matrix.python3-version == '13'
+        uses: actions/download-artifact@v4
+        with:
+          name: Linux_3.12_wheel
           path: wheelhouse/
       - name: Install wheel
         run: pip install wheelhouse/pytket-*.whl
@@ -226,10 +233,17 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: "3.${{ matrix.python3-version }}"
-    - name: Download wheel
+    - name: Download wheel (non-stable-ABI)
+      if: matrix.python3-version == '10' || matrix.python3-version == '11'
       uses: actions/download-artifact@v4
       with:
         name: Linux_aarch64_3.${{ matrix.python3-version }}_wheel
+        path: wheelhouse/
+    - name: Download wheel (stable-ABI)
+      if: matrix.python3-version == '12' || matrix.python3-version == '13'
+      uses: actions/download-artifact@v4
+      with:
+        name: Linux_aarch64_3.12_wheel
         path: wheelhouse/
     - name: Install wheel
       run: pip install wheelhouse/pytket-*.whl
@@ -256,10 +270,17 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Download wheels
+    - name: Download wheel (non-stable-ABI)
+      if: matrix.python-version == '3.10' || matrix.python-version == '3.11'
       uses: actions/download-artifact@v4
       with:
         name: MacOS_x86_${{ matrix.python-version }}_wheel
+        path: wheelhouse/
+    - name: Download wheel (stable-ABI)
+      if: matrix.python-version == '3.12' || matrix.python-version == '3.13'
+      uses: actions/download-artifact@v4
+      with:
+        name: MacOS_x86_3.12_wheel
         path: wheelhouse/
     - uses: actions/checkout@v4
       with:
@@ -286,10 +307,17 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Download wheels
+    - name: Download wheel (non-stable-ABI)
+      if: matrix.python-version == '3.10' || matrix.python-version == '3.11'
       uses: actions/download-artifact@v4
       with:
         name: MacOS_arm64_${{ matrix.python-version }}_wheel
+        path: wheelhouse/
+    - name: Download wheel (stable-ABI)
+      if: matrix.python-version == '3.12' || matrix.python-version == '3.13'
+      uses: actions/download-artifact@v4
+      with:
+        name: MacOS_arm64_3.12_wheel
         path: wheelhouse/
     - uses: actions/checkout@v4
       with:
@@ -315,10 +343,17 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Download wheel
+    - name: Download wheel (non-stable-ABI)
+      if: matrix.python-version == '3.10' || matrix.python-version == '3.11'
       uses: actions/download-artifact@v4
       with:
         name: Windows_${{ matrix.python-version }}_wheel
+        path: wheelhouse/
+    - name: Download wheel (stable-ABI)
+      if: matrix.python-version == '3.12' || matrix.python-version == '3.13'
+      uses: actions/download-artifact@v4
+      with:
+        name: Windows_3.12_wheel
         path: wheelhouse/
     - name: Install wheel
       shell: bash

--- a/pytket/CMakeLists.txt
+++ b/pytket/CMakeLists.txt
@@ -104,7 +104,9 @@ set(HEADER_FILES
         binders/include/UnitRegister.hpp
    )
 
-nanobind_add_module(circuit NB_DOMAIN pytket
+nanobind_add_module(circuit
+    STABLE_ABI
+    NB_DOMAIN pytket
     binders/circuit/boxes.cpp
     binders/circuit/Circuit/add_classical_op.cpp
     binders/circuit/Circuit/add_op.cpp
@@ -116,77 +118,107 @@ nanobind_add_module(circuit NB_DOMAIN pytket
 target_include_directories(circuit PRIVATE binders/include)
 target_link_libraries(circuit PRIVATE ${lib_deps})
 
-nanobind_add_module(circuit_library NB_DOMAIN pytket
+nanobind_add_module(circuit_library
+    STABLE_ABI
+    NB_DOMAIN pytket
     binders/circuit_library.cpp ${HEADER_FILES})
 target_include_directories(circuit_library PRIVATE binders/include)
 target_link_libraries(circuit_library PRIVATE ${lib_deps})
 
-nanobind_add_module(unit_id NB_DOMAIN pytket
+nanobind_add_module(unit_id
+    STABLE_ABI
+    NB_DOMAIN pytket
     binders/unitid.cpp ${HEADER_FILES})
 target_include_directories(unit_id PRIVATE binders/include)
 target_link_libraries(unit_id PRIVATE ${lib_deps})
 
-nanobind_add_module(mapping NB_DOMAIN pytket
+nanobind_add_module(mapping
+    STABLE_ABI
+    NB_DOMAIN pytket
     binders/mapping.cpp ${HEADER_FILES})
 target_include_directories(mapping PRIVATE binders/include)
 target_link_libraries(mapping PRIVATE ${lib_deps})
 
-nanobind_add_module(transform NB_DOMAIN pytket
+nanobind_add_module(transform
+    STABLE_ABI
+    NB_DOMAIN pytket
     binders/transform.cpp ${HEADER_FILES})
 target_include_directories(transform PRIVATE binders/include)
 target_link_libraries(transform PRIVATE ${lib_deps})
 
-nanobind_add_module(predicates NB_DOMAIN pytket
+nanobind_add_module(predicates
+    STABLE_ABI
+    NB_DOMAIN pytket
     binders/predicates.cpp ${HEADER_FILES})
 target_include_directories(predicates PRIVATE binders/include)
 target_link_libraries(predicates PRIVATE ${lib_deps})
 
-nanobind_add_module(passes NB_DOMAIN pytket
+nanobind_add_module(passes
+    STABLE_ABI
+    NB_DOMAIN pytket
     binders/passes.cpp ${HEADER_FILES})
 target_include_directories(passes PRIVATE binders/include)
 target_link_libraries(passes PRIVATE ${lib_deps})
 
-nanobind_add_module(architecture NB_DOMAIN pytket
+nanobind_add_module(architecture
+    STABLE_ABI
+    NB_DOMAIN pytket
     binders/architecture.cpp ${HEADER_FILES})
 target_include_directories(architecture PRIVATE binders/include)
 target_link_libraries(architecture PRIVATE ${lib_deps})
 
-nanobind_add_module(placement NB_DOMAIN pytket
+nanobind_add_module(placement
+    STABLE_ABI
+    NB_DOMAIN pytket
     binders/placement.cpp ${HEADER_FILES})
 target_include_directories(placement PRIVATE binders/include)
 target_link_libraries(placement PRIVATE ${lib_deps})
 
-nanobind_add_module(partition NB_DOMAIN pytket
+nanobind_add_module(partition
+    STABLE_ABI
+    NB_DOMAIN pytket
     binders/partition.cpp ${HEADER_FILES})
 target_include_directories(partition PRIVATE binders/include)
 target_link_libraries(partition PRIVATE ${lib_deps})
 
-nanobind_add_module(pauli NB_DOMAIN pytket
+nanobind_add_module(pauli
+    STABLE_ABI
+    NB_DOMAIN pytket
     binders/pauli.cpp ${HEADER_FILES})
 target_include_directories(pauli PRIVATE binders/include)
 target_link_libraries(pauli PRIVATE ${lib_deps})
 
-nanobind_add_module(logging NB_DOMAIN pytket
+nanobind_add_module(logging
+    STABLE_ABI
+    NB_DOMAIN pytket
     binders/logging.cpp ${HEADER_FILES})
 target_include_directories(logging PRIVATE binders/include)
 target_link_libraries(logging PRIVATE ${lib_deps})
 
-nanobind_add_module(utils_serialization NB_DOMAIN pytket
+nanobind_add_module(utils_serialization
+    STABLE_ABI
+    NB_DOMAIN pytket
     binders/utils_serialization.cpp ${HEADER_FILES})
 target_include_directories(utils_serialization PRIVATE binders/include)
 target_link_libraries(utils_serialization PRIVATE ${lib_deps})
 
-nanobind_add_module(tailoring NB_DOMAIN pytket
+nanobind_add_module(tailoring
+    STABLE_ABI
+    NB_DOMAIN pytket
     binders/tailoring.cpp ${HEADER_FILES})
 target_include_directories(tailoring PRIVATE binders/include)
 target_link_libraries(tailoring PRIVATE ${lib_deps})
 
-nanobind_add_module(tableau NB_DOMAIN pytket
+nanobind_add_module(tableau
+    STABLE_ABI
+    NB_DOMAIN pytket
     binders/tableau.cpp ${HEADER_FILES})
 target_include_directories(tableau PRIVATE binders/include)
 target_link_libraries(tableau PRIVATE ${lib_deps})
 
-nanobind_add_module(zx NB_DOMAIN pytket
+nanobind_add_module(zx
+    STABLE_ABI
+    NB_DOMAIN pytket
     binders/zx/diagram.cpp
     binders/zx/rewrite.cpp
     ${HEADER_FILES})

--- a/pytket/setup.py
+++ b/pytket/setup.py
@@ -17,6 +17,7 @@ import multiprocessing
 import os
 import shutil
 import subprocess
+import sys
 from sysconfig import get_config_var
 
 import setuptools  # type: ignore
@@ -50,6 +51,8 @@ binders = [
     "architecture",
 ]
 
+stable_abi = sys.version_info >= (3, 12)
+
 
 class CMakeBuild(build_ext):
     def run(self):
@@ -80,7 +83,7 @@ class CMakeBuild(build_ext):
         subprocess.run(["cmake", "--install", os.curdir], cwd=build_dir, check=True)
         lib_folder = os.path.join(install_dir, "lib")
         lib_names = ["libtklog.so", "libtket.so"]
-        ext_suffix = get_config_var("EXT_SUFFIX")
+        ext_suffix = ".abi3.so" if stable_abi else get_config_var("EXT_SUFFIX")
         lib_names.extend(f"{binder}{ext_suffix}" for binder in binders)
         # TODO make the above generic
         os.makedirs(extdir, exist_ok=True)
@@ -205,4 +208,5 @@ setup(
     include_package_data=True,
     package_data={"pytket": ["py.typed"]},
     zip_safe=False,
+    options={"bdist_wheel": {"py_limited_api": "cp312"}} if stable_abi else None,
 )


### PR DESCRIPTION
Closes #1722 .

We can now build stable ABI wheels for Python >= 3.12. Wheels for Python 3.10 and 3.11 still have to be built separately since nanobind does not support stable ABI wheels below 3.12.

Release workflow tested [here](https://github.com/CQCL/tket/actions/runs/14753995944).