### PR TITLE
docs: fix changelog heading

### DIFF
--- a/pytket/docs/changelog.md
+++ b/pytket/docs/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-# 2.17.0 (May 2026)
+## 2.17.0 (May 2026)
 
 Fixes:
 - Fix handling of wasm function calls in circuit boxes.


### PR DESCRIPTION
# Description

Fixing The 2.17 changelog entry to be consistent with the previous entries. The title heading `#` meant 2.17 was showing up in the sidebar.


<img width="241" height="134" alt="Screenshot 2026-05-14 at 13 31 12" src="https://github.com/user-attachments/assets/31740334-5712-4c68-9912-8b47eb28501b" />

<img width="631" height="336" alt="Screenshot 2026-05-14 at 13 31 20" src="https://github.com/user-attachments/assets/c37b272d-efef-49ff-8978-5ad7e5691ada" />
