### PR TITLE
docs: remove links to deprecated extensions

### DIFF
--- a/pytket/docs/extensions.md
+++ b/pytket/docs/extensions.md
@@ -3,7 +3,7 @@
 The pytket extensions are separate python modules which allow pytket to interface with backends from a range of providers including quantum devices from Quantinuum and IBM.
 In pytket a {py:class}`~.Backend` represents a connection to a QPU (Quantum Processing Unit) or simulator for processing quantum circuits. One can also access additional quantum devices and simulators via the cloud through the extensions for [Braket](inv:pytket-braket:std:doc#index).
 
-Additionally, the extensions allow pytket to cross-compile circuits from different quantum computing libraries e.g. [qiskit](inv:pytket-qiskit:std:doc#index). This enables pytket's compilation features to be used in conjunction with other software tools.
+Additionally, the extensions allow pytket to cross-compile circuits from different quantum computing libraries such [qiskit](inv:pytket-qiskit:std:doc#index). This enables pytket's compilation features to be used in conjunction with other software tools.
 
 The additional modules can be installed adding the extension name to the installation command for pytket. For example pytket-quantinuum can be installed by running
 
@@ -18,7 +18,7 @@ The following extensions are now unmaintained:
 pytket-cirq, pytket-pennylane, pytket-pyquil, pytket-pysimplex ,pytket-pyzx, pytket-stim, pytket-quest
 
 
-The source code will remain on github in the `Quantinuum` organistion and the packages will be on pypi. However there will be no active maintenance of these projects.
+The source code will remain on the [Quantinuum github organisation](https://github.com/Quantinuum/), though will be archived. The most recent package version (as of April 2026) will remain on pypi. There will be no active maintenance of these projects.
 ```
 
 The types of {py:class}`~.Backend` available in pytket are the following:

--- a/pytket/docs/extensions.md
+++ b/pytket/docs/extensions.md
@@ -18,7 +18,7 @@ The following extensions are now unmaintained:
 pytket-cirq, pytket-pennylane, pytket-pyquil, pytket-pysimplex ,pytket-pyzx, pytket-stim, pytket-quest
 
 
-The source code will remain on the [Quantinuum github organisation](https://github.com/Quantinuum/), though will be archived. The most recent package version (as of April 2026) will remain on pypi. There will be no active maintenance of these projects.
+The source code will remain on the [Quantinuum github organisation](https://github.com/Quantinuum/), though will be archived. The packages will remain on pypi. There will be no active maintenance of these projects.
 ```
 
 The types of {py:class}`~.Backend` available in pytket are the following:

--- a/pytket/docs/extensions.md
+++ b/pytket/docs/extensions.md
@@ -13,7 +13,7 @@ pip install pytket-quantinuum
 
 
 ```{warning}
-The following extensions are now unmaintained
+The following extensions are now unmaintained:
 
 pytket-cirq, pytket-pennylane, pytket-pyquil, pytket-pysimplex ,pytket-pyzx, pytket-stim, pytket-quest
 

--- a/pytket/docs/extensions.md
+++ b/pytket/docs/extensions.md
@@ -15,10 +15,10 @@ pip install pytket-quantinuum
 ```{warning}
 The following extensions are now unmaintained
 
-pytket-cirq ,pytket-pennylane ,pytket-pyquil ,pytket-pysimplex ,pytket-pyzx ,pytket-stim, pytket-quest
+pytket-cirq, pytket-pennylane, pytket-pyquil, pytket-pysimplex ,pytket-pyzx, pytket-stim, pytket-quest
 
 
-The source code will remain on github in the `Quantinuum` organistion but there will be no active maintenance of these projects.
+The source code will remain on github in the `Quantinuum` organistion and the packages will be on pypi. However there will be no active maintenance of these projects.
 ```
 
 The types of {py:class}`~.Backend` available in pytket are the following:

--- a/pytket/docs/extensions.md
+++ b/pytket/docs/extensions.md
@@ -1,9 +1,9 @@
 # Extension packages
 
 The pytket extensions are separate python modules which allow pytket to interface with backends from a range of providers including quantum devices from Quantinuum and IBM.
-In pytket a {py:class}`~.Backend` represents a connection to a QPU (Quantum Processing Unit) or simulator for processing quantum circuits. One can also access additional quantum devices and simulators via the cloud through the extensions for [Braket](inv:pytket-braket:std:doc#index) .
+In pytket a {py:class}`~.Backend` represents a connection to a QPU (Quantum Processing Unit) or simulator for processing quantum circuits. One can also access additional quantum devices and simulators via the cloud through the extensions for [Braket](inv:pytket-braket:std:doc#index).
 
-Additionally, the extensions allow pytket to cross-compile circuits from different quantum computing libraries with the extensions for [qiskit](inv:pytket-qiskit:std:doc#index), [cirq](inv:pytket-cirq:std:doc#index) and [pennylane](inv:pytket-pennylane:std:doc#index) . This enables pytket's compilation features to be used in conjunction with other software tools.
+Additionally, the extensions allow pytket to cross-compile circuits from different quantum computing libraries e.g. [qiskit](inv:pytket-qiskit:std:doc#index). This enables pytket's compilation features to be used in conjunction with other software tools.
 
 The additional modules can be installed adding the extension name to the installation command for pytket. For example pytket-quantinuum can be installed by running
 
@@ -18,10 +18,9 @@ The types of {py:class}`~.Backend` available in pytket are the following:
 - **QPUs** - These are real quantum computers that return shots based results. E.g the {py:class}`~pytket.extensions.quantinuum.backends.quantinuum.QuantinuumBackend`.
 - **Cloud Access** - Cloud backends allow pytket to interface with cloud platforms to access additional QPUs and simulators. E.g {py:class}`~pytket.extensions.braket.backends.braket.BraketBackend`.
 - **Emulators** - These classically simulate a circuit and produce shots based results. Sometimes emulators use a noise model and have connectivity constraints to emulate real QPUs. E.g. {py:class}`~pytket.extensions.qiskit.backends.ibmq_emulator.IBMQEmulatorBackend`.
-- **Statevector Simulators** - Calculates the pure quantum state prepared by a circuit returning a vector/ndarray. Examples of statevector simulators are the {py:class}`~pytket.extensions.pyquil.backends.forest.ForestStateBackend` and the {py:class}`~pytket.extensions.qiskit.backends.aer.AerStateBackend`.
+- **Statevector Simulators** - Calculates the pure quantum state prepared by a circuit returning a vector/ndarray. An Example of a statevector simulator is the {py:class}`~pytket.extensions.qiskit.backends.aer.AerStateBackend`.
 - **Unitary Simulators** - Unitary simulators calculate the unitary operator that is applied by a circuit. A unitary matrix/ndarray is returned {py:class}`~pytket.extensions.qiskit.backends.aer.AerUnitaryBackend` is an example of such a simulator.
-- **Density Matrix Simulators** - These simulators compute the density matrix prepared by a circuit. The result can be a statistical mixture of states in contrast to statevector simulation. E.g. {py:class}`~pytket.extensions.cirq.backends.cirq.CirqDensityMatrixSampleBackend`.
-- **Other specialised simulators** - There are extensions for simulating specific types of circuit. For instance the {py:class}`~pytket.extensions.pysimplex.backends.simplex_backend.SimplexBackend` is designed to simulate Clifford circuits.
+- **Density Matrix Simulators** - These simulators compute the density matrix prepared by a circuit. The result can be a statistical mixture of states in contrast to statevector simulation. E.g. {py:class}`~pytket.extensions.cirq.backends.qiskit.AerDensityMatrixBackend`.
 
 A full list of available pytket backends is shown below.
 
@@ -32,9 +31,6 @@ A full list of available pytket backends is shown below.
 
 {py:class}`~pytket.extensions.qiskit.backends.ibm.IBMQBackend`
 \- A backend for running circuits on remote IBMQ devices.
-
-{py:class}`~pytket.extensions.pyquil.backends.forest.ForestBackend`
-\- A backend for running circuits on remote Rigetti devices.
 
 {py:class}`~pytket.extensions.iqm.backends.iqm.IQMBackend`
 \- Interface to an IQM device or simulator.
@@ -53,17 +49,8 @@ A full list of available pytket backends is shown below.
 
 ## Statevector Simulators
 
-{py:class}`~pytket.extensions.cirq.backends.cirq.CirqStateSampleBackend`
-\- Backend for Cirq statevector simulator sampling.
-
-{py:class}`~pytket.extensions.cirq.backends.cirq.CirqStateSimBackend`
-\- Backend for Cirq statevector simulator state return.
-
 {py:class}`~pytket.extensions.qiskit.backends.aer.AerStateBackend` - Backend for running simulations on the Qiskit Aer Statevector simulator.
 
-{py:class}`~pytket.extensions.pyquil.backends.forest.ForestStateBackend` - State-based interface to a Rigetti device.
-
-{py:class}`~pytket.extensions.quest.backends.quest_backend.QuESTBackend` - Interface to the [QUEST simulator](https://quest.qtechtheory.org/docs/).
 
 ## Unitary Simulators
 
@@ -73,28 +60,10 @@ A full list of available pytket backends is shown below.
 
 {py:class}`~pytket.extensions.qiskit.backends.aer.AerDensityMatrixBackend` - Backend for density matrix simulation using qiskit Aer. Can take a `NoiseModel` as an optional argument.
 
-{py:class}`~pytket.extensions.cirq.backends.cirq.CirqDensityMatrixSampleBackend`
-\- Backend for Cirq density matrix simulator sampling.
-
-{py:class}`~pytket.extensions.cirq.backends.cirq.CirqDensityMatrixSimBackend`
-\- Backend for Cirq density matrix simulator density_matrix return.
-
 {py:class}`~pytket.extensions.qulacs.backends.qulacs_backend.QulacsBackend` - This has a configurable density matrix simulation option.
 
 Use `QulacsBackend(result_type="density_matrix")`.
 
-## Clifford Simulators
-
-{py:class}`~pytket.extensions.cirq.backends.cirq.CirqCliffordSampleBackend`
-\- Backend for Cirq Clifford simulator sampling.
-
-{py:class}`~pytket.extensions.cirq.backends.cirq.CirqCliffordSimBackend`
-\- Backend for Cirq Clifford simulator state return.
-
-{py:class}`~pytket.extensions.pysimplex.backends.simplex_backend.SimplexBackend` - Backend for simulating Clifford circuits using pysimplex.
-
-{py:class}`~pytket.extensions.stim.backends.stim_backend.StimBackend`
-\- Backend for simulating Clifford circuits using Stim.
 
 ## Other
 
@@ -109,19 +78,12 @@ Use `QulacsBackend(result_type="density_matrix")`.
 :maxdepth: 0
 
 pytket-braket <https://docs.quantinuum.com/tket/extensions/pytket-braket>
-pytket-cirq <https://docs.quantinuum.com/tket/extensions/pytket-cirq>
 pytket-iqm <https://docs.quantinuum.com/tket/extensions/pytket-iqm>
-pytket-pennylane <https://docs.quantinuum.com/tket/extensions/pytket-pennylane>
-pytket-pyquil <https://docs.quantinuum.com/tket/extensions/pytket-pyquil>
-pytket-pysimplex <https://docs.quantinuum.com/tket/extensions/pytket-pysimplex>
-pytket-pyzx <https://docs.quantinuum.com/tket/extensions/pytket-pyzx>
 pytket-qir <https://docs.quantinuum.com/tket/extensions/pytket-qir>
 pytket-qiskit <https://docs.quantinuum.com/tket/extensions/pytket-qiskit>
 pytket-quantinuum <https://docs.quantinuum.com/tket/extensions/pytket-quantinuum>
-pytket-quest <https://docs.quantinuum.com/tket/extensions/pytket-quest>
 pytket-cutensornet <https://docs.quantinuum.com/tket/extensions/pytket-cutensornet>
 pytket-qulacs <https://docs.quantinuum.com/tket/extensions/pytket-qulacs>
 pytket-qujax <https://docs.quantinuum.com/tket/extensions/pytket-qujax>
-pytket-stim <https://docs.quantinuum.com/tket/extensions/pytket-stim>
 ```
 

--- a/pytket/docs/extensions.md
+++ b/pytket/docs/extensions.md
@@ -11,6 +11,16 @@ The additional modules can be installed adding the extension name to the install
 pip install pytket-quantinuum
 ```
 
+
+```{warning}
+The following extensions are now unmaintained
+
+pytket-cirq ,pytket-pennylane ,pytket-pyquil ,pytket-pysimplex ,pytket-pyzx ,pytket-stim, pytket-quest
+
+
+The source code will remain on github in the `Quantinuum` organistion but there will be no active maintenance of these projects.
+```
+
 The types of {py:class}`~.Backend` available in pytket are the following:
 
 ## Types of Backend
@@ -20,7 +30,7 @@ The types of {py:class}`~.Backend` available in pytket are the following:
 - **Emulators** - These classically simulate a circuit and produce shots based results. Sometimes emulators use a noise model and have connectivity constraints to emulate real QPUs. E.g. {py:class}`~pytket.extensions.qiskit.backends.ibmq_emulator.IBMQEmulatorBackend`.
 - **Statevector Simulators** - Calculates the pure quantum state prepared by a circuit returning a vector/ndarray. An Example of a statevector simulator is the {py:class}`~pytket.extensions.qiskit.backends.aer.AerStateBackend`.
 - **Unitary Simulators** - Unitary simulators calculate the unitary operator that is applied by a circuit. A unitary matrix/ndarray is returned {py:class}`~pytket.extensions.qiskit.backends.aer.AerUnitaryBackend` is an example of such a simulator.
-- **Density Matrix Simulators** - These simulators compute the density matrix prepared by a circuit. The result can be a statistical mixture of states in contrast to statevector simulation. E.g. {py:class}`~pytket.extensions.cirq.backends.qiskit.AerDensityMatrixBackend`.
+- **Density Matrix Simulators** - These simulators compute the density matrix prepared by a circuit. The result can be a statistical mixture of states in contrast to statevector simulation. E.g. {py:class}`~pytket.extensions.qiskit.backends.aer.AerDensityMatrixBackend`.
 
 A full list of available pytket backends is shown below.
 


### PR DESCRIPTION
# Description

Removing refereneces and links to the following extensions from the extensions index page

```
pytket-cirq
pytket-pennylane
pytket-pyquil
pytket-pysimplex
pytket-pyzx
pytket-stim
pytket-quest
```

Also added a warning that we are no longer maintaining these projects.

<img width="757" height="171" alt="Screenshot 2026-04-08 at 16 34 21" src="https://github.com/user-attachments/assets/67c2991a-2948-475d-93d1-63622aaff87e" />


It will still be possible to visit these links for a while until I remove them from the website build. Ideally we would publish these changes first to avoid having broken links in the sidebar. This would require a new gtihub tag from this repository.
