### PR TITLE
chore: update slack links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # tket
 
-[![Slack](https://img.shields.io/badge/Slack-4A154B?style=for-the-badge&logo=slack&logoColor=white)](https://tketusers.slack.com/join/shared_invite/zt-18qmsamj9-UqQFVdkRzxnXCcKtcarLRA#)
+[![Slack](https://img.shields.io/badge/Slack-4A154B?style=for-the-badge&logo=slack&logoColor=white)](https://join.slack.com/t/tketusers/shared_invite/zt-3a7x4ots2-nZIUpOJ0cSnMM9E~oBm0xQ)
 [![Stack Exchange](https://img.shields.io/badge/StackExchange-%23ffffff.svg?style=for-the-badge&logo=StackExchange)](https://quantumcomputing.stackexchange.com/tags/pytket)
 [![PyPI version](https://badge.fury.io/py/pytket.svg)](https://badge.fury.io/py/pytket)
 

--- a/pytket/docs/index.md
+++ b/pytket/docs/index.md
@@ -54,7 +54,7 @@ We are also keen for others to benchmark their compilation techniques against us
 If you have problems with the use of tket or you think that you have found a bug there are several ways to contact us:
 
 - You can write an issue on [github](https://github.com/CQCL/tket/issues) with details of the problem and we will pick that up. Github issues are the preferred way to report bugs with tket or request features. You can also have a look on that page to see if your problem has already been reported by someone else.
-- We have a slack channel for community discussion and support. You can join by following [this link](https://tketusers.slack.com/join/shared_invite/zt-18qmsamj9-UqQFVdkRzxnXCcKtcarLRA#/shared-invite/email)
+- We have a slack channel for community discussion and support. You can join by following [this link](https://join.slack.com/t/tketusers/shared_invite/zt-3a7x4ots2-nZIUpOJ0cSnMM9E~oBm0xQ)
 - Write an email to <mailto:tket-support@quantinuum.com> and ask for help with your problem.
 - There is also a tag on [quantum computing stack exchange](https://quantumcomputing.stackexchange.com/questions/tagged/pytket) for questions relating to pytket.
 

--- a/pytket/package.md
+++ b/pytket/package.md
@@ -35,7 +35,7 @@ For bugs and feature requests we recommend creating an issue on the [github repo
 
 User support: tket-support@quantinuum.com
 
-For discussion, join the public slack channel [here](https://join.slack.com/t/tketusers/shared_invite/zt-18qmsamj9-UqQFVdkRzxnXCcKtcarLRA).
+For discussion, join the public slack channel [here](https://join.slack.com/t/tketusers/shared_invite/zt-3a7x4ots2-nZIUpOJ0cSnMM9E~oBm0xQ).
 
 There is also a [pytket tag](https://quantumcomputing.stackexchange.com/questions/tagged/pytket) on quantum computing stack exchange.
 


### PR DESCRIPTION
# Description

According to slack these "never expire"

# Related issues

closes #2003 
