### PR TITLE
fix: replace _tket modules in docs html pages

### DIFF
--- a/pytket/docs/justfile
+++ b/pytket/docs/justfile
@@ -10,23 +10,9 @@ install-dev: prepare
     uv sync
     uv pip install ../.[ZX] -v
 
-# replace _tket module in the html pages.
-# Apple MACOSX and Linux have differing sed replace syntax
-replace:
-    #!/usr/bin/env bash
-
-    if [[ "$OSTYPE" == darwin* ]]; then
-        find build/ -type f -name "*.html" | xargs sed -e 's/pytket._tket/pytket/g' -i ""
-        sed -i '' 's/pytket._tket/pytket/g' build/searchindex.js
-    else
-        find build/ -type f -name "*.html" | xargs sed -i 's/pytket._tket/pytket/g'
-        sed -i 's/pytket._tket/pytket/g' build/searchindex.js
-    fi
-
 build *SPHINX_ARGS:
     VERSION=$(uv run python -c "import pytket; print(pytket.__version__)") && \
     uv run sphinx-build {{SPHINX_ARGS}} -b html . build -D html_title="pytket v$VERSION API documentation"
-    just replace
 
 linkcheck: prepare
     uv run sphinx-build -W -b linkcheck . build

--- a/pytket/docs/justfile
+++ b/pytket/docs/justfile
@@ -11,9 +11,15 @@ install-dev: prepare
     uv pip install ../.[ZX] -v
 
 # replace _tket module in the html pages.
+# Apple MACOSX and Linux have differing sed replace syntax
 replace:
-    find build/ -type f -name "*.html" | xargs sed -i '' 's/pytket._tket/pytket/g'
-    sed -i '' 's/pytket._tket/pytket/g' build/searchindex.js
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        find build/ -type f -name "*.html" | xargs sed -e 's/pytket._tket/pytket/g' -i ""
+        sed -i '' 's/pytket._tket/pytket/g' build/searchindex.js
+    else
+        find build/ -type f -name "*.html" | xargs sed -i 's/pytket._tket/pytket/g'
+        sed -i 's/pytket._tket/pytket/g' build/searchindex.js
+    fi
 
 build *SPHINX_ARGS:
     VERSION=$(uv run python -c "import pytket; print(pytket.__version__)") && \

--- a/pytket/docs/justfile
+++ b/pytket/docs/justfile
@@ -13,7 +13,9 @@ install-dev: prepare
 # replace _tket module in the html pages.
 # Apple MACOSX and Linux have differing sed replace syntax
 replace:
-    if [[ "$OSTYPE" == "darwin"* ]]; then
+    #!/usr/bin/env bash
+
+    if [[ "$OSTYPE" == darwin* ]]; then
         find build/ -type f -name "*.html" | xargs sed -e 's/pytket._tket/pytket/g' -i ""
         sed -i '' 's/pytket._tket/pytket/g' build/searchindex.js
     else

--- a/pytket/docs/justfile
+++ b/pytket/docs/justfile
@@ -10,9 +10,15 @@ install-dev: prepare
     uv sync
     uv pip install ../.[ZX] -v
 
+# replace _tket module in the html pages.
+replace:
+    find build/ -type f -name "*.html" | xargs sed -i '' 's/pytket._tket/pytket/g'
+    sed -i '' 's/pytket._tket/pytket/g' build/searchindex.js
+
 build *SPHINX_ARGS:
     VERSION=$(uv run python -c "import pytket; print(pytket.__version__)") && \
     uv run sphinx-build {{SPHINX_ARGS}} -b html . build -D html_title="pytket v$VERSION API documentation"
+    just replace
 
 linkcheck: prepare
     uv run sphinx-build -W -b linkcheck . build


### PR DESCRIPTION
# Description

This PR fixes an apparent regression where `_tket` was showing up in the Sphinx API docs. Note that this fix only fixes the local build of the docs. I'll need to make a separate PR to the repo that deploys the website.

EDIT: now fixed at the sphinx configuration level thanks to @sburton84  in https://github.com/Quantinuum/pytket-docs-theming/pull/26

 I think its much better to do 

```python
from pytket.circuit import Op
```

than 

```python
from pytket._tket.circuit import Op
``` 

Before this change:

<img width="545" height="30" alt="Screenshot 2026-06-09 at 22 47 00" src="https://github.com/user-attachments/assets/bf7d8409-e1e2-4b2c-bd87-73064169672a" />

After:

<img width="504" height="31" alt="Screenshot 2026-06-09 at 22 47 11" src="https://github.com/user-attachments/assets/27136d33-7fd1-4ce5-b11f-37be0a2ae891" />
 
