### PR TITLE
fix: update incorrect CircBox example snippet

### DIFF
--- a/pytket/docs/circuit_class.md
+++ b/pytket/docs/circuit_class.md
@@ -355,7 +355,7 @@ condition on a specified set of bit values.)
 
       bigger_circ = Circuit(3)
 
-      # Equivalent to bigger_circ.add_circbox(box, [0, 1, 2])
+      # Equivalent to bigger_circ.add_circbox(box, [0, 1])
       bigger_circ.add_gate(box, [0, 1])
 
    .. automethod:: add_circbox


### PR DESCRIPTION
# Description

Spotted by @daniel-mills-cqc... this snippet actually fails as we pass a list of the wrong length when trying to append the `CircBox`

```
---------------------------------------------------------------------------
IndexError                                Traceback (most recent call last)
Cell In[4], [line 10](vscode-notebook-cell:?execution_count=4&line=10)
      7 bigger_circ = Circuit(3)
      9 # Equivalent to bigger_circ.add_circbox(box, [0, 1, 2])
---> [10](vscode-notebook-cell:?execution_count=4&line=10) bigger_circ.add_gate(box, [0, 1, 2])

IndexError: vector
``` 

Making the list of length two fixes the issue.
