### PR TITLE
Try to make tket thread-safe

### DIFF
--- a/pytket/conanfile.py
+++ b/pytket/conanfile.py
@@ -37,7 +37,7 @@ class pytketRecipe(ConanFile):
         self.requires("nanobind/tci-2.7.0@tket/stable")
         self.requires("symengine/tci-0.14.0.1@tket/stable")
         self.requires("tkassert/0.3.4@tket/stable")
-        self.requires("tket/2.1.32@tket/stable")
+        self.requires("tket/2.1.33@tket/stable")
         self.requires("tklog/0.3.3@tket/stable")
         self.requires("tkrng/0.3.3@tket/stable")
         self.requires("tktokenswap/0.3.11@tket/stable")

--- a/tket/conanfile.py
+++ b/tket/conanfile.py
@@ -22,7 +22,7 @@ from conan.errors import ConanInvalidConfiguration
 
 class TketConan(ConanFile):
     name = "tket"
-    version = "2.1.32"
+    version = "2.1.33"
     package_type = "library"
     license = "Apache 2"
     homepage = "https://github.com/CQCL/tket"

--- a/tket/src/Gate/OpPtrFunctions.cpp
+++ b/tket/src/Gate/OpPtrFunctions.cpp
@@ -24,6 +24,7 @@
 
 namespace tket {
 
+// Mutex to protect the global symbol table.
 static std::mutex mtx;
 
 Op_ptr get_op_ptr(OpType chosen_type, const Expr& param, unsigned n_qubits) {

--- a/tket/src/Gate/OpPtrFunctions.cpp
+++ b/tket/src/Gate/OpPtrFunctions.cpp
@@ -14,6 +14,8 @@
 
 #include "tket/Gate/OpPtrFunctions.hpp"
 
+#include <mutex>
+
 #include "tket/Gate/Gate.hpp"
 #include "tket/Gate/SymTable.hpp"
 #include "tket/OpType/OpTypeFunctions.hpp"
@@ -22,12 +24,15 @@
 
 namespace tket {
 
+static std::mutex mtx;
+
 Op_ptr get_op_ptr(OpType chosen_type, const Expr& param, unsigned n_qubits) {
   return get_op_ptr(chosen_type, std::vector<Expr>{param}, n_qubits);
 }
 
 Op_ptr get_op_ptr(
     OpType chosen_type, const std::vector<Expr>& params, unsigned n_qubits) {
+  std::lock_guard<std::mutex> lock(mtx);
   if (is_gate_type(chosen_type)) {
     SymTable::register_symbols(expr_free_symbols(params));
     return std::make_shared<const Gate>(chosen_type, params, n_qubits);

--- a/tket/test/CMakeLists.txt
+++ b/tket/test/CMakeLists.txt
@@ -112,6 +112,7 @@ add_executable(test-tket
     src/test_Clifford.cpp
     src/test_Combinators.cpp
     src/test_CompilerPass.cpp
+    src/test_Concurrency.cpp
     src/test_ContextOpt.cpp
     src/test_ControlDecomp.cpp
     src/test_DeviceCharacterisation.cpp

--- a/tket/test/src/test_Concurrency.cpp
+++ b/tket/test/src/test_Concurrency.cpp
@@ -1,0 +1,45 @@
+// Copyright Quantinuum
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <catch2/catch_test_macros.hpp>
+#include <functional>
+#include <nlohmann/json.hpp>
+#include <thread>
+
+#include "tket/Circuit/Circuit.hpp"
+#include "tket/Transformations/OptimisationPass.hpp"
+
+namespace tket {
+namespace test_Concurrency {
+
+SCENARIO("Concurrent transforms") {
+  GIVEN("clifford_simp") {
+    // https://github.com/CQCL/tket/issues/1953
+    const std::string json_str =
+        R"({"bits": [], "commands": [{"args": [["q", [0]], ["q", [1]]], "op": {"type": "CX"}}, {"args": [["q", [0]], ["q", [1]]], "op": {"type": "CX"}}], "created_qubits": [], "discarded_qubits": [], "implicit_permutation": [[["q", [0]], ["q", [0]]], [["q", [1]], ["q", [1]]]], "phase": "0.0", "qubits": [["q", [0]], ["q", [1]]]})";
+    Circuit circ = nlohmann::json::parse(json_str);
+    std::function<void(Circuit)> func = [](Circuit circ) {
+      // No test assertions here, as they are not thread-safe:
+      // https://catch2-temp.readthedocs.io/en/latest/limitations.html#thread-safe-assertions
+      Transforms::clifford_simp().apply(circ);
+    };
+    std::thread thread1(func, circ);
+    std::thread thread2(func, circ);
+    thread1.join();
+    thread2.join();
+  }
+}
+
+}  // namespace test_Concurrency
+}  // namespace tket

--- a/tket/test/src/test_Concurrency.cpp
+++ b/tket/test/src/test_Concurrency.cpp
@@ -24,6 +24,7 @@ namespace tket {
 namespace test_Concurrency {
 
 SCENARIO("Concurrent transforms") {
+#ifdef NDEBUG
   GIVEN("clifford_simp") {
     // https://github.com/CQCL/tket/issues/1953
     const std::string json_str =
@@ -39,6 +40,7 @@ SCENARIO("Concurrent transforms") {
     thread1.join();
     thread2.join();
   }
+#endif
 }
 
 }  // namespace test_Concurrency


### PR DESCRIPTION
Fixes #1953 .

Along with #1971 this seems to solve the concurrency issue described in the bug report. I have not tested other concurrency scenarios so there may be other issues lurking, but this seems like a good step at least.

We skip the concurrency test for debug builds, as it seems there is still an issue there coming from the teuchos library (used by debug builds of symengine). This warrants further investigation but _may_ be outside our control.