### PR TITLE
vscode circuit display issue

### DIFF
--- a/pytket/pytket/circuit/display/static/circuit.html
+++ b/pytket/pytket/circuit/display/static/circuit.html
@@ -15,7 +15,7 @@
     top:0;bottom:0;left:0;right:0;
     margin:auto;resize:both;display:block;overflow:hidden;
     width:min({{ min_width }}, 100%);
-    height:min({{ min_height }},100%);
+    height:min({{ min_height }}, 100%);
     max-width:100%;
     max-height:100%;">
 {% endif %}
@@ -49,6 +49,10 @@
 {% endmacro %}
 
 {% if jupyter %}
+
+<!-- Bypass some Iframe origin concerns for VS Code and import the scripts needed
+directly so they will be cached for the subsequent IFrame. -->
+{% include "html/head_imports.html" %}
 
 <div style="resize: vertical; overflow: auto; height: {{ min_height }}; display: block">
     <iframe srcdoc="{{ show_circuit_page(display_options, circuit_json, uid, min_width, min_height, view_format)|escape }}"


### PR DESCRIPTION
# Description

Amend the circuit display code to fix display issue that occurs in VS code.

This occurred due to how external links embedded in an iframe are handled: we must hence load these directly so that they are cached and available when the Iframe loads.

# Related issues

N/A

# Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented hard-to-understand parts of my code.
- [x] (N/A) I have made corresponding changes to the public API documentation.
- [x] (N/A) I have added tests that prove my fix is effective or that my feature works.
- [x] (N/A) I have updated the changelog with any user-facing changes.
