### PR TITLE
Add `windows-2025-vs2026` profile; use it for libraries; build new version of tklog using it

### DIFF
--- a/.github/workflows/build_libs.yml
+++ b/.github/workflows/build_libs.yml
@@ -46,7 +46,7 @@ jobs:
     if: ${{ needs.changes.outputs.libs != '[]' && needs.changes.outputs.libs != '' }}
     strategy:
       matrix:
-        os: ['ubuntu-24.04', 'macos-15', 'macos-15-intel', 'macos-26', 'windows-2022']
+        os: ['ubuntu-24.04', 'macos-15', 'macos-15-intel', 'macos-26', 'windows-2025-vs2026']
         lib: ${{ fromJson(needs.changes.outputs.libs) }}
         build_type: ['Release', 'Debug']
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test_libs.yml
+++ b/.github/workflows/test_libs.yml
@@ -63,7 +63,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ['ubuntu-24.04', 'macos-15', 'macos-15-intel', 'macos-26', 'windows-2022']
+        os: ['ubuntu-24.04', 'macos-15', 'macos-15-intel', 'macos-26', 'windows-2025-vs2026']
         lib: ${{ fromJson(needs.set_libs_matrix.outputs.libs) }}
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/test_libs_all.yml
+++ b/.github/workflows/test_libs_all.yml
@@ -10,7 +10,7 @@ jobs:
     name: test library
     strategy:
       matrix:
-        os: ['ubuntu-24.04', 'macos-15', 'macos-15-intel', 'macos-26', 'windows-2022']
+        os: ['ubuntu-24.04', 'macos-15', 'macos-15-intel', 'macos-26', 'windows-2025-vs2026']
         lib: ['tklog', 'tkassert', 'tkrng', 'tktokenswap', 'tkwsm']
     runs-on: ${{ matrix.os }}
     steps:

--- a/conan-profiles/windows-2025-vs2026
+++ b/conan-profiles/windows-2025-vs2026
@@ -1,0 +1,8 @@
+[settings]
+arch=x86_64
+build_type=Release
+compiler=msvc
+compiler.cppstd=14
+compiler.runtime=dynamic
+compiler.version=195
+os=Windows

--- a/libs/tkassert/test/conanfile.py
+++ b/libs/tkassert/test/conanfile.py
@@ -60,4 +60,4 @@ class test_tkassertRecipe(ConanFile):
 
     def requirements(self):
         self.requires("tkassert/0.3.4")
-        self.requires("catch2/3.14.0@tket/stable")
+        self.requires("catch2/3.15.0@tket/stable")

--- a/libs/tklog/conanfile.py
+++ b/libs/tklog/conanfile.py
@@ -21,7 +21,7 @@ required_conan_version = ">=2.4"
 
 class TklogConan(ConanFile):
     name = "tklog"
-    version = "0.3.3"
+    version = "0.3.4"
     package_type = "library"
     license = "Apache 2"
     url = "https://github.com/quantinuum/tket"

--- a/libs/tklog/test/conanfile.py
+++ b/libs/tklog/test/conanfile.py
@@ -19,7 +19,7 @@ from conan.errors import ConanInvalidConfiguration
 
 class test_tklogRecipe(ConanFile):
     name = "test-tklog"
-    version = "0.3.3"
+    version = "0.3.4"
     package_type = "application"
     license = "Apache 2"
     url = "https://github.com/quantinuum/tket"
@@ -59,5 +59,5 @@ class test_tklogRecipe(ConanFile):
         cmake.install()
 
     def requirements(self):
-        self.requires("tklog/0.3.3")
-        self.requires("catch2/3.14.0@tket/stable")
+        self.requires("tklog/0.3.4")
+        self.requires("catch2/3.15.0@tket/stable")

--- a/libs/tkrng/test/conanfile.py
+++ b/libs/tkrng/test/conanfile.py
@@ -60,4 +60,4 @@ class test_tkrngRecipe(ConanFile):
 
     def requirements(self):
         self.requires("tkrng/0.3.3")
-        self.requires("catch2/3.14.0@tket/stable")
+        self.requires("catch2/3.15.0@tket/stable")

--- a/libs/tktokenswap/test/conanfile.py
+++ b/libs/tktokenswap/test/conanfile.py
@@ -61,4 +61,4 @@ class test_tktokenswapRecipe(ConanFile):
     def requirements(self):
         self.requires("tktokenswap/0.3.13")
         self.requires("tkrng/0.3.3@tket/stable")
-        self.requires("catch2/3.14.0@tket/stable")
+        self.requires("catch2/3.15.0@tket/stable")

--- a/libs/tkwsm/test/conanfile.py
+++ b/libs/tkwsm/test/conanfile.py
@@ -62,4 +62,4 @@ class test_tkwsmRecipe(ConanFile):
         self.requires("tkwsm/0.3.13")
         self.requires("tkassert/0.3.4@tket/stable")
         self.requires("tkrng/0.3.3@tket/stable")
-        self.requires("catch2/3.14.0@tket/stable")
+        self.requires("catch2/3.15.0@tket/stable")


### PR DESCRIPTION
First of a short sequence of PRs to migrate to this platform.