### PR TITLE
Circuit renderer browser warnings

### DIFF
--- a/pytket/pytket/circuit/display/__init__.py
+++ b/pytket/pytket/circuit/display/__init__.py
@@ -66,6 +66,22 @@ loader = PrefixLoader(
 
 jinja_env = Environment(loader=loader, extensions=[IncludeRawExtension])
 
+
+def _use_vue_dev_build() -> bool:
+    """Whether to load the development build of Vue.
+
+    The development build emits extra runtime warnings that are useful when
+    debugging the circuit renderer. Set the ``PYTKET_CIRCUIT_RENDERER_DEV``
+    environment variable to a truthy value to enable it; otherwise the
+    production build is used.
+    """
+    return os.environ.get("PYTKET_CIRCUIT_RENDERER_DEV", "").lower() in (
+        "1",
+        "true",
+        "yes",
+        "on",
+    )
+
 RenderCircuit = dict[str, str | float | dict] | Circuit
 Orientation = Literal["row"] | Literal["column"]
 
@@ -230,6 +246,7 @@ class CircuitRenderer:
                 "min_height": self.config.min_height,
                 "min_width": self.config.min_width,
                 "view_format": orient or self.config.orient,
+                "vue_dev": _use_vue_dev_build(),
             }
         )
         if jupyter:

--- a/pytket/pytket/circuit/display/__init__.py
+++ b/pytket/pytket/circuit/display/__init__.py
@@ -70,10 +70,22 @@ jinja_env = Environment(loader=loader, extensions=[IncludeRawExtension])
 def _use_vue_dev_build() -> bool:
     """Whether to load the development build of Vue.
 
-    The development build emits extra runtime warnings that are useful when
-    debugging the circuit renderer. Set the ``PYTKET_CIRCUIT_RENDERER_DEV``
-    environment variable to a truthy value to enable it; otherwise the
-    production build is used.
+    During development Vue provides a number of features that improve the
+    debugging experience but are useless (and add a small performance overhead)
+    in production:
+
+    - warnings for common errors and pitfalls;
+    - props / events validation;
+    - reactivity debugging hooks;
+    - devtools integration.
+
+    The production build (dist files ending in ``.prod.js``) is pre-minified
+    with all of these development-only code branches removed. Set the
+    ``PYTKET_CIRCUIT_RENDERER_DEV`` environment variable to a truthy value to
+    load the development build instead; otherwise the production build is used.
+
+    See https://vuejs.org/guide/best-practices/production-deployment for
+    details.
     """
     return os.environ.get("PYTKET_CIRCUIT_RENDERER_DEV", "").lower() in (
         "1",

--- a/pytket/pytket/circuit/display/__init__.py
+++ b/pytket/pytket/circuit/display/__init__.py
@@ -94,6 +94,7 @@ def _use_vue_dev_build() -> bool:
         "on",
     )
 
+
 RenderCircuit = dict[str, str | float | dict] | Circuit
 Orientation = Literal["row"] | Literal["column"]
 

--- a/pytket/pytket/circuit/display/static/circuit.html
+++ b/pytket/pytket/circuit/display/static/circuit.html
@@ -26,7 +26,7 @@
         <circuit-display-container
                 :circuit-element-str="'#circuit-json-to-display'"
                 :init-render-options="initRenderOptions"
-                view-format="{{view_format}}"
+                {% if view_format %}view-format="{{view_format}}"{% endif %}
         ></circuit-display-container>
     </div>
     <script type="application/javascript">

--- a/pytket/pytket/circuit/display/static/head_imports.html
+++ b/pytket/pytket/circuit/display/static/head_imports.html
@@ -1,5 +1,5 @@
-<!-- Download Vue 3-->
-<script type="application/javascript" src="https://unpkg.com/vue@3"></script>
+<!-- Download Vue 3 (production build by default; development build for debugging) -->
+<script type="application/javascript" src="https://unpkg.com/vue@3/dist/{% if vue_dev %}vue.global.js{% else %}vue.global.prod.js{% endif %}"></script>
 <!-- Download Circuit Renderer with styles -->
 <script type="application/javascript" src="https://unpkg.com/pytket-circuit-renderer@0.10/dist/pytket-circuit-renderer.umd.js"></script>
 <link rel="stylesheet" href="https://unpkg.com/pytket-circuit-renderer@0.10/dist/pytket-circuit-renderer.css">
@@ -10,7 +10,7 @@
         const loadVue = new Promise(resolve => {
             const vueFallback = document.createElement("script")
             vueFallback.type = "application/javascript"
-            vueFallback.src = "https://cdn.jsdelivr.net/npm/vue@3"
+            vueFallback.src = "https://cdn.jsdelivr.net/npm/vue@3/dist/{% if vue_dev %}vue.global.js{% else %}vue.global.prod.js{% endif %}"
             vueFallback.async = false
             vueFallback.defer = false
             vueFallback.addEventListener('load', () => {


### PR DESCRIPTION
# Description

When displaying some of our documentation pages that use the TKET circuit renderer, such as at https://docs.quantinuum.com/inquanto/tutorials/InQ_tut_circ_comp.html, there are lots of warnings in the logs about using the development build of Vue and setting the `viewFormat` property to an invalid `"None"` string. This fixes those warnings by setting `viewFormat` only if the corresponding variable is not `None` (otherwise it will be left to the default value, which I believe is `"row"`), and using the production distribution of Vue. I have also included an environment variable that can be set to switch the Vue version back to the development version in case this is useful for debugging, but this could be removed if it's something that doesn't sound like it would be useful?

# Checklist

- [X] I have performed a self-review of my code.
- [X] I have commented hard-to-understand parts of my code.
- [ ] ~~I have made corresponding changes to the public API documentation.~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works.~~
- [ ] ~~I have updated the changelog with any user-facing changes.~~
