### PR TITLE
Use ubuntu-24.04-arm for Linux arm64 builds.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,8 +37,7 @@ jobs:
 
   build_Linux_aarch64_wheels:
     name: Build manylinux aarch64
-    # We need the one with 12GB RAM to build pytket.
-    runs-on: 'buildjet-8vcpu-ubuntu-2204-arm'
+    runs-on: 'ubuntu-24.04-arm'
     strategy:
       matrix:
         python3-version: ['10', '11', '12']
@@ -222,7 +221,7 @@ jobs:
   test_linux_aarch64_wheels:
     name: Test linux aarch64 wheels
     needs: build_Linux_aarch64_wheels
-    runs-on: 'buildjet-4vcpu-ubuntu-2204-arm'
+    runs-on: 'ubuntu-24.04-arm'
     strategy:
       matrix:
         python3-version: ['10', '11', '12', '13']


### PR DESCRIPTION
Towards #2019 .

Tested [here](https://github.com/CQCL/tket/actions/runs/17459658098/job/49581149382).