### PR TITLE
Change MacOS deployment target to 14.0.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,7 +105,7 @@ jobs:
     name: Build macos arm64 wheels
     runs-on: macos-26
     env:
-        MACOSX_DEPLOYMENT_TARGET: '13.0'
+        MACOSX_DEPLOYMENT_TARGET: '14.0'
     strategy:
       matrix:
         python-version: ['3.10', '3.11', '3.12']


### PR DESCRIPTION
MacOS 13 is already past EOL; and 14 is the lowest version we can easily test on.