### PR TITLE
Update changelog for 2.15.0 release.

### DIFF
--- a/pytket/docs/changelog.md
+++ b/pytket/docs/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 2.15.0 (March 2026)
 
 Fixes:
 


### PR DESCRIPTION
I made a 2.15.0rc2 release from `main`, to test the changes from #2125 , #2126 and #2127 . I've tested by running the unit tests of pytket-quantinuum and pytket-qiskit with it.