### PR TITLE
Revert underscoring of has_reg_output.

### DIFF
--- a/pytket/docs/changelog.md
+++ b/pytket/docs/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.4.1 (May 2025)
+
+Fixes:
+
+- Revert renaming of `has_reg_output` to `_has_reg_output`.
+
 ## 2.4.0 (May 2025)
 
 API changes:

--- a/pytket/pytket/circuit/clexpr.py
+++ b/pytket/pytket/circuit/clexpr.py
@@ -47,7 +47,7 @@ _reg_output_clops = {
 }
 
 
-def _has_reg_output(op: ClOp) -> bool:
+def has_reg_output(op: ClOp) -> bool:
     return op in _reg_output_clops
 
 
@@ -186,7 +186,7 @@ def check_register_alignments(circ: Circuit) -> bool:
                 tuple(args[i] for i in poslist) not in cregs
                 for poslist in wexpr.reg_posn.values()
             ) or (
-                _has_reg_output(wexpr.expr.op)
+                has_reg_output(wexpr.expr.op)
                 and tuple(args[i] for i in wexpr.output_posn) not in cregs
             ):
                 return False

--- a/pytket/pytket/circuit/decompose_classical.py
+++ b/pytket/pytket/circuit/decompose_classical.py
@@ -36,7 +36,7 @@ from pytket._tket.unit_id import (
     Bit,
     BitRegister,
 )
-from pytket.circuit.clexpr import _has_reg_output, check_register_alignments
+from pytket.circuit.clexpr import check_register_alignments, has_reg_output
 from pytket.circuit.logic_exp import Constant, Variable
 
 T = TypeVar("T")
@@ -207,7 +207,7 @@ class _ClExprDecomposer:
         :param out_var: where to put the output (if None, create a new scratch location)
         """
         op: ClOp = expr.op
-        heap: VarHeap = self.reg_heap if _has_reg_output(op) else self.bit_heap
+        heap: VarHeap = self.reg_heap if has_reg_output(op) else self.bit_heap
 
         # Eliminate (recursively) subsidiary expressions from the arguments, and convert
         # all terms to Bit or BitRegister:
@@ -355,7 +355,7 @@ def _decompose_expressions(circ: Circuit) -> tuple[Circuit, bool]:  # noqa: PLR0
             assert isinstance(output0, Bit)
             out_var: Variable = (
                 BitRegister(output0.reg_name, len(output_posn))
-                if _has_reg_output(expr.op)
+                if has_reg_output(expr.op)
                 else output0
             )
             decomposer = _ClExprDecomposer(

--- a/pytket/pytket/qasm/qasm.py
+++ b/pytket/pytket/qasm/qasm.py
@@ -52,8 +52,8 @@ from pytket.circuit import (
     UnitID,
 )
 from pytket.circuit.clexpr import (
-    _has_reg_output,
     check_register_alignments,
+    has_reg_output,
     wired_clexpr_from_logic_exp,
 )
 from pytket.circuit.decompose_classical import _int_to_bools
@@ -1826,7 +1826,7 @@ class _QasmWriter:
         output_repr: str | None = None
         output_args: list[Bit] = [args[j] for j in output_posn]
         n_output_args = len(output_args)
-        expect_reg_output = _has_reg_output(expr.op)
+        expect_reg_output = has_reg_output(expr.op)
         if n_output_args == 0:
             raise QASMUnsupportedError("Expression has no output.")
         if n_output_args == 1:


### PR DESCRIPTION
This method is used by `pytket-phir`.

I've checked that the pytket-quantinuum tests pass with this change.