### PR TITLE
Use `|` instead of `typing.Union` in binder.

### DIFF
--- a/pytket/binders/include/typecast.hpp
+++ b/pytket/binders/include/typecast.hpp
@@ -109,7 +109,7 @@ struct type_caster<SymEngine::Expression> {
  public:
   NB_TYPE_CASTER(
       SymEngine::Expression,
-      const_name("typing.Union[sympy.core.expr.Expr, float]"));
+      const_name("sympy.core.expr.Expr | float"));
 
   static void assert_tuple_length(nanobind::tuple t, unsigned len) {
     if (t.size() != len)


### PR DESCRIPTION
# Description

Please summarise the changes.

# Related issues

Please mention any github issues addressed by this PR.

# Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have commented hard-to-understand parts of my code.
- [ ] I have made corresponding changes to the public API documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the changelog with any user-facing changes.
