### PR TITLE
Support Python 3.14.

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -301,7 +301,7 @@ jobs:
       if: github.event_name == 'schedule'
       uses: actions/setup-python@v6
       with:
-        python-version: '3.13'
+        python-version: '3.14'
     - name: Build pytket
       run: |
         cd pytket
@@ -401,7 +401,7 @@ jobs:
       if: github.event_name == 'schedule'
       uses: actions/setup-python@v6
       with:
-        python-version: '3.13'
+        python-version: '3.14'
     - name: Build pytket
       run: |
         cd pytket

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -148,7 +148,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        python3-version: ['10', '11', '12', '13']
+        python3-version: ['10', '11', '12', '13', '14']
     steps:
       - name: Set up Python 3.${{ matrix.python3-version }}
         uses: actions/setup-python@v6
@@ -161,7 +161,7 @@ jobs:
           name: Linux_3.${{ matrix.python3-version }}_wheel
           path: wheelhouse/
       - name: Download wheel (stable-ABI)
-        if: matrix.python3-version == '12' || matrix.python3-version == '13'
+        if: matrix.python3-version == '12' || matrix.python3-version == '13' || matrix.python3-version == '14'
         uses: actions/download-artifact@v5
         with:
           name: Linux_3.12_wheel
@@ -184,7 +184,7 @@ jobs:
     runs-on: 'ubuntu-24.04-arm'
     strategy:
       matrix:
-        python3-version: ['10', '11', '12', '13']
+        python3-version: ['10', '11', '12', '13', '14']
     steps:
     - uses: actions/checkout@v5
       with:
@@ -200,7 +200,7 @@ jobs:
         name: Linux_aarch64_3.${{ matrix.python3-version }}_wheel
         path: wheelhouse/
     - name: Download wheel (stable-ABI)
-      if: matrix.python3-version == '12' || matrix.python3-version == '13'
+      if: matrix.python3-version == '12' || matrix.python3-version == '13' || matrix.python3-version == '14'
       uses: actions/download-artifact@v5
       with:
         name: Linux_aarch64_3.12_wheel
@@ -223,7 +223,7 @@ jobs:
     strategy:
       matrix:
         os: ['macos-14', 'macos-26']
-        python-version: ['3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
     runs-on: ${{ matrix.os }}
     steps:
     - name: Set up Python ${{ matrix.python-version }}
@@ -237,7 +237,7 @@ jobs:
         name: MacOS_arm64_${{ matrix.python-version }}_wheel
         path: wheelhouse/
     - name: Download wheel (stable-ABI)
-      if: matrix.python-version == '3.12' || matrix.python-version == '3.13'
+      if: matrix.python-version == '3.12' || matrix.python-version == '3.13' || matrix.python-version == '3.14'
       uses: actions/download-artifact@v5
       with:
         name: MacOS_arm64_3.12_wheel
@@ -260,7 +260,7 @@ jobs:
     runs-on: windows-2025
     strategy:
       matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
     steps:
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v6
@@ -273,7 +273,7 @@ jobs:
         name: Windows_${{ matrix.python-version }}_wheel
         path: wheelhouse/
     - name: Download wheel (stable-ABI)
-      if: matrix.python-version == '3.12' || matrix.python-version == '3.13'
+      if: matrix.python-version == '3.12' || matrix.python-version == '3.13' || matrix.python-version == '3.14'
       uses: actions/download-artifact@v5
       with:
         name: Windows_3.12_wheel

--- a/README.md
+++ b/README.md
@@ -76,9 +76,9 @@ depend on the features they support. The compiler version can be controlled by
 setting `CC` and `CXX` in your environment (e.g. `CC=gcc-11` and `CXX=g++-11`),
 or on Debian-based Linux systems using `update-alternatives`.
 
-You should also have Python (3.10, 3.11, 3.12 or 3.13) and `pip` installed. We
-use `cmake` and the package manager `conan` to build tket and pytket. The latter
-can be installed with `pip`:
+You should also have Python (3.10+) and `pip` installed. We use `cmake` and the
+package manager `conan` to build tket and pytket. The latter can be installed
+with `pip`:
 
 ```shell
 pip install conan

--- a/pytket/docs/getting_started.md
+++ b/pytket/docs/getting_started.md
@@ -11,8 +11,8 @@ NISQ (noisy intermediate-scale quantum) devices. The pytket package provides an
 API for interacting with tket and transpiling to and from other popular quantum
 circuit specifications.
 
-Pytket is compatible with 64-bit Python 3.10, 3.11, 3.12 and 3.13, on Linux,
-MacOS (13.0 or later) and Windows. Install pytket from PyPI using:
+Pytket is compatible with 64-bit Python 3.10+, on Linux, MacOS (13.0 or later)
+and Windows. Install pytket from PyPI using:
 
 ```
 pip install pytket

--- a/pytket/docs/index.md
+++ b/pytket/docs/index.md
@@ -4,8 +4,8 @@
 [numerous providers](extensions.md), allowing the
 tket tools to be used in conjunction with projects on their platforms.
 
-`pytket` is available for Python 3.10, 3.11, 3.12 and 3.13, on Linux, MacOS
-and Windows. To install, run
+`pytket` is available for Python 3.10+, on Linux, MacOS and Windows. To install,
+run
 
 ```
 pip install pytket

--- a/pytket/docs/install.md
+++ b/pytket/docs/install.md
@@ -32,7 +32,7 @@ For instructions on how to do this see the [tket repository README](https://gith
 
 ### Is there a build of `pytket` for my system?
 
-The core pytket package, as well as the separate extension modules are available on PyPI. Wheels are built to work on Linux, MacOS and Windows with Python versions 3.10, 3.11, 3.12 or 3.13, and `pip` version 20.0.0+.
+The core pytket package, as well as the separate extension modules are available on PyPI. Wheels are built to work on Linux, MacOS and Windows with Python versions 3.10+, and `pip` version 20.0.0+.
 
 :::{note}
 On M1-based Macs running in native (arm64) mode, this command may fail

--- a/pytket/package.md
+++ b/pytket/package.md
@@ -4,7 +4,7 @@ The source code for the TKET compiler can be found in [this github repository](h
 
 ## Installation
 
-Installation is supported for Linux, MacOS and Windows. Installation requires python 3.10, 3.11, 3.12 or 3.13.
+Installation is supported for Linux, MacOS and Windows. Installation requires python 3.10+.
 
 To install run the pip command: 
 

--- a/pytket/setup.py
+++ b/pytket/setup.py
@@ -197,6 +197,7 @@ setup(
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
         "Programming Language :: Python :: 3.13",
+        "Programming Language :: Python :: 3.14",
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: MacOS :: MacOS X",
         "Operating System :: POSIX :: Linux",


### PR DESCRIPTION
The stable-ABI wheels for pytket should "just work" with Python 3.14 and this PR adds tests that they do, and updates the documentation.

Release build tested [here](https://github.com/CQCL/tket/actions/runs/18591540266).